### PR TITLE
fix: route CALL statements to MutQueryExecutor in SDK

### DIFF
--- a/crates/samyama-sdk/src/embedded.rs
+++ b/crates/samyama-sdk/src/embedded.rs
@@ -232,10 +232,12 @@ fn is_write_query(cypher: &str) -> bool {
         || upper.starts_with("DELETE")
         || upper.starts_with("SET")
         || upper.starts_with("MERGE")
+        || upper.starts_with("CALL")
         || upper.contains(" CREATE ")
         || upper.contains(" DELETE ")
         || upper.contains(" SET ")
         || upper.contains(" MERGE ")
+        || upper.contains(" CALL ")
 }
 
 #[async_trait]


### PR DESCRIPTION
## Summary
- Fix `is_write_query()` in SDK to recognize `CALL` statements as write queries
- Without this fix, `CALL algo.or.solve(...)` was dispatched to the read-only executor, causing `smart_manufacturing_demo` to panic

## Test plan
- [x] `cargo test -p samyama-sdk` — all 11 tests + 2 doc-tests pass
- [x] `cargo run --example smart_manufacturing_demo` — runs to completion