### PR TITLE
fix: remove examples/ from .dockerignore for cargo build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@ target/
 *.md
 docs/
 tests/
-examples/
 .claude/
 *_data/
 vectors/


### PR DESCRIPTION
## Summary
- Remove `examples/` from `.dockerignore` — Cargo.toml has `[[example]]` targets so `cargo build` fails without this directory
- Follows up on PRs #63 and #64

## Test plan
- [ ] Docker build succeeds on Mac Mini