### PR TITLE
feat: add OpenAPI spec, Rust SDK, CLI, Python & TypeScript SDKs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +675,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.9.4",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +753,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1472,6 +1515,12 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -2553,6 +2602,7 @@ dependencies = [
  "rust-embed",
  "samyama-graph-algorithms",
  "samyama-optimization",
+ "samyama-sdk",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2565,6 +2615,17 @@ dependencies = [
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "samyama-cli"
+version = "0.5.0-alpha.1"
+dependencies = [
+ "clap",
+ "comfy-table",
+ "samyama-sdk",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -2585,6 +2646,19 @@ dependencies = [
  "rayon",
  "serde",
  "tracing",
+]
+
+[[package]]
+name = "samyama-sdk"
+version = "0.5.0-alpha.1"
+dependencies = [
+ "async-trait",
+ "reqwest",
+ "samyama",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -3282,6 +3356,18 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 members = [
     ".", "crates/samyama-graph-algorithms",
     "crates/samyama-optimization",
+    "crates/samyama-sdk",
+    "cli",
 ]
+exclude = ["sdk/python"]
 
 [package]
 name = "samyama"
@@ -73,6 +76,7 @@ reqwest = { version = "0.13.1", features = ["json"] }
 [dev-dependencies]
 tempfile = "3.8"
 criterion = "0.5"
+samyama-sdk = { path = "crates/samyama-sdk", version = "0.5.0-alpha.1" }
 
 [[bench]]
 name = "graph_benchmarks"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,182 @@
+openapi: 3.1.0
+info:
+  title: Samyama Graph Database API
+  version: 0.5.0-alpha.1
+  description: |
+    HTTP API for the Samyama high-performance distributed graph database.
+    Supports OpenCypher queries, graph status, and CRUD operations.
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  - url: http://localhost:8080
+    description: Local development server
+
+paths:
+  /api/query:
+    post:
+      operationId: executeQuery
+      summary: Execute a Cypher query
+      description: |
+        Execute an OpenCypher query against the graph database.
+        Supports both read (MATCH) and write (CREATE, SET, DELETE, MERGE) queries.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QueryRequest'
+            examples:
+              matchAll:
+                summary: Match all Person nodes
+                value:
+                  query: "MATCH (n:Person) RETURN n"
+              matchWithFilter:
+                summary: Match with WHERE filter
+                value:
+                  query: "MATCH (n:Person) WHERE n.age > 25 RETURN n.name, n.age"
+              createNode:
+                summary: Create a new node
+                value:
+                  query: 'CREATE (n:Person {name: "Alice", age: 30})'
+              traversal:
+                summary: Traverse relationships
+                value:
+                  query: "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a.name, b.name"
+      responses:
+        '200':
+          description: Query executed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryResponse'
+        '400':
+          description: Query error (parse error, execution error)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/status:
+    get:
+      operationId: getStatus
+      summary: Get server status
+      description: Returns the health status, version, and storage statistics of the database.
+      responses:
+        '200':
+          description: Server status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+              example:
+                status: healthy
+                version: 0.5.0-alpha.1
+                storage:
+                  nodes: 2000
+                  edges: 11000
+
+components:
+  schemas:
+    QueryRequest:
+      type: object
+      required:
+        - query
+      properties:
+        query:
+          type: string
+          description: An OpenCypher query string
+          examples:
+            - "MATCH (n:Person) RETURN n"
+
+    QueryResponse:
+      type: object
+      properties:
+        nodes:
+          type: array
+          description: Graph nodes referenced in the result (for visualization)
+          items:
+            $ref: '#/components/schemas/GraphNode'
+        edges:
+          type: array
+          description: Graph edges referenced in the result (for visualization)
+          items:
+            $ref: '#/components/schemas/GraphEdge'
+        columns:
+          type: array
+          description: Column names for the tabular result
+          items:
+            type: string
+        records:
+          type: array
+          description: Tabular result rows, one array per record
+          items:
+            type: array
+            items: {}
+
+    GraphNode:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Node ID
+        labels:
+          type: array
+          items:
+            type: string
+          description: Node labels
+        properties:
+          type: object
+          additionalProperties: true
+          description: Node properties
+
+    GraphEdge:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Edge ID
+        source:
+          type: string
+          description: Source node ID
+        target:
+          type: string
+          description: Target node ID
+        type:
+          type: string
+          description: Relationship type
+        properties:
+          type: object
+          additionalProperties: true
+          description: Edge properties
+
+    StatusResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          description: Server health status
+          examples:
+            - healthy
+        version:
+          type: string
+          description: Server version
+          examples:
+            - 0.5.0-alpha.1
+        storage:
+          type: object
+          properties:
+            nodes:
+              type: integer
+              description: Number of nodes in the graph
+            edges:
+              type: integer
+              description: Number of edges in the graph
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error message

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "samyama-cli"
+version = "0.5.0-alpha.1"
+edition = "2021"
+authors = ["Samyama Graph Database Team"]
+description = "CLI for Samyama Graph Database"
+license = "Apache-2.0"
+repository = "https://github.com/samyama-ai/samyama-graph"
+
+[[bin]]
+name = "samyama"
+path = "src/main.rs"
+
+[dependencies]
+samyama-sdk = { path = "../crates/samyama-sdk", version = "0.5.0-alpha.1" }
+clap = { version = "4", features = ["derive"] }
+tokio = { version = "1.35", features = ["full"] }
+serde_json = "1.0"
+comfy-table = "7"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,243 @@
+//! Samyama CLI — command-line interface for the Samyama Graph Database
+//!
+//! Uses the samyama-sdk RemoteClient to connect to a running server.
+
+use clap::{Parser, Subcommand};
+use comfy_table::{Table, ContentArrangement};
+use samyama_sdk::{RemoteClient, SamyamaClient};
+
+#[derive(Parser)]
+#[command(name = "samyama", version, about = "Samyama Graph Database CLI")]
+struct Cli {
+    /// Server HTTP URL
+    #[arg(long, default_value = "http://localhost:8080", global = true, env = "SAMYAMA_URL")]
+    url: String,
+
+    /// Output format
+    #[arg(long, default_value = "table", global = true)]
+    format: OutputFormat,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Clone, clap::ValueEnum)]
+enum OutputFormat {
+    Table,
+    Json,
+    Csv,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Execute a Cypher query
+    Query {
+        /// The Cypher query string
+        cypher: String,
+
+        /// Graph name
+        #[arg(long, default_value = "default")]
+        graph: String,
+
+        /// Use read-only mode
+        #[arg(long)]
+        readonly: bool,
+    },
+    /// Get server status
+    Status,
+    /// Ping the server
+    Ping,
+    /// Start an interactive REPL
+    Shell,
+}
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+    let client = RemoteClient::new(&cli.url);
+
+    let result = match cli.command {
+        Commands::Query { cypher, graph, readonly } => {
+            run_query(&client, &graph, &cypher, readonly, &cli.format).await
+        }
+        Commands::Status => run_status(&client, &cli.format).await,
+        Commands::Ping => run_ping(&client).await,
+        Commands::Shell => run_shell(&client, &cli.format).await,
+    };
+
+    if let Err(e) = result {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+}
+
+async fn run_query(
+    client: &RemoteClient,
+    graph: &str,
+    cypher: &str,
+    readonly: bool,
+    format: &OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = if readonly {
+        client.query_readonly(graph, cypher).await?
+    } else {
+        client.query(graph, cypher).await?
+    };
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&result)?);
+        }
+        OutputFormat::Csv => {
+            if !result.columns.is_empty() {
+                println!("{}", result.columns.join(","));
+                for row in &result.records {
+                    let cells: Vec<String> = row.iter().map(|v| format_csv_value(v)).collect();
+                    println!("{}", cells.join(","));
+                }
+            }
+        }
+        OutputFormat::Table => {
+            if result.columns.is_empty() {
+                println!("(no results)");
+                return Ok(());
+            }
+
+            let mut table = Table::new();
+            table.set_content_arrangement(ContentArrangement::Dynamic);
+            table.set_header(&result.columns);
+
+            for row in &result.records {
+                let cells: Vec<String> = row.iter().map(|v| format_table_value(v)).collect();
+                table.add_row(cells);
+            }
+
+            println!("{}", table);
+            println!("{} row(s)", result.records.len());
+        }
+    }
+
+    Ok(())
+}
+
+async fn run_status(
+    client: &RemoteClient,
+    format: &OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let status = client.status().await?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&status)?);
+        }
+        _ => {
+            println!("Status:  {}", status.status);
+            println!("Version: {}", status.version);
+            println!("Nodes:   {}", status.storage.nodes);
+            println!("Edges:   {}", status.storage.edges);
+        }
+    }
+
+    Ok(())
+}
+
+async fn run_ping(client: &RemoteClient) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client.ping().await?;
+    println!("{}", result);
+    Ok(())
+}
+
+async fn run_shell(
+    client: &RemoteClient,
+    format: &OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("Samyama Interactive Shell");
+    println!("Type Cypher queries, or :help for commands. :quit to exit.\n");
+
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+
+    loop {
+        eprint!("samyama> ");
+
+        line.clear();
+        if stdin.read_line(&mut line)? == 0 {
+            break; // EOF
+        }
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        match trimmed {
+            ":quit" | ":exit" | ":q" => break,
+            ":help" | ":h" => {
+                println!("Commands:");
+                println!("  :status   — Show server status");
+                println!("  :ping     — Ping server");
+                println!("  :quit     — Exit shell");
+                println!("  <cypher>  — Execute a Cypher query");
+            }
+            ":status" => {
+                if let Err(e) = run_status(client, format).await {
+                    eprintln!("Error: {}", e);
+                }
+            }
+            ":ping" => {
+                if let Err(e) = run_ping(client).await {
+                    eprintln!("Error: {}", e);
+                }
+            }
+            cypher => {
+                if let Err(e) = run_query(client, "default", cypher, false, format).await {
+                    eprintln!("Error: {}", e);
+                }
+            }
+        }
+    }
+
+    println!("Bye!");
+    Ok(())
+}
+
+fn format_table_value(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::Null => "null".to_string(),
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Object(map) => {
+            // If it looks like a node/edge, show a compact representation
+            if let Some(id) = map.get("id") {
+                if let Some(labels) = map.get("labels") {
+                    return format!("({}:{})", id, labels);
+                }
+                if let Some(t) = map.get("type") {
+                    return format!("[{}:{}]", id, t);
+                }
+            }
+            serde_json::to_string(v).unwrap_or_default()
+        }
+        serde_json::Value::Array(_) => serde_json::to_string(v).unwrap_or_default(),
+    }
+}
+
+fn format_csv_value(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::Null => "".to_string(),
+        serde_json::Value::String(s) => {
+            if s.contains(',') || s.contains('"') || s.contains('\n') {
+                format!("\"{}\"", s.replace('"', "\"\""))
+            } else {
+                s.clone()
+            }
+        }
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        _ => {
+            let json = serde_json::to_string(v).unwrap_or_default();
+            format!("\"{}\"", json.replace('"', "\"\""))
+        }
+    }
+}

