### PR TITLE
chore: bump all versions to v0.5.8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Samyama is a high-performance distributed graph database written in Rust with ~90% OpenCypher query support, Redis protocol (RESP) compatibility, multi-tenancy, vector search, NLQ, and graph algorithms. Currently at Phase 4 (High Availability Foundation), version v0.5.4.
+Samyama is a high-performance distributed graph database written in Rust with ~90% OpenCypher query support, Redis protocol (RESP) compatibility, multi-tenancy, vector search, NLQ, and graph algorithms. Currently at Phase 4 (High Availability Foundation), version v0.5.8.
 
 ## Build & Development Commands
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "samyama"
-version = "0.5.0-alpha.1"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "samyama-cli"
-version = "0.5.0-alpha.1"
+version = "0.5.8"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2633,14 +2633,14 @@ dependencies = [
 
 [[package]]
 name = "samyama-graph-algorithms"
-version = "0.5.0-alpha.1"
+version = "0.5.8"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "samyama-optimization"
-version = "0.5.0-alpha.1"
+version = "0.5.8"
 dependencies = [
  "criterion",
  "ndarray",
@@ -2653,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "samyama-sdk"
-version = "0.5.0-alpha.1"
+version = "0.5.8"
 dependencies = [
  "async-trait",
  "ndarray",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["sdk/python"]
 
 [package]
 name = "samyama"
-version = "0.5.0-alpha.1"
+version = "0.5.8"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "High-performance distributed graph database with OpenCypher support"
@@ -68,15 +68,15 @@ rand = "0.8"
 regex = "1"
 
 # Optimization Engine (Phase 7)
-samyama-optimization = { path = "crates/samyama-optimization", version = "0.5.0-alpha.1" }
-samyama-graph-algorithms = { path = "crates/samyama-graph-algorithms", version = "0.5.0-alpha.1" }
+samyama-optimization = { path = "crates/samyama-optimization", version = "0.5.8" }
+samyama-graph-algorithms = { path = "crates/samyama-graph-algorithms", version = "0.5.8" }
 ndarray = "0.15"
 reqwest = { version = "0.13.1", features = ["json"] }
 
 [dev-dependencies]
 tempfile = "3.8"
 criterion = "0.5"
-samyama-sdk = { path = "crates/samyama-sdk", version = "0.5.0-alpha.1" }
+samyama-sdk = { path = "crates/samyama-sdk", version = "0.5.8" }
 
 [[bench]]
 name = "graph_benchmarks"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Samyama Graph Database API
-  version: 0.5.0-alpha.1
+  version: 0.5.8
   description: |
     HTTP API for the Samyama high-performance distributed graph database.
     Supports OpenCypher queries, graph status, and CRUD operations.
@@ -72,7 +72,7 @@ paths:
                 $ref: '#/components/schemas/StatusResponse'
               example:
                 status: healthy
-                version: 0.5.0-alpha.1
+                version: 0.5.8
                 storage:
                   nodes: 2000
                   edges: 11000
@@ -163,7 +163,7 @@ components:
           type: string
           description: Server version
           examples:
-            - 0.5.0-alpha.1
+            - 0.5.8
         storage:
           type: object
           properties:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-cli"
-version = "0.5.0-alpha.1"
+version = "0.5.8"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "CLI for Samyama Graph Database"
@@ -12,7 +12,7 @@ name = "samyama-cli"
 path = "src/main.rs"
 
 [dependencies]
-samyama-sdk = { path = "../crates/samyama-sdk", version = "0.5.0-alpha.1" }
+samyama-sdk = { path = "../crates/samyama-sdk", version = "0.5.8" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/crates/samyama-graph-algorithms/Cargo.toml
+++ b/crates/samyama-graph-algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-graph-algorithms"
-version = "0.5.0-alpha.1"
+version = "0.5.8"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Graph algorithms (PageRank, WCC, BFS, Dijkstra) for Samyama Graph Database"

--- a/crates/samyama-optimization/Cargo.toml
+++ b/crates/samyama-optimization/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-optimization"
-version = "0.5.0-alpha.1"
+version = "0.5.8"
 edition = "2021"
 authors = ["Sandeep Kunkunuru <sandeep@samyama.ai>"]
 description = "High-performance metaheuristic optimization algorithms (Jaya, Rao, TLBO, BMR, BWR, QOJaya, ITLBO) in Rust."

--- a/crates/samyama-sdk/Cargo.toml
+++ b/crates/samyama-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-sdk"
-version = "0.5.0-alpha.1"
+version = "0.5.8"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Client SDK for Samyama Graph Database — embedded and remote modes"
@@ -25,13 +25,13 @@ reqwest = { version = "0.13.1", features = ["json"] }
 thiserror = "1.0"
 
 # Core graph database (for EmbeddedClient)
-samyama = { path = "../..", version = "0.5.0-alpha.1" }
+samyama = { path = "../..", version = "0.5.8" }
 
 # Graph algorithms (for AlgorithmClient)
-samyama-graph-algorithms = { path = "../samyama-graph-algorithms", version = "0.5.0-alpha.1" }
+samyama-graph-algorithms = { path = "../samyama-graph-algorithms", version = "0.5.8" }
 
 # Optimization engine (re-exported for examples)
-samyama-optimization = { path = "../samyama-optimization", version = "0.5.0-alpha.1" }
+samyama-optimization = { path = "../samyama-optimization", version = "0.5.8" }
 
 # Numeric arrays (re-exported for optimization problems)
 ndarray = "0.15"

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "samyama-python"
-version = "0.5.0-alpha.1"
+version = "0.5.8"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Python bindings for the Samyama Graph Database SDK"
@@ -14,6 +14,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.22", features = ["extension-module"] }
-samyama-sdk = { path = "../../crates/samyama-sdk", version = "0.5.0-alpha.1" }
+samyama-sdk = { path = "../../crates/samyama-sdk", version = "0.5.8" }
 tokio = { version = "1.35", features = ["rt-multi-thread"] }
 serde_json = "1.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "samyama"
-version = "0.5.0a1"
+version = "0.5.8"
 description = "Python SDK for the Samyama Graph Database"
 requires-python = ">=3.8"
 license = {text = "Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "samyama-sdk",
-  "version": "0.5.0-alpha.1",
+  "version": "0.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "samyama-sdk",
-      "version": "0.5.0-alpha.1",
+      "version": "0.5.8",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samyama-sdk",
-  "version": "0.5.0-alpha.1",
+  "version": "0.5.8",
   "description": "TypeScript SDK for the Samyama Graph Database",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,6 @@ mod tests {
     fn test_version() {
         let ver = version();
         assert!(!ver.is_empty());
-        assert_eq!(ver, "0.5.0-alpha.1");
+        assert_eq!(ver, "0.5.8");
     }
 }


### PR DESCRIPTION
## Summary
- Bumps all package versions from `0.5.0-alpha.1` to `0.5.8` across 13 files
- Root crate, CLI, Rust SDK, graph-algorithms, optimization, Python SDK, TypeScript SDK, OpenAPI spec, CLAUDE.md

## Test plan
- [x] `cargo test test_version --lib` passes
- [x] `cargo check` compiles