### PR TITLE
fix: LRU AST cache + shared QueryEngine for HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,6 +835,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,6 +1040,17 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.12",
  "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -1526,6 +1543,15 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -2587,6 +2613,7 @@ dependencies = [
  "criterion",
  "hnsw_rs",
  "indexmap",
+ "lru",
  "mime",
  "ndarray",
  "openraft",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ mime = "0.3"               # MIME types
 hnsw_rs = "0.2.1"
 rand = "0.8"
 regex = "1"
+lru = "0.12"
 
 # Optimization Engine (Phase 7)
 samyama-optimization = { path = "crates/samyama-optimization", version = "0.5.8" }

--- a/crates/samyama-sdk/src/embedded.rs
+++ b/crates/samyama-sdk/src/embedded.rs
@@ -87,6 +87,11 @@ impl EmbeddedClient {
     pub fn tenant_manager(&self) -> samyama::TenantManager {
         samyama::TenantManager::new()
     }
+
+    /// Return AST cache statistics (hits, misses).
+    pub fn cache_stats(&self) -> &samyama::query::CacheStats {
+        self.engine.cache_stats()
+    }
 }
 
 impl Default for EmbeddedClient {

--- a/crates/samyama-sdk/src/lib.rs
+++ b/crates/samyama-sdk/src/lib.rs
@@ -68,7 +68,7 @@ pub use samyama::graph::{
     PropertyValue, PropertyMap,
     GraphError, GraphResult,
 };
-pub use samyama::query::{QueryEngine, RecordBatch};
+pub use samyama::query::{QueryEngine, RecordBatch, CacheStats};
 
 // ============================================================
 // Algorithm types (re-exported from samyama-graph-algorithms)

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -4,12 +4,10 @@ use axum::{
     extract::{State, Json},
     response::IntoResponse,
 };
-use crate::graph::GraphStore;
-use crate::query::{QueryEngine, Value};
+use crate::query::Value;
+use crate::http::server::AppState;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::sync::Arc;
-use tokio::sync::RwLock;
 use std::collections::HashMap;
 
 /// Request for executing a Cypher query
@@ -29,23 +27,21 @@ pub struct QueryResponse {
 
 /// Handler for Cypher queries
 pub async fn query_handler(
-    State(store): State<Arc<RwLock<GraphStore>>>,
+    State(state): State<AppState>,
     Json(payload): Json<QueryRequest>,
 ) -> impl IntoResponse {
-    let engine = QueryEngine::new();
-    
     // Check if query is write or read
     let query_upper = payload.query.trim().to_uppercase();
-    let is_write = query_upper.starts_with("CREATE") || 
-                   query_upper.starts_with("SET") || 
+    let is_write = query_upper.starts_with("CREATE") ||
+                   query_upper.starts_with("SET") ||
                    query_upper.starts_with("DELETE");
 
     let result = if is_write {
-        let mut store_guard = store.write().await;
-        engine.execute_mut(&payload.query, &mut *store_guard, "default")
+        let mut store_guard = state.store.write().await;
+        state.engine.execute_mut(&payload.query, &mut *store_guard, "default")
     } else {
-        let store_guard = store.read().await;
-        engine.execute(&payload.query, &*store_guard)
+        let store_guard = state.store.read().await;
+        state.engine.execute(&payload.query, &*store_guard)
     };
 
     match result {
@@ -136,15 +132,21 @@ pub async fn query_handler(
 
 /// Handler for system status
 pub async fn status_handler(
-    State(store): State<Arc<RwLock<GraphStore>>>,
+    State(state): State<AppState>,
 ) -> impl IntoResponse {
-    let store_guard = store.read().await;
+    let store_guard = state.store.read().await;
+    let stats = state.engine.cache_stats();
     Json(json!({
         "status": "healthy",
         "version": crate::VERSION,
         "storage": {
             "nodes": store_guard.node_count(),
             "edges": store_guard.edge_count(),
+        },
+        "cache": {
+            "hits": stats.hits(),
+            "misses": stats.misses(),
+            "size": state.engine.cache_len(),
         }
     }))
 }

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -6,6 +6,7 @@ use axum::{
     response::{Html, IntoResponse},
 };
 use crate::graph::GraphStore;
+use crate::query::QueryEngine;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tower_http::cors::CorsLayer;
@@ -27,6 +28,13 @@ async fn static_handler() -> impl IntoResponse {
     }
 }
 
+/// Shared application state for HTTP routes
+#[derive(Clone)]
+pub struct AppState {
+    pub store: Arc<RwLock<GraphStore>>,
+    pub engine: Arc<QueryEngine>,
+}
+
 /// HTTP server managing the Visualizer API and static assets
 pub struct HttpServer {
     store: Arc<RwLock<GraphStore>>,
@@ -41,20 +49,25 @@ impl HttpServer {
 
     /// Start the HTTP server
     pub async fn start(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let state = AppState {
+            store: Arc::clone(&self.store),
+            engine: Arc::new(QueryEngine::new()),
+        };
+
         let app = Router::new()
             .route("/", get(static_handler))
             .route("/api/query", post(query_handler))
             .route("/api/status", get(status_handler))
             .layer(CorsLayer::permissive())
-            .with_state(Arc::clone(&self.store));
+            .with_state(state);
 
         let addr = format!("0.0.0.0:{}", self.port);
         let listener = tokio::net::TcpListener::bind(&addr).await?;
-        
+
         info!("Visualizer available at http://localhost:{}", self.port);
-        
+
         axum::serve(listener, app).await?;
-        
+
         Ok(())
     }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -14,8 +14,10 @@ pub mod ast;
 pub mod parser;
 pub mod executor;
 
-use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use lru::LruCache;
 
 // Re-export main types
 pub use ast::Query;
@@ -26,44 +28,99 @@ pub use executor::{
     MutQueryExecutor,  // Added for CREATE/DELETE/SET support
 };
 
+/// Default LRU cache capacity
+const DEFAULT_CACHE_CAPACITY: usize = 1024;
+
+/// Lock-free cache hit/miss counters.
+pub struct CacheStats {
+    hits: AtomicU64,
+    misses: AtomicU64,
+}
+
+impl CacheStats {
+    fn new() -> Self {
+        Self {
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+        }
+    }
+
+    /// Total cache hits since engine creation.
+    pub fn hits(&self) -> u64 {
+        self.hits.load(Ordering::Relaxed)
+    }
+
+    /// Total cache misses since engine creation.
+    pub fn misses(&self) -> u64 {
+        self.misses.load(Ordering::Relaxed)
+    }
+
+    fn record_hit(&self) {
+        self.hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_miss(&self) {
+        self.misses.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
 /// Query engine - high-level interface for executing queries
 ///
-/// Includes an AST cache that eliminates repeated parsing overhead
+/// Includes an LRU AST cache that eliminates repeated parsing overhead
 /// for identical queries. The cache is keyed by whitespace-normalized
-/// query strings.
+/// query strings and evicts least-recently-used entries when full.
 pub struct QueryEngine {
     /// Parsed AST cache: normalized query string -> Query AST
-    ast_cache: Mutex<HashMap<String, Query>>,
+    ast_cache: Mutex<LruCache<String, Query>>,
+    /// Lock-free hit/miss counters
+    stats: CacheStats,
 }
 
 impl QueryEngine {
-    /// Create a new query engine
+    /// Create a new query engine with the default cache capacity (1024 entries)
     pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_CACHE_CAPACITY)
+    }
+
+    /// Create a new query engine with a specific cache capacity
+    pub fn with_capacity(capacity: usize) -> Self {
+        let cap = NonZeroUsize::new(capacity).unwrap_or(NonZeroUsize::new(1).unwrap());
         Self {
-            ast_cache: Mutex::new(HashMap::new()),
+            ast_cache: Mutex::new(LruCache::new(cap)),
+            stats: CacheStats::new(),
         }
+    }
+
+    /// Return a reference to the cache statistics (hits/misses).
+    pub fn cache_stats(&self) -> &CacheStats {
+        &self.stats
+    }
+
+    /// Return the current number of entries in the cache.
+    pub fn cache_len(&self) -> usize {
+        self.ast_cache.lock().unwrap().len()
     }
 
     /// Parse with caching — normalizes whitespace for cache hits
     fn cached_parse(&self, query_str: &str) -> Result<Query, Box<dyn std::error::Error>> {
         let normalized = query_str.split_whitespace().collect::<Vec<_>>().join(" ");
 
-        // Check cache
+        // Check cache (LruCache::get promotes to most-recently-used)
         {
-            let cache = self.ast_cache.lock().unwrap();
+            let mut cache = self.ast_cache.lock().unwrap();
             if let Some(cached) = cache.get(&normalized) {
+                self.stats.record_hit();
                 return Ok(cached.clone());
             }
         }
 
-        // Parse and cache
+        self.stats.record_miss();
+
+        // Parse and cache (LRU evicts automatically when full)
         let query = parse_query(query_str)?;
         {
             let mut cache = self.ast_cache.lock().unwrap();
-            if cache.len() > 1024 {
-                cache.clear();
-            }
-            cache.insert(normalized, query.clone());
+            cache.put(normalized, query.clone());
         }
         Ok(query)
     }
@@ -407,5 +464,54 @@ mod tests {
         );
         assert!(likes_result.is_ok());
         assert_eq!(likes_result.unwrap().len(), 1, "Should have 1 LIKES relationship");
+    }
+
+    #[test]
+    fn test_cache_hit_miss_tracking() {
+        let store = GraphStore::new();
+        let engine = QueryEngine::new();
+
+        // First execution — cache miss
+        let _ = engine.execute("MATCH (n:Person) RETURN n", &store);
+        assert_eq!(engine.cache_stats().hits(), 0);
+        assert_eq!(engine.cache_stats().misses(), 1);
+        assert_eq!(engine.cache_len(), 1);
+
+        // Second identical query — cache hit
+        let _ = engine.execute("MATCH (n:Person) RETURN n", &store);
+        assert_eq!(engine.cache_stats().hits(), 1);
+        assert_eq!(engine.cache_stats().misses(), 1);
+
+        // Different query — cache miss
+        let _ = engine.execute("MATCH (n:Movie) RETURN n", &store);
+        assert_eq!(engine.cache_stats().hits(), 1);
+        assert_eq!(engine.cache_stats().misses(), 2);
+        assert_eq!(engine.cache_len(), 2);
+
+        // Whitespace-normalized hit
+        let _ = engine.execute("MATCH  (n:Person)  RETURN  n", &store);
+        assert_eq!(engine.cache_stats().hits(), 2);
+        assert_eq!(engine.cache_stats().misses(), 2);
+    }
+
+    #[test]
+    fn test_lru_eviction() {
+        let store = GraphStore::new();
+        let engine = QueryEngine::with_capacity(2);
+
+        // Fill cache to capacity
+        let _ = engine.execute("MATCH (a:Person) RETURN a", &store);
+        let _ = engine.execute("MATCH (b:Movie) RETURN b", &store);
+        assert_eq!(engine.cache_len(), 2);
+
+        // Third distinct query should evict the LRU entry
+        let _ = engine.execute("MATCH (c:Company) RETURN c", &store);
+        assert_eq!(engine.cache_len(), 2); // Still 2, not 3
+
+        // The first query should have been evicted (was LRU)
+        let _ = engine.execute("MATCH (a:Person) RETURN a", &store);
+        // If evicted: miss count goes up; if still cached: hit count goes up
+        // We had 3 misses so far, this should be a 4th miss
+        assert_eq!(engine.cache_stats().misses(), 4);
     }
 }


### PR DESCRIPTION
## Summary
- Replace per-request `QueryEngine::new()` in HTTP handlers with a shared `Arc<QueryEngine>` in `AppState` — AST cache now persists across requests
- Replace `HashMap` + clear-at-1024 eviction with `lru::LruCache` (proper LRU semantics)
- Add lock-free `CacheStats` (hit/miss counters) exposed via `/api/status` and SDK `EmbeddedClient::cache_stats()`

## Test plan
- [x] `cargo test` — all 250 unit tests pass (pre-existing `test_create_vector_index_query` failure is unrelated)
- [x] New tests: `test_cache_hit_miss_tracking`, `test_lru_eviction`
- [ ] Manual: start server, POST `/api/query` twice with same query, GET `/api/status` shows cache hits > 0