### PR TITLE
fix: Dockerfile add benches/ and examples/ for cargo build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 COPY crates ./crates
+COPY benches ./benches
+COPY examples ./examples
 
 # Build the application
 RUN cargo build --release


### PR DESCRIPTION
## Summary
- Add `COPY benches ./benches` and `COPY examples ./examples` to Dockerfile
- Cargo.toml references bench and example targets — `cargo build` fails without these directories

Follows up on PR #63 which added the `crates/` directory.

## Test plan
- [ ] Docker build succeeds: `docker build -t sandeepkunkunuru/samyama-graph:v0.5.6 .`