### PR TITLE
Add ClaudeCode LLM provider, wire enrichment through NLQ pipeline

### DIFF
--- a/src/embed/client.rs
+++ b/src/embed/client.rs
@@ -30,6 +30,7 @@ impl EmbeddingClient {
                 LLMProvider::Gemini => "https://generativelanguage.googleapis.com/v1beta".to_string(),
                 LLMProvider::AzureOpenAI => String::new(), // Must be provided
                 LLMProvider::Anthropic => "https://api.anthropic.com/v1".to_string(),
+                LLMProvider::ClaudeCode => String::new(),
                 LLMProvider::Mock => String::new(),
             }
         });

--- a/src/persistence/tenant.rs
+++ b/src/persistence/tenant.rs
@@ -201,6 +201,7 @@ pub enum LLMProvider {
     Gemini,
     AzureOpenAI,
     Anthropic,
+    ClaudeCode,
     Mock,
 }
 


### PR DESCRIPTION
## Summary
- Add `ClaudeCode` variant to `LLMProvider` enum — uses `claude -p` CLI, no API key needed
- Add `claude_code_generate()` method to `NLQClient` using `tokio::process::Command`
- Implement `AgentRuntime::process_trigger()` to create `NLQClient` from `AgentConfig` (replaces stub)
- Rewrite `agentic_enrichment_demo` to use full pipeline: `TenantManager` → `AgentRuntime` → `NLQClient`
- Demo Phase 1 now uses `NLQPipeline::text_to_cypher()` for natural language → Cypher translation

## Test plan
- [x] `cargo test` — all 188 tests pass
- [x] `cargo build --example agentic_enrichment_demo` — compiles
- [x] `cargo run --release --example agentic_enrichment_demo` — runs end-to-end (13/13 statements, 7 nodes, 6 edges)