### PR TITLE
fix: Dockerfile missing workspace crates and unreachable bind address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /app
 # Copy all source files
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
+COPY crates ./crates
 
 # Build the application
 RUN cargo build --release
@@ -41,7 +42,10 @@ EXPOSE 8080
 
 # Set environment variables
 ENV RUST_LOG=info
-ENV BIND_ADDRESS=0.0.0.0
 
-# Run the server
-CMD ["samyama"]
+# Healthcheck via RESP PING
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD echo "PING" | nc -w1 localhost 6379 | grep -q PONG || exit 1
+
+# Run the server, binding to 0.0.0.0 so it's reachable from outside the container
+CMD ["samyama", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Summary
- Add `COPY crates ./crates` so workspace members (`samyama-graph-algorithms`, `samyama-optimization`) are included in the build — previously `cargo build` would fail
- Replace unused `ENV BIND_ADDRESS=0.0.0.0` with `CMD ["samyama", "--host", "0.0.0.0"]` — the code reads `--host` CLI arg, not env var, so the container was unreachable
- Add `HEALTHCHECK` using RESP PING for production readiness

## Test plan
- [ ] Build Docker image: `docker build -t sandeepkunkunuru/samyama-graph:v0.5.5 .`
- [ ] Run container: `docker run -d -p 6379:6379 -p 8080:8080 sandeepkunkunuru/samyama-graph:v0.5.5`
- [ ] Verify RESP: `redis-cli PING` → PONG
- [ ] Verify health: `docker inspect --format='{{.State.Health.Status}}'`