### PR TITLE
Update Gemini Model

### DIFF
--- a/examples/agent_demo.rs
+++ b/examples/agent_demo.rs
@@ -10,7 +10,7 @@ async fn main() {
     let agent_config = AgentConfig {
         enabled: true,
         provider: LLMProvider::Gemini,
-        model: "gemini-2.0-flash-exp".to_string(),
+        model: "gemini-2.5-flash".to_string(),
         api_key: std::env::var("GEMINI_API_KEY").ok(),
         api_base_url: None,
         system_prompt: None,

--- a/examples/nlq_demo.rs
+++ b/examples/nlq_demo.rs
@@ -21,7 +21,7 @@ async fn main() {
     let nlq_config = NLQConfig {
         enabled: true,
         provider: LLMProvider::Gemini,
-        model: "gemini-2.0-flash-exp".to_string(),
+        model: "gemini-2.5-flash".to_string(),
         api_key: Some(api_key),
         api_base_url: None,
         system_prompt: None,

--- a/examples/supply_chain_demo.rs
+++ b/examples/supply_chain_demo.rs
@@ -62,7 +62,7 @@ async fn main() {
     let agent_config = AgentConfig {
         enabled: true,
         provider: LLMProvider::Mock,
-        model: "gemini-1.5-flash".to_string(),
+        model: "gemini-2.5-flash".to_string(),
         api_key: Some("mock".to_string()),
         api_base_url: None,
         system_prompt: Some("You are a supply chain risk agent.".to_string()),
@@ -75,7 +75,7 @@ async fn main() {
     let nlq_config = NLQConfig {
         enabled: true,
         provider: LLMProvider::Mock,
-        model: "gemini-1.5-flash".to_string(),
+        model: "gemini-2.5-flash".to_string(),
         api_key: Some("mock".to_string()),
         api_base_url: None,
         system_prompt: None,


### PR DESCRIPTION
Updates examples to use 'gemini-2.5-flash' as '2.0-flash-exp' is not available on v1beta.