### PR TITLE
fix: NLQ nested session error, cross-type comparison coercion

### DIFF
--- a/src/nlq/client.rs
+++ b/src/nlq/client.rs
@@ -144,6 +144,9 @@ impl NLQClient {
         let output = tokio::process::Command::new("claude")
             .arg("-p")
             .arg(prompt)
+            .arg("--max-turns")
+            .arg("2")
+            .env_remove("CLAUDECODE")
             .output()
             .await
             .map_err(|e| NLQError::ApiError(format!("Claude Code CLI error: {}", e)))?;


### PR DESCRIPTION
## Summary
- Fix NLQ `env_remove("CLAUDECODE")` to prevent nested Claude Code session errors  
- Add `--max-turns 2` to claude CLI invocation
- Add `coerced_eq()` for Integer↔Float and String↔Boolean equality
- Add Integer↔Float coercion to `compare_lt/le/gt/ge`  
- Add `extract_cypher()` to handle markdown fences in LLM responses
- 2 new cross-type comparison tests

## Test plan
- [x] All 247 lib tests pass
- [x] Full suite passes (284 total)
- [x] `test_cross_type_numeric_comparison` — Float property > Integer literal
- [x] `test_cross_type_string_boolean_eq` — Boolean property = String 'true'