--- a/crates/samyama-sdk/Cargo.toml
+++ b/crates/samyama-sdk/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "samyama-sdk"
+version = "0.5.0-alpha.1"
+edition = "2021"
+authors = ["Samyama Graph Database Team"]
+description = "Client SDK for Samyama Graph Database — embedded and remote modes"
+license = "Apache-2.0"
+repository = "https://github.com/samyama-ai/samyama-graph"
+keywords = ["graph", "database", "sdk", "cypher", "client"]
+categories = ["database", "api-bindings"]
+
+[dependencies]
+# Async runtime
+tokio = { version = "1.35", features = ["net", "io-util", "rt"] }
+async-trait = "0.1"
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# HTTP client (for RemoteClient)
+reqwest = { version = "0.13.1", features = ["json"] }
+
+# Error handling
+thiserror = "1.0"
+
+# Core graph database (for EmbeddedClient)
+samyama = { path = "../..", version = "0.5.0-alpha.1" }
+
+[dev-dependencies]
+tokio = { version = "1.35", features = ["full"] }

--- a/crates/samyama-sdk/src/client.rs
+++ b/crates/samyama-sdk/src/client.rs
@@ -1,0 +1,31 @@
+//! SamyamaClient trait — the unified interface for embedded and remote modes
+
+use async_trait::async_trait;
+use crate::error::SamyamaResult;
+use crate::models::{QueryResult, ServerStatus};
+
+/// Unified client interface for the Samyama graph database.
+///
+/// Implemented by:
+/// - `EmbeddedClient` — in-process, no network (for examples, tests, embedded use)
+/// - `RemoteClient` — connects to a running Samyama server via HTTP
+#[async_trait]
+pub trait SamyamaClient: Send + Sync {
+    /// Execute a read-write Cypher query
+    async fn query(&self, graph: &str, cypher: &str) -> SamyamaResult<QueryResult>;
+
+    /// Execute a read-only Cypher query
+    async fn query_readonly(&self, graph: &str, cypher: &str) -> SamyamaResult<QueryResult>;
+
+    /// Delete a graph
+    async fn delete_graph(&self, graph: &str) -> SamyamaResult<()>;
+
+    /// List all graphs
+    async fn list_graphs(&self) -> SamyamaResult<Vec<String>>;
+
+    /// Get server status
+    async fn status(&self) -> SamyamaResult<ServerStatus>;
+
+    /// Ping the server
+    async fn ping(&self) -> SamyamaResult<String>;
+}

