### PR TITLE
feat: extend SDK with AlgorithmClient, VectorClient and migrate all examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,8 +2656,11 @@ name = "samyama-sdk"
 version = "0.5.0-alpha.1"
 dependencies = [
  "async-trait",
+ "ndarray",
  "reqwest",
  "samyama",
+ "samyama-graph-algorithms",
+ "samyama-optimization",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/crates/samyama-sdk/Cargo.toml
+++ b/crates/samyama-sdk/Cargo.toml
@@ -27,5 +27,14 @@ thiserror = "1.0"
 # Core graph database (for EmbeddedClient)
 samyama = { path = "../..", version = "0.5.0-alpha.1" }
 
+# Graph algorithms (for AlgorithmClient)
+samyama-graph-algorithms = { path = "../samyama-graph-algorithms", version = "0.5.0-alpha.1" }
+
+# Optimization engine (re-exported for examples)
+samyama-optimization = { path = "../samyama-optimization", version = "0.5.0-alpha.1" }
+
+# Numeric arrays (re-exported for optimization problems)
+ndarray = "0.15"
+
 [dev-dependencies]
 tokio = { version = "1.35", features = ["full"] }

--- a/crates/samyama-sdk/src/algo.rs
+++ b/crates/samyama-sdk/src/algo.rs
@@ -1,0 +1,266 @@
+//! AlgorithmClient — extension trait for graph algorithms (EmbeddedClient only)
+//!
+//! Provides PageRank, community detection, pathfinding, and other graph algorithms
+//! via the `AlgorithmClient` trait. Only `EmbeddedClient` implements this trait
+//! since algorithms require direct in-process access to the graph store.
+
+use async_trait::async_trait;
+use std::collections::HashMap;
+
+use samyama::algo::{
+    build_view, page_rank, weakly_connected_components, strongly_connected_components,
+    bfs, dijkstra, edmonds_karp, prim_mst, count_triangles,
+    PageRankConfig, PathResult, WccResult, SccResult, FlowResult, MSTResult,
+};
+use samyama_graph_algorithms::GraphView;
+
+use crate::embedded::EmbeddedClient;
+
+/// Extension trait for graph algorithm operations.
+///
+/// Only implemented by `EmbeddedClient` since algorithms need direct store access.
+#[async_trait]
+pub trait AlgorithmClient {
+    /// Build a `GraphView` projection for algorithm execution.
+    ///
+    /// Optionally filter by node label, edge type, and extract edge weights.
+    async fn build_view(
+        &self,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+        weight_prop: Option<&str>,
+    ) -> GraphView;
+
+    /// Run PageRank on the graph (or a subgraph filtered by label/edge_type).
+    async fn page_rank(
+        &self,
+        config: PageRankConfig,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> HashMap<u64, f64>;
+
+    /// Detect weakly connected components.
+    async fn weakly_connected_components(
+        &self,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> WccResult;
+
+    /// Detect strongly connected components.
+    async fn strongly_connected_components(
+        &self,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> SccResult;
+
+    /// Breadth-first search from source to target.
+    async fn bfs(
+        &self,
+        source: u64,
+        target: u64,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> Option<PathResult>;
+
+    /// Dijkstra's shortest path from source to target (weighted).
+    async fn dijkstra(
+        &self,
+        source: u64,
+        target: u64,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+        weight_prop: Option<&str>,
+    ) -> Option<PathResult>;
+
+    /// Edmonds-Karp maximum flow from source to sink.
+    async fn edmonds_karp(
+        &self,
+        source: u64,
+        sink: u64,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> Option<FlowResult>;
+
+    /// Prim's minimum spanning tree.
+    async fn prim_mst(
+        &self,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+        weight_prop: Option<&str>,
+    ) -> MSTResult;
+
+    /// Count triangles in the graph.
+    async fn count_triangles(
+        &self,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> usize;
+}
+
+#[async_trait]
+impl AlgorithmClient for EmbeddedClient {
+    async fn build_view(
+        &self,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+        weight_prop: Option<&str>,
+    ) -> GraphView {
+        let store = self.store.read().await;
+        build_view(&store, label, edge_type, weight_prop)
+    }
+
+    async fn page_rank(
+        &self,
+        config: PageRankConfig,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> HashMap<u64, f64> {
+        let store = self.store.read().await;
+        let view = build_view(&store, label, edge_type, None);
+        page_rank(&view, config)
+    }
+
+    async fn weakly_connected_components(
+        &self,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> WccResult {
+        let store = self.store.read().await;
+        let view = build_view(&store, label, edge_type, None);
+        weakly_connected_components(&view)
+    }
+
+    async fn strongly_connected_components(
+        &self,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> SccResult {
+        let store = self.store.read().await;
+        let view = build_view(&store, label, edge_type, None);
+        strongly_connected_components(&view)
+    }
+
+    async fn bfs(
+        &self,
+        source: u64,
+        target: u64,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> Option<PathResult> {
+        let store = self.store.read().await;
+        let view = build_view(&store, label, edge_type, None);
+        bfs(&view, source, target)
+    }
+
+    async fn dijkstra(
+        &self,
+        source: u64,
+        target: u64,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+        weight_prop: Option<&str>,
+    ) -> Option<PathResult> {
+        let store = self.store.read().await;
+        let view = build_view(&store, label, edge_type, weight_prop);
+        dijkstra(&view, source, target)
+    }
+
+    async fn edmonds_karp(
+        &self,
+        source: u64,
+        sink: u64,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> Option<FlowResult> {
+        let store = self.store.read().await;
+        let view = build_view(&store, label, edge_type, None);
+        edmonds_karp(&view, source, sink)
+    }
+
+    async fn prim_mst(
+        &self,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+        weight_prop: Option<&str>,
+    ) -> MSTResult {
+        let store = self.store.read().await;
+        let view = build_view(&store, label, edge_type, weight_prop);
+        prim_mst(&view)
+    }
+
+    async fn count_triangles(
+        &self,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> usize {
+        let store = self.store.read().await;
+        let view = build_view(&store, label, edge_type, None);
+        count_triangles(&view)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EmbeddedClient, SamyamaClient};
+
+    #[tokio::test]
+    async fn test_page_rank() {
+        let client = EmbeddedClient::new();
+
+        // Create a small graph: A -> B -> C, A -> C
+        client.query("default", r#"CREATE (a:Person {name: "Alice"})"#).await.unwrap();
+        client.query("default", r#"CREATE (b:Person {name: "Bob"})"#).await.unwrap();
+        client.query("default", r#"CREATE (c:Person {name: "Carol"})"#).await.unwrap();
+        client.query("default",
+            r#"MATCH (a:Person {name: "Alice"}), (b:Person {name: "Bob"}) CREATE (a)-[:KNOWS]->(b)"#
+        ).await.unwrap();
+        client.query("default",
+            r#"MATCH (b:Person {name: "Bob"}), (c:Person {name: "Carol"}) CREATE (b)-[:KNOWS]->(c)"#
+        ).await.unwrap();
+        client.query("default",
+            r#"MATCH (a:Person {name: "Alice"}), (c:Person {name: "Carol"}) CREATE (a)-[:KNOWS]->(c)"#
+        ).await.unwrap();
+
+        let scores = client.page_rank(PageRankConfig::default(), Some("Person"), Some("KNOWS")).await;
+        assert_eq!(scores.len(), 3);
+        // Carol should have highest PageRank (most incoming links)
+        let max_node = scores.iter().max_by(|a, b| a.1.partial_cmp(b.1).unwrap()).unwrap();
+        // At least verify we got results
+        assert!(*max_node.1 > 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_wcc() {
+        let client = EmbeddedClient::new();
+
+        // Two disconnected components
+        client.query("default", r#"CREATE (a:Person {name: "Alice"})-[:KNOWS]->(b:Person {name: "Bob"})"#).await.unwrap();
+        client.query("default", r#"CREATE (c:Person {name: "Carol"})-[:KNOWS]->(d:Person {name: "Dave"})"#).await.unwrap();
+
+        let wcc = client.weakly_connected_components(Some("Person"), Some("KNOWS")).await;
+        assert_eq!(wcc.components.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_bfs() {
+        let client = EmbeddedClient::new();
+
+        client.query("default", r#"CREATE (a:Person {name: "Alice"})-[:KNOWS]->(b:Person {name: "Bob"})"#).await.unwrap();
+        client.query("default",
+            r#"MATCH (b:Person {name: "Bob"}) CREATE (b)-[:KNOWS]->(c:Person {name: "Carol"})"#
+        ).await.unwrap();
+
+        // Get node IDs
+        let store = client.store().read().await;
+        let all_nodes: Vec<_> = store.all_nodes().iter().map(|n| n.id.as_u64()).collect();
+        drop(store);
+
+        if all_nodes.len() >= 3 {
+            let result = client.bfs(all_nodes[0], all_nodes[2], Some("Person"), Some("KNOWS")).await;
+            assert!(result.is_some());
+            let path = result.unwrap();
+            assert!(path.path.len() >= 2);
+        }
+    }
+}

--- a/crates/samyama-sdk/src/error.rs
+++ b/crates/samyama-sdk/src/error.rs
@@ -28,6 +28,18 @@ pub enum SamyamaError {
     /// I/O error
     #[error("I/O error: {0}")]
     IoError(#[from] std::io::Error),
+
+    /// Vector search error
+    #[error("Vector error: {0}")]
+    VectorError(String),
+
+    /// Graph algorithm error
+    #[error("Algorithm error: {0}")]
+    AlgorithmError(String),
+
+    /// Persistence error
+    #[error("Persistence error: {0}")]
+    PersistenceError(String),
 }
 
 pub type SamyamaResult<T> = Result<T, SamyamaError>;

--- a/crates/samyama-sdk/src/lib.rs
+++ b/crates/samyama-sdk/src/lib.rs
@@ -10,6 +10,10 @@
 //!
 //! Both implement the `SamyamaClient` trait for a unified API.
 //!
+//! Extension traits (EmbeddedClient only):
+//! - **`AlgorithmClient`** — PageRank, WCC, SCC, BFS, Dijkstra, and more
+//! - **`VectorClient`** — Vector index creation, insertion, and k-NN search
+//!
 //! # Quick Start
 //!
 //! ```rust
@@ -35,14 +39,105 @@ pub mod embedded;
 pub mod error;
 pub mod models;
 pub mod remote;
+pub mod algo;
+pub mod vector_ext;
 
-// Re-export main types
+// ============================================================
+// Core SDK types
+// ============================================================
+
 pub use client::SamyamaClient;
 pub use embedded::EmbeddedClient;
 pub use remote::RemoteClient;
 pub use error::{SamyamaError, SamyamaResult};
 pub use models::{QueryResult, SdkNode, SdkEdge, ServerStatus, StorageStats};
 
-// Re-export graph types for convenience when using EmbeddedClient
-pub use samyama::graph::{GraphStore, NodeId, EdgeId, Label, PropertyValue};
-pub use samyama::query::QueryEngine;
+// ============================================================
+// Extension traits (EmbeddedClient only)
+// ============================================================
+
+pub use algo::AlgorithmClient;
+pub use vector_ext::VectorClient;
+
+// ============================================================
+// Graph types (re-exported from samyama core)
+// ============================================================
+
+pub use samyama::graph::{
+    GraphStore, Node, Edge, NodeId, EdgeId, EdgeType, Label,
+    PropertyValue, PropertyMap,
+    GraphError, GraphResult,
+};
+pub use samyama::query::{QueryEngine, RecordBatch};
+
+// ============================================================
+// Algorithm types (re-exported from samyama-graph-algorithms)
+// ============================================================
+
+pub use samyama::algo::{
+    build_view, page_rank, weakly_connected_components, strongly_connected_components,
+    bfs, dijkstra, edmonds_karp, prim_mst, count_triangles,
+    PageRankConfig, PathResult, WccResult, SccResult, FlowResult, MSTResult,
+};
+pub use samyama_graph_algorithms::GraphView;
+
+// ============================================================
+// Vector types (re-exported from samyama core)
+// ============================================================
+
+pub use samyama::vector::{
+    DistanceMetric, VectorIndex, VectorIndexManager, IndexKey,
+    VectorError, VectorResult,
+};
+
+// ============================================================
+// NLQ types (re-exported from samyama core)
+// ============================================================
+
+pub use samyama::{NLQPipeline, NLQError, NLQResult};
+
+// ============================================================
+// Agent types (re-exported from samyama core)
+// ============================================================
+
+pub use samyama::agent::AgentRuntime;
+
+// ============================================================
+// Persistence & Multi-Tenancy types (re-exported from samyama core)
+// ============================================================
+
+pub use samyama::{
+    PersistenceManager, PersistenceError, PersistenceResult,
+    PersistentStorage, StorageError, StorageResult,
+    Tenant, TenantManager, ResourceQuotas, ResourceUsage,
+    TenantError, TenantResult,
+    Wal, WalEntry, WalError, WalResult,
+    NLQConfig, LLMProvider, AutoEmbedConfig,
+};
+pub use samyama::persistence::tenant::{AgentConfig, ToolConfig};
+
+// ============================================================
+// Optimization types (re-exported from samyama-optimization)
+// ============================================================
+
+pub use samyama_optimization::{
+    SolverConfig, OptimizationResult, Individual, SimpleProblem,
+    Problem, MultiObjectiveProblem, MultiObjectiveIndividual, MultiObjectiveResult,
+};
+pub use samyama_optimization::algorithms::{
+    JayaSolver, CuckooSolver, NSGA2Solver,
+    RaoSolver, TLBOSolver, PSOSolver, DESolver, GASolver,
+    FireflySolver, GWOSolver, SASolver, BatSolver, ABCSolver,
+};
+
+// ============================================================
+// ndarray (re-exported for optimization problem definitions)
+// ============================================================
+
+pub use ndarray::Array1;
+
+// ============================================================
+// Version
+// ============================================================
+
+pub use samyama::VERSION;

--- a/crates/samyama-sdk/src/vector_ext.rs
+++ b/crates/samyama-sdk/src/vector_ext.rs
@@ -1,0 +1,119 @@
+//! VectorClient — extension trait for vector search operations (EmbeddedClient only)
+//!
+//! Provides vector index creation, insertion, and k-NN search via the
+//! `VectorClient` trait. Only `EmbeddedClient` implements this trait
+//! since vector operations require direct in-process access to the graph store.
+
+use async_trait::async_trait;
+
+use samyama::graph::NodeId;
+use samyama::vector::DistanceMetric;
+
+use crate::embedded::EmbeddedClient;
+use crate::error::{SamyamaError, SamyamaResult};
+
+/// Extension trait for vector search operations.
+///
+/// Only implemented by `EmbeddedClient` since vector ops need direct store access.
+#[async_trait]
+pub trait VectorClient {
+    /// Create a vector index for a given label and property.
+    async fn create_vector_index(
+        &self,
+        label: &str,
+        property: &str,
+        dimensions: usize,
+        metric: DistanceMetric,
+    ) -> SamyamaResult<()>;
+
+    /// Add a vector to the index for a given node.
+    async fn add_vector(
+        &self,
+        label: &str,
+        property: &str,
+        node_id: NodeId,
+        vector: &[f32],
+    ) -> SamyamaResult<()>;
+
+    /// Search for the k nearest neighbors to a query vector.
+    async fn vector_search(
+        &self,
+        label: &str,
+        property: &str,
+        query_vec: &[f32],
+        k: usize,
+    ) -> SamyamaResult<Vec<(NodeId, f32)>>;
+}
+
+#[async_trait]
+impl VectorClient for EmbeddedClient {
+    async fn create_vector_index(
+        &self,
+        label: &str,
+        property: &str,
+        dimensions: usize,
+        metric: DistanceMetric,
+    ) -> SamyamaResult<()> {
+        let store = self.store.read().await;
+        store.create_vector_index(label, property, dimensions, metric)
+            .map_err(|e| SamyamaError::VectorError(e.to_string()))
+    }
+
+    async fn add_vector(
+        &self,
+        label: &str,
+        property: &str,
+        node_id: NodeId,
+        vector: &[f32],
+    ) -> SamyamaResult<()> {
+        let store = self.store.read().await;
+        store.vector_index
+            .add_vector(label, property, node_id, &vector.to_vec())
+            .map_err(|e| SamyamaError::VectorError(e.to_string()))
+    }
+
+    async fn vector_search(
+        &self,
+        label: &str,
+        property: &str,
+        query_vec: &[f32],
+        k: usize,
+    ) -> SamyamaResult<Vec<(NodeId, f32)>> {
+        let store = self.store.read().await;
+        store.vector_search(label, property, query_vec, k)
+            .map_err(|e| SamyamaError::VectorError(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EmbeddedClient, SamyamaClient};
+
+    #[tokio::test]
+    async fn test_vector_index_create_and_search() {
+        let client = EmbeddedClient::new();
+
+        // Create index
+        client.create_vector_index("Doc", "embedding", 4, DistanceMetric::Cosine)
+            .await.unwrap();
+
+        // Create some nodes
+        client.query("default", r#"CREATE (d:Doc {title: "Alpha"})"#).await.unwrap();
+        client.query("default", r#"CREATE (d:Doc {title: "Beta"})"#).await.unwrap();
+
+        // Add vectors
+        let store = client.store().read().await;
+        let nodes: Vec<_> = store.all_nodes().iter().map(|n| n.id).collect();
+        drop(store);
+
+        client.add_vector("Doc", "embedding", nodes[0], &[1.0, 0.0, 0.0, 0.0]).await.unwrap();
+        client.add_vector("Doc", "embedding", nodes[1], &[0.0, 1.0, 0.0, 0.0]).await.unwrap();
+
+        // Search
+        let results = client.vector_search("Doc", "embedding", &[1.0, 0.1, 0.0, 0.0], 2).await.unwrap();
+        assert_eq!(results.len(), 2);
+        // First result should be closest to query
+        assert_eq!(results[0].0, nodes[0]);
+    }
+}

--- a/docs/SDK_API_CLI_ARCHITECTURE.md
+++ b/docs/SDK_API_CLI_ARCHITECTURE.md
@@ -1,0 +1,341 @@
+# SDK, API & CLI — Connection Architecture
+
+How the SDK, API, and CLI connect to the Samyama graph database.
+
+---
+
+## SDKs Overview
+
+Samyama provides SDKs in three languages. The **Rust SDK** is the primary SDK and the most feature-complete.
+
+| SDK | Crate / Package | Clients | Built On | Key Dependencies |
+|-----|----------------|---------|----------|-----------------|
+| **Rust SDK** | `samyama-sdk` (`crates/samyama-sdk/`) | `EmbeddedClient`, `RemoteClient` | samyama core (direct) | samyama, reqwest, tokio |
+| **Python SDK** | `samyama` (`sdk/python/`) | `SamyamaClient.embedded()`, `.connect(url)` | **Rust SDK via PyO3** | samyama-sdk, pyo3 0.22, tokio |
+| **TypeScript SDK** | `samyama-sdk` (`sdk/typescript/`) | `SamyamaClient.connectHttp(url)` | Independent (HTTP only) | fetch (native) |
+
+The **Rust SDK** is the foundation:
+- Defines the `SamyamaClient` async trait with two implementations:
+  - **`EmbeddedClient`** — in-process, no network, full feature set (algorithms, vector, NLQ, persistence)
+  - **`RemoteClient`** — HTTP client to a running server, core query features only
+- The **Python SDK wraps the Rust SDK** via PyO3 — it imports `EmbeddedClient` and `RemoteClient` directly from the `samyama-sdk` crate and exposes them as Python classes. Both embedded and remote modes work from Python.
+- The **TypeScript SDK is independent** — it reimplements the HTTP client protocol using native `fetch`, targeting the same `/api/query` and `/api/status` endpoints. HTTP-only, no embedded mode.
+
+---
+
+## Connection Summary
+
+| Component | Type | Protocol | Port | Transport Layer | GraphStore Access | Requires Server? |
+|-----------|------|----------|------|-----------------|-------------------|------------------|
+| **Rust SDK — EmbeddedClient** | SDK (Rust) | Direct | N/A | In-process `Arc<RwLock<GraphStore>>` | Direct memory | No |
+| **Rust SDK — RemoteClient** | SDK (Rust) | HTTP/JSON | 8080 | `reqwest` async HTTP | `/api/query`, `/api/status` | Yes |
+| **CLI** (`samyama-cli`) | Tool | HTTP/JSON | 8080 | Uses Rust SDK `RemoteClient` | Via RemoteClient | Yes |
+| **Python SDK** | SDK (Python) | Direct / HTTP | N/A / 8080 | PyO3 wrapping **Rust SDK** (`EmbeddedClient` + `RemoteClient`) | Both modes | Depends on mode |
+| **TypeScript SDK** | SDK (TS) | HTTP/JSON | 8080 | Native `fetch` (independent) | Via HTTP endpoints | Yes |
+| **RESP Server** | Protocol | RESP3 (Redis) | 6379 | TCP socket | Direct `Arc<RwLock<>>` | Is the server |
+| **HTTP Server** | Protocol | HTTP/JSON | 8080 | Axum async | Direct `Arc<RwLock<>>` | Is the server |
+
+---
+
+## Data Flow
+
+```mermaid
+graph TB
+    subgraph "Rust SDK (samyama-sdk crate)"
+        EC[EmbeddedClient<br/><i>in-process, no network</i>]
+        RC[RemoteClient<br/><i>HTTP client</i>]
+    end
+
+    subgraph "Built on Rust SDK"
+        CLI[CLI — samyama-cli<br/><i>uses RemoteClient</i>]
+        PY[Python SDK<br/><i>PyO3 wrapping Rust SDK</i>]
+    end
+
+    subgraph "Independent Clients"
+        TS[TypeScript SDK<br/><i>native fetch HTTP</i>]
+        REDIS_CLI[redis-cli<br/><i>RESP3 protocol</i>]
+    end
+
+    subgraph "Samyama Server Process"
+        HTTP_SRV["HTTP Server (Axum :8080)<br/>POST /api/query<br/>GET /api/status"]
+        RESP_SRV["RESP Server (TCP :6379)<br/>GRAPH.QUERY<br/>GRAPH.RO_QUERY"]
+        QE[QueryEngine]
+        GS["Arc&lt;RwLock&lt;GraphStore&gt;&gt;<br/><i>in-memory property graph</i>"]
+        PERSIST["PersistenceManager<br/><i>RocksDB + WAL (optional)</i>"]
+    end
+
+    EC -->|"direct Rust call"| GS
+    RC -->|"HTTP :8080"| HTTP_SRV
+    CLI -->|"HTTP :8080"| HTTP_SRV
+    PY -->|"direct (embedded mode)"| GS
+    PY -->|"HTTP (remote mode)"| HTTP_SRV
+    TS -->|"HTTP :8080"| HTTP_SRV
+    REDIS_CLI -->|"TCP :6379"| RESP_SRV
+
+    HTTP_SRV --> QE
+    RESP_SRV --> QE
+    QE --> GS
+    GS -.->|"optional"| PERSIST
+```
+
+---
+
+## Component Details
+
+### 1. Rust SDK (`samyama-sdk`)
+
+**Crate:** `crates/samyama-sdk/` — workspace member, published as `samyama-sdk`
+
+The Rust SDK is the primary client library. It provides:
+- **`SamyamaClient`** trait — unified async API implemented by both clients
+- **`EmbeddedClient`** — in-process, zero-network access (tests, examples, embedded apps)
+- **`RemoteClient`** — HTTP client for production use against a running server
+- **Extension traits** — `AlgorithmClient`, `VectorClient` (EmbeddedClient only)
+- **Re-exports** — all core types (graph, algo, vector, NLQ, persistence, optimization)
+
+#### 1a. EmbeddedClient (In-Process, Direct)
+
+**File:** `crates/samyama-sdk/src/embedded.rs`
+
+- No network, no serialization overhead
+- Wraps `Arc<RwLock<GraphStore>>` directly in memory
+- Two construction modes:
+  - `EmbeddedClient::new()` — creates fresh empty GraphStore
+  - `EmbeddedClient::with_store(arc)` — wraps an existing store
+
+**Query execution path:**
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant EC as EmbeddedClient
+    participant QE as QueryEngine
+    participant GS as GraphStore
+
+    App->>EC: client.query("default", cypher)
+    EC->>GS: store.write().await
+    EC->>QE: execute_mut(query, &mut store)
+    QE-->>EC: RecordBatch
+    EC-->>App: QueryResult { nodes, edges, columns, records }
+```
+
+**Exclusive features** (not available on RemoteClient):
+
+| Extension Trait | Methods |
+|----------------|---------|
+| `AlgorithmClient` | `page_rank`, `weakly_connected_components`, `strongly_connected_components`, `bfs`, `dijkstra`, `edmonds_karp`, `prim_mst`, `count_triangles`, `build_view` |
+| `VectorClient` | `create_vector_index`, `add_vector`, `vector_search` |
+
+**Factory methods** on EmbeddedClient:
+
+| Method | Returns | Purpose |
+|--------|---------|---------|
+| `nlq_pipeline(config)` | `NLQPipeline` | Natural language to Cypher |
+| `agent_runtime(config)` | `AgentRuntime` | Agentic enrichment (GAK) |
+| `persistence_manager(path)` | `PersistenceManager` | RocksDB + WAL |
+| `tenant_manager()` | `TenantManager` | Multi-tenancy + quotas |
+| `store_read()` | `RwLockReadGuard` | Direct read access |
+| `store_write()` | `RwLockWriteGuard` | Direct write access |
+
+---
+
+#### 1b. RemoteClient (HTTP Network)
+
+**File:** `crates/samyama-sdk/src/remote.rs`
+
+- Connects to a running Samyama server via HTTP
+- Uses `reqwest` async HTTP client
+- Default URL: `http://localhost:8080`
+
+**Endpoints used:**
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| POST | `/api/query` | Execute Cypher (body: `{ "query": "..." }`) |
+| GET | `/api/status` | Server health and stats |
+
+**Query execution path:**
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant RC as RemoteClient
+    participant HTTP as HTTP Server (:8080)
+    participant QE as QueryEngine
+    participant GS as GraphStore
+
+    App->>RC: client.query("default", cypher)
+    RC->>HTTP: POST /api/query { "query": "..." }
+    HTTP->>QE: execute(query, &store)
+    QE-->>HTTP: RecordBatch
+    HTTP-->>RC: JSON { nodes, edges, columns, records }
+    RC-->>App: QueryResult
+```
+
+---
+
+### 2. CLI (`samyama-cli`)
+
+**File:** `cli/src/main.rs`
+
+- Thin wrapper around `RemoteClient`
+- Built with `clap` (arg parsing) + `comfy-table` (table formatting)
+- URL from `--url` flag or `SAMYAMA_URL` env var
+
+**Subcommands:**
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `query <cypher>` | Execute Cypher | `samyama-cli query "MATCH (n) RETURN n"` |
+| `status` | Server stats | `samyama-cli status` |
+| `ping` | Health check | `samyama-cli ping` |
+| `shell` | Interactive REPL | `samyama-cli shell` |
+
+**Output formats:** `--format table` (default), `--format json`, `--format csv`
+
+---
+
+### 3. Python & TypeScript SDKs
+
+#### Python SDK (`sdk/python/`)
+
+**Built on the Rust SDK** — a PyO3 cdylib that wraps `samyama-sdk` directly.
+
+- **Dependency:** `samyama-sdk = { path = "../../crates/samyama-sdk" }` in `Cargo.toml`
+- **Internal:** `ClientInner` enum holds either `EmbeddedClient` or `RemoteClient` from the Rust SDK
+- **Build:** `maturin develop` / `maturin build`
+- **Two modes:**
+  - `SamyamaClient.embedded()` — wraps Rust `EmbeddedClient` (in-process, no server)
+  - `SamyamaClient.connect(url)` — wraps Rust `RemoteClient` (HTTP to server)
+
+```mermaid
+graph LR
+    PY_APP[Python App] --> PY_SDK[Python SDK<br/><i>PyO3 bindings</i>]
+    PY_SDK --> RUST_SDK[Rust SDK<br/><i>EmbeddedClient / RemoteClient</i>]
+    RUST_SDK -->|"embedded mode"| GS[GraphStore]
+    RUST_SDK -->|"remote mode"| HTTP[HTTP Server :8080]
+```
+
+#### TypeScript SDK (`sdk/typescript/`)
+
+**Independent implementation** — pure TypeScript, does NOT use the Rust SDK.
+
+- Reimplements HTTP client protocol using native `fetch`
+- Targets the same endpoints: `POST /api/query`, `GET /api/status`
+- HTTP-only — no embedded mode available
+- `SamyamaClient.connectHttp(url)` factory method
+
+---
+
+### 4. HTTP API Server
+
+**Files:** `src/http/server.rs`, `src/http/handler.rs`
+
+- Framework: **Axum** (async Rust web framework)
+- Port: **8080** (default)
+- CORS: permissive (enabled)
+
+**Endpoints:**
+
+| Method | Path | Handler | Description |
+|--------|------|---------|-------------|
+| POST | `/api/query` | `query_handler` | Execute Cypher, return nodes/edges/records |
+| GET | `/api/status` | `status_handler` | Return `{ status, version, storage }` |
+| GET | `/` | static | Serve HTML graph visualizer |
+
+**Response format** (matches `QueryResult` in SDK):
+
+```json
+{
+  "nodes": [{ "id": 1, "labels": ["Person"], "properties": {"name": "Alice"} }],
+  "edges": [{ "id": 1, "source": 1, "target": 2, "type": "KNOWS", "properties": {} }],
+  "columns": ["n.name"],
+  "records": [["Alice"]]
+}
+```
+
+**OpenAPI spec:** `api/openapi.yaml`
+
+---
+
+### 5. RESP Protocol Server
+
+**Files:** `src/protocol/server.rs`, `src/protocol/command.rs`, `src/protocol/resp.rs`
+
+- Protocol: **RESP3** (Redis Serialization Protocol)
+- Port: **6379** (Redis-compatible)
+- Compatible clients: `redis-cli`, `redis-py`, `ioredis`, etc.
+
+**Supported commands:**
+
+| Command | Description |
+|---------|-------------|
+| `GRAPH.QUERY graph "CYPHER"` | Execute Cypher (read or write) |
+| `GRAPH.RO_QUERY graph "CYPHER"` | Read-only query |
+| `GRAPH.DELETE graph` | Delete all nodes/edges |
+| `GRAPH.LIST` | List graphs |
+| `PING` | Health check |
+| `ECHO msg` | Echo back |
+| `INFO` | Server info |
+
+---
+
+## Shared Trait: `SamyamaClient`
+
+**File:** `crates/samyama-sdk/src/client.rs`
+
+Both `EmbeddedClient` and `RemoteClient` implement this async trait:
+
+```rust
+#[async_trait]
+pub trait SamyamaClient {
+    async fn query(&self, graph: &str, cypher: &str) -> SamyamaResult<QueryResult>;
+    async fn query_readonly(&self, graph: &str, cypher: &str) -> SamyamaResult<QueryResult>;
+    async fn delete_graph(&self, graph: &str) -> SamyamaResult<()>;
+    async fn list_graphs(&self) -> SamyamaResult<Vec<String>>;
+    async fn status(&self) -> SamyamaResult<ServerStatus>;
+    async fn ping(&self) -> SamyamaResult<String>;
+}
+```
+
+---
+
+## Capability Matrix
+
+| Capability | Rust SDK (Embedded) | Rust SDK (Remote) | CLI | Python SDK | TS SDK | RESP |
+|------------|:-:|:-:|:-:|:-:|:-:|:-:|
+| Cypher queries | Y | Y | Y | Y | Y | Y |
+| Read-only queries | Y | Y | Y | Y | Y | Y |
+| Graph algorithms | Y | - | - | - | - | - |
+| Vector search (HNSW) | Y | - | - | - | - | - |
+| NLQ (natural language) | Y | - | - | - | - | - |
+| Agent enrichment (GAK) | Y | - | - | - | - | - |
+| Persistence (RocksDB) | Y | - | - | - | - | Y |
+| Multi-tenancy | Y | - | - | - | - | Y |
+| Direct store access | Y | - | - | - | - | - |
+| Network required | - | Y | Y | Y | Y | Y |
+
+---
+
+## File Index
+
+| Area | File | Purpose |
+|------|------|---------|
+| **Rust SDK** | `crates/samyama-sdk/src/lib.rs` | Module root + re-exports |
+| | `crates/samyama-sdk/src/client.rs` | `SamyamaClient` trait definition |
+| | `crates/samyama-sdk/src/embedded.rs` | In-process client + factory methods |
+| | `crates/samyama-sdk/src/remote.rs` | HTTP client via reqwest |
+| | `crates/samyama-sdk/src/models.rs` | `QueryResult`, `SdkNode`, `SdkEdge`, `ServerStatus` |
+| | `crates/samyama-sdk/src/algo.rs` | `AlgorithmClient` extension trait |
+| | `crates/samyama-sdk/src/vector_ext.rs` | `VectorClient` extension trait |
+| | `crates/samyama-sdk/src/error.rs` | `SamyamaError` enum |
+| **Python SDK** | `sdk/python/src/lib.rs` | PyO3 bindings (embedded + HTTP) |
+| **TypeScript SDK** | `sdk/typescript/src/client.ts` | Fetch-based HTTP client |
+| **CLI** | `cli/src/main.rs` | Clap subcommands + table/json/csv output |
+| **HTTP Server** | `src/http/server.rs` | Axum server setup |
+| | `src/http/handler.rs` | `/api/query`, `/api/status` handlers |
+| **RESP Server** | `src/protocol/server.rs` | TCP listener + connection handler |
+| | `src/protocol/command.rs` | `GRAPH.QUERY` etc. |
+| | `src/protocol/resp.rs` | RESP3 encoding/decoding |
+| **Specs** | `api/openapi.yaml` | HTTP API specification (OpenAPI 3.0) |
+| **Server** | `src/main.rs` | Server startup (RESP + HTTP) |

--- a/examples/persistence_demo.rs
+++ b/examples/persistence_demo.rs
@@ -7,9 +7,9 @@
 //! - Checkpoint, recovery, and incremental persistence
 //! - Backup/restore simulation
 
-use samyama::{
+use samyama_sdk::{
     PersistenceManager, ResourceQuotas,
-    graph::{Node, Edge, NodeId, EdgeId, Label, EdgeType},
+    Node, Edge, NodeId, EdgeId, Label, EdgeType,
 };
 use std::time::Instant;
 

--- a/examples/social_network_demo.rs
+++ b/examples/social_network_demo.rs
@@ -5,14 +5,11 @@
 //! community detection (WCC/SCC), BFS information diffusion, network
 //! statistics, and force-directed SVG visualization.
 
-use samyama::graph::{GraphStore, Label, PropertyValue};
-use samyama::query::QueryEngine;
-use samyama::algo::{
-    build_view, page_rank, weakly_connected_components, strongly_connected_components,
-    bfs, PageRankConfig,
+use samyama_sdk::{
+    EmbeddedClient, SamyamaClient, AlgorithmClient,
+    Label, PropertyValue, NodeId, PageRankConfig,
+    NLQConfig, LLMProvider,
 };
-use samyama::{NLQPipeline, TenantManager};
-use samyama::persistence::tenant::{LLMProvider, NLQConfig};
 use std::fs::File;
 use std::io::Write;
 use rand::Rng;
@@ -120,8 +117,7 @@ async fn main() {
     println!("=== Social Network Analysis Platform ===");
     println!("    Samyama Graph Database - Tech Professional Community\n");
 
-    let mut store = GraphStore::new();
-    let engine = QueryEngine::new();
+    let client = EmbeddedClient::new();
     let mut rng = rand::thread_rng();
 
     // -----------------------------------------------------------------------
@@ -130,30 +126,33 @@ async fn main() {
     println!("Step 1: Building social network graph");
     println!("------------------------------------------------------------------------");
 
-    // Create user nodes
+    // Create user nodes via direct store access (bulk insert for performance)
     let mut node_ids = Vec::with_capacity(NUM_USERS);
     let mut community_members: Vec<Vec<usize>> = vec![Vec::new(); NUM_COMMUNITIES];
 
-    for i in 0..NUM_USERS {
-        let community_idx = i % NUM_COMMUNITIES;
-        let first = FIRST_NAMES[rng.gen_range(0..FIRST_NAMES.len())];
-        let last = LAST_NAMES[rng.gen_range(0..LAST_NAMES.len())];
-        let company = COMPANIES[rng.gen_range(0..COMPANIES.len())];
-        let skill = COMMUNITY_SKILLS[community_idx][rng.gen_range(0..4)];
-        let years_exp: i64 = rng.gen_range(1..20);
+    {
+        let mut store = client.store_write().await;
+        for i in 0..NUM_USERS {
+            let community_idx = i % NUM_COMMUNITIES;
+            let first = FIRST_NAMES[rng.gen_range(0..FIRST_NAMES.len())];
+            let last = LAST_NAMES[rng.gen_range(0..LAST_NAMES.len())];
+            let company = COMPANIES[rng.gen_range(0..COMPANIES.len())];
+            let skill = COMMUNITY_SKILLS[community_idx][rng.gen_range(0..4)];
+            let years_exp: i64 = rng.gen_range(1..20);
 
-        let id = store.create_node(Label::new("User"));
-        if let Some(node) = store.get_node_mut(id) {
-            node.set_property("name", format!("{} {}", first, last));
-            node.set_property("company", company);
-            node.set_property("primary_skill", skill);
-            node.set_property("years_experience", years_exp);
-            node.set_property("community", COMMUNITIES[community_idx]);
-            node.set_property("community_idx", community_idx as i64);
+            let id = store.create_node(Label::new("User"));
+            if let Some(node) = store.get_node_mut(id) {
+                node.set_property("name", format!("{} {}", first, last));
+                node.set_property("company", company);
+                node.set_property("primary_skill", skill);
+                node.set_property("years_experience", years_exp);
+                node.set_property("community", COMMUNITIES[community_idx]);
+                node.set_property("community_idx", community_idx as i64);
+            }
+
+            node_ids.push(id);
+            community_members[community_idx].push(i);
         }
-
-        node_ids.push(id);
-        community_members[community_idx].push(i);
     }
 
     // Create edges: FOLLOWS, COLLABORATES, ENDORSED
@@ -162,50 +161,50 @@ async fn main() {
     let mut collabs_count: usize = 0;
     let mut endorsed_count: usize = 0;
 
-    for i in 0..NUM_USERS {
-        let community_idx = i % NUM_COMMUNITIES;
-        let src = node_ids[i];
+    {
+        let mut store = client.store_write().await;
+        for i in 0..NUM_USERS {
+            let community_idx = i % NUM_COMMUNITIES;
+            let src = node_ids[i];
 
-        // Each node gets 4-7 connections on average -> targets ~11K edges total
-        let degree = rng.gen_range(4..8);
-        for _ in 0..degree {
-            let is_intra = rng.gen_bool(0.80);
-            let target_idx = if is_intra {
-                // Pick from same community
-                let members = &community_members[community_idx];
-                members[rng.gen_range(0..members.len())]
-            } else {
-                // Pick from any other community
-                rng.gen_range(0..NUM_USERS)
-            };
-
-            if i == target_idx {
-                continue;
-            }
-
-            let tgt = node_ids[target_idx];
-            let target_community = target_idx % NUM_COMMUNITIES;
-
-            let edge_type = if community_idx == target_community {
-                if rng.gen_bool(0.5) {
-                    follows_count += 1;
-                    "FOLLOWS"
+            let degree = rng.gen_range(4..8);
+            for _ in 0..degree {
+                let is_intra = rng.gen_bool(0.80);
+                let target_idx = if is_intra {
+                    let members = &community_members[community_idx];
+                    members[rng.gen_range(0..members.len())]
                 } else {
-                    collabs_count += 1;
-                    "COLLABORATES"
-                }
-            } else {
-                if rng.gen_bool(0.6) {
-                    follows_count += 1;
-                    "FOLLOWS"
-                } else {
-                    endorsed_count += 1;
-                    "ENDORSED"
-                }
-            };
+                    rng.gen_range(0..NUM_USERS)
+                };
 
-            if store.create_edge(src, tgt, edge_type).is_ok() {
-                edge_count += 1;
+                if i == target_idx {
+                    continue;
+                }
+
+                let tgt = node_ids[target_idx];
+                let target_community = target_idx % NUM_COMMUNITIES;
+
+                let edge_type = if community_idx == target_community {
+                    if rng.gen_bool(0.5) {
+                        follows_count += 1;
+                        "FOLLOWS"
+                    } else {
+                        collabs_count += 1;
+                        "COLLABORATES"
+                    }
+                } else {
+                    if rng.gen_bool(0.6) {
+                        follows_count += 1;
+                        "FOLLOWS"
+                    } else {
+                        endorsed_count += 1;
+                        "ENDORSED"
+                    }
+                };
+
+                if store.create_edge(src, tgt, edge_type).is_ok() {
+                    edge_count += 1;
+                }
             }
         }
     }
@@ -224,8 +223,7 @@ async fn main() {
     println!("Step 2: Influencer Identification (PageRank)");
     println!("------------------------------------------------------------------------");
 
-    let view = build_view(&store, None, None, None);
-    let scores = page_rank(&view, PageRankConfig::default());
+    let scores = client.page_rank(PageRankConfig::default(), None, None).await;
 
     // Sort by PageRank score descending
     let mut ranked: Vec<(u64, f64)> = scores.iter().map(|(&id, &s)| (id, s)).collect();
@@ -237,28 +235,31 @@ async fn main() {
     println!("  | Rank | Name                       | Company          | Community        | PageRank  |");
     println!("  +------+----------------------------+------------------+------------------+-----------+");
 
-    for (rank, &(node_id, score)) in ranked.iter().take(10).enumerate() {
-        let graph_nid = samyama::graph::NodeId::new(node_id);
-        let nodes = store.all_nodes();
-        let node = nodes.iter().find(|n| n.id == graph_nid).unwrap();
+    {
+        let store = client.store_read().await;
+        for (rank, &(node_id, score)) in ranked.iter().take(10).enumerate() {
+            let graph_nid = NodeId::new(node_id);
+            let nodes = store.all_nodes();
+            let node = nodes.iter().find(|n| n.id == graph_nid).unwrap();
 
-        let name = match node.get_property("name") {
-            Some(PropertyValue::String(s)) => s.clone(),
-            _ => "Unknown".to_string(),
-        };
-        let company = match node.get_property("company") {
-            Some(PropertyValue::String(s)) => s.clone(),
-            _ => "Unknown".to_string(),
-        };
-        let community = match node.get_property("community") {
-            Some(PropertyValue::String(s)) => s.clone(),
-            _ => "Unknown".to_string(),
-        };
+            let name = match node.get_property("name") {
+                Some(PropertyValue::String(s)) => s.clone(),
+                _ => "Unknown".to_string(),
+            };
+            let company = match node.get_property("company") {
+                Some(PropertyValue::String(s)) => s.clone(),
+                _ => "Unknown".to_string(),
+            };
+            let community = match node.get_property("community") {
+                Some(PropertyValue::String(s)) => s.clone(),
+                _ => "Unknown".to_string(),
+            };
 
-        println!(
-            "  | {:>4} | {:<26} | {:<16} | {:<16} | {:>9.4} |",
-            rank + 1, name, company, community, score
-        );
+            println!(
+                "  | {:>4} | {:<26} | {:<16} | {:<16} | {:>9.4} |",
+                rank + 1, name, company, community, score
+            );
+        }
     }
     println!("  +------+----------------------------+------------------+------------------+-----------+");
     println!();
@@ -269,10 +270,10 @@ async fn main() {
     println!("Step 3: Community Detection (Weakly Connected Components)");
     println!("------------------------------------------------------------------------");
 
-    let wcc = weakly_connected_components(&view);
+    let view = client.build_view(None, None, None).await;
+    let wcc = client.weakly_connected_components(None, None).await;
     let num_wcc = wcc.components.len();
 
-    // Compute component sizes
     let mut comp_sizes: Vec<(usize, usize)> = wcc.components.iter()
         .map(|(&comp_id, members)| (comp_id, members.len()))
         .collect();
@@ -294,7 +295,7 @@ async fn main() {
             "  | {:>10} | {:>6} | {:<41} |",
             idx + 1, size, bar
         );
-        let _ = comp_id; // used for iteration
+        let _ = comp_id;
     }
     println!("  +------------+--------+-------------------------------------------+");
 
@@ -312,7 +313,7 @@ async fn main() {
     println!("Step 4: Echo Chamber Analysis (Strongly Connected Components)");
     println!("------------------------------------------------------------------------");
 
-    let scc = strongly_connected_components(&view);
+    let scc = client.strongly_connected_components(None, None).await;
     let num_scc = scc.components.len();
 
     let mut scc_sizes: Vec<(usize, usize)> = scc.components.iter()
@@ -360,7 +361,8 @@ async fn main() {
 
     let top_influencer_id = ranked[0].0;
     let top_name = {
-        let graph_nid = samyama::graph::NodeId::new(top_influencer_id);
+        let store = client.store_read().await;
+        let graph_nid = NodeId::new(top_influencer_id);
         let nodes = store.all_nodes();
         let node = nodes.iter().find(|n| n.id == graph_nid).unwrap();
         match node.get_property("name") {
@@ -369,17 +371,13 @@ async fn main() {
         }
     };
 
-    // BFS requires (source, target). We try multiple candidates from the bottom half
-    // of the ranking to find a reachable target that demonstrates path traversal.
     let mut bfs_result = None;
-    let mut chosen_target_id = 0u64;
     let mid = ranked.len() / 2;
     for &(candidate_id, _) in ranked[mid..].iter().take(50) {
         if candidate_id == top_influencer_id {
             continue;
         }
-        if let Some(path) = bfs(&view, top_influencer_id, candidate_id) {
-            chosen_target_id = candidate_id;
+        if let Some(path) = client.bfs(top_influencer_id, candidate_id, None, None).await {
             bfs_result = Some(path);
             break;
         }
@@ -407,10 +405,10 @@ async fn main() {
             println!("  +----------+-------------------------------------------+");
             println!();
 
-            // Show first few nodes in the path
             println!("  Path trace (first 6 hops):");
+            let store = client.store_read().await;
             for (step, &nid) in path.path.iter().take(6).enumerate() {
-                let graph_nid = samyama::graph::NodeId::new(nid);
+                let graph_nid = NodeId::new(nid);
                 let nodes = store.all_nodes();
                 let node = nodes.iter().find(|n| n.id == graph_nid).unwrap();
                 let name = match node.get_property("name") {
@@ -446,19 +444,16 @@ async fn main() {
         .sum();
     let avg_degree = total_degree as f64 / view.node_count as f64;
 
-    // Max degree
     let max_degree = (0..view.node_count)
         .map(|idx| view.out_degree(idx) + view.in_degree(idx))
         .max()
         .unwrap_or(0);
 
-    // Min degree
     let min_degree = (0..view.node_count)
         .map(|idx| view.out_degree(idx) + view.in_degree(idx))
         .min()
         .unwrap_or(0);
 
-    // Degree distribution histogram
     let mut degree_dist: HashMap<usize, usize> = HashMap::new();
     for idx in 0..view.node_count {
         let deg = view.out_degree(idx) + view.in_degree(idx);
@@ -475,7 +470,6 @@ async fn main() {
         if k < 2 {
             continue;
         }
-        // Count edges between neighbors
         let mut triangles = 0;
         for i in 0..k {
             let ni_successors = view.successors(neighbors[i]);
@@ -497,7 +491,7 @@ async fn main() {
         0.0
     };
 
-    // Diameter estimate via BFS from a few nodes
+    // Diameter estimate via BFS
     let mut max_path_len: usize = 0;
     let sample_nodes = [0usize, NUM_USERS / 4, NUM_USERS / 2, 3 * NUM_USERS / 4, NUM_USERS - 1];
     for &src_idx in &sample_nodes {
@@ -505,13 +499,12 @@ async fn main() {
             continue;
         }
         let src_id = view.index_to_node[src_idx];
-        // Try reaching a few distant nodes
         for &tgt_idx in &sample_nodes {
             if tgt_idx >= view.node_count || src_idx == tgt_idx {
                 continue;
             }
             let tgt_id = view.index_to_node[tgt_idx];
-            if let Some(result) = bfs(&view, src_id, tgt_id) {
+            if let Some(result) = samyama_sdk::bfs(&view, src_id, tgt_id) {
                 let hops = result.cost as usize;
                 if hops > max_path_len {
                     max_path_len = hops;
@@ -545,7 +538,7 @@ async fn main() {
     println!("  +-------------------------------+-------------------+");
     println!();
 
-    // Degree distribution (top buckets)
+    // Degree distribution
     let mut deg_buckets: Vec<(usize, usize)> = degree_dist.into_iter().collect();
     deg_buckets.sort_by_key(|&(deg, _)| deg);
     println!("  Degree Distribution (sampled buckets):");
@@ -572,12 +565,15 @@ async fn main() {
 
     // Build node index -> community_idx mapping
     let mut node_community: HashMap<u64, usize> = HashMap::new();
-    for node in store.all_nodes() {
-        let cidx = match node.get_property("community_idx") {
-            Some(PropertyValue::Integer(v)) => *v as usize,
-            _ => 0,
-        };
-        node_community.insert(node.id.as_u64(), cidx);
+    {
+        let store = client.store_read().await;
+        for node in store.all_nodes() {
+            let cidx = match node.get_property("community_idx") {
+                Some(PropertyValue::Integer(v)) => *v as usize,
+                _ => 0,
+            };
+            node_community.insert(node.id.as_u64(), cidx);
+        }
     }
 
     // Initialize positions randomly
@@ -590,14 +586,10 @@ async fn main() {
 
     println!("  Running 100 physics iterations on {} nodes...", view.node_count);
 
-    // Force-directed layout: 100 iterations
-    // For performance with 2000 nodes, use sampling for repulsion
     for iter in 0..100 {
         let mut forces: Vec<Vec2> = vec![Vec2 { x: 0.0, y: 0.0 }; view.node_count];
-        let temperature = 10.0 * (1.0 - iter as f64 / 100.0); // cooling
+        let temperature = 10.0 * (1.0 - iter as f64 / 100.0);
 
-        // Repulsion: sample pairs for O(N*k) instead of O(N^2)
-        // Each node repels ~50 random others
         let repulsion_samples = 50;
         for i in 0..view.node_count {
             for _ in 0..repulsion_samples {
@@ -614,7 +606,6 @@ async fn main() {
             }
         }
 
-        // Attraction along edges
         for u_idx in 0..view.node_count {
             for &v_idx in view.successors(u_idx) {
                 let dx = positions[v_idx].x - positions[u_idx].x;
@@ -632,16 +623,13 @@ async fn main() {
             }
         }
 
-        // Apply forces with temperature-based clamping
         for i in 0..view.node_count {
             positions[i].x += forces[i].x.clamp(-temperature, temperature);
             positions[i].y += forces[i].y.clamp(-temperature, temperature);
 
-            // Center gravity
             positions[i].x += (500.0 - positions[i].x) * 0.01;
             positions[i].y += (500.0 - positions[i].y) * 0.01;
 
-            // Keep in bounds
             positions[i].x = positions[i].x.clamp(20.0, 980.0);
             positions[i].y = positions[i].y.clamp(20.0, 980.0);
         }
@@ -654,11 +642,9 @@ async fn main() {
     svg.push_str(r#"<svg width="1000" height="1000" xmlns="http://www.w3.org/2000/svg" style="background-color: #0f172a;">"#);
     svg.push('\n');
 
-    // Title
     svg.push_str(r##"<text x="500" y="30" text-anchor="middle" fill="#e2e8f0" font-family="sans-serif" font-size="18" font-weight="bold">Samyama Social Network - Tech Professional Community (2000 nodes)</text>"##);
     svg.push('\n');
 
-    // Legend
     for (ci, &color) in COMMUNITY_COLORS.iter().enumerate() {
         let lx = 20 + (ci % 5) * 200;
         let ly = 960 + (ci / 5) * 20;
@@ -669,38 +655,40 @@ async fn main() {
         svg.push('\n');
     }
 
-    // Draw edges (low opacity)
-    let edge_colors: HashMap<&str, &str> = HashMap::from([
-        ("FOLLOWS", "#334155"),
-        ("COLLABORATES", "#1e3a5f"),
-        ("ENDORSED", "#3f2a1e"),
-    ]);
+    // Draw edges
+    {
+        let store = client.store_read().await;
+        let edge_colors: HashMap<&str, &str> = HashMap::from([
+            ("FOLLOWS", "#334155"),
+            ("COLLABORATES", "#1e3a5f"),
+            ("ENDORSED", "#3f2a1e"),
+        ]);
 
-    for node in store.all_nodes() {
-        let src_id = node.id.as_u64();
-        if let Some(&src_idx) = view.node_to_index.get(&src_id) {
-            for edge in store.get_outgoing_edges(node.id) {
-                let tgt_id = edge.target.as_u64();
-                if let Some(&tgt_idx) = view.node_to_index.get(&tgt_id) {
-                    let color = edge_colors
-                        .get(edge.edge_type.as_str())
-                        .unwrap_or(&"#334155");
-                    svg.push_str(&format!(
-                        r##"<line x1="{:.1}" y1="{:.1}" x2="{:.1}" y2="{:.1}" stroke="{}" stroke-width="0.3" opacity="0.4"/>"##,
-                        positions[src_idx].x,
-                        positions[src_idx].y,
-                        positions[tgt_idx].x,
-                        positions[tgt_idx].y,
-                        color
-                    ));
-                    svg.push('\n');
+        for node in store.all_nodes() {
+            let src_id = node.id.as_u64();
+            if let Some(&src_idx) = view.node_to_index.get(&src_id) {
+                for edge in store.get_outgoing_edges(node.id) {
+                    let tgt_id = edge.target.as_u64();
+                    if let Some(&tgt_idx) = view.node_to_index.get(&tgt_id) {
+                        let color = edge_colors
+                            .get(edge.edge_type.as_str())
+                            .unwrap_or(&"#334155");
+                        svg.push_str(&format!(
+                            r##"<line x1="{:.1}" y1="{:.1}" x2="{:.1}" y2="{:.1}" stroke="{}" stroke-width="0.3" opacity="0.4"/>"##,
+                            positions[src_idx].x,
+                            positions[src_idx].y,
+                            positions[tgt_idx].x,
+                            positions[tgt_idx].y,
+                            color
+                        ));
+                        svg.push('\n');
+                    }
                 }
             }
         }
     }
 
-    // Draw nodes (sized by PageRank, colored by community)
-    // Normalize PageRank for radius
+    // Draw nodes
     let pr_range = (pr_max - pr_min).max(0.001);
 
     for idx in 0..view.node_count {
@@ -709,7 +697,7 @@ async fn main() {
         let color = COMMUNITY_COLORS[cidx % COMMUNITY_COLORS.len()];
         let rank_score = scores.get(&nid).unwrap_or(&pr_avg);
         let normalized = (rank_score - pr_min) / pr_range;
-        let radius = 1.5 + normalized * 6.0; // 1.5 to 7.5
+        let radius = 1.5 + normalized * 6.0;
 
         svg.push_str(&format!(
             r##"<circle cx="{:.1}" cy="{:.1}" r="{:.1}" fill="{}" stroke="#1e293b" stroke-width="0.5" opacity="0.85"/>"##,
@@ -718,26 +706,29 @@ async fn main() {
         svg.push('\n');
     }
 
-    // Highlight top 5 influencers with labels
-    for (rank, &(nid, _score)) in ranked.iter().take(5).enumerate() {
-        if let Some(&idx) = view.node_to_index.get(&nid) {
-            let graph_nid = samyama::graph::NodeId::new(nid);
-            let nodes = store.all_nodes();
-            let node = nodes.iter().find(|n| n.id == graph_nid).unwrap();
-            let name = match node.get_property("name") {
-                Some(PropertyValue::String(s)) => s.clone(),
-                _ => "?".to_string(),
-            };
+    // Highlight top 5 influencers
+    {
+        let store = client.store_read().await;
+        for (rank, &(nid, _score)) in ranked.iter().take(5).enumerate() {
+            if let Some(&idx) = view.node_to_index.get(&nid) {
+                let graph_nid = NodeId::new(nid);
+                let nodes = store.all_nodes();
+                let node = nodes.iter().find(|n| n.id == graph_nid).unwrap();
+                let name = match node.get_property("name") {
+                    Some(PropertyValue::String(s)) => s.clone(),
+                    _ => "?".to_string(),
+                };
 
-            svg.push_str(&format!(
-                r##"<circle cx="{:.1}" cy="{:.1}" r="8" fill="none" stroke="#fbbf24" stroke-width="2"/>"##,
-                positions[idx].x, positions[idx].y
-            ));
-            svg.push_str(&format!(
-                r##"<text x="{:.1}" y="{:.1}" fill="#fbbf24" font-family="sans-serif" font-size="9" text-anchor="middle">#{} {}</text>"##,
-                positions[idx].x, positions[idx].y - 12.0, rank + 1, name
-            ));
-            svg.push('\n');
+                svg.push_str(&format!(
+                    r##"<circle cx="{:.1}" cy="{:.1}" r="8" fill="none" stroke="#fbbf24" stroke-width="2"/>"##,
+                    positions[idx].x, positions[idx].y
+                ));
+                svg.push_str(&format!(
+                    r##"<text x="{:.1}" y="{:.1}" fill="#fbbf24" font-family="sans-serif" font-size="9" text-anchor="middle">#{} {}</text>"##,
+                    positions[idx].x, positions[idx].y - 12.0, rank + 1, name
+                ));
+                svg.push('\n');
+            }
         }
     }
 
@@ -771,7 +762,7 @@ async fn main() {
             system_prompt: Some("You are a Cypher query expert for a social network graph.".to_string()),
         };
 
-        let tenant_mgr = TenantManager::new();
+        let tenant_mgr = client.tenant_manager();
         tenant_mgr.create_tenant("social_nlq".to_string(), "Social NLQ".to_string(), None).unwrap();
         tenant_mgr.update_nlq_config("social_nlq", Some(nlq_config.clone())).unwrap();
 
@@ -780,7 +771,7 @@ async fn main() {
                               Properties: User(name, company['Google'/'Meta'/'Apple'/'Amazon'/'Microsoft'/'Netflix'/'Stripe'/'Airbnb'/'Uber'/etc.], primary_skill, community['AI/ML Engineers'/'Frontend Developers'/'Backend Engineers'/'DevOps/SRE'/'Data Engineers'/'Mobile Developers'/'Security Engineers'/'Product Managers'/'UX Designers'/'QA Engineers'], years_experience)\n\
                               Notes: Follower counts are computed from FOLLOWS edges, not stored as properties. Filter by community or primary_skill, not role/specialty.";
 
-        let nlq_pipeline = NLQPipeline::new(nlq_config).unwrap();
+        let nlq_pipeline = client.nlq_pipeline(nlq_config).unwrap();
 
         let nlq_questions = vec![
             "Who are the most followed AI/ML engineers at Google?",
@@ -792,8 +783,8 @@ async fn main() {
             match nlq_pipeline.text_to_cypher(question, schema_summary).await {
                 Ok(cypher) => {
                     println!("  Generated Cypher: {}", cypher);
-                    match engine.execute(&cypher, &store) {
-                        Ok(batch) => println!("  Results: {} records", batch.len()),
+                    match client.query_readonly("default", &cypher).await {
+                        Ok(result) => println!("  Results: {} records", result.len()),
                         Err(e) => println!("  Execution error: {}", e),
                     }
                 }


### PR DESCRIPTION
## Summary
- Add `AlgorithmClient` extension trait (PageRank, WCC, SCC, BFS, Dijkstra, Edmonds-Karp, Prim MST, triangle count) with 3 unit tests
- Add `VectorClient` extension trait (create index, add vector, k-NN search) with 1 unit test
- Add factory methods on `EmbeddedClient`: `nlq_pipeline()`, `agent_runtime()`, `persistence_manager()`, `tenant_manager()`, `store_read()`, `store_write()`
- Re-export optimization types (Jaya, Cuckoo, NSGA2, etc.) and ndarray from samyama-sdk
- Migrate all 10 domain examples from direct `samyama::*` imports to `samyama_sdk::*`
- Add `docs/SDK_API_CLI_ARCHITECTURE.md` documenting SDK/API/CLI connection architecture

## Migrated Examples
| Example | Features Used |
|---------|-------------|
| `sdk_demo.rs` | AlgorithmClient, VectorClient |
| `social_network_demo.rs` | Algo (PR/WCC/SCC/BFS), NLQ |
| `agentic_enrichment_demo.rs` | NLQ, Agent |
| `banking_demo.rs` | Persistence, NLQ |
| `persistence_demo.rs` | Persistence, Tenant |
| `knowledge_graph_demo.rs` | Algo, Vector, NLQ, Agent |
| `clinical_trials_demo.rs` | Algo, Vector, NSGA2, NLQ, Agent |
| `supply_chain_demo.rs` | Algo, Vector, Jaya, NLQ, Agent |
| `smart_manufacturing_demo.rs` | Algo, Cuckoo+Jaya, NLQ |
| `enterprise_soc_demo.rs` | Algo (Dijkstra), Vector, Persistence, NLQ, Agent |

## Test plan
- [x] `cargo test --lib` — 248 tests pass
- [x] `cargo test -p samyama-sdk` — 11 unit tests + 2 doc-tests pass
- [x] `cargo check --examples` — all 15 examples compile
- [x] `cargo bench --no-run` — benchmarks compile in release mode