### PR TITLE
feat: recover persisted data from RocksDB on server startup

### DIFF
--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -205,6 +205,11 @@ impl PersistenceManager {
         Ok(())
     }
 
+    /// List all tenants that have persisted data in RocksDB
+    pub fn list_persisted_tenants(&self) -> Result<Vec<String>, PersistenceError> {
+        Ok(self.storage.list_persisted_tenants()?)
+    }
+
     /// Recover from storage and WAL
     pub fn recover(&self, tenant: &str) -> Result<(Vec<Node>, Vec<Edge>), PersistenceError> {
         info!("Starting recovery for tenant: {}", tenant);


### PR DESCRIPTION
## Summary

- Add `list_persisted_tenants()` to `PersistentStorage` and `PersistenceManager` to discover which tenants have data in RocksDB
- Reorder `start_server()` to initialize persistence first, then recover persisted nodes/edges before starting the server
- Only load hardcoded demo data (Alice/Bob, clinical trials) when no persisted data exists (fresh database)

## Files Changed

- `src/persistence/storage.rs` — `list_persisted_tenants()`: scans RocksDB nodes column family, collects unique tenant prefixes
- `src/persistence/mod.rs` — Forwarding method on `PersistenceManager`
- `src/main.rs` — Reordered startup: persistence init → recovery → conditional demo data → server

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` — 239 passed (1 pre-existing failure in `test_execute_optional_match`, unrelated)
- [ ] Fresh start: delete `./samyama_data`, start server → should load demo data
- [ ] Persistence: create data via GRAPH.QUERY, restart → data persists
- [ ] Multi-tenant: create data in multiple tenants, restart → all recovered