### PR TITLE
Add IS NULL / IS NOT NULL support to Cypher engine

### DIFF
--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -76,7 +76,8 @@ order_direction = { ^"ASC" | ^"DESC" }
 
 // Expressions
 expression = { term ~ (binary_op ~ term)* }
-term = { unary_op* ~ primary }
+term = { unary_op* ~ primary ~ postfix_op? }
+postfix_op = { ^"IS" ~ ^"NOT" ~ ^"NULL" | ^"IS" ~ ^"NULL" }
 primary = {
     function_call |
     property_access |
@@ -98,10 +99,7 @@ or_op = @{ ^"OR" ~ !(ASCII_ALPHANUMERIC | "_") }
 
 binary_op = _{ mul_div_mod_op | add_sub_op | comparison_op | and_op | or_op }
 
-unary_op = {
-    ^"NOT" | "-" |
-    ^"IS" ~ ^"NULL" | ^"IS" ~ ^"NOT" ~ ^"NULL"
-}
+unary_op = { ^"NOT" | "-" }
 
 // Values
 value = {


### PR DESCRIPTION
## Summary
- Moves `IS NULL` / `IS NOT NULL` from prefix `unary_op` to a new `postfix_op` rule in the PEG grammar, matching standard Cypher syntax (`expr IS NULL`)
- Rewrites `parse_term()` to handle both prefix (`NOT`, `-`) and postfix operators correctly
- Adds `Expression::Unary` evaluation in `FilterOperator` for `IsNull`, `IsNotNull`, `Not`, and `Minus`
- Fixes NLQ pipeline queries like `WHERE s.state IS NOT NULL` that were failing at parse time

## Test plan
- [x] 3 new parser tests: `test_parse_is_null`, `test_parse_is_not_null`, `test_parse_not_expression`
- [x] 2 new executor tests: `test_execute_is_null_filter`, `test_execute_is_not_null_filter`
- [x] All 193 library tests pass