--- a/crates/samyama-sdk/src/embedded.rs
+++ b/crates/samyama-sdk/src/embedded.rs
@@ -1,0 +1,341 @@
+//! EmbeddedClient — in-process graph database client
+//!
+//! Uses GraphStore and QueryEngine directly, no network needed.
+
+use async_trait::async_trait;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use std::collections::HashMap;
+
+use samyama::graph::GraphStore;
+use samyama::query::{QueryEngine, Value, RecordBatch};
+
+use crate::client::SamyamaClient;
+use crate::error::{SamyamaError, SamyamaResult};
+use crate::models::{QueryResult, SdkNode, SdkEdge, ServerStatus, StorageStats};
+
+/// In-process client that wraps a GraphStore directly.
+///
+/// No network overhead — queries execute in the same process.
+/// Ideal for examples, tests, and embedded applications.
+pub struct EmbeddedClient {
+    store: Arc<RwLock<GraphStore>>,
+    engine: QueryEngine,
+}
+
+impl EmbeddedClient {
+    /// Create a new EmbeddedClient with a fresh empty graph store
+    pub fn new() -> Self {
+        Self {
+            store: Arc::new(RwLock::new(GraphStore::new())),
+            engine: QueryEngine::new(),
+        }
+    }
+
+    /// Create an EmbeddedClient wrapping an existing store
+    pub fn with_store(store: Arc<RwLock<GraphStore>>) -> Self {
+        Self {
+            store,
+            engine: QueryEngine::new(),
+        }
+    }
+
+    /// Get a reference to the underlying store (for direct graph manipulation)
+    pub fn store(&self) -> &Arc<RwLock<GraphStore>> {
+        &self.store
+    }
+}
+
+impl Default for EmbeddedClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Convert a RecordBatch from the query engine into an SDK QueryResult.
+fn record_batch_to_query_result(batch: &RecordBatch, store: &GraphStore) -> QueryResult {
+    let mut nodes_map: HashMap<String, SdkNode> = HashMap::new();
+    let mut edges_map: HashMap<String, SdkEdge> = HashMap::new();
+    let mut records = Vec::new();
+
+    for record in &batch.records {
+        let mut row = Vec::new();
+        for col in &batch.columns {
+            let val = match record.get(col) {
+                Some(v) => v,
+                None => {
+                    row.push(serde_json::Value::Null);
+                    continue;
+                }
+            };
+
+            match val {
+                Value::Node(id, node) => {
+                    let mut properties = serde_json::Map::new();
+                    for (k, v) in &node.properties {
+                        properties.insert(k.clone(), v.to_json());
+                    }
+                    let id_str = id.as_u64().to_string();
+                    let labels: Vec<String> = node.labels.iter().map(|l| l.as_str().to_string()).collect();
+
+                    let node_json = serde_json::json!({
+                        "id": id_str,
+                        "labels": labels,
+                        "properties": properties,
+                    });
+
+                    nodes_map.entry(id_str.clone()).or_insert_with(|| SdkNode {
+                        id: id_str,
+                        labels,
+                        properties: properties.into_iter().collect(),
+                    });
+
+                    row.push(node_json);
+                }
+                Value::NodeRef(id) => {
+                    let id_str = id.as_u64().to_string();
+                    // Try to resolve from store
+                    let (labels, properties, node_json) = if let Some(node) = store.get_node(*id) {
+                        let mut props = serde_json::Map::new();
+                        for (k, v) in &node.properties {
+                            props.insert(k.clone(), v.to_json());
+                        }
+                        let lbls: Vec<String> = node.labels.iter().map(|l| l.as_str().to_string()).collect();
+                        let json = serde_json::json!({
+                            "id": id_str,
+                            "labels": lbls,
+                            "properties": props,
+                        });
+                        (lbls, props.into_iter().collect(), json)
+                    } else {
+                        let json = serde_json::json!({ "id": id_str, "labels": [], "properties": {} });
+                        (vec![], HashMap::new(), json)
+                    };
+
+                    nodes_map.entry(id_str.clone()).or_insert_with(|| SdkNode {
+                        id: id_str,
+                        labels,
+                        properties,
+                    });
+
+                    row.push(node_json);
+                }
+                Value::Edge(id, edge) => {
+                    let mut properties = serde_json::Map::new();
+                    for (k, v) in &edge.properties {
+                        properties.insert(k.clone(), v.to_json());
+                    }
+                    let id_str = id.as_u64().to_string();
+                    let edge_json = serde_json::json!({
+                        "id": id_str,
+                        "source": edge.source.as_u64().to_string(),
+                        "target": edge.target.as_u64().to_string(),
+                        "type": edge.edge_type.as_str(),
+                        "properties": properties,
+                    });
+
+                    edges_map.entry(id_str.clone()).or_insert_with(|| SdkEdge {
+                        id: id_str,
+                        source: edge.source.as_u64().to_string(),
+                        target: edge.target.as_u64().to_string(),
+                        edge_type: edge.edge_type.as_str().to_string(),
+                        properties: properties.into_iter().collect(),
+                    });
+
+                    row.push(edge_json);
+                }
+                Value::EdgeRef(id, src, tgt, et) => {
+                    let id_str = id.as_u64().to_string();
+                    let edge_json = serde_json::json!({
+                        "id": id_str,
+                        "source": src.as_u64().to_string(),
+                        "target": tgt.as_u64().to_string(),
+                        "type": et.as_str(),
+                        "properties": {},
+                    });
+
+                    edges_map.entry(id_str.clone()).or_insert_with(|| SdkEdge {
+                        id: id_str,
+                        source: src.as_u64().to_string(),
+                        target: tgt.as_u64().to_string(),
+                        edge_type: et.as_str().to_string(),
+                        properties: HashMap::new(),
+                    });
+
+                    row.push(edge_json);
+                }
+                Value::Property(p) => {
+                    row.push(p.to_json());
+                }
+                Value::Null => {
+                    row.push(serde_json::Value::Null);
+                }
+            }
+        }
+        records.push(row);
+    }
+
+    QueryResult {
+        nodes: nodes_map.into_values().collect(),
+        edges: edges_map.into_values().collect(),
+        columns: batch.columns.clone(),
+        records,
+    }
+}
+
+fn is_write_query(cypher: &str) -> bool {
+    let upper = cypher.trim().to_uppercase();
+    upper.starts_with("CREATE")
+        || upper.starts_with("DELETE")
+        || upper.starts_with("SET")
+        || upper.starts_with("MERGE")
+        || upper.contains(" CREATE ")
+        || upper.contains(" DELETE ")
+        || upper.contains(" SET ")
+        || upper.contains(" MERGE ")
+}
+
+#[async_trait]
+impl SamyamaClient for EmbeddedClient {
+    async fn query(&self, graph: &str, cypher: &str) -> SamyamaResult<QueryResult> {
+        if is_write_query(cypher) {
+            let mut store_guard = self.store.write().await;
+            let batch = self.engine.execute_mut(cypher, &mut *store_guard, graph)
+                .map_err(|e| SamyamaError::QueryError(e.to_string()))?;
+            Ok(record_batch_to_query_result(&batch, &*store_guard))
+        } else {
+            let store_guard = self.store.read().await;
+            let batch = self.engine.execute(cypher, &*store_guard)
+                .map_err(|e| SamyamaError::QueryError(e.to_string()))?;
+            Ok(record_batch_to_query_result(&batch, &*store_guard))
+        }
+    }
+
+    async fn query_readonly(&self, _graph: &str, cypher: &str) -> SamyamaResult<QueryResult> {
+        let store_guard = self.store.read().await;
+        let batch = self.engine.execute(cypher, &*store_guard)
+            .map_err(|e| SamyamaError::QueryError(e.to_string()))?;
+        Ok(record_batch_to_query_result(&batch, &*store_guard))
+    }
+
+    async fn delete_graph(&self, _graph: &str) -> SamyamaResult<()> {
+        let mut store_guard = self.store.write().await;
+        store_guard.clear();
+        Ok(())
+    }
+
+    async fn list_graphs(&self) -> SamyamaResult<Vec<String>> {
+        Ok(vec!["default".to_string()])
+    }
+
+    async fn status(&self) -> SamyamaResult<ServerStatus> {
+        let store_guard = self.store.read().await;
+        Ok(ServerStatus {
+            status: "healthy".to_string(),
+            version: samyama::VERSION.to_string(),
+            storage: StorageStats {
+                nodes: store_guard.node_count() as u64,
+                edges: store_guard.edge_count() as u64,
+            },
+        })
+    }
+
+    async fn ping(&self) -> SamyamaResult<String> {
+        Ok("PONG".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_embedded_ping() {
+        let client = EmbeddedClient::new();
+        let result = client.ping().await.unwrap();
+        assert_eq!(result, "PONG");
+    }
+
+    #[tokio::test]
+    async fn test_embedded_status() {
+        let client = EmbeddedClient::new();
+        let status = client.status().await.unwrap();
+        assert_eq!(status.status, "healthy");
+        assert_eq!(status.storage.nodes, 0);
+    }
+
+    #[tokio::test]
+    async fn test_embedded_create_and_query() {
+        let client = EmbeddedClient::new();
+
+        // Create nodes
+        client.query("default", r#"CREATE (n:Person {name: "Alice", age: 30})"#)
+            .await.unwrap();
+        client.query("default", r#"CREATE (n:Person {name: "Bob", age: 25})"#)
+            .await.unwrap();
+
+        // Query
+        let result = client.query_readonly("default", "MATCH (n:Person) RETURN n.name, n.age")
+            .await.unwrap();
+        assert_eq!(result.columns.len(), 2);
+        assert_eq!(result.records.len(), 2);
+
+        // Status should reflect 2 nodes
+        let status = client.status().await.unwrap();
+        assert_eq!(status.storage.nodes, 2);
+    }
+
+    #[tokio::test]
+    async fn test_embedded_delete_graph() {
+        let client = EmbeddedClient::new();
+
+        client.query("default", r#"CREATE (n:Person {name: "Alice"})"#)
+            .await.unwrap();
+
+        let status = client.status().await.unwrap();
+        assert_eq!(status.storage.nodes, 1);
+
+        client.delete_graph("default").await.unwrap();
+
+        let status = client.status().await.unwrap();
+        assert_eq!(status.storage.nodes, 0);
+    }
+
+    #[tokio::test]
+    async fn test_embedded_list_graphs() {
+        let client = EmbeddedClient::new();
+        let graphs = client.list_graphs().await.unwrap();
+        assert_eq!(graphs, vec!["default"]);
+    }
+
+    #[tokio::test]
+    async fn test_embedded_query_with_edges() {
+        let client = EmbeddedClient::new();
+
+        client.query("default",
+            r#"CREATE (a:Person {name: "Alice"})-[:KNOWS]->(b:Person {name: "Bob"})"#
+        ).await.unwrap();
+
+        let result = client.query_readonly("default",
+            "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a.name, b.name"
+        ).await.unwrap();
+
+        assert_eq!(result.records.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_embedded_with_existing_store() {
+        let mut store = GraphStore::new();
+        let alice = store.create_node("Person");
+        if let Some(node) = store.get_node_mut(alice) {
+            node.set_property("name", "Alice");
+        }
+
+        let store = Arc::new(RwLock::new(store));
+        let client = EmbeddedClient::with_store(store);
+
+        let result = client.query_readonly("default", "MATCH (n:Person) RETURN n.name")
+            .await.unwrap();
+        assert_eq!(result.records.len(), 1);
+    }
+}

--- a/crates/samyama-sdk/src/error.rs
+++ b/crates/samyama-sdk/src/error.rs
@@ -1,0 +1,33 @@
+//! Error types for the Samyama SDK
+
+use thiserror::Error;
+
+/// Errors that can occur when using the Samyama SDK
+#[derive(Error, Debug)]
+pub enum SamyamaError {
+    /// Query parsing or execution error
+    #[error("Query error: {0}")]
+    QueryError(String),
+
+    /// Connection error (remote mode)
+    #[error("Connection error: {0}")]
+    ConnectionError(String),
+
+    /// RESP protocol error
+    #[error("Protocol error: {0}")]
+    ProtocolError(String),
+
+    /// HTTP transport error
+    #[error("HTTP error: {0}")]
+    HttpError(#[from] reqwest::Error),
+
+    /// JSON serialization/deserialization error
+    #[error("Serialization error: {0}")]
+    SerializationError(#[from] serde_json::Error),
+
+    /// I/O error
+    #[error("I/O error: {0}")]
+    IoError(#[from] std::io::Error),
+}
+
+pub type SamyamaResult<T> = Result<T, SamyamaError>;

--- a/crates/samyama-sdk/src/lib.rs
+++ b/crates/samyama-sdk/src/lib.rs
@@ -1,0 +1,48 @@
+//! Samyama SDK — Client library for the Samyama Graph Database
+//!
+//! Provides two client implementations:
+//!
+//! - **`EmbeddedClient`** — In-process, no network. Uses `GraphStore` and `QueryEngine`
+//!   directly. Ideal for tests, examples, and embedded applications.
+//!
+//! - **`RemoteClient`** — Connects to a running Samyama server via HTTP.
+//!   For production client applications.
+//!
+//! Both implement the `SamyamaClient` trait for a unified API.
+//!
+//! # Quick Start
+//!
+//! ```rust
+//! use samyama_sdk::{EmbeddedClient, SamyamaClient};
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let client = EmbeddedClient::new();
+//!
+//!     // Create data
+//!     client.query("default", r#"CREATE (n:Person {name: "Alice"})"#)
+//!         .await.unwrap();
+//!
+//!     // Query data
+//!     let result = client.query_readonly("default", "MATCH (n:Person) RETURN n.name")
+//!         .await.unwrap();
+//!     println!("Found {} records", result.len());
+//! }
+//! ```
+
+pub mod client;
+pub mod embedded;
+pub mod error;
+pub mod models;
+pub mod remote;
+
+// Re-export main types
+pub use client::SamyamaClient;
+pub use embedded::EmbeddedClient;
+pub use remote::RemoteClient;
+pub use error::{SamyamaError, SamyamaResult};
+pub use models::{QueryResult, SdkNode, SdkEdge, ServerStatus, StorageStats};
+
+// Re-export graph types for convenience when using EmbeddedClient
+pub use samyama::graph::{GraphStore, NodeId, EdgeId, Label, PropertyValue};
+pub use samyama::query::QueryEngine;

--- a/crates/samyama-sdk/src/models.rs
+++ b/crates/samyama-sdk/src/models.rs
@@ -1,0 +1,79 @@
+//! Data models for the Samyama SDK
+//!
+//! These types represent the API response structures and are used
+//! by both EmbeddedClient and RemoteClient.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A graph node returned from a query
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SdkNode {
+    /// Node ID
+    pub id: String,
+    /// Node labels
+    pub labels: Vec<String>,
+    /// Node properties
+    pub properties: HashMap<String, serde_json::Value>,
+}
+
+/// A graph edge returned from a query
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SdkEdge {
+    /// Edge ID
+    pub id: String,
+    /// Source node ID
+    pub source: String,
+    /// Target node ID
+    pub target: String,
+    /// Relationship type
+    #[serde(rename = "type")]
+    pub edge_type: String,
+    /// Edge properties
+    pub properties: HashMap<String, serde_json::Value>,
+}
+
+/// Result of executing a Cypher query
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryResult {
+    /// Graph nodes referenced in the result
+    pub nodes: Vec<SdkNode>,
+    /// Graph edges referenced in the result
+    pub edges: Vec<SdkEdge>,
+    /// Column names
+    pub columns: Vec<String>,
+    /// Tabular result rows
+    pub records: Vec<Vec<serde_json::Value>>,
+}
+
+impl QueryResult {
+    /// Number of result records
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    /// Whether the result is empty
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+}
+
+/// Server status information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerStatus {
+    /// Health status (e.g., "healthy")
+    pub status: String,
+    /// Server version
+    pub version: String,
+    /// Storage statistics
+    pub storage: StorageStats,
+}
+
+/// Storage statistics
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageStats {
+    /// Number of nodes
+    pub nodes: u64,
+    /// Number of edges
+    pub edges: u64,
+}

--- a/crates/samyama-sdk/src/remote.rs
+++ b/crates/samyama-sdk/src/remote.rs
@@ -1,0 +1,108 @@
+//! RemoteClient — network client for a running Samyama server
+//!
+//! Connects via HTTP to the Samyama HTTP API.
+
+use async_trait::async_trait;
+use reqwest::Client;
+
+use crate::client::SamyamaClient;
+use crate::error::{SamyamaError, SamyamaResult};
+use crate::models::{QueryResult, ServerStatus};
+
+/// Network client that connects to a running Samyama server.
+///
+/// Uses HTTP transport for `/api/query` and `/api/status` endpoints.
+pub struct RemoteClient {
+    http_base_url: String,
+    http_client: Client,
+}
+
+impl RemoteClient {
+    /// Create a new RemoteClient connecting to the given HTTP base URL.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use samyama_sdk::RemoteClient;
+    /// let client = RemoteClient::new("http://localhost:8080");
+    /// ```
+    pub fn new(http_base_url: &str) -> Self {
+        Self {
+            http_base_url: http_base_url.trim_end_matches('/').to_string(),
+            http_client: Client::new(),
+        }
+    }
+
+    /// Execute a POST request to /api/query
+    async fn post_query(&self, cypher: &str) -> SamyamaResult<QueryResult> {
+        let url = format!("{}/api/query", self.http_base_url);
+        let body = serde_json::json!({ "query": cypher });
+
+        let response = self.http_client.post(&url)
+            .json(&body)
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            let result: QueryResult = response.json().await?;
+            Ok(result)
+        } else {
+            let error_body: serde_json::Value = response.json().await
+                .unwrap_or_else(|_| serde_json::json!({"error": "Unknown error"}));
+            let msg = error_body.get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Unknown error")
+                .to_string();
+            Err(SamyamaError::QueryError(msg))
+        }
+    }
+}
+
+#[async_trait]
+impl SamyamaClient for RemoteClient {
+    async fn query(&self, _graph: &str, cypher: &str) -> SamyamaResult<QueryResult> {
+        self.post_query(cypher).await
+    }
+
+    async fn query_readonly(&self, _graph: &str, cypher: &str) -> SamyamaResult<QueryResult> {
+        self.post_query(cypher).await
+    }
+
+    async fn delete_graph(&self, _graph: &str) -> SamyamaResult<()> {
+        // The HTTP API doesn't expose GRAPH.DELETE directly.
+        // We can execute a Cypher that deletes all nodes/edges.
+        self.post_query("MATCH (n) DELETE n").await?;
+        Ok(())
+    }
+
+    async fn list_graphs(&self) -> SamyamaResult<Vec<String>> {
+        // Single-graph mode in OSS
+        Ok(vec!["default".to_string()])
+    }
+
+    async fn status(&self) -> SamyamaResult<ServerStatus> {
+        let url = format!("{}/api/status", self.http_base_url);
+        let response = self.http_client.get(&url)
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            let status: ServerStatus = response.json().await?;
+            Ok(status)
+        } else {
+            Err(SamyamaError::ConnectionError(
+                format!("Status endpoint returned {}", response.status())
+            ))
+        }
+    }
+
+    async fn ping(&self) -> SamyamaResult<String> {
+        let status = self.status().await?;
+        if status.status == "healthy" {
+            Ok("PONG".to_string())
+        } else {
+            Err(SamyamaError::ConnectionError(
+                format!("Server unhealthy: {}", status.status)
+            ))
+        }
+    }
+}

--- a/examples/sdk_demo.rs
+++ b/examples/sdk_demo.rs
@@ -1,0 +1,138 @@
+//! SDK Demo — demonstrates the samyama-sdk EmbeddedClient
+//!
+//! Shows how to use the unified SamyamaClient trait for:
+//! - Creating nodes and edges via Cypher
+//! - Running read-only queries
+//! - Getting server status
+//! - Working with query results
+//!
+//! Run with: cargo run --example sdk_demo
+
+use samyama_sdk::{EmbeddedClient, SamyamaClient, GraphStore, Label};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+#[tokio::main]
+async fn main() {
+    println!("=== Samyama SDK Demo (EmbeddedClient) ===\n");
+
+    // --- Option 1: Create a fresh embedded client ---
+    let client = EmbeddedClient::new();
+
+    // Check status
+    let status = client.status().await.unwrap();
+    println!("Status: {} (v{})", status.status, status.version);
+    println!("Initial: {} nodes, {} edges\n", status.storage.nodes, status.storage.edges);
+
+    // --- Create a social network via Cypher ---
+    println!("Creating social network...");
+
+    let people = [
+        ("Alice", 30, "Engineering"),
+        ("Bob", 25, "Engineering"),
+        ("Carol", 35, "Product"),
+        ("Dave", 28, "Engineering"),
+        ("Eve", 32, "Design"),
+    ];
+
+    for (name, age, dept) in &people {
+        client.query("default", &format!(
+            r#"CREATE (n:Person {{name: "{}", age: {}, department: "{}"}})"#,
+            name, age, dept
+        )).await.unwrap();
+    }
+
+    // Create relationships
+    let rels = [
+        ("Alice", "Bob", "MANAGES"),
+        ("Alice", "Dave", "MANAGES"),
+        ("Bob", "Carol", "COLLABORATES"),
+        ("Carol", "Eve", "COLLABORATES"),
+        ("Dave", "Eve", "KNOWS"),
+        ("Alice", "Carol", "KNOWS"),
+    ];
+
+    for (from, to, rel_type) in &rels {
+        client.query("default", &format!(
+            r#"MATCH (a:Person {{name: "{}"}}), (b:Person {{name: "{}"}}) CREATE (a)-[:{}]->(b)"#,
+            from, to, rel_type
+        )).await.unwrap();
+    }
+
+    let status = client.status().await.unwrap();
+    println!("Created: {} nodes, {} edges\n", status.storage.nodes, status.storage.edges);
+
+    // --- Query: All people ---
+    println!("All people:");
+    let result = client.query_readonly("default",
+        "MATCH (n:Person) RETURN n.name, n.age, n.department"
+    ).await.unwrap();
+
+    println!("  Columns: {:?}", result.columns);
+    for row in &result.records {
+        println!("  {:?}", row);
+    }
+    println!();
+
+    // --- Query: Engineers ---
+    println!("Engineers:");
+    let result = client.query_readonly("default",
+        r#"MATCH (n:Person) WHERE n.department = "Engineering" RETURN n.name, n.age"#
+    ).await.unwrap();
+    for row in &result.records {
+        println!("  {:?}", row);
+    }
+    println!();
+
+    // --- Query: Relationships ---
+    println!("Who manages whom:");
+    let result = client.query_readonly("default",
+        "MATCH (a:Person)-[:MANAGES]->(b:Person) RETURN a.name, b.name"
+    ).await.unwrap();
+    for row in &result.records {
+        println!("  {} manages {}", row[0], row[1]);
+    }
+    println!();
+
+    // --- Query: 2-hop connections ---
+    println!("2-hop connections from Alice:");
+    let result = client.query_readonly("default",
+        r#"MATCH (a:Person {name: "Alice"})-[]->(mid:Person)-[]->(b:Person)
+           RETURN DISTINCT a.name, mid.name, b.name"#
+    ).await.unwrap();
+    for row in &result.records {
+        println!("  {} -> {} -> {}", row[0], row[1], row[2]);
+    }
+    println!();
+
+    // --- Option 2: Wrap an existing GraphStore ---
+    println!("--- Using EmbeddedClient with existing GraphStore ---");
+    let mut store = GraphStore::new();
+    let n1 = store.create_node(Label::new("City"));
+    if let Some(node) = store.get_node_mut(n1) {
+        node.set_property("name", "San Francisco");
+    }
+    let n2 = store.create_node(Label::new("City"));
+    if let Some(node) = store.get_node_mut(n2) {
+        node.set_property("name", "New York");
+    }
+    store.create_edge(n1, n2, "CONNECTED_TO").unwrap();
+
+    let client2 = EmbeddedClient::with_store(Arc::new(RwLock::new(store)));
+    let result = client2.query_readonly("default",
+        "MATCH (a:City)-[:CONNECTED_TO]->(b:City) RETURN a.name, b.name"
+    ).await.unwrap();
+    for row in &result.records {
+        println!("  {} -> {}", row[0], row[1]);
+    }
+
+    // --- Ping ---
+    let pong = client.ping().await.unwrap();
+    println!("\nPing: {}", pong);
+
+    // --- List graphs ---
+    let graphs = client.list_graphs().await.unwrap();
+    println!("Graphs: {:?}", graphs);
+
+    println!("\n=== SDK Demo Complete ===");
+}

--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -1,0 +1,6 @@
+target/
+Cargo.lock
+*.so
+*.dylib
+__pycache__/
+*.egg-info/

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,0 +1,19 @@
+[workspace]
+
+[package]
+name = "samyama-python"
+version = "0.5.0-alpha.1"
+edition = "2021"
+authors = ["Samyama Graph Database Team"]
+description = "Python bindings for the Samyama Graph Database SDK"
+license = "Apache-2.0"
+
+[lib]
+name = "samyama"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.22", features = ["extension-module"] }
+samyama-sdk = { path = "../../crates/samyama-sdk", version = "0.5.0-alpha.1" }
+tokio = { version = "1.35", features = ["rt-multi-thread"] }
+serde_json = "1.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "samyama"
+version = "0.5.0a1"
+description = "Python SDK for the Samyama Graph Database"
+requires-python = ">=3.8"
+license = {text = "Apache-2.0"}
+authors = [{name = "Samyama Graph Database Team"}]
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: Database",
+]
+
+[tool.maturin]
+features = ["pyo3/extension-module"]

--- a/sdk/python/src/lib.rs
+++ b/sdk/python/src/lib.rs
@@ -1,0 +1,270 @@
+//! Python bindings for the Samyama Graph Database SDK
+//!
+//! Exposes SamyamaClient with both embedded and remote modes to Python.
+
+use pyo3::prelude::*;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::types::PyDict;
+use samyama_sdk::{
+    EmbeddedClient, RemoteClient, SamyamaClient as SamyamaClientTrait,
+    QueryResult as SdkQueryResult,
+};
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+/// Create a shared tokio runtime for all async operations
+fn get_runtime() -> &'static Runtime {
+    use std::sync::OnceLock;
+    static RT: OnceLock<Runtime> = OnceLock::new();
+    RT.get_or_init(|| {
+        Runtime::new().expect("Failed to create tokio runtime")
+    })
+}
+
+/// Query result returned from Cypher queries
+#[pyclass]
+struct QueryResult {
+    #[pyo3(get)]
+    columns: Vec<String>,
+    records_json: Vec<Vec<serde_json::Value>>,
+    nodes_json: Vec<serde_json::Value>,
+    edges_json: Vec<serde_json::Value>,
+}
+
+#[pymethods]
+impl QueryResult {
+    fn __len__(&self) -> usize {
+        self.records_json.len()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("QueryResult(columns={:?}, records={})", self.columns, self.records_json.len())
+    }
+
+    #[getter]
+    fn records(&self, py: Python<'_>) -> PyResult<PyObject> {
+        json_to_py(py, &serde_json::Value::Array(
+            self.records_json.iter().map(|row| serde_json::Value::Array(row.clone())).collect()
+        ))
+    }
+
+    #[getter]
+    fn nodes(&self, py: Python<'_>) -> PyResult<PyObject> {
+        json_to_py(py, &serde_json::Value::Array(self.nodes_json.clone()))
+    }
+
+    #[getter]
+    fn edges(&self, py: Python<'_>) -> PyResult<PyObject> {
+        json_to_py(py, &serde_json::Value::Array(self.edges_json.clone()))
+    }
+}
+
+/// Server status information
+#[pyclass]
+#[derive(Clone)]
+struct ServerStatus {
+    #[pyo3(get)]
+    status: String,
+    #[pyo3(get)]
+    version: String,
+    #[pyo3(get)]
+    nodes: u64,
+    #[pyo3(get)]
+    edges: u64,
+}
+
+#[pymethods]
+impl ServerStatus {
+    fn __repr__(&self) -> String {
+        format!(
+            "ServerStatus(status='{}', version='{}', nodes={}, edges={})",
+            self.status, self.version, self.nodes, self.edges
+        )
+    }
+}
+
+/// Convert SDK QueryResult to Python QueryResult
+fn convert_query_result(result: SdkQueryResult) -> PyResult<QueryResult> {
+    let nodes_json: Vec<serde_json::Value> = result.nodes.iter().map(|n| {
+        serde_json::json!({
+            "id": n.id,
+            "labels": n.labels,
+            "properties": n.properties,
+        })
+    }).collect();
+
+    let edges_json: Vec<serde_json::Value> = result.edges.iter().map(|e| {
+        serde_json::json!({
+            "id": e.id,
+            "source": e.source,
+            "target": e.target,
+            "type": e.edge_type,
+            "properties": e.properties,
+        })
+    }).collect();
+
+    Ok(QueryResult {
+        columns: result.columns,
+        records_json: result.records,
+        nodes_json,
+        edges_json,
+    })
+}
+
+/// Convert a serde_json::Value to a Python object
+fn json_to_py(py: Python<'_>, value: &serde_json::Value) -> PyResult<PyObject> {
+    match value {
+        serde_json::Value::Null => Ok(py.None()),
+        serde_json::Value::Bool(b) => Ok(b.to_object(py)),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(i.to_object(py))
+            } else if let Some(f) = n.as_f64() {
+                Ok(f.to_object(py))
+            } else {
+                Ok(py.None())
+            }
+        }
+        serde_json::Value::String(s) => Ok(s.to_object(py)),
+        serde_json::Value::Array(arr) => {
+            let list: Vec<PyObject> = arr.iter()
+                .map(|v| json_to_py(py, v))
+                .collect::<PyResult<_>>()?;
+            Ok(list.to_object(py))
+        }
+        serde_json::Value::Object(map) => {
+            let dict = PyDict::new_bound(py);
+            for (k, v) in map {
+                dict.set_item(k, json_to_py(py, v)?)?;
+            }
+            Ok(dict.to_object(py))
+        }
+    }
+}
+
+/// Internal enum to hold either embedded or remote client
+enum ClientInner {
+    Embedded(EmbeddedClient),
+    Remote(RemoteClient),
+}
+
+/// Python client for the Samyama Graph Database.
+///
+/// Create with `SamyamaClient.embedded()` for in-process mode
+/// or `SamyamaClient.connect(url)` for remote mode.
+#[pyclass]
+struct SamyamaClient {
+    inner: Arc<ClientInner>,
+}
+
+#[pymethods]
+impl SamyamaClient {
+    /// Create an in-process embedded client (no server needed)
+    #[staticmethod]
+    fn embedded() -> PyResult<Self> {
+        Ok(SamyamaClient {
+            inner: Arc::new(ClientInner::Embedded(EmbeddedClient::new())),
+        })
+    }
+
+    /// Connect to a running Samyama server via HTTP
+    #[staticmethod]
+    fn connect(url: &str) -> PyResult<Self> {
+        Ok(SamyamaClient {
+            inner: Arc::new(ClientInner::Remote(RemoteClient::new(url))),
+        })
+    }
+
+    /// Execute a Cypher query
+    #[pyo3(signature = (cypher, graph="default"))]
+    fn query(&self, cypher: &str, graph: &str) -> PyResult<QueryResult> {
+        let rt = get_runtime();
+        let result = match &*self.inner {
+            ClientInner::Embedded(c) => rt.block_on(c.query(graph, cypher)),
+            ClientInner::Remote(c) => rt.block_on(c.query(graph, cypher)),
+        };
+        match result {
+            Ok(r) => convert_query_result(r),
+            Err(e) => Err(PyRuntimeError::new_err(e.to_string())),
+        }
+    }
+
+    /// Execute a read-only Cypher query
+    #[pyo3(signature = (cypher, graph="default"))]
+    fn query_readonly(&self, cypher: &str, graph: &str) -> PyResult<QueryResult> {
+        let rt = get_runtime();
+        let result = match &*self.inner {
+            ClientInner::Embedded(c) => rt.block_on(c.query_readonly(graph, cypher)),
+            ClientInner::Remote(c) => rt.block_on(c.query_readonly(graph, cypher)),
+        };
+        match result {
+            Ok(r) => convert_query_result(r),
+            Err(e) => Err(PyRuntimeError::new_err(e.to_string())),
+        }
+    }
+
+    /// Get server status
+    fn status(&self) -> PyResult<ServerStatus> {
+        let rt = get_runtime();
+        let result = match &*self.inner {
+            ClientInner::Embedded(c) => rt.block_on(c.status()),
+            ClientInner::Remote(c) => rt.block_on(c.status()),
+        };
+        match result {
+            Ok(s) => Ok(ServerStatus {
+                status: s.status,
+                version: s.version,
+                nodes: s.storage.nodes,
+                edges: s.storage.edges,
+            }),
+            Err(e) => Err(PyRuntimeError::new_err(e.to_string())),
+        }
+    }
+
+    /// Ping the server
+    fn ping(&self) -> PyResult<String> {
+        let rt = get_runtime();
+        let result = match &*self.inner {
+            ClientInner::Embedded(c) => rt.block_on(c.ping()),
+            ClientInner::Remote(c) => rt.block_on(c.ping()),
+        };
+        result.map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    }
+
+    /// Delete a graph
+    #[pyo3(signature = (graph="default"))]
+    fn delete_graph(&self, graph: &str) -> PyResult<()> {
+        let rt = get_runtime();
+        let result = match &*self.inner {
+            ClientInner::Embedded(c) => rt.block_on(c.delete_graph(graph)),
+            ClientInner::Remote(c) => rt.block_on(c.delete_graph(graph)),
+        };
+        result.map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    }
+
+    /// List graphs
+    fn list_graphs(&self) -> PyResult<Vec<String>> {
+        let rt = get_runtime();
+        let result = match &*self.inner {
+            ClientInner::Embedded(c) => rt.block_on(c.list_graphs()),
+            ClientInner::Remote(c) => rt.block_on(c.list_graphs()),
+        };
+        result.map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    }
+
+    fn __repr__(&self) -> String {
+        match &*self.inner {
+            ClientInner::Embedded(_) => "SamyamaClient(mode='embedded')".to_string(),
+            ClientInner::Remote(_) => "SamyamaClient(mode='remote')".to_string(),
+        }
+    }
+}
+
+/// Python module for the Samyama Graph Database
+#[pymodule]
+fn samyama(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<SamyamaClient>()?;
+    m.add_class::<QueryResult>()?;
+    m.add_class::<ServerStatus>()?;
+    Ok(())
+}

--- a/sdk/python/tests/test_embedded.py
+++ b/sdk/python/tests/test_embedded.py
@@ -1,0 +1,59 @@
+"""Tests for the Samyama Python SDK (embedded mode)."""
+
+import samyama
+
+
+def test_embedded_create():
+    """Test creating an embedded client."""
+    client = samyama.SamyamaClient.embedded()
+    assert repr(client) == "SamyamaClient(mode='embedded')"
+
+
+def test_ping():
+    """Test ping."""
+    client = samyama.SamyamaClient.embedded()
+    assert client.ping() == "PONG"
+
+
+def test_status():
+    """Test status."""
+    client = samyama.SamyamaClient.embedded()
+    status = client.status()
+    assert status.status == "healthy"
+    assert status.nodes == 0
+    assert status.edges == 0
+
+
+def test_create_and_query():
+    """Test creating nodes and querying them."""
+    client = samyama.SamyamaClient.embedded()
+
+    # Create nodes
+    client.query('CREATE (n:Person {name: "Alice", age: 30})')
+    client.query('CREATE (n:Person {name: "Bob", age: 25})')
+
+    # Query
+    result = client.query_readonly("MATCH (n:Person) RETURN n.name, n.age")
+    assert len(result) == 2
+    assert result.columns == ["n.name", "n.age"]
+
+    # Status should reflect 2 nodes
+    status = client.status()
+    assert status.nodes == 2
+
+
+def test_list_graphs():
+    """Test listing graphs."""
+    client = samyama.SamyamaClient.embedded()
+    graphs = client.list_graphs()
+    assert graphs == ["default"]
+
+
+def test_delete_graph():
+    """Test deleting a graph."""
+    client = samyama.SamyamaClient.embedded()
+    client.query('CREATE (n:Person {name: "Alice"})')
+    assert client.status().nodes == 1
+
+    client.delete_graph()
+    assert client.status().nodes == 0

--- a/sdk/typescript/.gitignore
+++ b/sdk/typescript/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.js
+*.d.ts
+*.js.map

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,0 +1,48 @@
+{
+  "name": "samyama-sdk",
+  "version": "0.5.0-alpha.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "samyama-sdk",
+      "version": "0.5.0-alpha.1",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^25.3.0",
+        "typescript": "^5.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
+      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "samyama-sdk",
+  "version": "0.5.0-alpha.1",
+  "description": "TypeScript SDK for the Samyama Graph Database",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "node --test dist/tests/*.test.js",
+    "check": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "graph",
+    "database",
+    "cypher",
+    "samyama"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/samyama-ai/samyama-graph"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.0",
+    "typescript": "^5.3"
+  }
+}

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,0 +1,70 @@
+import type { QueryResult, ServerStatus, ClientOptions } from "./types";
+import { HttpTransport } from "./http-client";
+
+const DEFAULT_URL = "http://localhost:8080";
+
+/**
+ * Client for the Samyama Graph Database.
+ *
+ * @example
+ * ```ts
+ * const client = new SamyamaClient({ url: "http://localhost:8080" });
+ *
+ * // Create data
+ * await client.query('CREATE (n:Person {name: "Alice"})');
+ *
+ * // Query data
+ * const result = await client.queryReadonly("MATCH (n:Person) RETURN n.name");
+ * console.log(result.records);
+ * ```
+ */
+export class SamyamaClient {
+  private http: HttpTransport;
+
+  constructor(options?: ClientOptions) {
+    const url = options?.url ?? DEFAULT_URL;
+    this.http = new HttpTransport(url);
+  }
+
+  /**
+   * Connect to a Samyama server via HTTP.
+   * Factory method for a more readable API.
+   */
+  static connectHttp(url: string = DEFAULT_URL): SamyamaClient {
+    return new SamyamaClient({ url });
+  }
+
+  /** Execute a read-write Cypher query */
+  async query(cypher: string, _graph: string = "default"): Promise<QueryResult> {
+    return this.http.query(cypher);
+  }
+
+  /** Execute a read-only Cypher query */
+  async queryReadonly(cypher: string, _graph: string = "default"): Promise<QueryResult> {
+    return this.http.query(cypher);
+  }
+
+  /** Delete a graph (executes MATCH (n) DELETE n) */
+  async deleteGraph(_graph: string = "default"): Promise<void> {
+    await this.http.query("MATCH (n) DELETE n");
+  }
+
+  /** List graphs (OSS: always returns ["default"]) */
+  async listGraphs(): Promise<string[]> {
+    return ["default"];
+  }
+
+  /** Get server status */
+  async status(): Promise<ServerStatus> {
+    return this.http.status();
+  }
+
+  /** Ping the server */
+  async ping(): Promise<string> {
+    const s = await this.status();
+    if (s.status === "healthy") {
+      return "PONG";
+    }
+    throw new Error(`Server unhealthy: ${s.status}`);
+  }
+}

--- a/sdk/typescript/src/http-client.ts
+++ b/sdk/typescript/src/http-client.ts
@@ -1,0 +1,42 @@
+import type { QueryResult, ServerStatus, ErrorResponse } from "./types";
+
+/**
+ * HTTP transport for the Samyama SDK.
+ * Uses the native `fetch` API (works in Node.js 18+ and browsers).
+ */
+export class HttpTransport {
+  private baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+  }
+
+  /** Execute a Cypher query via POST /api/query */
+  async query(cypher: string): Promise<QueryResult> {
+    const response = await fetch(`${this.baseUrl}/api/query`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: cypher }),
+    });
+
+    if (!response.ok) {
+      const body = (await response.json().catch(() => ({
+        error: `HTTP ${response.status}`,
+      }))) as ErrorResponse;
+      throw new Error(body.error || `HTTP ${response.status}`);
+    }
+
+    return (await response.json()) as QueryResult;
+  }
+
+  /** Get server status via GET /api/status */
+  async status(): Promise<ServerStatus> {
+    const response = await fetch(`${this.baseUrl}/api/status`);
+
+    if (!response.ok) {
+      throw new Error(`Status endpoint returned ${response.status}`);
+    }
+
+    return (await response.json()) as ServerStatus;
+  }
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,0 +1,10 @@
+export { SamyamaClient } from "./client";
+export { HttpTransport } from "./http-client";
+export type {
+  SdkNode,
+  SdkEdge,
+  QueryResult,
+  ServerStatus,
+  ErrorResponse,
+  ClientOptions,
+} from "./types";

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -1,0 +1,44 @@
+/** A graph node returned from a query */
+export interface SdkNode {
+  id: string;
+  labels: string[];
+  properties: Record<string, unknown>;
+}
+
+/** A graph edge returned from a query */
+export interface SdkEdge {
+  id: string;
+  source: string;
+  target: string;
+  type: string;
+  properties: Record<string, unknown>;
+}
+
+/** Result of executing a Cypher query */
+export interface QueryResult {
+  nodes: SdkNode[];
+  edges: SdkEdge[];
+  columns: string[];
+  records: unknown[][];
+}
+
+/** Server status information */
+export interface ServerStatus {
+  status: string;
+  version: string;
+  storage: {
+    nodes: number;
+    edges: number;
+  };
+}
+
+/** Error response from the server */
+export interface ErrorResponse {
+  error: string;
+}
+
+/** Options for creating a client */
+export interface ClientOptions {
+  /** Base URL for HTTP transport (default: http://localhost:8080) */
+  url?: string;
+}

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import { SamyamaClient, HttpTransport } from "../src/index";
+import type { QueryResult, ServerStatus } from "../src/index";
+
+describe("SamyamaClient", () => {
+  it("should create a client with default URL", () => {
+    const client = new SamyamaClient();
+    assert.ok(client);
+  });
+
+  it("should create a client with custom URL", () => {
+    const client = SamyamaClient.connectHttp("http://localhost:9090");
+    assert.ok(client);
+  });
+
+  it("should expose listGraphs", async () => {
+    const client = new SamyamaClient();
+    const graphs = await client.listGraphs();
+    assert.deepEqual(graphs, ["default"]);
+  });
+});
+
+describe("HttpTransport", () => {
+  it("should construct with a URL", () => {
+    const transport = new HttpTransport("http://localhost:8080");
+    assert.ok(transport);
+  });
+
+  it("should strip trailing slashes from URL", () => {
+    const transport = new HttpTransport("http://localhost:8080///");
+    assert.ok(transport);
+  });
+});

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- **OpenAPI 3.1 spec** (`api/openapi.yaml`) documenting HTTP API endpoints
- **Rust SDK** (`crates/samyama-sdk/`) with unified `SamyamaClient` trait, `EmbeddedClient` (in-process) and `RemoteClient` (HTTP) modes
- **CLI tool** (`cli/`) — Rust binary using SDK with subcommands: query, status, ping, shell (REPL)
- **Python SDK** (`sdk/python/`) — PyO3 bindings with maturin build, supports embedded + remote modes
- **TypeScript SDK** (`sdk/typescript/`) — Native SDK using fetch API
- **SDK demo** (`examples/sdk_demo.rs`) — Proof-of-concept using EmbeddedClient

## Architecture
```
CLI → samyama-sdk (RemoteClient) → HTTP API
Tests/Examples → samyama-sdk (EmbeddedClient) → GraphStore directly
Python/TS → same SamyamaClient interface
```

## Test plan
- [x] `cargo test -p samyama-sdk` — 7 SDK unit tests pass
- [x] `cargo run --example sdk_demo` — runs successfully
- [x] `cd sdk/typescript && npm test` — 5 tests pass
- [x] All 248 existing tests continue to pass