### PR TITLE
feat: complete LDBC benchmark coverage (4 benchmarks, 87 queries)

### DIFF
--- a/crates/samyama-graph-algorithms/src/cdlp.rs
+++ b/crates/samyama-graph-algorithms/src/cdlp.rs
@@ -1,0 +1,150 @@
+//! Community Detection via Label Propagation (CDLP)
+//!
+//! Synchronous label propagation algorithm for community detection.
+//! Each node starts with its own ID as label, then iteratively sets its
+//! label to the most frequent label among its neighbors.
+
+use super::common::{GraphView, NodeId};
+use std::collections::HashMap;
+
+/// Result of CDLP algorithm
+#[derive(Debug, Clone)]
+pub struct CdlpResult {
+    /// Mapping from NodeId to community label
+    pub labels: HashMap<NodeId, NodeId>,
+    /// Number of iterations until convergence
+    pub iterations: usize,
+}
+
+/// Configuration for CDLP
+pub struct CdlpConfig {
+    /// Maximum number of iterations
+    pub max_iterations: usize,
+}
+
+impl Default for CdlpConfig {
+    fn default() -> Self {
+        Self {
+            max_iterations: 100,
+        }
+    }
+}
+
+/// Run synchronous CDLP on the given graph view
+///
+/// Returns community labels for each node. Uses undirected edges
+/// (both successors and predecessors).
+pub fn cdlp(view: &GraphView, config: &CdlpConfig) -> CdlpResult {
+    let n = view.node_count;
+    if n == 0 {
+        return CdlpResult { labels: HashMap::new(), iterations: 0 };
+    }
+
+    // Initialize: each node gets its own NodeId as label
+    let mut labels: Vec<NodeId> = (0..n).map(|i| view.index_to_node[i]).collect();
+    let mut new_labels = labels.clone();
+    let mut converged = false;
+    let mut iterations = 0;
+
+    for _iter in 0..config.max_iterations {
+        converged = true;
+        iterations += 1;
+
+        for idx in 0..n {
+            // Collect neighbor labels (undirected)
+            let mut label_counts: HashMap<NodeId, usize> = HashMap::new();
+            for &neighbor in view.successors(idx) {
+                *label_counts.entry(labels[neighbor]).or_insert(0) += 1;
+            }
+            for &neighbor in view.predecessors(idx) {
+                *label_counts.entry(labels[neighbor]).or_insert(0) += 1;
+            }
+
+            if label_counts.is_empty() {
+                new_labels[idx] = labels[idx];
+                continue;
+            }
+
+            // Pick the most frequent label; break ties by choosing smallest label
+            let max_count = *label_counts.values().max().unwrap();
+            let best_label = label_counts.into_iter()
+                .filter(|(_, count)| *count == max_count)
+                .map(|(label, _)| label)
+                .min()
+                .unwrap();
+
+            if best_label != labels[idx] {
+                converged = false;
+            }
+            new_labels[idx] = best_label;
+        }
+
+        std::mem::swap(&mut labels, &mut new_labels);
+
+        if converged {
+            break;
+        }
+    }
+
+    let result_labels: HashMap<NodeId, NodeId> = (0..n)
+        .map(|idx| (view.index_to_node[idx], labels[idx]))
+        .collect();
+
+    CdlpResult { labels: result_labels, iterations }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use crate::common::GraphView;
+
+    fn make_triangle_graph() -> GraphView {
+        // Triangle: 1-2, 2-3, 1-3
+        let index_to_node = vec![1, 2, 3];
+        let mut node_to_index = HashMap::new();
+        node_to_index.insert(1, 0);
+        node_to_index.insert(2, 1);
+        node_to_index.insert(3, 2);
+
+        let outgoing = vec![vec![1, 2], vec![0, 2], vec![0, 1]];
+        let incoming = vec![vec![1, 2], vec![0, 2], vec![0, 1]];
+
+        GraphView::from_adjacency_list(3, index_to_node, node_to_index, outgoing, incoming, None)
+    }
+
+    #[test]
+    fn test_cdlp_triangle() {
+        let view = make_triangle_graph();
+        let result = cdlp(&view, &CdlpConfig::default());
+        // In a triangle, all nodes should converge to the same label
+        let labels: Vec<NodeId> = result.labels.values().cloned().collect();
+        assert!(labels.iter().all(|l| *l == labels[0]),
+            "All nodes in a triangle should have the same community label");
+    }
+
+    #[test]
+    fn test_cdlp_disconnected() {
+        // Two disconnected nodes: 1 and 2
+        let index_to_node = vec![1, 2];
+        let mut node_to_index = HashMap::new();
+        node_to_index.insert(1, 0);
+        node_to_index.insert(2, 1);
+
+        let view = GraphView::from_adjacency_list(
+            2, index_to_node, node_to_index,
+            vec![vec![], vec![]], vec![vec![], vec![]], None,
+        );
+        let result = cdlp(&view, &CdlpConfig::default());
+        assert_ne!(result.labels[&1], result.labels[&2]);
+    }
+
+    #[test]
+    fn test_cdlp_empty() {
+        let view = GraphView::from_adjacency_list(
+            0, vec![], HashMap::new(), vec![], vec![], None,
+        );
+        let result = cdlp(&view, &CdlpConfig::default());
+        assert!(result.labels.is_empty());
+    }
+}

--- a/crates/samyama-graph-algorithms/src/lcc.rs
+++ b/crates/samyama-graph-algorithms/src/lcc.rs
@@ -1,0 +1,131 @@
+//! Local Clustering Coefficient (LCC)
+//!
+//! Computes the local clustering coefficient for each node.
+//! LCC(v) = 2 * T(v) / (deg(v) * (deg(v) - 1))
+//! where T(v) is the number of triangles containing v.
+
+use super::common::{GraphView, NodeId};
+use std::collections::{HashMap, HashSet};
+
+/// Result of LCC computation
+#[derive(Debug, Clone)]
+pub struct LccResult {
+    /// Clustering coefficient per node
+    pub coefficients: HashMap<NodeId, f64>,
+    /// Global average clustering coefficient
+    pub average: f64,
+}
+
+/// Compute local clustering coefficients for all nodes
+///
+/// Uses undirected edges (union of successors + predecessors).
+pub fn local_clustering_coefficient(view: &GraphView) -> LccResult {
+    let n = view.node_count;
+    if n == 0 {
+        return LccResult { coefficients: HashMap::new(), average: 0.0 };
+    }
+
+    // Build undirected neighbor sets for each node
+    let mut neighbors: Vec<HashSet<usize>> = Vec::with_capacity(n);
+    for idx in 0..n {
+        let mut set = HashSet::new();
+        for &s in view.successors(idx) {
+            if s != idx { set.insert(s); }
+        }
+        for &p in view.predecessors(idx) {
+            if p != idx { set.insert(p); }
+        }
+        neighbors.push(set);
+    }
+
+    let mut coefficients = HashMap::with_capacity(n);
+    let mut sum = 0.0;
+
+    for idx in 0..n {
+        let deg = neighbors[idx].len();
+        if deg < 2 {
+            coefficients.insert(view.index_to_node[idx], 0.0);
+            continue;
+        }
+
+        // Count edges among neighbors
+        let neighbor_vec: Vec<usize> = neighbors[idx].iter().cloned().collect();
+        let mut triangle_edges = 0usize;
+        for i in 0..neighbor_vec.len() {
+            for j in (i + 1)..neighbor_vec.len() {
+                if neighbors[neighbor_vec[i]].contains(&neighbor_vec[j]) {
+                    triangle_edges += 1;
+                }
+            }
+        }
+
+        let max_edges = deg * (deg - 1) / 2;
+        let cc = triangle_edges as f64 / max_edges as f64;
+        coefficients.insert(view.index_to_node[idx], cc);
+        sum += cc;
+    }
+
+    let average = if n > 0 { sum / n as f64 } else { 0.0 };
+
+    LccResult { coefficients, average }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use crate::common::GraphView;
+
+    #[test]
+    fn test_lcc_triangle() {
+        // Complete triangle: 1-2, 2-3, 1-3
+        let index_to_node = vec![1, 2, 3];
+        let mut node_to_index = HashMap::new();
+        node_to_index.insert(1, 0);
+        node_to_index.insert(2, 1);
+        node_to_index.insert(3, 2);
+
+        let outgoing = vec![vec![1, 2], vec![0, 2], vec![0, 1]];
+        let incoming = vec![vec![1, 2], vec![0, 2], vec![0, 1]];
+
+        let view = GraphView::from_adjacency_list(3, index_to_node, node_to_index, outgoing, incoming, None);
+        let result = local_clustering_coefficient(&view);
+
+        // All nodes in a complete triangle have LCC = 1.0
+        for (_node, cc) in &result.coefficients {
+            assert!((cc - 1.0).abs() < 1e-10, "Complete triangle LCC should be 1.0, got {}", cc);
+        }
+        assert!((result.average - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_lcc_star() {
+        // Star: center 1 connected to 2, 3, 4 (no edges among 2,3,4)
+        let index_to_node = vec![1, 2, 3, 4];
+        let mut node_to_index = HashMap::new();
+        for (i, &id) in index_to_node.iter().enumerate() {
+            node_to_index.insert(id, i);
+        }
+
+        let outgoing = vec![vec![1, 2, 3], vec![0], vec![0], vec![0]];
+        let incoming = vec![vec![1, 2, 3], vec![0], vec![0], vec![0]];
+
+        let view = GraphView::from_adjacency_list(4, index_to_node, node_to_index, outgoing, incoming, None);
+        let result = local_clustering_coefficient(&view);
+
+        // Center node: 3 neighbors, no edges among them → LCC = 0
+        assert!((result.coefficients[&1] - 0.0).abs() < 1e-10);
+        // Leaf nodes: degree 1 → LCC = 0
+        assert!((result.coefficients[&2] - 0.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_lcc_empty() {
+        let view = GraphView::from_adjacency_list(
+            0, vec![], HashMap::new(), vec![], vec![], None,
+        );
+        let result = local_clustering_coefficient(&view);
+        assert!(result.coefficients.is_empty());
+        assert!((result.average - 0.0).abs() < 1e-10);
+    }
+}

--- a/crates/samyama-graph-algorithms/src/lib.rs
+++ b/crates/samyama-graph-algorithms/src/lib.rs
@@ -5,11 +5,15 @@ pub mod pathfinding;
 pub mod flow;
 pub mod mst;
 pub mod topology;
+pub mod cdlp;
+pub mod lcc;
 
 pub use common::{GraphView, NodeId};
 pub use pagerank::{page_rank, PageRankConfig};
 pub use community::{weakly_connected_components, WccResult, strongly_connected_components, SccResult};
-pub use pathfinding::{bfs, dijkstra, PathResult};
+pub use pathfinding::{bfs, dijkstra, bfs_all_shortest_paths, PathResult};
 pub use flow::{edmonds_karp, FlowResult};
 pub use mst::{prim_mst, MSTResult};
 pub use topology::count_triangles;
+pub use cdlp::{cdlp, CdlpResult, CdlpConfig};
+pub use lcc::{local_clustering_coefficient, LccResult};

--- a/crates/samyama-graph-algorithms/src/pathfinding.rs
+++ b/crates/samyama-graph-algorithms/src/pathfinding.rs
@@ -150,6 +150,108 @@ pub fn dijkstra(
     None
 }
 
+/// BFS that returns ALL shortest paths between source and target
+pub fn bfs_all_shortest_paths(
+    view: &GraphView,
+    source: NodeId,
+    target: NodeId,
+) -> Vec<PathResult> {
+    let source_idx = match view.node_to_index.get(&source) {
+        Some(&idx) => idx,
+        None => return vec![],
+    };
+    let target_idx = match view.node_to_index.get(&target) {
+        Some(&idx) => idx,
+        None => return vec![],
+    };
+
+    if source_idx == target_idx {
+        return vec![PathResult {
+            source,
+            target,
+            path: vec![source],
+            cost: 0.0,
+        }];
+    }
+
+    // BFS tracking all parents for each discovered node
+    let mut parents: HashMap<usize, Vec<usize>> = HashMap::new();
+    let mut distance: HashMap<usize, usize> = HashMap::new();
+    let mut queue = VecDeque::new();
+
+    queue.push_back(source_idx);
+    distance.insert(source_idx, 0);
+
+    let mut target_distance: Option<usize> = None;
+
+    while let Some(current) = queue.pop_front() {
+        let current_dist = distance[&current];
+
+        // Stop if we've gone past the target distance
+        if let Some(td) = target_distance {
+            if current_dist >= td {
+                continue;
+            }
+        }
+
+        for &next_idx in view.successors(current) {
+            let next_dist = current_dist + 1;
+
+            if let Some(&existing_dist) = distance.get(&next_idx) {
+                if next_dist == existing_dist {
+                    // Same distance — add as additional parent
+                    parents.entry(next_idx).or_default().push(current);
+                }
+                // Longer path — skip
+            } else {
+                // First time reaching this node
+                distance.insert(next_idx, next_dist);
+                parents.insert(next_idx, vec![current]);
+                queue.push_back(next_idx);
+
+                if next_idx == target_idx {
+                    target_distance = Some(next_dist);
+                }
+            }
+        }
+    }
+
+    // If target not reached, return empty
+    if !distance.contains_key(&target_idx) {
+        return vec![];
+    }
+
+    // Reconstruct all paths from target back to source
+    let mut all_paths = Vec::new();
+    let mut stack: Vec<(usize, Vec<usize>)> = vec![(target_idx, vec![target_idx])];
+
+    while let Some((node, partial_path)) = stack.pop() {
+        if node == source_idx {
+            let mut path: Vec<NodeId> = partial_path.iter()
+                .rev()
+                .map(|&idx| view.index_to_node[idx])
+                .collect();
+            all_paths.push(PathResult {
+                source,
+                target,
+                cost: (path.len() - 1) as f64,
+                path,
+            });
+            continue;
+        }
+
+        if let Some(parent_list) = parents.get(&node) {
+            for &parent in parent_list {
+                let mut new_path = partial_path.clone();
+                new_path.push(parent);
+                stack.push((parent, new_path));
+            }
+        }
+    }
+
+    all_paths
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -211,5 +313,59 @@ mod tests {
         let result = dijkstra(&view, 1, 3).unwrap();
         assert_eq!(result.path, vec![1, 2, 3]);
         assert_eq!(result.cost, 15.0);
+    }
+
+    #[test]
+    fn test_bfs_all_shortest_paths() {
+        // Diamond: 1->2, 1->3, 2->4, 3->4
+        let index_to_node = vec![1, 2, 3, 4];
+        let mut node_to_index = HashMap::new();
+        node_to_index.insert(1, 0);
+        node_to_index.insert(2, 1);
+        node_to_index.insert(3, 2);
+        node_to_index.insert(4, 3);
+
+        let mut outgoing = vec![vec![]; 4];
+        outgoing[0] = vec![1, 2]; // 1->2, 1->3
+        outgoing[1] = vec![3];    // 2->4
+        outgoing[2] = vec![3];    // 3->4
+
+        let view = GraphView::from_adjacency_list(
+            4,
+            index_to_node,
+            node_to_index,
+            outgoing,
+            vec![vec![]; 4],
+            None,
+        );
+
+        let results = bfs_all_shortest_paths(&view, 1, 4);
+        assert_eq!(results.len(), 2, "Should find 2 shortest paths in diamond graph");
+        for r in &results {
+            assert_eq!(r.cost, 2.0);
+            assert_eq!(r.path.len(), 3);
+            assert_eq!(r.path[0], 1);
+            assert_eq!(r.path[2], 4);
+        }
+    }
+
+    #[test]
+    fn test_bfs_all_shortest_paths_no_path() {
+        let index_to_node = vec![1, 2];
+        let mut node_to_index = HashMap::new();
+        node_to_index.insert(1, 0);
+        node_to_index.insert(2, 1);
+
+        let view = GraphView::from_adjacency_list(
+            2,
+            index_to_node,
+            node_to_index,
+            vec![vec![], vec![]],
+            vec![vec![], vec![]],
+            None,
+        );
+
+        let results = bfs_all_shortest_paths(&view, 1, 2);
+        assert!(results.is_empty());
     }
 }

--- a/crates/samyama-sdk/src/algo.rs
+++ b/crates/samyama-sdk/src/algo.rs
@@ -9,8 +9,10 @@ use std::collections::HashMap;
 
 use samyama::algo::{
     build_view, page_rank, weakly_connected_components, strongly_connected_components,
-    bfs, dijkstra, edmonds_karp, prim_mst, count_triangles,
+    bfs, dijkstra, bfs_all_shortest_paths, edmonds_karp, prim_mst, count_triangles,
+    cdlp, local_clustering_coefficient,
     PageRankConfig, PathResult, WccResult, SccResult, FlowResult, MSTResult,
+    CdlpConfig, CdlpResult, LccResult,
 };
 use samyama_graph_algorithms::GraphView;
 
@@ -95,6 +97,30 @@ pub trait AlgorithmClient {
         label: Option<&str>,
         edge_type: Option<&str>,
     ) -> usize;
+
+    /// Find all shortest paths between source and target (BFS).
+    async fn bfs_all_shortest_paths(
+        &self,
+        source: u64,
+        target: u64,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> Vec<PathResult>;
+
+    /// Community Detection via Label Propagation (CDLP).
+    async fn cdlp(
+        &self,
+        config: CdlpConfig,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> CdlpResult;
+
+    /// Local Clustering Coefficient for all nodes.
+    async fn local_clustering_coefficient(
+        &self,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> LccResult;
 }
 
 #[async_trait]
@@ -196,6 +222,39 @@ impl AlgorithmClient for EmbeddedClient {
         let store = self.store.read().await;
         let view = build_view(&store, label, edge_type, None);
         count_triangles(&view)
+    }
+
+    async fn bfs_all_shortest_paths(
+        &self,
+        source: u64,
+        target: u64,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> Vec<PathResult> {
+        let store = self.store.read().await;
+        let view = build_view(&store, label, edge_type, None);
+        bfs_all_shortest_paths(&view, source, target)
+    }
+
+    async fn cdlp(
+        &self,
+        config: CdlpConfig,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> CdlpResult {
+        let store = self.store.read().await;
+        let view = build_view(&store, label, edge_type, None);
+        cdlp(&view, &config)
+    }
+
+    async fn local_clustering_coefficient(
+        &self,
+        label: Option<&str>,
+        edge_type: Option<&str>,
+    ) -> LccResult {
+        let store = self.store.read().await;
+        let view = build_view(&store, label, edge_type, None);
+        local_clustering_coefficient(&view)
     }
 }
 

--- a/crates/samyama-sdk/src/embedded.rs
+++ b/crates/samyama-sdk/src/embedded.rs
@@ -215,6 +215,13 @@ fn record_batch_to_query_result(batch: &RecordBatch, store: &GraphStore) -> Quer
                 Value::Property(p) => {
                     row.push(p.to_json());
                 }
+                Value::Path { nodes: path_nodes, edges: path_edges } => {
+                    row.push(serde_json::json!({
+                        "nodes": path_nodes.iter().map(|n| n.as_u64().to_string()).collect::<Vec<_>>(),
+                        "edges": path_edges.iter().map(|e| e.as_u64().to_string()).collect::<Vec<_>>(),
+                        "length": path_edges.len(),
+                    }));
+                }
                 Value::Null => {
                     row.push(serde_json::Value::Null);
                 }

--- a/examples/finbench_benchmark.rs
+++ b/examples/finbench_benchmark.rs
@@ -1,0 +1,680 @@
+//! LDBC FinBench Query Benchmark — Samyama Graph Database
+//!
+//! Benchmarks Samyama's query engine against 40+ LDBC FinBench workload queries
+//! covering Complex Reads (CR1-CR12), Simple Reads (SR1-SR6), Read-Writes (RW1-RW3),
+//! and Write operations (W1-W19).
+//!
+//! The FinBench workload models financial transaction networks with accounts,
+//! persons, companies, loans, and mediums connected by transfers, deposits,
+//! repayments, sign-ins, investments, and guarantees.
+//!
+//! Usage:
+//!   cargo run --release --example finbench_benchmark
+//!   cargo run --release --example finbench_benchmark -- --runs 10
+//!   cargo run --release --example finbench_benchmark -- --query CR-1
+//!   cargo run --release --example finbench_benchmark -- --data-dir /path/to/data
+//!   cargo run --release --example finbench_benchmark -- --writes   # include write operations
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use samyama_sdk::{EmbeddedClient, SamyamaClient};
+
+mod finbench_common;
+use finbench_common::{format_duration, format_num, GeneratorConfig};
+
+type Error = Box<dyn std::error::Error>;
+
+// ============================================================================
+// QUERY DEFINITIONS
+// ============================================================================
+
+struct FinBenchQuery {
+    id: &'static str,
+    name: &'static str,
+    cypher: &'static str,
+    category: &'static str,
+}
+
+/// Build the 12 Complex Read queries (CR1-CR12).
+///
+/// Parameter choices (from synthetic dataset, deterministic seed=42):
+///   accountId     = 1       (first account)
+///   accountId2    = 100     (another account for path queries)
+///   personId      = 1       (first person)
+///   companyId     = 1       (first company)
+///   loanId        = 1       (first loan)
+///   mediumId      = 1       (first medium)
+///   startTime     = 1577836800000   (2020-01-01)
+///   endTime       = 1609459200000   (2021-01-01)
+fn complex_reads() -> Vec<FinBenchQuery> {
+    vec![
+        FinBenchQuery {
+            id: "CR-1",
+            name: "Transfer In/Out Amounts",
+            category: "complex",
+            // Find total transfer-in and transfer-out amounts for an account
+            cypher: "\
+MATCH (src:Account)-[t:TRANSFER]->(a:Account {id: 1})
+RETURN a.id, count(t) AS transferInCount, sum(t.amount) AS totalIn",
+        },
+
+        FinBenchQuery {
+            id: "CR-2",
+            name: "Blocked Account Transfers",
+            category: "complex",
+            // Find accounts that transferred money to a blocked account within time range
+            cypher: "\
+MATCH (src:Account)-[t:TRANSFER]->(dst:Account {isBlocked: true})
+WHERE t.timestamp >= 1577836800000 AND t.timestamp < 1609459200000
+RETURN src.id, dst.id, t.amount, t.timestamp
+ORDER BY t.amount DESC
+LIMIT 20",
+        },
+
+        FinBenchQuery {
+            id: "CR-3",
+            name: "Shortest Transfer Path",
+            category: "complex",
+            // Shortest path between two accounts via TRANSFER edges
+            cypher: "\
+MATCH p = shortestPath((a1:Account {id: 1})-[:TRANSFER*]-(a2:Account {id: 100}))
+RETURN length(p) AS pathLength",
+        },
+
+        FinBenchQuery {
+            id: "CR-4",
+            name: "Transfer Cycle Detection",
+            category: "complex",
+            // 3-hop transfer cycle: A->B->C->A
+            cypher: "\
+MATCH (a:Account {id: 1})-[t1:TRANSFER]->(b:Account)-[t2:TRANSFER]->(c:Account)-[t3:TRANSFER]->(a)
+WHERE b.id <> a.id AND c.id <> a.id AND b.id <> c.id
+RETURN a.id, b.id, c.id, t1.amount, t2.amount, t3.amount
+LIMIT 10",
+        },
+
+        FinBenchQuery {
+            id: "CR-5",
+            name: "Owner Account Transfer Patterns",
+            category: "complex",
+            // Persons/companies connected to an account and their other accounts' transfers
+            cypher: "\
+MATCH (owner)-[:OWN]->(a:Account {id: 1})
+WITH owner
+MATCH (owner)-[:OWN]->(otherAcct:Account)
+MATCH (otherAcct)-[t:TRANSFER]->(dst:Account)
+RETURN owner.name, otherAcct.id, count(t) AS transferCount, sum(t.amount) AS totalAmount
+ORDER BY totalAmount DESC
+LIMIT 20",
+        },
+
+        FinBenchQuery {
+            id: "CR-6",
+            name: "Loan Deposit Tracing",
+            category: "complex",
+            // Find accounts that got deposits from a loan and trace where money went
+            cypher: "\
+MATCH (l:Loan {id: 1})-[d:DEPOSIT]->(a:Account)-[t:TRANSFER]->(dst:Account)
+RETURN a.id, d.amount AS depositAmount, dst.id AS transferTarget, t.amount AS transferAmount
+ORDER BY d.amount DESC
+LIMIT 20",
+        },
+
+        FinBenchQuery {
+            id: "CR-7",
+            name: "Transfer Chain Analysis",
+            category: "complex",
+            // 2-hop transfers in and out of an account
+            cypher: "\
+MATCH (upstream:Account)-[t1:TRANSFER]->(mid:Account)-[t2:TRANSFER]->(a:Account {id: 1})
+RETURN upstream.id, mid.id, t1.amount AS upstreamAmount, t2.amount AS midAmount
+ORDER BY t2.amount DESC
+LIMIT 20",
+        },
+
+        FinBenchQuery {
+            id: "CR-8",
+            name: "Loan Deposit Distribution",
+            category: "complex",
+            // Where did loan deposits go — all deposits from all loans above a threshold
+            cypher: "\
+MATCH (l:Loan)-[d:DEPOSIT]->(a:Account)
+WHERE d.amount > 10000.0
+RETURN l.id, l.loanAmount, a.id AS targetAccount, d.amount AS depositAmount
+ORDER BY d.amount DESC
+LIMIT 20",
+        },
+
+        FinBenchQuery {
+            id: "CR-9",
+            name: "Guarantee Chain",
+            category: "complex",
+            // Find guarantee chains from a company (up to 3 hops)
+            cypher: "\
+MATCH (c:Company {id: 1})-[:GUARANTEE*1..3]->(guaranteed)
+RETURN DISTINCT guaranteed.id, guaranteed.name
+LIMIT 20",
+        },
+
+        FinBenchQuery {
+            id: "CR-10",
+            name: "Investment Network",
+            category: "complex",
+            // Companies connected by INVEST edges — count investors per company
+            cypher: "\
+MATCH (investor)-[inv:INVEST]->(target:Company)
+RETURN target.id, target.name, count(investor) AS investorCount, sum(inv.ratio) AS totalRatio
+ORDER BY investorCount DESC
+LIMIT 20",
+        },
+
+        FinBenchQuery {
+            id: "CR-11",
+            name: "Shared Medium Sign-In",
+            category: "complex",
+            // Find accounts that signed in with the same medium as account 1
+            cypher: "\
+MATCH (a:Account {id: 1})-[:SIGN_IN]->(m:Medium)<-[:SIGN_IN]-(other:Account)
+WHERE other.id <> 1
+RETURN DISTINCT other.id, other.accountType, m.mediumType
+ORDER BY other.id
+LIMIT 20",
+        },
+
+        FinBenchQuery {
+            id: "CR-12",
+            name: "Person Account Transfer Stats",
+            category: "complex",
+            // Transfer amount statistics for accounts owned by a person
+            cypher: "\
+MATCH (p:Person {id: 1})-[:OWN]->(a:Account)-[t:TRANSFER]->(dst:Account)
+RETURN a.id, count(t) AS transferCount, sum(t.amount) AS totalAmount
+ORDER BY totalAmount DESC",
+        },
+    ]
+}
+
+/// Build the 6 Simple Read queries (SR1-SR6).
+fn simple_reads() -> Vec<FinBenchQuery> {
+    vec![
+        FinBenchQuery {
+            id: "SR-1",
+            name: "Account by ID",
+            category: "simple",
+            cypher: "\
+MATCH (a:Account {id: 1})
+RETURN a.id, a.createTime, a.isBlocked, a.accountType",
+        },
+
+        FinBenchQuery {
+            id: "SR-2",
+            name: "Account Transfers in Window",
+            category: "simple",
+            // Get transfers from an account in a time window
+            cypher: "\
+MATCH (a:Account {id: 1})-[t:TRANSFER]->(dst:Account)
+WHERE t.timestamp >= 1577836800000 AND t.timestamp < 1609459200000
+RETURN dst.id, t.amount, t.timestamp
+ORDER BY t.timestamp DESC
+LIMIT 10",
+        },
+
+        FinBenchQuery {
+            id: "SR-3",
+            name: "Person's Accounts",
+            category: "simple",
+            // Get all accounts owned by a person
+            cypher: "\
+MATCH (p:Person {id: 1})-[:OWN]->(a:Account)
+RETURN a.id, a.accountType, a.isBlocked, a.createTime
+ORDER BY a.id",
+        },
+
+        FinBenchQuery {
+            id: "SR-4",
+            name: "Transfer-In Accounts",
+            category: "simple",
+            // Get transfer-in accounts for an account within time range
+            cypher: "\
+MATCH (src:Account)-[t:TRANSFER]->(a:Account {id: 1})
+WHERE t.timestamp >= 1577836800000 AND t.timestamp < 1609459200000
+RETURN src.id, t.amount, t.timestamp
+ORDER BY t.timestamp DESC
+LIMIT 10",
+        },
+
+        FinBenchQuery {
+            id: "SR-5",
+            name: "Transfer-Out Accounts",
+            category: "simple",
+            // Get transfer-out accounts for an account within time range
+            cypher: "\
+MATCH (a:Account {id: 1})-[t:TRANSFER]->(dst:Account)
+WHERE t.timestamp >= 1577836800000 AND t.timestamp < 1609459200000
+RETURN dst.id, t.amount, t.timestamp
+ORDER BY t.timestamp DESC
+LIMIT 10",
+        },
+
+        FinBenchQuery {
+            id: "SR-6",
+            name: "Loan by ID",
+            category: "simple",
+            cypher: "\
+MATCH (l:Loan {id: 1})
+RETURN l.id, l.loanAmount, l.balance",
+        },
+    ]
+}
+
+/// Build the 3 Read-Write queries (RW1-RW3).
+fn read_writes() -> Vec<FinBenchQuery> {
+    vec![
+        FinBenchQuery {
+            id: "RW-1",
+            name: "Block Account + Read Transfers",
+            category: "readwrite",
+            // Block an account and then read its transfers
+            cypher: "MATCH (a:Account {id: 2}) SET a.isBlocked = true RETURN a.id, a.isBlocked",
+        },
+
+        FinBenchQuery {
+            id: "RW-2",
+            name: "Block Medium + Find Accounts",
+            category: "readwrite",
+            // Block a medium then find connected accounts
+            cypher: "MATCH (m:Medium {id: 2}) SET m.isBlocked = true RETURN m.id, m.isBlocked",
+        },
+
+        FinBenchQuery {
+            id: "RW-3",
+            name: "Block Person + Accounts",
+            category: "readwrite",
+            // Block a person (their accounts would need separate queries in real FinBench)
+            cypher: "MATCH (p:Person {id: 2}) SET p.isBlocked = true RETURN p.id, p.name, p.isBlocked",
+        },
+    ]
+}
+
+/// Build the 19 Write queries (W1-W19) — CREATE operations for all node and edge types.
+fn writes() -> Vec<FinBenchQuery> {
+    vec![
+        // --- Node creation ---
+        FinBenchQuery {
+            id: "W-1",
+            name: "Create Person",
+            category: "write",
+            cypher: "\
+CREATE (p:Person {id: 999001, name: \"Benchmark Person\", isBlocked: false})",
+        },
+        FinBenchQuery {
+            id: "W-2",
+            name: "Create Company",
+            category: "write",
+            cypher: "\
+CREATE (c:Company {id: 999001, name: \"Benchmark Corp\", isBlocked: false})",
+        },
+        FinBenchQuery {
+            id: "W-3",
+            name: "Create Account",
+            category: "write",
+            cypher: "\
+CREATE (a:Account {id: 999001, createTime: 1709251200000, isBlocked: false, accountType: \"checking\"})",
+        },
+        FinBenchQuery {
+            id: "W-4",
+            name: "Create Loan",
+            category: "write",
+            cypher: "\
+CREATE (l:Loan {id: 999001, loanAmount: 50000.0, balance: 50000.0})",
+        },
+        FinBenchQuery {
+            id: "W-5",
+            name: "Create Medium",
+            category: "write",
+            cypher: "\
+CREATE (m:Medium {id: 999001, mediumType: \"phone\", isBlocked: false})",
+        },
+
+        // --- Edge creation ---
+        FinBenchQuery {
+            id: "W-6",
+            name: "Person Owns Account",
+            category: "write",
+            cypher: "MATCH (p:Person {id: 999001}), (a:Account {id: 999001}) CREATE (p)-[:OWN {timestamp: 1709251200000}]->(a)",
+        },
+        FinBenchQuery {
+            id: "W-7",
+            name: "Company Owns Account",
+            category: "write",
+            cypher: "MATCH (c:Company {id: 999001}), (a:Account {id: 1}) CREATE (c)-[:OWN {timestamp: 1709251200000}]->(a)",
+        },
+        FinBenchQuery {
+            id: "W-8",
+            name: "Transfer Between Accounts",
+            category: "write",
+            cypher: "MATCH (src:Account {id: 999001}), (dst:Account {id: 1}) CREATE (src)-[:TRANSFER {timestamp: 1709251200000, amount: 1500.0}]->(dst)",
+        },
+        FinBenchQuery {
+            id: "W-9",
+            name: "Withdraw Between Accounts",
+            category: "write",
+            cypher: "MATCH (src:Account {id: 999001}), (dst:Account {id: 2}) CREATE (src)-[:WITHDRAW {timestamp: 1709251200000, amount: 500.0}]->(dst)",
+        },
+        FinBenchQuery {
+            id: "W-10",
+            name: "Loan Deposit to Account",
+            category: "write",
+            cypher: "MATCH (l:Loan {id: 999001}), (a:Account {id: 999001}) CREATE (l)-[:DEPOSIT {timestamp: 1709251200000, amount: 50000.0}]->(a)",
+        },
+        FinBenchQuery {
+            id: "W-11",
+            name: "Account Repays Loan",
+            category: "write",
+            cypher: "MATCH (a:Account {id: 999001}), (l:Loan {id: 999001}) CREATE (a)-[:REPAY {timestamp: 1709251200000, amount: 5000.0}]->(l)",
+        },
+        FinBenchQuery {
+            id: "W-12",
+            name: "Account Sign-In Medium",
+            category: "write",
+            cypher: "MATCH (a:Account {id: 999001}), (m:Medium {id: 999001}) CREATE (a)-[:SIGN_IN {timestamp: 1709251200000}]->(m)",
+        },
+        FinBenchQuery {
+            id: "W-13",
+            name: "Person Applies for Loan",
+            category: "write",
+            cypher: "MATCH (p:Person {id: 999001}), (l:Loan {id: 999001}) CREATE (p)-[:APPLY {timestamp: 1709251200000}]->(l)",
+        },
+        FinBenchQuery {
+            id: "W-14",
+            name: "Company Applies for Loan",
+            category: "write",
+            cypher: "MATCH (c:Company {id: 999001}), (l:Loan {id: 1}) CREATE (c)-[:APPLY {timestamp: 1709251200000}]->(l)",
+        },
+        FinBenchQuery {
+            id: "W-15",
+            name: "Company Invests in Company",
+            category: "write",
+            cypher: "MATCH (c1:Company {id: 999001}), (c2:Company {id: 1}) CREATE (c1)-[:INVEST {timestamp: 1709251200000, ratio: 0.15}]->(c2)",
+        },
+        FinBenchQuery {
+            id: "W-16",
+            name: "Person Invests in Company",
+            category: "write",
+            cypher: "MATCH (p:Person {id: 999001}), (c:Company {id: 1}) CREATE (p)-[:INVEST {timestamp: 1709251200000, ratio: 0.05}]->(c)",
+        },
+        FinBenchQuery {
+            id: "W-17",
+            name: "Company Guarantees Company",
+            category: "write",
+            cypher: "MATCH (c1:Company {id: 999001}), (c2:Company {id: 2}) CREATE (c1)-[:GUARANTEE {timestamp: 1709251200000}]->(c2)",
+        },
+        FinBenchQuery {
+            id: "W-18",
+            name: "Person Guarantees Person",
+            category: "write",
+            cypher: "MATCH (p1:Person {id: 999001}), (p2:Person {id: 2}) CREATE (p1)-[:GUARANTEE {timestamp: 1709251200000}]->(p2)",
+        },
+        FinBenchQuery {
+            id: "W-19",
+            name: "Delete Account",
+            category: "write",
+            cypher: "MATCH (a:Account {id: 999001}) DELETE a",
+        },
+    ]
+}
+
+// ============================================================================
+// BENCHMARK RUNNER
+// ============================================================================
+
+struct BenchResult {
+    id: &'static str,
+    name: &'static str,
+    rows: usize,
+    min: Duration,
+    median: Duration,
+    max: Duration,
+    error: Option<String>,
+}
+
+fn format_ms(d: Duration) -> String {
+    let ms = d.as_secs_f64() * 1000.0;
+    if ms < 1.0 {
+        format!("{:.2}ms", ms)
+    } else if ms < 100.0 {
+        format!("{:.1}ms", ms)
+    } else if ms < 10_000.0 {
+        format!("{:.0}ms", ms)
+    } else {
+        format!("{:.1}s", d.as_secs_f64())
+    }
+}
+
+async fn run_benchmark(
+    client: &EmbeddedClient,
+    query: &FinBenchQuery,
+    runs: usize,
+) -> BenchResult {
+    let is_mutating = query.category == "write" || query.category == "readwrite";
+
+    // Warm-up: 1 run, discard (skip for writes — they mutate state)
+    let warmup = if is_mutating {
+        client.query("default", query.cypher).await
+    } else {
+        client.query_readonly("default", query.cypher).await
+    };
+    if let Err(e) = &warmup {
+        return BenchResult {
+            id: query.id,
+            name: query.name,
+            rows: 0,
+            min: Duration::ZERO,
+            median: Duration::ZERO,
+            max: Duration::ZERO,
+            error: Some(e.to_string()),
+        };
+    }
+
+    let mut timings = Vec::with_capacity(runs);
+    let mut row_count = 0;
+
+    let actual_runs = if is_mutating { 1 } else { runs }; // mutations run once
+    for _ in 0..actual_runs {
+        let start = Instant::now();
+        let run_result = if is_mutating {
+            client.query("default", query.cypher).await
+        } else {
+            client.query_readonly("default", query.cypher).await
+        };
+        match run_result {
+            Ok(result) => {
+                row_count = result.records.len();
+                timings.push(start.elapsed());
+            }
+            Err(e) => {
+                return BenchResult {
+                    id: query.id,
+                    name: query.name,
+                    rows: 0,
+                    min: Duration::ZERO,
+                    median: Duration::ZERO,
+                    max: Duration::ZERO,
+                    error: Some(e.to_string()),
+                };
+            }
+        }
+    }
+
+    timings.sort();
+
+    let len = timings.len();
+    BenchResult {
+        id: query.id,
+        name: query.name,
+        rows: row_count,
+        min: timings[0],
+        median: timings[len / 2],
+        max: timings[len - 1],
+        error: None,
+    }
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let args: Vec<String> = std::env::args().collect();
+
+    let data_dir = if let Some(pos) = args.iter().position(|a| a == "--data-dir") {
+        Some(PathBuf::from(args.get(pos + 1).expect("--data-dir requires a path argument")))
+    } else {
+        None
+    };
+
+    let runs: usize = if let Some(pos) = args.iter().position(|a| a == "--runs") {
+        args.get(pos + 1).expect("--runs requires a number").parse().expect("--runs must be a positive integer")
+    } else {
+        5
+    };
+
+    let filter_query: Option<String> = if let Some(pos) = args.iter().position(|a| a == "--query") {
+        Some(args.get(pos + 1).expect("--query requires a query ID (e.g. CR-1, SR-3)").to_uppercase())
+    } else {
+        None
+    };
+
+    let include_writes = args.iter().any(|a| a == "--writes");
+
+    // ========================================================================
+    // Load dataset
+    // ========================================================================
+    eprintln!("LDBC FinBench Benchmark — Samyama v0.5.8");
+    eprintln!();
+
+    let client = EmbeddedClient::new();
+    let load_start = Instant::now();
+
+    let load_result = if let Some(ref dir) = data_dir {
+        if !dir.exists() {
+            eprintln!("ERROR: Data directory not found: {}", dir.display());
+            eprintln!("Run `scripts/download_finbench.sh` to generate data, or use synthetic mode (no --data-dir)");
+            std::process::exit(1);
+        }
+        eprintln!("Loading FinBench dataset from CSV: {}", dir.display());
+        eprintln!();
+        let mut graph = client.store_write().await;
+        finbench_common::load_dataset(&mut graph, dir)?
+    } else {
+        eprintln!("Generating synthetic FinBench dataset in-memory...");
+        eprintln!();
+        let config = GeneratorConfig::default();
+        let mut graph = client.store_write().await;
+        finbench_common::generate_dataset(&mut graph, &config)
+    };
+
+    let load_time = load_start.elapsed();
+
+    eprintln!();
+    eprintln!("Dataset: {} nodes, {} edges (loaded in {})",
+        format_num(load_result.total_nodes),
+        format_num(load_result.total_edges),
+        format_duration(load_time));
+    eprintln!("Runs per query: {}", runs);
+    eprintln!();
+
+    // ========================================================================
+    // Build query list
+    // ========================================================================
+    let mut all_queries = Vec::new();
+    all_queries.extend(complex_reads());
+    all_queries.extend(simple_reads());
+    all_queries.extend(read_writes());
+    if include_writes {
+        all_queries.extend(writes());
+    }
+
+    let queries: Vec<&FinBenchQuery> = if let Some(ref filter) = filter_query {
+        all_queries.iter().filter(|q| q.id == filter.as_str()).collect()
+    } else {
+        all_queries.iter().collect()
+    };
+
+    if queries.is_empty() {
+        eprintln!("ERROR: No matching query found for filter '{}'", filter_query.unwrap_or_default());
+        eprintln!("Available: CR-1..CR-12, SR-1..SR-6, RW-1..RW-3, W-1..W-19 (with --writes)");
+        std::process::exit(1);
+    }
+
+    // ========================================================================
+    // Run benchmarks
+    // ========================================================================
+
+    // Print header
+    println!("{:<8}{:<36}{:>8}{:>12}{:>12}{:>12}  {}",
+        "ID", "Name", "Rows", "Min", "Median", "Max", "Status");
+    println!("{:<8}{:<36}{:>8}{:>12}{:>12}{:>12}  {}",
+        "------", "------------------------------------", "------", "----------", "----------", "----------", "------");
+
+    let mut passed = 0usize;
+    let mut errors = 0usize;
+    let mut last_category = "";
+    let bench_start = Instant::now();
+
+    for query in &queries {
+        // Print section separator when category changes
+        if query.category != last_category {
+            if !last_category.is_empty() { println!(); }
+            let label = match query.category {
+                "complex"   => "--- Complex Reads (CR) ---",
+                "simple"    => "--- Simple Reads (SR) ---",
+                "readwrite" => "--- Read-Write Operations (RW) ---",
+                "write"     => "--- Write Operations (W) ---",
+                other       => other,
+            };
+            println!("{}", label);
+            last_category = query.category;
+        }
+
+        eprint!("  Running {}...\r", query.id);
+
+        let result = run_benchmark(&client, query, runs).await;
+
+        if let Some(ref err) = result.error {
+            println!("{:<8}{:<36}{:>8}{:>12}{:>12}{:>12}  ERROR",
+                result.id, result.name, "-", "-", "-", "-");
+            eprintln!("       {}", err);
+            errors += 1;
+        } else {
+            println!("{:<8}{:<36}{:>8}{:>12}{:>12}{:>12}  OK",
+                result.id, result.name,
+                result.rows,
+                format_ms(result.min),
+                format_ms(result.median),
+                format_ms(result.max));
+            passed += 1;
+        }
+    }
+
+    let bench_time = bench_start.elapsed();
+
+    // ========================================================================
+    // Summary
+    // ========================================================================
+    println!();
+    println!("Summary: {}/{} passed, {} errors (total benchmark time: {})",
+        passed, queries.len(), errors, format_duration(bench_time));
+
+    // Cache stats
+    let stats = client.cache_stats();
+    println!("AST cache: {} hits, {} misses", stats.hits(), stats.misses());
+
+    if errors > 0 {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}

--- a/examples/finbench_common/mod.rs
+++ b/examples/finbench_common/mod.rs
@@ -1,0 +1,1237 @@
+//! Shared LDBC FinBench data loading and generation utilities.
+//!
+//! Used by both `finbench_loader` and `finbench_benchmark` examples.
+//!
+//! Since LDBC FinBench does not have a widely-available SF1 CSV download like
+//! LDBC SNB, this module provides both:
+//!   1. CSV file loading (when pre-generated data is available)
+//!   2. Synthetic data generation that matches the FinBench schema
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+
+use samyama_sdk::{GraphStore, NodeId, PropertyValue};
+
+pub type Error = Box<dyn std::error::Error>;
+
+// ============================================================================
+// ID MAPPINGS
+// ============================================================================
+
+pub struct IdMaps {
+    pub account: HashMap<i64, NodeId>,
+    pub person: HashMap<i64, NodeId>,
+    pub company: HashMap<i64, NodeId>,
+    pub loan: HashMap<i64, NodeId>,
+    pub medium: HashMap<i64, NodeId>,
+}
+
+impl IdMaps {
+    pub fn new() -> Self {
+        Self {
+            account: HashMap::new(),
+            person: HashMap::new(),
+            company: HashMap::new(),
+            loan: HashMap::new(),
+            medium: HashMap::new(),
+        }
+    }
+}
+
+// ============================================================================
+// GENERIC HELPERS
+// ============================================================================
+
+/// Load nodes from a pipe-delimited CSV file.
+/// `parse_props` receives the header-keyed row and returns (key, PropertyValue) pairs.
+pub fn load_nodes<F>(
+    path: &Path,
+    label: &str,
+    graph: &mut GraphStore,
+    id_map: &mut HashMap<i64, NodeId>,
+    parse_props: F,
+) -> Result<usize, Error>
+where
+    F: Fn(&[&str], &[&str]) -> Vec<(&'static str, PropertyValue)>,
+{
+    if !path.exists() {
+        eprintln!("  WARNING: {} not found, skipping", path.display());
+        return Ok(0);
+    }
+
+    let file = File::open(path)?;
+    let reader = BufReader::with_capacity(1 << 16, file);
+    let mut lines = reader.lines();
+
+    let header = lines.next().ok_or("Empty file")??;
+    let headers: Vec<&str> = header.split('|').collect();
+
+    let id_col = headers.iter().position(|h| *h == "id")
+        .ok_or_else(|| format!("No 'id' column in {}", path.display()))?;
+
+    let mut count = 0usize;
+    for line_result in lines {
+        let line = line_result?;
+        if line.is_empty() { continue; }
+
+        let fields: Vec<&str> = line.split('|').collect();
+        if fields.len() <= id_col { continue; }
+
+        let csv_id: i64 = fields[id_col].parse()?;
+
+        let node_id = graph.create_node(label);
+
+        // Set properties
+        let props = parse_props(&headers, &fields);
+        if let Some(node) = graph.get_node_mut(node_id) {
+            for (key, val) in props {
+                node.set_property(key, val);
+            }
+            // Store the FinBench id as a property too
+            node.set_property("id", csv_id);
+        }
+
+        id_map.insert(csv_id, node_id);
+        count += 1;
+
+        if count % 500_000 == 0 && io::stderr().is_terminal() {
+            eprint!("\r  {:16} {:>12} nodes...          ", label, format_num(count));
+        }
+    }
+
+    Ok(count)
+}
+
+/// Load edges from a pipe-delimited CSV file.
+/// `parse_props` receives (headers, fields) and returns edge properties (may be empty).
+pub fn load_edges<F>(
+    path: &Path,
+    edge_type: &str,
+    graph: &mut GraphStore,
+    src_map: &HashMap<i64, NodeId>,
+    tgt_map: &HashMap<i64, NodeId>,
+    parse_props: F,
+) -> Result<usize, Error>
+where
+    F: Fn(&[&str], &[&str]) -> Vec<(&'static str, PropertyValue)>,
+{
+    if !path.exists() {
+        eprintln!("  WARNING: {} not found, skipping", path.display());
+        return Ok(0);
+    }
+
+    let file = File::open(path)?;
+    let reader = BufReader::with_capacity(1 << 16, file);
+    let mut lines = reader.lines();
+
+    let header = lines.next().ok_or("Empty file")??;
+    let headers: Vec<&str> = header.split('|').collect();
+
+    let mut count = 0usize;
+    let mut skipped = 0usize;
+    for line_result in lines {
+        let line = line_result?;
+        if line.is_empty() { continue; }
+
+        let fields: Vec<&str> = line.split('|').collect();
+        if fields.len() < 2 { continue; }
+
+        let src_id: i64 = match fields[0].parse() {
+            Ok(v) => v,
+            Err(_) => { skipped += 1; continue; }
+        };
+        let tgt_id: i64 = match fields[1].parse() {
+            Ok(v) => v,
+            Err(_) => { skipped += 1; continue; }
+        };
+
+        let src_node = match src_map.get(&src_id) {
+            Some(&n) => n,
+            None => { skipped += 1; continue; }
+        };
+        let tgt_node = match tgt_map.get(&tgt_id) {
+            Some(&n) => n,
+            None => { skipped += 1; continue; }
+        };
+
+        match graph.create_edge(src_node, tgt_node, edge_type) {
+            Ok(edge_id) => {
+                let props = parse_props(&headers, &fields);
+                if !props.is_empty() {
+                    if let Some(edge) = graph.get_edge_mut(edge_id) {
+                        for (key, val) in props {
+                            edge.set_property(key, val);
+                        }
+                    }
+                }
+                count += 1;
+            }
+            Err(_) => { skipped += 1; }
+        }
+
+        if count % 500_000 == 0 && count > 0 && io::stderr().is_terminal() {
+            eprint!("\r  {:42} {:>12} edges...          ", edge_type, format_num(count));
+        }
+    }
+
+    if skipped > 0 {
+        eprintln!("  (skipped {} rows for {})", format_num(skipped), edge_type);
+    }
+
+    Ok(count)
+}
+
+// ============================================================================
+// PROPERTY PARSERS — Field helpers
+// ============================================================================
+
+pub fn field_str(headers: &[&str], fields: &[&str], name: &str) -> Option<String> {
+    headers.iter().position(|h| *h == name)
+        .and_then(|i| fields.get(i))
+        .filter(|v| !v.is_empty())
+        .map(|v| v.to_string())
+}
+
+pub fn field_i64(headers: &[&str], fields: &[&str], name: &str) -> Option<i64> {
+    headers.iter().position(|h| *h == name)
+        .and_then(|i| fields.get(i))
+        .and_then(|v| v.parse().ok())
+}
+
+pub fn field_f64(headers: &[&str], fields: &[&str], name: &str) -> Option<f64> {
+    headers.iter().position(|h| *h == name)
+        .and_then(|i| fields.get(i))
+        .and_then(|v| v.parse().ok())
+}
+
+pub fn field_bool(headers: &[&str], fields: &[&str], name: &str) -> Option<bool> {
+    headers.iter().position(|h| *h == name)
+        .and_then(|i| fields.get(i))
+        .and_then(|v| match v.to_lowercase().as_str() {
+            "true" | "1" => Some(true),
+            "false" | "0" => Some(false),
+            _ => None,
+        })
+}
+
+// ============================================================================
+// PROPERTY PARSERS — Node types
+// ============================================================================
+
+pub fn props_account(headers: &[&str], fields: &[&str]) -> Vec<(&'static str, PropertyValue)> {
+    let mut props = Vec::new();
+    if let Some(v) = field_i64(headers, fields, "createTime") {
+        props.push(("createTime", PropertyValue::DateTime(v)));
+    }
+    if let Some(v) = field_bool(headers, fields, "isBlocked") {
+        props.push(("isBlocked", PropertyValue::Boolean(v)));
+    }
+    if let Some(v) = field_str(headers, fields, "accountType") {
+        props.push(("accountType", PropertyValue::String(v)));
+    }
+    props
+}
+
+pub fn props_person(headers: &[&str], fields: &[&str]) -> Vec<(&'static str, PropertyValue)> {
+    let mut props = Vec::new();
+    if let Some(v) = field_str(headers, fields, "name") {
+        props.push(("name", PropertyValue::String(v)));
+    }
+    if let Some(v) = field_bool(headers, fields, "isBlocked") {
+        props.push(("isBlocked", PropertyValue::Boolean(v)));
+    }
+    props
+}
+
+pub fn props_company(headers: &[&str], fields: &[&str]) -> Vec<(&'static str, PropertyValue)> {
+    let mut props = Vec::new();
+    if let Some(v) = field_str(headers, fields, "name") {
+        props.push(("name", PropertyValue::String(v)));
+    }
+    if let Some(v) = field_bool(headers, fields, "isBlocked") {
+        props.push(("isBlocked", PropertyValue::Boolean(v)));
+    }
+    props
+}
+
+pub fn props_loan(headers: &[&str], fields: &[&str]) -> Vec<(&'static str, PropertyValue)> {
+    let mut props = Vec::new();
+    if let Some(v) = field_f64(headers, fields, "loanAmount") {
+        props.push(("loanAmount", PropertyValue::Float(v)));
+    }
+    if let Some(v) = field_f64(headers, fields, "balance") {
+        props.push(("balance", PropertyValue::Float(v)));
+    }
+    props
+}
+
+pub fn props_medium(headers: &[&str], fields: &[&str]) -> Vec<(&'static str, PropertyValue)> {
+    let mut props = Vec::new();
+    if let Some(v) = field_str(headers, fields, "mediumType") {
+        props.push(("mediumType", PropertyValue::String(v)));
+    }
+    if let Some(v) = field_bool(headers, fields, "isBlocked") {
+        props.push(("isBlocked", PropertyValue::Boolean(v)));
+    }
+    props
+}
+
+// ============================================================================
+// PROPERTY PARSERS — Edge types
+// ============================================================================
+
+pub fn no_props(_headers: &[&str], _fields: &[&str]) -> Vec<(&'static str, PropertyValue)> {
+    Vec::new()
+}
+
+/// timestamp only (for OWN, SIGN_IN, APPLY, GUARANTEE)
+pub fn props_timestamp(headers: &[&str], fields: &[&str]) -> Vec<(&'static str, PropertyValue)> {
+    let mut props = Vec::new();
+    if let Some(v) = field_i64(headers, fields, "timestamp") {
+        props.push(("timestamp", PropertyValue::DateTime(v)));
+    }
+    // Fallback: try column index 2
+    if props.is_empty() && fields.len() > 2 {
+        if let Ok(v) = fields[2].parse::<i64>() {
+            props.push(("timestamp", PropertyValue::DateTime(v)));
+        }
+    }
+    props
+}
+
+/// timestamp + amount (for TRANSFER, WITHDRAW, DEPOSIT, REPAY)
+pub fn props_timestamp_amount(headers: &[&str], fields: &[&str]) -> Vec<(&'static str, PropertyValue)> {
+    let mut props = Vec::new();
+    if let Some(v) = field_i64(headers, fields, "timestamp") {
+        props.push(("timestamp", PropertyValue::DateTime(v)));
+    } else if fields.len() > 2 {
+        if let Ok(v) = fields[2].parse::<i64>() {
+            props.push(("timestamp", PropertyValue::DateTime(v)));
+        }
+    }
+    if let Some(v) = field_f64(headers, fields, "amount") {
+        props.push(("amount", PropertyValue::Float(v)));
+    } else if fields.len() > 3 {
+        if let Ok(v) = fields[3].parse::<f64>() {
+            props.push(("amount", PropertyValue::Float(v)));
+        }
+    }
+    props
+}
+
+/// timestamp + ratio (for INVEST)
+pub fn props_timestamp_ratio(headers: &[&str], fields: &[&str]) -> Vec<(&'static str, PropertyValue)> {
+    let mut props = Vec::new();
+    if let Some(v) = field_i64(headers, fields, "timestamp") {
+        props.push(("timestamp", PropertyValue::DateTime(v)));
+    } else if fields.len() > 2 {
+        if let Ok(v) = fields[2].parse::<i64>() {
+            props.push(("timestamp", PropertyValue::DateTime(v)));
+        }
+    }
+    if let Some(v) = field_f64(headers, fields, "ratio") {
+        props.push(("ratio", PropertyValue::Float(v)));
+    } else if fields.len() > 3 {
+        if let Ok(v) = fields[3].parse::<f64>() {
+            props.push(("ratio", PropertyValue::Float(v)));
+        }
+    }
+    props
+}
+
+// ============================================================================
+// FORMATTING
+// ============================================================================
+
+pub fn format_num(n: usize) -> String {
+    let s = n.to_string();
+    let mut result = String::new();
+    for (i, ch) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 { result.push(','); }
+        result.push(ch);
+    }
+    result.chars().rev().collect()
+}
+
+pub fn format_duration(d: std::time::Duration) -> String {
+    let secs = d.as_secs_f64();
+    if secs < 1.0 {
+        format!("{:.0}ms", secs * 1000.0)
+    } else {
+        format!("{:.1}s", secs)
+    }
+}
+
+/// Print a final summary line, clearing any inline progress.
+pub fn print_done(msg: &str) {
+    eprintln!("\r{:80}", msg);
+}
+
+// ============================================================================
+// LOAD RESULT
+// ============================================================================
+
+pub struct LoadResult {
+    pub total_nodes: usize,
+    pub total_edges: usize,
+}
+
+// ============================================================================
+// CSV DATASET LOADER
+// ============================================================================
+
+/// Load the FinBench dataset from CSV files into the given GraphStore.
+/// Expected directory structure:
+///   data_dir/
+///     account.csv, person.csv, company.csv, loan.csv, medium.csv
+///     own.csv, transfer.csv, withdraw.csv, deposit.csv, repay.csv
+///     signIn.csv, apply.csv, invest.csv, guarantee.csv
+pub fn load_dataset(graph: &mut GraphStore, data_dir: &Path) -> Result<LoadResult, Error> {
+    let mut ids = IdMaps::new();
+    let mut total_nodes = 0usize;
+    let mut total_edges = 0usize;
+
+    // ====================================================================
+    // PHASE 1: Load all nodes
+    // ====================================================================
+    eprintln!("=== Phase 1: Loading Nodes ===");
+
+    let t = std::time::Instant::now();
+    let n = load_nodes(&data_dir.join("account.csv"), "Account", graph, &mut ids.account, props_account)?;
+    print_done(&format!("  Account:       {:>12} nodes ({})", format_num(n), format_duration(t.elapsed())));
+    total_nodes += n;
+
+    let t = std::time::Instant::now();
+    let n = load_nodes(&data_dir.join("person.csv"), "Person", graph, &mut ids.person, props_person)?;
+    print_done(&format!("  Person:        {:>12} nodes ({})", format_num(n), format_duration(t.elapsed())));
+    total_nodes += n;
+
+    let t = std::time::Instant::now();
+    let n = load_nodes(&data_dir.join("company.csv"), "Company", graph, &mut ids.company, props_company)?;
+    print_done(&format!("  Company:       {:>12} nodes ({})", format_num(n), format_duration(t.elapsed())));
+    total_nodes += n;
+
+    let t = std::time::Instant::now();
+    let n = load_nodes(&data_dir.join("loan.csv"), "Loan", graph, &mut ids.loan, props_loan)?;
+    print_done(&format!("  Loan:          {:>12} nodes ({})", format_num(n), format_duration(t.elapsed())));
+    total_nodes += n;
+
+    let t = std::time::Instant::now();
+    let n = load_nodes(&data_dir.join("medium.csv"), "Medium", graph, &mut ids.medium, props_medium)?;
+    print_done(&format!("  Medium:        {:>12} nodes ({})", format_num(n), format_duration(t.elapsed())));
+    total_nodes += n;
+
+    eprintln!();
+
+    // ====================================================================
+    // PHASE 2: Load all edges
+    // ====================================================================
+    eprintln!("=== Phase 2: Loading Edges ===");
+
+    // OWN: Person/Company -> Account
+    let t = std::time::Instant::now();
+    let n = load_edges(&data_dir.join("personOwnAccount.csv"), "OWN", graph, &ids.person, &ids.account, props_timestamp)?;
+    print_done(&format!("  OWN (Person->Account):                 {:>12} edges ({})", format_num(n), format_duration(t.elapsed())));
+    total_edges += n;
+
+    let t = std::time::Instant::now();
+    let n = load_edges(&data_dir.join("companyOwnAccount.csv"), "OWN", graph, &ids.company, &ids.account, props_timestamp)?;
+    print_done(&format!("  OWN (Company->Account):                {:>12} edges ({})", format_num(n), format_duration(t.elapsed())));
+    total_edges += n;
+
+    // TRANSFER: Account -> Account
+    let t = std::time::Instant::now();
+    let n = load_edges(&data_dir.join("transfer.csv"), "TRANSFER", graph, &ids.account, &ids.account, props_timestamp_amount)?;
+    print_done(&format!("  TRANSFER (Account->Account):           {:>12} edges ({})", format_num(n), format_duration(t.elapsed())));
+    total_edges += n;
+
+    // WITHDRAW: Account -> Account
+    let t = std::time::Instant::now();
+    let n = load_edges(&data_dir.join("withdraw.csv"), "WITHDRAW", graph, &ids.account, &ids.account, props_timestamp_amount)?;
+    print_done(&format!("  WITHDRAW (Account->Account):           {:>12} edges ({})", format_num(n), format_duration(t.elapsed())));
+    total_edges += n;
+
+    // DEPOSIT: Loan -> Account
+    let t = std::time::Instant::now();
+    let n = load_edges(&data_dir.join("deposit.csv"), "DEPOSIT", graph, &ids.loan, &ids.account, props_timestamp_amount)?;
+    print_done(&format!("  DEPOSIT (Loan->Account):               {:>12} edges ({})", format_num(n), format_duration(t.elapsed())));
+    total_edges += n;
+
+    // REPAY: Account -> Loan
+    let t = std::time::Instant::now();
+    let n = load_edges(&data_dir.join("repay.csv"), "REPAY", graph, &ids.account, &ids.loan, props_timestamp_amount)?;
+    print_done(&format!("  REPAY (Account->Loan):                 {:>12} edges ({})", format_num(n), format_duration(t.elapsed())));
+    total_edges += n;
+
+    // SIGN_IN: Account -> Medium
+    let t = std::time::Instant::now();
+    let n = load_edges(&data_dir.join("signIn.csv"), "SIGN_IN", graph, &ids.account, &ids.medium, props_timestamp)?;
+    print_done(&format!("  SIGN_IN (Account->Medium):             {:>12} edges ({})", format_num(n), format_duration(t.elapsed())));
+    total_edges += n;
+
+    // APPLY: Person/Company -> Loan
+    let t = std::time::Instant::now();
+    let n = load_edges(&data_dir.join("personApplyLoan.csv"), "APPLY", graph, &ids.person, &ids.loan, props_timestamp)?;
+    print_done(&format!("  APPLY (Person->Loan):                  {:>12} edges ({})", format_num(n), format_duration(t.elapsed())));
+    total_edges += n;
+
+    let t = std::time::Instant::now();
+    let n = load_edges(&data_dir.join("companyApplyLoan.csv"), "APPLY", graph, &ids.company, &ids.loan, props_timestamp)?;
+    print_done(&format!("  APPLY (Company->Loan):                 {:>12} edges ({})", format_num(n), format_duration(t.elapsed())));
+    total_edges += n;
+
+    // INVEST: Company/Person -> Company
+    let t = std::time::Instant::now();
+    let n = load_edges(&data_dir.join("companyInvestCompany.csv"), "INVEST", graph, &ids.company, &ids.company, props_timestamp_ratio)?;
+    print_done(&format!("  INVEST (Company->Company):             {:>12} edges ({})", format_num(n), format_duration(t.elapsed())));
+    total_edges += n;
+
+    let t = std::time::Instant::now();
+    let n = load_edges(&data_dir.join("personInvestCompany.csv"), "INVEST", graph, &ids.person, &ids.company, props_timestamp_ratio)?;
+    print_done(&format!("  INVEST (Person->Company):              {:>12} edges ({})", format_num(n), format_duration(t.elapsed())));
+    total_edges += n;
+
+    // GUARANTEE: Company/Person -> Company/Person
+    let t = std::time::Instant::now();
+    let n = load_edges(&data_dir.join("companyGuaranteeCompany.csv"), "GUARANTEE", graph, &ids.company, &ids.company, props_timestamp)?;
+    print_done(&format!("  GUARANTEE (Company->Company):          {:>12} edges ({})", format_num(n), format_duration(t.elapsed())));
+    total_edges += n;
+
+    let t = std::time::Instant::now();
+    let n = load_edges(&data_dir.join("personGuaranteePerson.csv"), "GUARANTEE", graph, &ids.person, &ids.person, props_timestamp)?;
+    print_done(&format!("  GUARANTEE (Person->Person):            {:>12} edges ({})", format_num(n), format_duration(t.elapsed())));
+    total_edges += n;
+
+    Ok(LoadResult { total_nodes, total_edges })
+}
+
+// ============================================================================
+// SYNTHETIC DATA GENERATOR
+// ============================================================================
+
+/// Configuration for synthetic data generation.
+pub struct GeneratorConfig {
+    pub num_persons: usize,
+    pub num_companies: usize,
+    pub num_accounts: usize,
+    pub num_loans: usize,
+    pub num_mediums: usize,
+    pub num_transfers: usize,
+    pub num_withdrawals: usize,
+    pub num_deposits: usize,
+    pub num_repayments: usize,
+    pub num_sign_ins: usize,
+}
+
+impl Default for GeneratorConfig {
+    fn default() -> Self {
+        Self {
+            num_persons: 1_000,
+            num_companies: 500,
+            num_accounts: 5_000,
+            num_loans: 1_000,
+            num_mediums: 200,
+            num_transfers: 20_000,
+            num_withdrawals: 5_000,
+            num_deposits: 2_000,
+            num_repayments: 3_000,
+            num_sign_ins: 8_000,
+        }
+    }
+}
+
+/// Simple deterministic pseudo-random number generator (xorshift64).
+/// Used instead of `rand` so this module has no extra dependencies.
+struct SimpleRng {
+    state: u64,
+}
+
+impl SimpleRng {
+    fn new(seed: u64) -> Self {
+        Self { state: if seed == 0 { 1 } else { seed } }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.state = x;
+        x
+    }
+
+    fn next_usize(&mut self, max: usize) -> usize {
+        (self.next_u64() % max as u64) as usize
+    }
+
+    fn next_f64(&mut self) -> f64 {
+        (self.next_u64() & 0x001F_FFFF_FFFF_FFFF) as f64 / (1u64 << 53) as f64
+    }
+
+    fn next_bool(&mut self, prob: f64) -> bool {
+        self.next_f64() < prob
+    }
+}
+
+const FIRST_NAMES: &[&str] = &[
+    "Alice", "Bob", "Charlie", "Diana", "Eve", "Frank", "Grace", "Henry",
+    "Ivy", "Jack", "Karen", "Leo", "Mona", "Nathan", "Olivia", "Paul",
+    "Quinn", "Rachel", "Sam", "Tina", "Uma", "Victor", "Wendy", "Xavier",
+    "Yuki", "Zara", "Amit", "Bala", "Chen", "Dev", "Elena", "Feng",
+    "Gita", "Hans", "Ines", "Jun", "Kira", "Liam", "Mai", "Noor",
+    "Omar", "Priya", "Raj", "Suki", "Tao", "Uri", "Vera", "Wei",
+];
+
+const LAST_NAMES: &[&str] = &[
+    "Smith", "Johnson", "Williams", "Brown", "Jones", "Garcia", "Miller",
+    "Davis", "Rodriguez", "Martinez", "Kumar", "Singh", "Wang", "Li",
+    "Zhang", "Chen", "Yang", "Huang", "Zhao", "Wu", "Patel", "Shah",
+    "Gupta", "Muller", "Schmidt", "Fischer", "Weber", "Meyer", "Tanaka",
+    "Suzuki", "Takahashi", "Watanabe", "Kim", "Park", "Lee", "Choi",
+];
+
+const COMPANY_SUFFIXES: &[&str] = &[
+    "Corp", "Inc", "Ltd", "Group", "Holdings", "Partners", "Capital",
+    "Technologies", "Financial", "Solutions", "Global", "Systems",
+    "Ventures", "Dynamics", "Industries", "Consulting", "Networks",
+    "Analytics", "Digital", "Services",
+];
+
+const COMPANY_PREFIXES: &[&str] = &[
+    "Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Theta",
+    "Atlas", "Nova", "Apex", "Vertex", "Nexus", "Prism", "Quantum",
+    "Stellar", "Fusion", "Orion", "Phoenix", "Summit", "Prime",
+    "Azure", "Cobalt", "Emerald", "Falcon", "Glacier", "Harbor",
+    "Ivory", "Jade", "Keystone", "Lunar", "Marble", "Neptune",
+];
+
+const ACCOUNT_TYPES: &[&str] = &["checking", "savings", "investment", "business"];
+const MEDIUM_TYPES: &[&str] = &["phone", "tablet", "laptop", "desktop", "ATM"];
+
+/// Generate a synthetic FinBench dataset directly into GraphStore.
+pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> LoadResult {
+    let mut rng = SimpleRng::new(42);
+    let mut ids = IdMaps::new();
+    let mut total_nodes = 0usize;
+    let mut total_edges = 0usize;
+
+    // Base timestamp: 2020-01-01 00:00:00 UTC (in milliseconds)
+    let base_ts: i64 = 1_577_836_800_000;
+    // Time range: 3 years in milliseconds
+    let time_range: i64 = 3 * 365 * 24 * 3600 * 1000;
+
+    let random_ts = |rng: &mut SimpleRng| -> i64 {
+        base_ts + (rng.next_u64() % time_range as u64) as i64
+    };
+
+    // ====================================================================
+    // PHASE 1: Generate nodes
+    // ====================================================================
+    eprintln!("=== Phase 1: Generating Nodes ===");
+
+    // Persons
+    let t = std::time::Instant::now();
+    for i in 0..config.num_persons {
+        let person_id = (i + 1) as i64;
+        let node_id = graph.create_node("Person");
+        if let Some(node) = graph.get_node_mut(node_id) {
+            node.set_property("id", person_id);
+            let first = FIRST_NAMES[rng.next_usize(FIRST_NAMES.len())];
+            let last = LAST_NAMES[rng.next_usize(LAST_NAMES.len())];
+            node.set_property("name", PropertyValue::String(format!("{} {}", first, last)));
+            node.set_property("isBlocked", PropertyValue::Boolean(rng.next_bool(0.02)));
+        }
+        ids.person.insert(person_id, node_id);
+        total_nodes += 1;
+    }
+    print_done(&format!("  Person:        {:>12} nodes ({})", format_num(config.num_persons), format_duration(t.elapsed())));
+
+    // Companies
+    let t = std::time::Instant::now();
+    for i in 0..config.num_companies {
+        let company_id = (i + 1) as i64;
+        let node_id = graph.create_node("Company");
+        if let Some(node) = graph.get_node_mut(node_id) {
+            node.set_property("id", company_id);
+            let prefix = COMPANY_PREFIXES[rng.next_usize(COMPANY_PREFIXES.len())];
+            let suffix = COMPANY_SUFFIXES[rng.next_usize(COMPANY_SUFFIXES.len())];
+            node.set_property("name", PropertyValue::String(format!("{} {}", prefix, suffix)));
+            node.set_property("isBlocked", PropertyValue::Boolean(rng.next_bool(0.01)));
+        }
+        ids.company.insert(company_id, node_id);
+        total_nodes += 1;
+    }
+    print_done(&format!("  Company:       {:>12} nodes ({})", format_num(config.num_companies), format_duration(t.elapsed())));
+
+    // Accounts
+    let t = std::time::Instant::now();
+    for i in 0..config.num_accounts {
+        let account_id = (i + 1) as i64;
+        let node_id = graph.create_node("Account");
+        if let Some(node) = graph.get_node_mut(node_id) {
+            node.set_property("id", account_id);
+            node.set_property("createTime", PropertyValue::DateTime(random_ts(&mut rng)));
+            node.set_property("isBlocked", PropertyValue::Boolean(rng.next_bool(0.03)));
+            let acct_type = ACCOUNT_TYPES[rng.next_usize(ACCOUNT_TYPES.len())];
+            node.set_property("accountType", PropertyValue::String(acct_type.to_string()));
+        }
+        ids.account.insert(account_id, node_id);
+        total_nodes += 1;
+    }
+    print_done(&format!("  Account:       {:>12} nodes ({})", format_num(config.num_accounts), format_duration(t.elapsed())));
+
+    // Loans
+    let t = std::time::Instant::now();
+    for i in 0..config.num_loans {
+        let loan_id = (i + 1) as i64;
+        let node_id = graph.create_node("Loan");
+        if let Some(node) = graph.get_node_mut(node_id) {
+            node.set_property("id", loan_id);
+            // Loan amounts between 1,000 and 500,000
+            let amount = 1000.0 + rng.next_f64() * 499_000.0;
+            node.set_property("loanAmount", PropertyValue::Float(amount));
+            // Balance is some fraction of the original amount
+            let balance = amount * rng.next_f64();
+            node.set_property("balance", PropertyValue::Float(balance));
+        }
+        ids.loan.insert(loan_id, node_id);
+        total_nodes += 1;
+    }
+    print_done(&format!("  Loan:          {:>12} nodes ({})", format_num(config.num_loans), format_duration(t.elapsed())));
+
+    // Mediums
+    let t = std::time::Instant::now();
+    for i in 0..config.num_mediums {
+        let medium_id = (i + 1) as i64;
+        let node_id = graph.create_node("Medium");
+        if let Some(node) = graph.get_node_mut(node_id) {
+            node.set_property("id", medium_id);
+            let mtype = MEDIUM_TYPES[rng.next_usize(MEDIUM_TYPES.len())];
+            node.set_property("mediumType", PropertyValue::String(mtype.to_string()));
+            node.set_property("isBlocked", PropertyValue::Boolean(rng.next_bool(0.02)));
+        }
+        ids.medium.insert(medium_id, node_id);
+        total_nodes += 1;
+    }
+    print_done(&format!("  Medium:        {:>12} nodes ({})", format_num(config.num_mediums), format_duration(t.elapsed())));
+
+    eprintln!();
+
+    // ====================================================================
+    // PHASE 2: Generate edges
+    // ====================================================================
+    eprintln!("=== Phase 2: Generating Edges ===");
+
+    // Collect IDs for random selection
+    let person_ids: Vec<i64> = (1..=config.num_persons as i64).collect();
+    let company_ids: Vec<i64> = (1..=config.num_companies as i64).collect();
+    let account_ids: Vec<i64> = (1..=config.num_accounts as i64).collect();
+    let loan_ids: Vec<i64> = (1..=config.num_loans as i64).collect();
+    let medium_ids: Vec<i64> = (1..=config.num_mediums as i64).collect();
+
+    // OWN: Each person owns 1-5 accounts, each company owns 1-3 accounts
+    let t = std::time::Instant::now();
+    let mut own_count = 0usize;
+    let mut owned_accounts = std::collections::HashSet::new();
+
+    for &pid in &person_ids {
+        let num_accounts = 1 + rng.next_usize(5);
+        for _ in 0..num_accounts {
+            let aid = account_ids[rng.next_usize(account_ids.len())];
+            if owned_accounts.contains(&aid) { continue; }
+            let src = ids.person[&pid];
+            let tgt = ids.account[&aid];
+            if let Ok(eid) = graph.create_edge(src, tgt, "OWN") {
+                if let Some(edge) = graph.get_edge_mut(eid) {
+                    edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+                }
+                own_count += 1;
+                owned_accounts.insert(aid);
+            }
+        }
+    }
+    for &cid in &company_ids {
+        let num_accounts = 1 + rng.next_usize(3);
+        for _ in 0..num_accounts {
+            let aid = account_ids[rng.next_usize(account_ids.len())];
+            if owned_accounts.contains(&aid) { continue; }
+            let src = ids.company[&cid];
+            let tgt = ids.account[&aid];
+            if let Ok(eid) = graph.create_edge(src, tgt, "OWN") {
+                if let Some(edge) = graph.get_edge_mut(eid) {
+                    edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+                }
+                own_count += 1;
+                owned_accounts.insert(aid);
+            }
+        }
+    }
+    print_done(&format!("  OWN:                                   {:>12} edges ({})", format_num(own_count), format_duration(t.elapsed())));
+    total_edges += own_count;
+
+    // TRANSFER: Account -> Account
+    let t = std::time::Instant::now();
+    let mut transfer_count = 0usize;
+    for _ in 0..config.num_transfers {
+        let src_aid = account_ids[rng.next_usize(account_ids.len())];
+        let mut tgt_aid = account_ids[rng.next_usize(account_ids.len())];
+        while tgt_aid == src_aid {
+            tgt_aid = account_ids[rng.next_usize(account_ids.len())];
+        }
+        let src = ids.account[&src_aid];
+        let tgt = ids.account[&tgt_aid];
+        if let Ok(eid) = graph.create_edge(src, tgt, "TRANSFER") {
+            if let Some(edge) = graph.get_edge_mut(eid) {
+                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+                let amount = 10.0 + rng.next_f64() * 50_000.0;
+                edge.set_property("amount", PropertyValue::Float(amount));
+            }
+            transfer_count += 1;
+        }
+    }
+    print_done(&format!("  TRANSFER:                              {:>12} edges ({})", format_num(transfer_count), format_duration(t.elapsed())));
+    total_edges += transfer_count;
+
+    // WITHDRAW: Account -> Account
+    let t = std::time::Instant::now();
+    let mut withdraw_count = 0usize;
+    for _ in 0..config.num_withdrawals {
+        let src_aid = account_ids[rng.next_usize(account_ids.len())];
+        let mut tgt_aid = account_ids[rng.next_usize(account_ids.len())];
+        while tgt_aid == src_aid {
+            tgt_aid = account_ids[rng.next_usize(account_ids.len())];
+        }
+        let src = ids.account[&src_aid];
+        let tgt = ids.account[&tgt_aid];
+        if let Ok(eid) = graph.create_edge(src, tgt, "WITHDRAW") {
+            if let Some(edge) = graph.get_edge_mut(eid) {
+                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+                let amount = 50.0 + rng.next_f64() * 20_000.0;
+                edge.set_property("amount", PropertyValue::Float(amount));
+            }
+            withdraw_count += 1;
+        }
+    }
+    print_done(&format!("  WITHDRAW:                              {:>12} edges ({})", format_num(withdraw_count), format_duration(t.elapsed())));
+    total_edges += withdraw_count;
+
+    // DEPOSIT: Loan -> Account
+    let t = std::time::Instant::now();
+    let mut deposit_count = 0usize;
+    for _ in 0..config.num_deposits {
+        let lid = loan_ids[rng.next_usize(loan_ids.len())];
+        let aid = account_ids[rng.next_usize(account_ids.len())];
+        let src = ids.loan[&lid];
+        let tgt = ids.account[&aid];
+        if let Ok(eid) = graph.create_edge(src, tgt, "DEPOSIT") {
+            if let Some(edge) = graph.get_edge_mut(eid) {
+                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+                let amount = 500.0 + rng.next_f64() * 100_000.0;
+                edge.set_property("amount", PropertyValue::Float(amount));
+            }
+            deposit_count += 1;
+        }
+    }
+    print_done(&format!("  DEPOSIT:                               {:>12} edges ({})", format_num(deposit_count), format_duration(t.elapsed())));
+    total_edges += deposit_count;
+
+    // REPAY: Account -> Loan
+    let t = std::time::Instant::now();
+    let mut repay_count = 0usize;
+    for _ in 0..config.num_repayments {
+        let aid = account_ids[rng.next_usize(account_ids.len())];
+        let lid = loan_ids[rng.next_usize(loan_ids.len())];
+        let src = ids.account[&aid];
+        let tgt = ids.loan[&lid];
+        if let Ok(eid) = graph.create_edge(src, tgt, "REPAY") {
+            if let Some(edge) = graph.get_edge_mut(eid) {
+                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+                let amount = 100.0 + rng.next_f64() * 50_000.0;
+                edge.set_property("amount", PropertyValue::Float(amount));
+            }
+            repay_count += 1;
+        }
+    }
+    print_done(&format!("  REPAY:                                 {:>12} edges ({})", format_num(repay_count), format_duration(t.elapsed())));
+    total_edges += repay_count;
+
+    // SIGN_IN: Account -> Medium
+    let t = std::time::Instant::now();
+    let mut signin_count = 0usize;
+    for _ in 0..config.num_sign_ins {
+        let aid = account_ids[rng.next_usize(account_ids.len())];
+        let mid = medium_ids[rng.next_usize(medium_ids.len())];
+        let src = ids.account[&aid];
+        let tgt = ids.medium[&mid];
+        if let Ok(eid) = graph.create_edge(src, tgt, "SIGN_IN") {
+            if let Some(edge) = graph.get_edge_mut(eid) {
+                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+            }
+            signin_count += 1;
+        }
+    }
+    print_done(&format!("  SIGN_IN:                               {:>12} edges ({})", format_num(signin_count), format_duration(t.elapsed())));
+    total_edges += signin_count;
+
+    // APPLY: Person/Company -> Loan
+    let t = std::time::Instant::now();
+    let mut apply_count = 0usize;
+    // Each loan has 1 applicant
+    for &lid in &loan_ids {
+        let src = if rng.next_bool(0.6) {
+            let pid = person_ids[rng.next_usize(person_ids.len())];
+            ids.person[&pid]
+        } else {
+            let cid = company_ids[rng.next_usize(company_ids.len())];
+            ids.company[&cid]
+        };
+        let tgt = ids.loan[&lid];
+        if let Ok(eid) = graph.create_edge(src, tgt, "APPLY") {
+            if let Some(edge) = graph.get_edge_mut(eid) {
+                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+            }
+            apply_count += 1;
+        }
+    }
+    print_done(&format!("  APPLY:                                 {:>12} edges ({})", format_num(apply_count), format_duration(t.elapsed())));
+    total_edges += apply_count;
+
+    // INVEST: Company/Person -> Company
+    let t = std::time::Instant::now();
+    let mut invest_count = 0usize;
+    let num_investments = config.num_companies / 2;
+    for _ in 0..num_investments {
+        let tgt_cid = company_ids[rng.next_usize(company_ids.len())];
+        let src = if rng.next_bool(0.7) {
+            let cid = company_ids[rng.next_usize(company_ids.len())];
+            if cid == tgt_cid { continue; }
+            ids.company[&cid]
+        } else {
+            let pid = person_ids[rng.next_usize(person_ids.len())];
+            ids.person[&pid]
+        };
+        let tgt = ids.company[&tgt_cid];
+        if let Ok(eid) = graph.create_edge(src, tgt, "INVEST") {
+            if let Some(edge) = graph.get_edge_mut(eid) {
+                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+                let ratio = rng.next_f64();
+                edge.set_property("ratio", PropertyValue::Float(ratio));
+            }
+            invest_count += 1;
+        }
+    }
+    print_done(&format!("  INVEST:                                {:>12} edges ({})", format_num(invest_count), format_duration(t.elapsed())));
+    total_edges += invest_count;
+
+    // GUARANTEE: Company/Person -> Company/Person
+    let t = std::time::Instant::now();
+    let mut guarantee_count = 0usize;
+    let num_guarantees = config.num_persons / 5;
+    for _ in 0..num_guarantees {
+        // Mostly company-company guarantees, some person-person
+        if rng.next_bool(0.6) {
+            let src_cid = company_ids[rng.next_usize(company_ids.len())];
+            let tgt_cid = company_ids[rng.next_usize(company_ids.len())];
+            if src_cid == tgt_cid { continue; }
+            let src = ids.company[&src_cid];
+            let tgt = ids.company[&tgt_cid];
+            if let Ok(eid) = graph.create_edge(src, tgt, "GUARANTEE") {
+                if let Some(edge) = graph.get_edge_mut(eid) {
+                    edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+                }
+                guarantee_count += 1;
+            }
+        } else {
+            let src_pid = person_ids[rng.next_usize(person_ids.len())];
+            let tgt_pid = person_ids[rng.next_usize(person_ids.len())];
+            if src_pid == tgt_pid { continue; }
+            let src = ids.person[&src_pid];
+            let tgt = ids.person[&tgt_pid];
+            if let Ok(eid) = graph.create_edge(src, tgt, "GUARANTEE") {
+                if let Some(edge) = graph.get_edge_mut(eid) {
+                    edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+                }
+                guarantee_count += 1;
+            }
+        }
+    }
+    print_done(&format!("  GUARANTEE:                             {:>12} edges ({})", format_num(guarantee_count), format_duration(t.elapsed())));
+    total_edges += guarantee_count;
+
+    LoadResult { total_nodes, total_edges }
+}
+
+// ============================================================================
+// CSV DATA GENERATOR (writes to disk)
+// ============================================================================
+
+/// Write generated CSV files to disk for the FinBench schema.
+/// Uses the same synthetic generator logic but writes pipe-delimited CSVs.
+pub fn write_csv_dataset(data_dir: &Path, config: &GeneratorConfig) -> Result<(), Error> {
+    std::fs::create_dir_all(data_dir)?;
+    let mut rng = SimpleRng::new(42);
+
+    // Base timestamp: 2020-01-01 00:00:00 UTC (in milliseconds)
+    let base_ts: i64 = 1_577_836_800_000;
+    let time_range: i64 = 3 * 365 * 24 * 3600 * 1000;
+    let random_ts = |rng: &mut SimpleRng| -> i64 {
+        base_ts + (rng.next_u64() % time_range as u64) as i64
+    };
+
+    eprintln!("Writing FinBench CSV files to: {}", data_dir.display());
+
+    // --- Person ---
+    {
+        let mut f = File::create(data_dir.join("person.csv"))?;
+        writeln!(f, "id|name|isBlocked")?;
+        for i in 0..config.num_persons {
+            let first = FIRST_NAMES[rng.next_usize(FIRST_NAMES.len())];
+            let last = LAST_NAMES[rng.next_usize(LAST_NAMES.len())];
+            writeln!(f, "{}|{} {}|{}", i + 1, first, last, rng.next_bool(0.02))?;
+        }
+    }
+    eprintln!("  person.csv             ({} rows)", format_num(config.num_persons));
+
+    // --- Company ---
+    {
+        let mut f = File::create(data_dir.join("company.csv"))?;
+        writeln!(f, "id|name|isBlocked")?;
+        for i in 0..config.num_companies {
+            let prefix = COMPANY_PREFIXES[rng.next_usize(COMPANY_PREFIXES.len())];
+            let suffix = COMPANY_SUFFIXES[rng.next_usize(COMPANY_SUFFIXES.len())];
+            writeln!(f, "{}|{} {}|{}", i + 1, prefix, suffix, rng.next_bool(0.01))?;
+        }
+    }
+    eprintln!("  company.csv            ({} rows)", format_num(config.num_companies));
+
+    // --- Account ---
+    {
+        let mut f = File::create(data_dir.join("account.csv"))?;
+        writeln!(f, "id|createTime|isBlocked|accountType")?;
+        for i in 0..config.num_accounts {
+            let acct_type = ACCOUNT_TYPES[rng.next_usize(ACCOUNT_TYPES.len())];
+            writeln!(f, "{}|{}|{}|{}", i + 1, random_ts(&mut rng), rng.next_bool(0.03), acct_type)?;
+        }
+    }
+    eprintln!("  account.csv            ({} rows)", format_num(config.num_accounts));
+
+    // --- Loan ---
+    {
+        let mut f = File::create(data_dir.join("loan.csv"))?;
+        writeln!(f, "id|loanAmount|balance")?;
+        for i in 0..config.num_loans {
+            let amount = 1000.0 + rng.next_f64() * 499_000.0;
+            let balance = amount * rng.next_f64();
+            writeln!(f, "{}|{:.2}|{:.2}", i + 1, amount, balance)?;
+        }
+    }
+    eprintln!("  loan.csv               ({} rows)", format_num(config.num_loans));
+
+    // --- Medium ---
+    {
+        let mut f = File::create(data_dir.join("medium.csv"))?;
+        writeln!(f, "id|mediumType|isBlocked")?;
+        for i in 0..config.num_mediums {
+            let mtype = MEDIUM_TYPES[rng.next_usize(MEDIUM_TYPES.len())];
+            writeln!(f, "{}|{}|{}", i + 1, mtype, rng.next_bool(0.02))?;
+        }
+    }
+    eprintln!("  medium.csv             ({} rows)", format_num(config.num_mediums));
+
+    // --- Edge CSVs ---
+
+    // personOwnAccount.csv
+    let mut owned_accounts = std::collections::HashSet::new();
+    {
+        let mut f = File::create(data_dir.join("personOwnAccount.csv"))?;
+        writeln!(f, "srcId|tgtId|timestamp")?;
+        let mut count = 0;
+        for i in 0..config.num_persons {
+            let pid = (i + 1) as i64;
+            let num_accounts = 1 + rng.next_usize(5);
+            for _ in 0..num_accounts {
+                let aid = (1 + rng.next_usize(config.num_accounts)) as i64;
+                if owned_accounts.contains(&aid) { continue; }
+                writeln!(f, "{}|{}|{}", pid, aid, random_ts(&mut rng))?;
+                owned_accounts.insert(aid);
+                count += 1;
+            }
+        }
+        eprintln!("  personOwnAccount.csv   ({} rows)", format_num(count));
+    }
+
+    // companyOwnAccount.csv
+    {
+        let mut f = File::create(data_dir.join("companyOwnAccount.csv"))?;
+        writeln!(f, "srcId|tgtId|timestamp")?;
+        let mut count = 0;
+        for i in 0..config.num_companies {
+            let cid = (i + 1) as i64;
+            let num_accounts = 1 + rng.next_usize(3);
+            for _ in 0..num_accounts {
+                let aid = (1 + rng.next_usize(config.num_accounts)) as i64;
+                if owned_accounts.contains(&aid) { continue; }
+                writeln!(f, "{}|{}|{}", cid, aid, random_ts(&mut rng))?;
+                owned_accounts.insert(aid);
+                count += 1;
+            }
+        }
+        eprintln!("  companyOwnAccount.csv  ({} rows)", format_num(count));
+    }
+
+    // transfer.csv
+    {
+        let mut f = File::create(data_dir.join("transfer.csv"))?;
+        writeln!(f, "srcId|tgtId|timestamp|amount")?;
+        for _ in 0..config.num_transfers {
+            let src = (1 + rng.next_usize(config.num_accounts)) as i64;
+            let mut tgt = (1 + rng.next_usize(config.num_accounts)) as i64;
+            while tgt == src { tgt = (1 + rng.next_usize(config.num_accounts)) as i64; }
+            let amount = 10.0 + rng.next_f64() * 50_000.0;
+            writeln!(f, "{}|{}|{}|{:.2}", src, tgt, random_ts(&mut rng), amount)?;
+        }
+        eprintln!("  transfer.csv           ({} rows)", format_num(config.num_transfers));
+    }
+
+    // withdraw.csv
+    {
+        let mut f = File::create(data_dir.join("withdraw.csv"))?;
+        writeln!(f, "srcId|tgtId|timestamp|amount")?;
+        for _ in 0..config.num_withdrawals {
+            let src = (1 + rng.next_usize(config.num_accounts)) as i64;
+            let mut tgt = (1 + rng.next_usize(config.num_accounts)) as i64;
+            while tgt == src { tgt = (1 + rng.next_usize(config.num_accounts)) as i64; }
+            let amount = 50.0 + rng.next_f64() * 20_000.0;
+            writeln!(f, "{}|{}|{}|{:.2}", src, tgt, random_ts(&mut rng), amount)?;
+        }
+        eprintln!("  withdraw.csv           ({} rows)", format_num(config.num_withdrawals));
+    }
+
+    // deposit.csv
+    {
+        let mut f = File::create(data_dir.join("deposit.csv"))?;
+        writeln!(f, "srcId|tgtId|timestamp|amount")?;
+        for _ in 0..config.num_deposits {
+            let lid = (1 + rng.next_usize(config.num_loans)) as i64;
+            let aid = (1 + rng.next_usize(config.num_accounts)) as i64;
+            let amount = 500.0 + rng.next_f64() * 100_000.0;
+            writeln!(f, "{}|{}|{}|{:.2}", lid, aid, random_ts(&mut rng), amount)?;
+        }
+        eprintln!("  deposit.csv            ({} rows)", format_num(config.num_deposits));
+    }
+
+    // repay.csv
+    {
+        let mut f = File::create(data_dir.join("repay.csv"))?;
+        writeln!(f, "srcId|tgtId|timestamp|amount")?;
+        for _ in 0..config.num_repayments {
+            let aid = (1 + rng.next_usize(config.num_accounts)) as i64;
+            let lid = (1 + rng.next_usize(config.num_loans)) as i64;
+            let amount = 100.0 + rng.next_f64() * 50_000.0;
+            writeln!(f, "{}|{}|{}|{:.2}", aid, lid, random_ts(&mut rng), amount)?;
+        }
+        eprintln!("  repay.csv              ({} rows)", format_num(config.num_repayments));
+    }
+
+    // signIn.csv
+    {
+        let mut f = File::create(data_dir.join("signIn.csv"))?;
+        writeln!(f, "srcId|tgtId|timestamp")?;
+        for _ in 0..config.num_sign_ins {
+            let aid = (1 + rng.next_usize(config.num_accounts)) as i64;
+            let mid = (1 + rng.next_usize(config.num_mediums)) as i64;
+            writeln!(f, "{}|{}|{}", aid, mid, random_ts(&mut rng))?;
+        }
+        eprintln!("  signIn.csv             ({} rows)", format_num(config.num_sign_ins));
+    }
+
+    // personApplyLoan.csv and companyApplyLoan.csv
+    {
+        let mut fp = File::create(data_dir.join("personApplyLoan.csv"))?;
+        let mut fc = File::create(data_dir.join("companyApplyLoan.csv"))?;
+        writeln!(fp, "srcId|tgtId|timestamp")?;
+        writeln!(fc, "srcId|tgtId|timestamp")?;
+        let mut pcount = 0;
+        let mut ccount = 0;
+        for i in 0..config.num_loans {
+            let lid = (i + 1) as i64;
+            if rng.next_bool(0.6) {
+                let pid = (1 + rng.next_usize(config.num_persons)) as i64;
+                writeln!(fp, "{}|{}|{}", pid, lid, random_ts(&mut rng))?;
+                pcount += 1;
+            } else {
+                let cid = (1 + rng.next_usize(config.num_companies)) as i64;
+                writeln!(fc, "{}|{}|{}", cid, lid, random_ts(&mut rng))?;
+                ccount += 1;
+            }
+        }
+        eprintln!("  personApplyLoan.csv    ({} rows)", format_num(pcount));
+        eprintln!("  companyApplyLoan.csv   ({} rows)", format_num(ccount));
+    }
+
+    // companyInvestCompany.csv and personInvestCompany.csv
+    {
+        let mut fc = File::create(data_dir.join("companyInvestCompany.csv"))?;
+        let mut fp = File::create(data_dir.join("personInvestCompany.csv"))?;
+        writeln!(fc, "srcId|tgtId|timestamp|ratio")?;
+        writeln!(fp, "srcId|tgtId|timestamp|ratio")?;
+        let mut ccount = 0;
+        let mut pcount = 0;
+        let num_investments = config.num_companies / 2;
+        for _ in 0..num_investments {
+            let tgt_cid = (1 + rng.next_usize(config.num_companies)) as i64;
+            if rng.next_bool(0.7) {
+                let src_cid = (1 + rng.next_usize(config.num_companies)) as i64;
+                if src_cid == tgt_cid { continue; }
+                writeln!(fc, "{}|{}|{}|{:.4}", src_cid, tgt_cid, random_ts(&mut rng), rng.next_f64())?;
+                ccount += 1;
+            } else {
+                let pid = (1 + rng.next_usize(config.num_persons)) as i64;
+                writeln!(fp, "{}|{}|{}|{:.4}", pid, tgt_cid, random_ts(&mut rng), rng.next_f64())?;
+                pcount += 1;
+            }
+        }
+        eprintln!("  companyInvestCompany.csv ({} rows)", format_num(ccount));
+        eprintln!("  personInvestCompany.csv  ({} rows)", format_num(pcount));
+    }
+
+    // companyGuaranteeCompany.csv and personGuaranteePerson.csv
+    {
+        let mut fc = File::create(data_dir.join("companyGuaranteeCompany.csv"))?;
+        let mut fp = File::create(data_dir.join("personGuaranteePerson.csv"))?;
+        writeln!(fc, "srcId|tgtId|timestamp")?;
+        writeln!(fp, "srcId|tgtId|timestamp")?;
+        let mut ccount = 0;
+        let mut pcount = 0;
+        let num_guarantees = config.num_persons / 5;
+        for _ in 0..num_guarantees {
+            if rng.next_bool(0.6) {
+                let src = (1 + rng.next_usize(config.num_companies)) as i64;
+                let tgt = (1 + rng.next_usize(config.num_companies)) as i64;
+                if src == tgt { continue; }
+                writeln!(fc, "{}|{}|{}", src, tgt, random_ts(&mut rng))?;
+                ccount += 1;
+            } else {
+                let src = (1 + rng.next_usize(config.num_persons)) as i64;
+                let tgt = (1 + rng.next_usize(config.num_persons)) as i64;
+                if src == tgt { continue; }
+                writeln!(fp, "{}|{}|{}", src, tgt, random_ts(&mut rng))?;
+                pcount += 1;
+            }
+        }
+        eprintln!("  companyGuaranteeCompany.csv ({} rows)", format_num(ccount));
+        eprintln!("  personGuaranteePerson.csv  ({} rows)", format_num(pcount));
+    }
+
+    eprintln!();
+    eprintln!("CSV generation complete.");
+
+    Ok(())
+}
+
+/// Get the default data directory path.
+pub fn default_data_dir() -> PathBuf {
+    PathBuf::from("data/finbench-sf1")
+}

--- a/examples/finbench_loader.rs
+++ b/examples/finbench_loader.rs
@@ -1,0 +1,125 @@
+//! LDBC FinBench Dataset Loader — Samyama Graph Database
+//!
+//! Loads the LDBC FinBench dataset into GraphStore via the Rust SDK API.
+//! Supports both CSV loading from disk and synthetic data generation.
+//!
+//! Usage:
+//!   cargo run --release --example finbench_loader                          # Generate synthetic data in-memory
+//!   cargo run --release --example finbench_loader -- --generate            # Generate CSV files to disk then load
+//!   cargo run --release --example finbench_loader -- --data-dir /path      # Load from existing CSV files
+//!   cargo run --release --example finbench_loader -- --query               # Drop into query loop after loading
+
+use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
+use std::time::Instant;
+
+use samyama_sdk::{EmbeddedClient, SamyamaClient};
+
+mod finbench_common;
+use finbench_common::{format_duration, format_num, GeneratorConfig};
+
+type Error = Box<dyn std::error::Error>;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let args: Vec<String> = std::env::args().collect();
+
+    let data_dir = if let Some(pos) = args.iter().position(|a| a == "--data-dir") {
+        Some(PathBuf::from(args.get(pos + 1).expect("--data-dir requires a path argument")))
+    } else {
+        None
+    };
+
+    let generate_csv = args.iter().any(|a| a == "--generate");
+    let query_mode = args.iter().any(|a| a == "--query");
+
+    eprintln!("LDBC FinBench Dataset Loader — Samyama v0.5.8");
+    eprintln!();
+
+    let client = EmbeddedClient::new();
+    let total_start = Instant::now();
+
+    let result = if let Some(ref dir) = data_dir {
+        // Load from existing CSV files
+        if !dir.exists() {
+            eprintln!("ERROR: Data directory not found: {}", dir.display());
+            eprintln!("Run with --generate to create synthetic data, or provide a valid --data-dir");
+            std::process::exit(1);
+        }
+        eprintln!("Loading FinBench dataset from CSV: {}", dir.display());
+        eprintln!();
+        let mut graph = client.store_write().await;
+        finbench_common::load_dataset(&mut graph, dir)?
+    } else if generate_csv {
+        // Generate CSV files to disk, then load them
+        let dir = finbench_common::default_data_dir();
+        eprintln!("Generating FinBench CSV files to: {}", dir.display());
+        eprintln!();
+        let config = GeneratorConfig::default();
+        finbench_common::write_csv_dataset(&dir, &config)?;
+        eprintln!();
+        eprintln!("Loading generated CSV files...");
+        eprintln!();
+        let mut graph = client.store_write().await;
+        finbench_common::load_dataset(&mut graph, &dir)?
+    } else {
+        // Generate synthetic data directly in memory (fastest)
+        eprintln!("Generating synthetic FinBench dataset in-memory...");
+        eprintln!();
+        let config = GeneratorConfig::default();
+        let mut graph = client.store_write().await;
+        finbench_common::generate_dataset(&mut graph, &config)
+    };
+
+    let total_elapsed = total_start.elapsed();
+    eprintln!();
+    eprintln!("========================================");
+    eprintln!("Total load time: {}", format_duration(total_elapsed));
+    eprintln!("Graph ready. Nodes: {}, Edges: {}", format_num(result.total_nodes), format_num(result.total_edges));
+    eprintln!("========================================");
+
+    // ========================================================================
+    // OPTIONAL: Interactive query mode
+    // ========================================================================
+    if query_mode {
+        eprintln!();
+        eprintln!("Entering query mode. Type Cypher queries or 'quit' to exit.");
+        eprintln!();
+
+        let stdin = io::stdin();
+        loop {
+            eprint!("cypher> ");
+            io::stderr().flush()?;
+
+            let mut input = String::new();
+            if stdin.lock().read_line(&mut input)? == 0 { break; }
+            let query = input.trim();
+            if query.is_empty() { continue; }
+            if query == "quit" || query == "exit" { break; }
+
+            match client.query("default", query).await {
+                Ok(result) => {
+                    if result.columns.is_empty() {
+                        eprintln!("(empty result)");
+                    } else {
+                        // Print header
+                        eprintln!("{}", result.columns.join(" | "));
+                        eprintln!("{}", "-".repeat(result.columns.len() * 20));
+                        // Print rows
+                        for row in &result.records {
+                            let vals: Vec<String> = row.iter()
+                                .map(|v| format!("{}", v))
+                                .collect();
+                            eprintln!("{}", vals.join(" | "));
+                        }
+                        eprintln!("({} rows)", result.records.len());
+                    }
+                }
+                Err(e) => eprintln!("ERROR: {}", e),
+            }
+            eprintln!();
+        }
+    }
+
+    Ok(())
+}

--- a/examples/graphalytics_benchmark.rs
+++ b/examples/graphalytics_benchmark.rs
@@ -1,0 +1,815 @@
+//! LDBC Graphalytics Benchmark Runner for Samyama Graph Database
+//!
+//! Implements the 6 core LDBC Graphalytics algorithms:
+//!   1. BFS  — Breadth-First Search (single-source, all distances)
+//!   2. PR   — PageRank
+//!   3. WCC  — Weakly Connected Components
+//!   4. CDLP — Community Detection via Label Propagation
+//!   5. LCC  — Local Clustering Coefficient
+//!   6. SSSP — Single-Source Shortest Path (Dijkstra)
+//!
+//! Loads graphs from standard Graphalytics edge-list format and builds a
+//! `GraphView` directly for pure algorithm benchmarking.
+//!
+//! When validation output files are present (downloaded by the script),
+//! results are compared against the official LDBC expected values.
+//!
+//! Usage:
+//!   cargo run --release --example graphalytics_benchmark -- --all
+//!   cargo run --release --example graphalytics_benchmark -- --dataset example-directed --algo BFS
+//!   cargo run --release --example graphalytics_benchmark -- --data-dir data/graphalytics/ --all
+
+use std::collections::{HashMap, VecDeque, BinaryHeap};
+use std::cmp::Ordering;
+use std::path::Path;
+use std::time::Instant;
+
+use samyama_graph_algorithms::{
+    GraphView,
+    page_rank, PageRankConfig,
+    weakly_connected_components,
+    cdlp, CdlpConfig,
+    local_clustering_coefficient,
+};
+
+mod graphalytics_common;
+use graphalytics_common::{
+    load_graphalytics_dataset, find_dataset_files, find_properties_file,
+    parse_properties, load_validation, DatasetProperties,
+    format_num, format_duration,
+};
+
+// ============================================================================
+// ALGORITHM IMPLEMENTATIONS (Graphalytics-specific single-source variants)
+// ============================================================================
+
+/// BFS from a single source, returning distances to all reachable nodes.
+/// Unreachable nodes get `u64::MAX` (matches Graphalytics convention of Long.MAX_VALUE).
+fn bfs_single_source(view: &GraphView, source_id: u64) -> HashMap<u64, u64> {
+    let mut result: HashMap<u64, u64> = HashMap::with_capacity(view.node_count);
+
+    // Initialize all nodes as unreachable
+    for &nid in &view.index_to_node {
+        result.insert(nid, u64::MAX);
+    }
+
+    let Some(&source_idx) = view.node_to_index.get(&source_id) else {
+        return result;
+    };
+
+    let mut distances: Vec<Option<u64>> = vec![None; view.node_count];
+    distances[source_idx] = Some(0);
+    let mut queue = VecDeque::new();
+    queue.push_back(source_idx);
+
+    while let Some(current) = queue.pop_front() {
+        let current_dist = distances[current].unwrap();
+        for &neighbor in view.successors(current) {
+            if distances[neighbor].is_none() {
+                distances[neighbor] = Some(current_dist + 1);
+                queue.push_back(neighbor);
+            }
+        }
+    }
+
+    for (idx, dist) in distances.into_iter().enumerate() {
+        if let Some(d) = dist {
+            result.insert(view.index_to_node[idx], d);
+        }
+    }
+    result
+}
+
+/// Dijkstra SSSP from a single source, returning distances to all reachable nodes.
+/// Uses edge weights if available, otherwise assumes weight 1.0.
+/// Unreachable nodes get `f64::INFINITY` (matches Graphalytics convention).
+fn sssp_single_source(view: &GraphView, source_id: u64) -> HashMap<u64, f64> {
+    let mut result: HashMap<u64, f64> = HashMap::with_capacity(view.node_count);
+
+    // Initialize all nodes as unreachable
+    for &nid in &view.index_to_node {
+        result.insert(nid, f64::INFINITY);
+    }
+
+    let Some(&source_idx) = view.node_to_index.get(&source_id) else {
+        return result;
+    };
+
+    #[derive(Copy, Clone, PartialEq)]
+    struct State {
+        cost: f64,
+        idx: usize,
+    }
+    impl Eq for State {}
+    impl Ord for State {
+        fn cmp(&self, other: &Self) -> Ordering {
+            other.cost.partial_cmp(&self.cost).unwrap_or(Ordering::Equal)
+        }
+    }
+    impl PartialOrd for State {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    let mut dist: Vec<f64> = vec![f64::INFINITY; view.node_count];
+    dist[source_idx] = 0.0;
+    let mut heap = BinaryHeap::new();
+    heap.push(State { cost: 0.0, idx: source_idx });
+
+    while let Some(State { cost, idx }) = heap.pop() {
+        if cost > dist[idx] {
+            continue;
+        }
+
+        let edges = view.successors(idx);
+        let weights = view.weights(idx);
+
+        for (i, &next_idx) in edges.iter().enumerate() {
+            let w = if let Some(ws) = weights { ws[i] } else { 1.0 };
+            if w < 0.0 {
+                continue;
+            }
+            let next_cost = cost + w;
+            if next_cost < dist[next_idx] {
+                dist[next_idx] = next_cost;
+                heap.push(State { cost: next_cost, idx: next_idx });
+            }
+        }
+    }
+
+    for (idx, &d) in dist.iter().enumerate() {
+        result.insert(view.index_to_node[idx], d);
+    }
+    result
+}
+
+// ============================================================================
+// BENCHMARK RUNNER
+// ============================================================================
+
+const ALL_ALGOS: &[&str] = &["BFS", "PR", "WCC", "CDLP", "LCC", "SSSP"];
+
+/// Default datasets to run when --all is specified without --dataset.
+const DEFAULT_DATASETS: &[&str] = &["example-directed", "example-undirected"];
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    let data_dir = get_arg(&args, "--data-dir")
+        .unwrap_or_else(|| "data/graphalytics".to_string());
+    let dataset_arg = get_arg(&args, "--dataset");
+    let algo_arg = get_arg(&args, "--algo");
+    let run_all = args.iter().any(|a| a == "--all");
+    let validate = !args.iter().any(|a| a == "--no-validate");
+
+    if !run_all && dataset_arg.is_none() && algo_arg.is_none() {
+        print_usage();
+        return;
+    }
+
+    // Determine which datasets to run
+    let datasets: Vec<String> = if let Some(ds) = dataset_arg {
+        vec![ds]
+    } else {
+        DEFAULT_DATASETS.iter().map(|s| s.to_string()).collect()
+    };
+
+    // Determine which algorithms to run
+    let algos: Vec<String> = if let Some(algo) = algo_arg {
+        vec![algo.to_uppercase()]
+    } else {
+        ALL_ALGOS.iter().map(|s| s.to_string()).collect()
+    };
+
+    println!();
+    println!("================================================================");
+    println!("  LDBC Graphalytics Benchmark -- Samyama Graph Database");
+    println!("================================================================");
+    println!();
+    println!("  Data directory: {}", data_dir);
+    println!("  Datasets:       {:?}", datasets);
+    println!("  Algorithms:     {:?}", algos);
+    println!("  Validation:     {}", if validate { "enabled" } else { "disabled" });
+    println!();
+
+    let data_path = Path::new(&data_dir);
+
+    let mut results: Vec<BenchmarkResult> = Vec::new();
+
+    for dataset in &datasets {
+        println!("----------------------------------------------------------------");
+        println!("  Dataset: {}", dataset);
+        println!("----------------------------------------------------------------");
+
+        // Find dataset files
+        let (vertex_path, edge_path) = match find_dataset_files(data_path, dataset) {
+            Ok(paths) => paths,
+            Err(e) => {
+                eprintln!("  ERROR: {}", e);
+                eprintln!("  Run scripts/download_graphalytics.sh to download datasets.");
+                eprintln!();
+                continue;
+            }
+        };
+
+        // Parse properties file for algorithm parameters
+        let props = if let Some(props_path) = find_properties_file(data_path, dataset) {
+            let p = parse_properties(&props_path);
+            println!("  Properties loaded from {}", props_path.display());
+            p
+        } else {
+            DatasetProperties::default()
+        };
+
+        let directed = props.directed.unwrap_or_else(|| {
+            graphalytics_common::is_directed(dataset)
+        });
+
+        // Load the graph
+        println!("  Loading {} (directed={})...", dataset, directed);
+        let load_start = Instant::now();
+        let loaded = match load_graphalytics_dataset(&vertex_path, &edge_path, directed, dataset) {
+            Ok(g) => g,
+            Err(e) => {
+                eprintln!("  ERROR loading dataset: {}", e);
+                continue;
+            }
+        };
+        let load_time = load_start.elapsed();
+
+        println!(
+            "  Loaded: {} vertices, {} edges in {}",
+            format_num(loaded.info.vertex_count),
+            format_num(loaded.info.edge_count),
+            format_duration(load_time),
+        );
+        println!();
+
+        let view = &loaded.view;
+
+        // Run each requested algorithm
+        for algo in &algos {
+            let result = run_algorithm(algo, view, dataset, &props, data_path, validate);
+            if let Some(r) = result {
+                let status = if r.validated {
+                    if r.validation_passed { "  PASS" } else { "  FAIL" }
+                } else {
+                    ""
+                };
+                println!(
+                    "  {:>6}  {:>12}  {}{}",
+                    r.algorithm,
+                    format_duration(r.duration),
+                    r.summary,
+                    status,
+                );
+                results.push(r);
+            }
+        }
+        println!();
+    }
+
+    // ── Final Summary Table ─────────────────────────────────────────────
+    if results.len() > 1 {
+        println!("================================================================");
+        println!("  SUMMARY");
+        println!("================================================================");
+        println!();
+        println!(
+            "  {:>20} {:>6} {:>10} {:>12}  {:>6}  {}",
+            "Dataset", "Algo", "Vertices", "Time", "Valid", "Result"
+        );
+        println!(
+            "  {:>20} {:>6} {:>10} {:>12}  {:>6}  {}",
+            "-------", "----", "--------", "----", "-----", "------"
+        );
+        for r in &results {
+            let valid_str = if r.validated {
+                if r.validation_passed { "PASS" } else { "FAIL" }
+            } else {
+                "-"
+            };
+            println!(
+                "  {:>20} {:>6} {:>10} {:>12}  {:>6}  {}",
+                r.dataset,
+                r.algorithm,
+                format_num(r.vertex_count),
+                format_duration(r.duration),
+                valid_str,
+                r.summary,
+            );
+        }
+        println!();
+    }
+
+    // Exit with non-zero status if any validations failed
+    let failures = results.iter().filter(|r| r.validated && !r.validation_passed).count();
+    if failures > 0 {
+        eprintln!("  {} validation(s) FAILED", failures);
+        std::process::exit(1);
+    }
+}
+
+// ============================================================================
+// ALGORITHM DISPATCH
+// ============================================================================
+
+struct BenchmarkResult {
+    dataset: String,
+    algorithm: String,
+    vertex_count: usize,
+    duration: std::time::Duration,
+    summary: String,
+    validated: bool,
+    validation_passed: bool,
+}
+
+fn run_algorithm(
+    algo: &str,
+    view: &GraphView,
+    dataset: &str,
+    props: &DatasetProperties,
+    data_dir: &Path,
+    validate: bool,
+) -> Option<BenchmarkResult> {
+    match algo {
+        "BFS" => {
+            let source_id = props.bfs_source.unwrap_or_else(|| {
+                if view.node_count > 0 { view.index_to_node[0] } else { 0 }
+            });
+
+            let start = Instant::now();
+            let distances = bfs_single_source(view, source_id);
+            let duration = start.elapsed();
+
+            let reachable = distances.values().filter(|&&d| d < u64::MAX).count();
+            let max_dist = distances.values().filter(|&&d| d < u64::MAX).max().copied().unwrap_or(0);
+
+            // Validation
+            let (validated, passed) = if validate {
+                validate_bfs(&distances, data_dir, dataset)
+            } else {
+                (false, false)
+            };
+
+            Some(BenchmarkResult {
+                dataset: dataset.to_string(),
+                algorithm: "BFS".to_string(),
+                vertex_count: view.node_count,
+                duration,
+                summary: format!(
+                    "source={}, reachable={}, max_depth={}",
+                    source_id, format_num(reachable), max_dist
+                ),
+                validated,
+                validation_passed: passed,
+            })
+        }
+
+        "PR" | "PAGERANK" => {
+            let damping = props.pr_damping.unwrap_or(0.85);
+            let iterations = props.pr_iterations.unwrap_or(20);
+
+            let config = PageRankConfig {
+                damping_factor: damping,
+                iterations,
+                tolerance: 0.0, // Use fixed iteration count
+            };
+
+            let start = Instant::now();
+            let scores = page_rank(view, config);
+            let duration = start.elapsed();
+
+            let max_score = scores.values().cloned().fold(0.0f64, f64::max);
+            let min_score = scores.values().cloned().fold(f64::MAX, f64::min);
+
+            let (validated, passed) = if validate {
+                validate_float_map(&scores, data_dir, dataset, "PR", 1e-6)
+            } else {
+                (false, false)
+            };
+
+            Some(BenchmarkResult {
+                dataset: dataset.to_string(),
+                algorithm: "PR".to_string(),
+                vertex_count: view.node_count,
+                duration,
+                summary: format!(
+                    "iters={}, d={}, min={:.6}, max={:.6}",
+                    iterations, damping, min_score, max_score
+                ),
+                validated,
+                validation_passed: passed,
+            })
+        }
+
+        "WCC" => {
+            let start = Instant::now();
+            let wcc = weakly_connected_components(view);
+            let duration = start.elapsed();
+
+            let num_components = wcc.components.len();
+            let largest = wcc.components.values().map(|v| v.len()).max().unwrap_or(0);
+
+            // WCC validation: compare component IDs (two nodes in same component
+            // should have the same component label in expected output)
+            let (validated, passed) = if validate {
+                validate_wcc(&wcc.node_component, data_dir, dataset)
+            } else {
+                (false, false)
+            };
+
+            Some(BenchmarkResult {
+                dataset: dataset.to_string(),
+                algorithm: "WCC".to_string(),
+                vertex_count: view.node_count,
+                duration,
+                summary: format!(
+                    "components={}, largest={}",
+                    format_num(num_components), format_num(largest)
+                ),
+                validated,
+                validation_passed: passed,
+            })
+        }
+
+        "CDLP" => {
+            let max_iters = props.cdlp_max_iterations.unwrap_or(100);
+            let config = CdlpConfig {
+                max_iterations: max_iters,
+            };
+
+            let start = Instant::now();
+            let result = cdlp(view, &config);
+            let duration = start.elapsed();
+
+            // Count distinct communities
+            let mut community_counts: HashMap<u64, usize> = HashMap::new();
+            for &label in result.labels.values() {
+                *community_counts.entry(label).or_insert(0) += 1;
+            }
+            let num_communities = community_counts.len();
+            let largest = community_counts.values().max().copied().unwrap_or(0);
+
+            // CDLP validation: same as WCC, compare community partitions
+            let (validated, passed) = if validate {
+                validate_cdlp(&result.labels, data_dir, dataset)
+            } else {
+                (false, false)
+            };
+
+            Some(BenchmarkResult {
+                dataset: dataset.to_string(),
+                algorithm: "CDLP".to_string(),
+                vertex_count: view.node_count,
+                duration,
+                summary: format!(
+                    "communities={}, largest={}, iters={}",
+                    format_num(num_communities), format_num(largest), result.iterations,
+                ),
+                validated,
+                validation_passed: passed,
+            })
+        }
+
+        "LCC" => {
+            let start = Instant::now();
+            let result = local_clustering_coefficient(view);
+            let duration = start.elapsed();
+
+            let non_zero = result.coefficients.values().filter(|&&cc| cc > 0.0).count();
+
+            let (validated, passed) = if validate {
+                validate_float_map(&result.coefficients, data_dir, dataset, "LCC", 1e-6)
+            } else {
+                (false, false)
+            };
+
+            Some(BenchmarkResult {
+                dataset: dataset.to_string(),
+                algorithm: "LCC".to_string(),
+                vertex_count: view.node_count,
+                duration,
+                summary: format!(
+                    "avg_cc={:.6}, non_zero={}",
+                    result.average, format_num(non_zero),
+                ),
+                validated,
+                validation_passed: passed,
+            })
+        }
+
+        "SSSP" => {
+            let source_id = props.sssp_source.unwrap_or_else(|| {
+                if view.node_count > 0 { view.index_to_node[0] } else { 0 }
+            });
+
+            let start = Instant::now();
+            let distances = sssp_single_source(view, source_id);
+            let duration = start.elapsed();
+
+            let reachable = distances.values().filter(|&&d| d < f64::INFINITY).count();
+            let max_dist = distances
+                .values()
+                .filter(|&&d| d < f64::INFINITY)
+                .cloned()
+                .fold(0.0f64, f64::max);
+
+            let (validated, passed) = if validate {
+                validate_sssp(&distances, data_dir, dataset)
+            } else {
+                (false, false)
+            };
+
+            Some(BenchmarkResult {
+                dataset: dataset.to_string(),
+                algorithm: "SSSP".to_string(),
+                vertex_count: view.node_count,
+                duration,
+                summary: format!(
+                    "source={}, reachable={}, max_dist={:.4}",
+                    source_id, format_num(reachable), max_dist,
+                ),
+                validated,
+                validation_passed: passed,
+            })
+        }
+
+        _ => {
+            eprintln!(
+                "  WARNING: Unknown algorithm '{}'. Valid: {:?}",
+                algo, ALL_ALGOS
+            );
+            None
+        }
+    }
+}
+
+// ============================================================================
+// VALIDATION FUNCTIONS
+// ============================================================================
+
+/// Validate BFS distances against expected output.
+fn validate_bfs(
+    actual: &HashMap<u64, u64>,
+    data_dir: &Path,
+    dataset: &str,
+) -> (bool, bool) {
+    let expected = match load_validation(data_dir, dataset, "BFS") {
+        Some(e) => e,
+        None => return (false, false),
+    };
+
+    let mut all_match = true;
+    let mut mismatches = 0;
+
+    for (node_id, expected_str) in &expected {
+        let expected_val: u64 = if expected_str == "9223372036854775807" {
+            u64::MAX
+        } else {
+            match expected_str.parse() {
+                Ok(v) => v,
+                Err(_) => { mismatches += 1; continue; }
+            }
+        };
+
+        let actual_val = actual.get(node_id).copied().unwrap_or(u64::MAX);
+        if actual_val != expected_val {
+            if mismatches < 3 {
+                eprintln!(
+                    "    BFS mismatch: node {} expected {} got {}",
+                    node_id, expected_val, actual_val
+                );
+            }
+            mismatches += 1;
+            all_match = false;
+        }
+    }
+
+    if mismatches > 3 {
+        eprintln!("    ... and {} more mismatches", mismatches - 3);
+    }
+
+    (true, all_match)
+}
+
+/// Validate float-valued results (PR, LCC) against expected output.
+fn validate_float_map(
+    actual: &HashMap<u64, f64>,
+    data_dir: &Path,
+    dataset: &str,
+    algo: &str,
+    tolerance: f64,
+) -> (bool, bool) {
+    let expected = match load_validation(data_dir, dataset, algo) {
+        Some(e) => e,
+        None => return (false, false),
+    };
+
+    let mut all_match = true;
+    let mut mismatches = 0;
+
+    for (node_id, expected_str) in &expected {
+        let expected_val: f64 = match expected_str.parse() {
+            Ok(v) => v,
+            Err(_) => { mismatches += 1; continue; }
+        };
+
+        let actual_val = actual.get(node_id).copied().unwrap_or(0.0);
+        let diff = (actual_val - expected_val).abs();
+        let rel_diff = if expected_val.abs() > 1e-12 {
+            diff / expected_val.abs()
+        } else {
+            diff
+        };
+
+        if diff > tolerance && rel_diff > tolerance {
+            if mismatches < 3 {
+                eprintln!(
+                    "    {} mismatch: node {} expected {:.15e} got {:.15e} (diff={:.2e})",
+                    algo, node_id, expected_val, actual_val, diff
+                );
+            }
+            mismatches += 1;
+            all_match = false;
+        }
+    }
+
+    if mismatches > 3 {
+        eprintln!("    ... and {} more mismatches", mismatches - 3);
+    }
+
+    (true, all_match)
+}
+
+/// Validate WCC results: two nodes with the same expected label should be
+/// in the same component, and vice versa.
+fn validate_wcc(
+    actual: &HashMap<u64, usize>,
+    data_dir: &Path,
+    dataset: &str,
+) -> (bool, bool) {
+    let expected = match load_validation(data_dir, dataset, "WCC") {
+        Some(e) => e,
+        None => return (false, false),
+    };
+
+    // Build expected partition: group nodes by their expected label
+    let mut expected_groups: HashMap<String, Vec<u64>> = HashMap::new();
+    for (&node_id, label) in &expected {
+        expected_groups.entry(label.clone()).or_default().push(node_id);
+    }
+
+    // Check that nodes in the same expected group share the same actual component
+    let mut all_match = true;
+    let mut mismatches = 0;
+
+    for (_label, group) in &expected_groups {
+        if group.len() < 2 {
+            continue;
+        }
+        let first_comp = actual.get(&group[0]);
+        for &node_id in &group[1..] {
+            let comp = actual.get(&node_id);
+            if comp != first_comp {
+                if mismatches < 3 {
+                    eprintln!(
+                        "    WCC mismatch: nodes {} and {} should be in same component",
+                        group[0], node_id
+                    );
+                }
+                mismatches += 1;
+                all_match = false;
+            }
+        }
+    }
+
+    if mismatches > 3 {
+        eprintln!("    ... and {} more mismatches", mismatches - 3);
+    }
+
+    (true, all_match)
+}
+
+/// Validate CDLP results by exact label comparison.
+fn validate_cdlp(
+    actual: &HashMap<u64, u64>,
+    data_dir: &Path,
+    dataset: &str,
+) -> (bool, bool) {
+    let expected = match load_validation(data_dir, dataset, "CDLP") {
+        Some(e) => e,
+        None => return (false, false),
+    };
+
+    let mut all_match = true;
+    let mut mismatches = 0;
+
+    for (node_id, expected_str) in &expected {
+        let expected_label: u64 = match expected_str.parse() {
+            Ok(v) => v,
+            Err(_) => { mismatches += 1; continue; }
+        };
+        let actual_label = actual.get(node_id).copied().unwrap_or(0);
+        if actual_label != expected_label {
+            if mismatches < 3 {
+                eprintln!(
+                    "    CDLP mismatch: node {} expected label {} got {}",
+                    node_id, expected_label, actual_label
+                );
+            }
+            mismatches += 1;
+            all_match = false;
+        }
+    }
+
+    if mismatches > 3 {
+        eprintln!("    ... and {} more mismatches", mismatches - 3);
+    }
+
+    (true, all_match)
+}
+
+/// Validate SSSP distances against expected output.
+fn validate_sssp(
+    actual: &HashMap<u64, f64>,
+    data_dir: &Path,
+    dataset: &str,
+) -> (bool, bool) {
+    let expected = match load_validation(data_dir, dataset, "SSSP") {
+        Some(e) => e,
+        None => return (false, false),
+    };
+
+    let mut all_match = true;
+    let mut mismatches = 0;
+
+    for (node_id, expected_str) in &expected {
+        let expected_val: f64 = if expected_str == "Infinity" || expected_str == "infinity" {
+            f64::INFINITY
+        } else {
+            match expected_str.parse() {
+                Ok(v) => v,
+                Err(_) => { mismatches += 1; continue; }
+            }
+        };
+
+        let actual_val = actual.get(node_id).copied().unwrap_or(f64::INFINITY);
+
+        if expected_val.is_infinite() && actual_val.is_infinite() {
+            continue; // both unreachable
+        }
+
+        let diff = (actual_val - expected_val).abs();
+        if diff > 1e-6 {
+            if mismatches < 3 {
+                eprintln!(
+                    "    SSSP mismatch: node {} expected {:.15e} got {:.15e} (diff={:.2e})",
+                    node_id, expected_val, actual_val, diff
+                );
+            }
+            mismatches += 1;
+            all_match = false;
+        }
+    }
+
+    if mismatches > 3 {
+        eprintln!("    ... and {} more mismatches", mismatches - 3);
+    }
+
+    (true, all_match)
+}
+
+// ============================================================================
+// CLI HELPERS
+// ============================================================================
+
+fn get_arg(args: &[String], flag: &str) -> Option<String> {
+    args.iter()
+        .position(|a| a == flag)
+        .and_then(|i| args.get(i + 1))
+        .cloned()
+}
+
+fn print_usage() {
+    println!("LDBC Graphalytics Benchmark for Samyama Graph Database");
+    println!();
+    println!("Usage:");
+    println!("  cargo run --release --example graphalytics_benchmark -- --all");
+    println!("  cargo run --release --example graphalytics_benchmark -- --dataset example-directed --algo BFS");
+    println!("  cargo run --release --example graphalytics_benchmark -- --data-dir data/graphalytics/ --all");
+    println!();
+    println!("Options:");
+    println!("  --all              Run all algorithms on all default datasets");
+    println!("  --dataset <name>   Specify a dataset (e.g., example-directed)");
+    println!("  --algo <name>      Run a specific algorithm: BFS, PR, WCC, CDLP, LCC, SSSP");
+    println!("  --data-dir <path>  Dataset directory (default: data/graphalytics/)");
+    println!("  --no-validate      Skip result validation against expected outputs");
+    println!();
+    println!("Datasets are expected in Graphalytics edge-list format:");
+    println!("  <data-dir>/<dataset>/<dataset>.v   -- one vertex ID per line");
+    println!("  <data-dir>/<dataset>/<dataset>.e   -- source|target[|weight] per line");
+    println!();
+    println!("Download datasets with: scripts/download_graphalytics.sh");
+}

--- a/examples/graphalytics_common/mod.rs
+++ b/examples/graphalytics_common/mod.rs
@@ -1,0 +1,402 @@
+//! LDBC Graphalytics edge-list dataset loader.
+//!
+//! Parses the standard Graphalytics file format:
+//!   - Vertex file:  one vertex ID per line
+//!   - Edge file:    "source|target" or "source|target|weight" per line
+//!     (also supports space-delimited, as used by official example datasets)
+//!
+//! Builds a `samyama_graph_algorithms::GraphView` directly without going through
+//! the main GraphStore, so the benchmark measures pure algorithm time.
+
+use samyama_graph_algorithms::GraphView;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+/// Metadata about a loaded graph.
+pub struct GraphInfo {
+    pub name: String,
+    pub directed: bool,
+    pub vertex_count: usize,
+    pub edge_count: usize,
+}
+
+/// Result of loading a Graphalytics dataset.
+pub struct LoadedGraph {
+    pub view: GraphView,
+    pub info: GraphInfo,
+}
+
+/// Algorithm parameters parsed from a `.properties` file.
+pub struct DatasetProperties {
+    pub directed: Option<bool>,
+    pub bfs_source: Option<u64>,
+    pub sssp_source: Option<u64>,
+    pub pr_damping: Option<f64>,
+    pub pr_iterations: Option<usize>,
+    pub cdlp_max_iterations: Option<usize>,
+}
+
+impl Default for DatasetProperties {
+    fn default() -> Self {
+        Self {
+            directed: None,
+            bfs_source: None,
+            sssp_source: None,
+            pr_damping: None,
+            pr_iterations: None,
+            cdlp_max_iterations: None,
+        }
+    }
+}
+
+/// Parse a Graphalytics `.properties` file for algorithm parameters.
+pub fn parse_properties(path: &Path) -> DatasetProperties {
+    let mut props = DatasetProperties::default();
+
+    let file = match File::open(path) {
+        Ok(f) => f,
+        Err(_) => return props,
+    };
+
+    let reader = BufReader::new(file);
+    for line_result in reader.lines() {
+        let line = match line_result {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let line = line.trim().to_string();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        if let Some((key, value)) = line.split_once('=') {
+            let key = key.trim();
+            let value = value.trim();
+
+            if key.ends_with(".directed") {
+                props.directed = value.parse().ok();
+            } else if key.ends_with(".bfs.source-vertex") {
+                props.bfs_source = value.parse().ok();
+            } else if key.ends_with(".sssp.source-vertex") {
+                props.sssp_source = value.parse().ok();
+            } else if key.ends_with(".pr.damping-factor") {
+                props.pr_damping = value.parse().ok();
+            } else if key.ends_with(".pr.num-iterations") {
+                props.pr_iterations = value.parse().ok();
+            } else if key.ends_with(".cdlp.max-iterations") {
+                props.cdlp_max_iterations = value.parse().ok();
+            }
+        }
+    }
+
+    props
+}
+
+/// Load expected validation output for an algorithm.
+/// Returns a map from vertex ID to the expected value string.
+pub fn load_validation(
+    data_dir: &Path,
+    dataset: &str,
+    algo: &str,
+) -> Option<HashMap<u64, String>> {
+    // Try: <data_dir>/<dataset>/<dataset>-<ALGO>
+    let dataset_dir = data_dir.join(dataset);
+    let path = dataset_dir.join(format!("{}-{}", dataset, algo));
+
+    if !path.exists() {
+        return None;
+    }
+
+    let file = File::open(&path).ok()?;
+    let reader = BufReader::new(file);
+    let mut result = HashMap::new();
+
+    for line_result in reader.lines() {
+        let line = match line_result {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let line = line.trim().to_string();
+        if line.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() >= 2 {
+            if let Ok(id) = parts[0].parse::<u64>() {
+                result.insert(id, parts[1].to_string());
+            }
+        }
+    }
+
+    if result.is_empty() { None } else { Some(result) }
+}
+
+/// Load a Graphalytics dataset from vertex and edge files.
+///
+/// The vertex file contains one vertex ID (u64) per line.
+/// The edge file contains rows: `source|target[|weight]` or `source target [weight]`.
+///
+/// If `directed` is false, each edge is stored in both directions.
+pub fn load_graphalytics_dataset(
+    vertex_path: &Path,
+    edge_path: &Path,
+    directed: bool,
+    dataset_name: &str,
+) -> Result<LoadedGraph, Box<dyn std::error::Error>> {
+    // ── Phase 1: Load vertices ──────────────────────────────────────────
+    let mut node_ids: Vec<u64> = Vec::new();
+
+    if vertex_path.exists() {
+        let file = File::open(vertex_path)?;
+        let reader = BufReader::new(file);
+        for line_result in reader.lines() {
+            let line = line_result?;
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') || line.starts_with('%') {
+                continue;
+            }
+            let id: u64 = line.parse().map_err(|e| {
+                format!("Failed to parse vertex ID '{}': {}", line, e)
+            })?;
+            node_ids.push(id);
+        }
+    }
+
+    // ── Phase 2: Load edges ─────────────────────────────────────────────
+    struct RawEdge {
+        source: u64,
+        target: u64,
+        weight: f64,
+    }
+
+    let mut raw_edges: Vec<RawEdge> = Vec::new();
+    let mut has_weights = false;
+
+    if edge_path.exists() {
+        let file = File::open(edge_path)?;
+        let reader = BufReader::new(file);
+        for line_result in reader.lines() {
+            let line = line_result?;
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') || line.starts_with('%') {
+                continue;
+            }
+
+            // Try pipe delimiter first, then whitespace
+            let parts: Vec<&str> = if line.contains('|') {
+                line.split('|').collect()
+            } else {
+                line.split_whitespace().collect()
+            };
+
+            if parts.len() < 2 {
+                continue;
+            }
+
+            let source: u64 = parts[0].parse().map_err(|e| {
+                format!("Failed to parse source ID '{}': {}", parts[0], e)
+            })?;
+            let target: u64 = parts[1].parse().map_err(|e| {
+                format!("Failed to parse target ID '{}': {}", parts[1], e)
+            })?;
+
+            let weight = if parts.len() >= 3 {
+                has_weights = true;
+                parts[2].parse::<f64>().unwrap_or(1.0)
+            } else {
+                1.0
+            };
+
+            raw_edges.push(RawEdge { source, target, weight });
+        }
+    }
+
+    // ── Phase 3: Discover all vertex IDs ────────────────────────────────
+    // If vertex file was empty or missing, infer vertices from edges.
+    if node_ids.is_empty() {
+        let mut seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        for e in &raw_edges {
+            seen.insert(e.source);
+            seen.insert(e.target);
+        }
+        node_ids = seen.into_iter().collect();
+        node_ids.sort();
+    }
+
+    // ── Phase 4: Build index mappings ───────────────────────────────────
+    let node_count = node_ids.len();
+    let mut node_to_index: HashMap<u64, usize> = HashMap::with_capacity(node_count);
+    let mut index_to_node: Vec<u64> = Vec::with_capacity(node_count);
+
+    for (idx, &nid) in node_ids.iter().enumerate() {
+        node_to_index.insert(nid, idx);
+        index_to_node.push(nid);
+    }
+
+    // ── Phase 5: Build adjacency lists ──────────────────────────────────
+    let mut outgoing: Vec<Vec<usize>> = vec![Vec::new(); node_count];
+    let mut incoming: Vec<Vec<usize>> = vec![Vec::new(); node_count];
+    let mut weights_out: Vec<Vec<f64>> = if has_weights {
+        vec![Vec::new(); node_count]
+    } else {
+        Vec::new()
+    };
+
+    let mut edge_count = 0usize;
+
+    for e in &raw_edges {
+        let Some(&src_idx) = node_to_index.get(&e.source) else { continue };
+        let Some(&tgt_idx) = node_to_index.get(&e.target) else { continue };
+
+        outgoing[src_idx].push(tgt_idx);
+        incoming[tgt_idx].push(src_idx);
+        if has_weights {
+            weights_out[src_idx].push(e.weight);
+        }
+        edge_count += 1;
+
+        if !directed {
+            // Add reverse edge for undirected graphs
+            outgoing[tgt_idx].push(src_idx);
+            incoming[src_idx].push(tgt_idx);
+            if has_weights {
+                weights_out[tgt_idx].push(e.weight);
+            }
+            edge_count += 1;
+        }
+    }
+
+    // ── Phase 6: Build GraphView via from_adjacency_list ────────────────
+    let weight_vecs = if has_weights { Some(weights_out) } else { None };
+
+    let view = GraphView::from_adjacency_list(
+        node_count,
+        index_to_node,
+        node_to_index,
+        outgoing,
+        incoming,
+        weight_vecs,
+    );
+
+    let info = GraphInfo {
+        name: dataset_name.to_string(),
+        directed,
+        vertex_count: node_count,
+        edge_count,
+    };
+
+    Ok(LoadedGraph { view, info })
+}
+
+/// Attempt to auto-detect whether a dataset is directed or undirected
+/// based on the dataset name convention or properties file.
+pub fn is_directed(dataset_name: &str) -> bool {
+    let lower = dataset_name.to_lowercase();
+    if lower.contains("undirected") {
+        false
+    } else if lower.contains("directed") {
+        true
+    } else {
+        // Default to directed
+        true
+    }
+}
+
+/// Find the vertex, edge, and properties file paths for a given dataset.
+///
+/// Looks for standard Graphalytics naming:
+///   - `<dataset>.v`  or `<dataset>.vertices`
+///   - `<dataset>.e`  or `<dataset>.edges`
+///   - `<dataset>.properties`
+pub fn find_dataset_files(
+    data_dir: &Path,
+    dataset: &str,
+) -> Result<(std::path::PathBuf, std::path::PathBuf), Box<dyn std::error::Error>> {
+    let dataset_dir = data_dir.join(dataset);
+
+    // Try inside a subdirectory named after the dataset
+    let candidates_v = [
+        dataset_dir.join(format!("{}.v", dataset)),
+        dataset_dir.join(format!("{}.vertices", dataset)),
+        // Also try directly in data_dir
+        data_dir.join(format!("{}.v", dataset)),
+        data_dir.join(format!("{}.vertices", dataset)),
+    ];
+
+    let candidates_e = [
+        dataset_dir.join(format!("{}.e", dataset)),
+        dataset_dir.join(format!("{}.edges", dataset)),
+        data_dir.join(format!("{}.e", dataset)),
+        data_dir.join(format!("{}.edges", dataset)),
+    ];
+
+    let vertex_path = candidates_v
+        .iter()
+        .find(|p| p.exists())
+        .cloned()
+        .ok_or_else(|| {
+            format!(
+                "Vertex file not found. Tried:\n  {}",
+                candidates_v
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n  ")
+            )
+        })?;
+
+    let edge_path = candidates_e
+        .iter()
+        .find(|p| p.exists())
+        .cloned()
+        .ok_or_else(|| {
+            format!(
+                "Edge file not found. Tried:\n  {}",
+                candidates_e
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n  ")
+            )
+        })?;
+
+    Ok((vertex_path, edge_path))
+}
+
+/// Find the properties file for a dataset (if it exists).
+pub fn find_properties_file(data_dir: &Path, dataset: &str) -> Option<std::path::PathBuf> {
+    let candidates = [
+        data_dir.join(dataset).join(format!("{}.properties", dataset)),
+        data_dir.join(format!("{}.properties", dataset)),
+    ];
+    candidates.iter().find(|p| p.exists()).cloned()
+}
+
+// ============================================================================
+// FORMATTING HELPERS
+// ============================================================================
+
+pub fn format_num(n: usize) -> String {
+    let s = n.to_string();
+    let mut result = String::new();
+    for (i, ch) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(ch);
+    }
+    result.chars().rev().collect()
+}
+
+pub fn format_duration(d: std::time::Duration) -> String {
+    let secs = d.as_secs_f64();
+    if secs < 0.001 {
+        format!("{:.0}us", secs * 1_000_000.0)
+    } else if secs < 1.0 {
+        format!("{:.2}ms", secs * 1000.0)
+    } else {
+        format!("{:.3}s", secs)
+    }
+}

--- a/examples/ldbc_benchmark.rs
+++ b/examples/ldbc_benchmark.rs
@@ -1,7 +1,7 @@
 //! LDBC SNB Interactive Query Benchmark — Samyama Graph Database
 //!
-//! Benchmarks Samyama's query engine against 19 LDBC SNB Interactive workload queries
-//! (IS1-IS7, IC1-IC12; IC13/IC14 skipped — require shortestPath).
+//! Benchmarks Samyama's query engine against all 21 LDBC SNB Interactive workload queries
+//! (IS1-IS7, IC1-IC14) plus 8 update operations (INS1-INS8) via --updates flag.
 //!
 //! Prerequisites:
 //!   Download and extract LDBC SF1 data to:
@@ -34,7 +34,7 @@ struct LdbcQuery {
     category: &'static str,
 }
 
-/// Build the list of 19 LDBC SNB Interactive queries adapted for Samyama.
+/// Build the list of 21 LDBC SNB Interactive queries adapted for Samyama.
 ///
 /// Parameter choices (from SF1 dataset):
 ///   personId    = 933              (Mahinda Perera)
@@ -297,6 +297,92 @@ RETURN friend.id, friend.firstName, friend.lastName, count(DISTINCT c) AS replyC
 ORDER BY replyCount DESC
 LIMIT 10",
         },
+
+        // IC13: Shortest path (uses shortestPath pattern)
+        LdbcQuery {
+            id: "IC13",
+            name: "Single Shortest Path",
+            category: "complex",
+            cypher: "\
+MATCH p = shortestPath((p1:Person {id: 933})-[:KNOWS*]-(p2:Person {id: 4139}))
+RETURN length(p) AS pathLength",
+        },
+
+        // IC14: Weighted paths (uses allShortestPaths)
+        LdbcQuery {
+            id: "IC14",
+            name: "Trusted Connection Paths",
+            category: "complex",
+            cypher: "\
+MATCH p = allShortestPaths((p1:Person {id: 933})-[:KNOWS*]-(p2:Person {id: 4139}))
+RETURN length(p) AS pathLength, nodes(p) AS pathNodes",
+        },
+    ]
+}
+
+/// Build the list of 8 LDBC SNB Interactive update operations
+fn ldbc_updates() -> Vec<LdbcQuery> {
+    vec![
+        LdbcQuery {
+            id: "INS1",
+            name: "Add Person",
+            category: "update",
+            cypher: "\
+CREATE (p:Person {id: 999999, firstName: \"TestUser\", lastName: \"Benchmark\", gender: \"male\", birthday: 631152000000, creationDate: 1709251200000, locationIP: \"1.2.3.4\", browserUsed: \"Firefox\"})",
+        },
+        LdbcQuery {
+            id: "INS2",
+            name: "Add Like to Post",
+            category: "update",
+            cypher: "\
+MATCH (p:Person {id: 999999}), (m:Post {id: 1236950581248})
+CREATE (p)-[:LIKES {creationDate: 1709251200000}]->(m)",
+        },
+        LdbcQuery {
+            id: "INS3",
+            name: "Add Like to Comment",
+            category: "update",
+            cypher: "\
+MATCH (p:Person {id: 999999}), (m:Comment {id: 1236950581249})
+CREATE (p)-[:LIKES {creationDate: 1709251200000}]->(m)",
+        },
+        LdbcQuery {
+            id: "INS4",
+            name: "Add Forum",
+            category: "update",
+            cypher: "\
+CREATE (f:Forum {id: 999998, title: \"Benchmark Forum\", creationDate: 1709251200000})",
+        },
+        LdbcQuery {
+            id: "INS5",
+            name: "Add Forum Member",
+            category: "update",
+            cypher: "\
+MATCH (f:Forum {id: 999998}), (p:Person {id: 933})
+CREATE (f)-[:HAS_MEMBER {joinDate: 1709251200000}]->(p)",
+        },
+        LdbcQuery {
+            id: "INS6",
+            name: "Add Post",
+            category: "update",
+            cypher: "\
+CREATE (m:Post {id: 999997, imageFile: \"\", creationDate: 1709251200000, locationIP: \"1.2.3.4\", browserUsed: \"Firefox\", language: \"en\", content: \"Benchmark post content\", length: 24})",
+        },
+        LdbcQuery {
+            id: "INS7",
+            name: "Add Comment",
+            category: "update",
+            cypher: "\
+CREATE (c:Comment {id: 999996, creationDate: 1709251200000, locationIP: \"1.2.3.4\", browserUsed: \"Firefox\", content: \"Benchmark comment\", length: 18})",
+        },
+        LdbcQuery {
+            id: "INS8",
+            name: "Add Friendship",
+            category: "update",
+            cypher: "\
+MATCH (p1:Person {id: 933}), (p2:Person {id: 999999})
+CREATE (p1)-[:KNOWS {creationDate: 1709251200000}]->(p2)",
+        },
     ]
 }
 
@@ -332,8 +418,13 @@ async fn run_benchmark(
     query: &LdbcQuery,
     runs: usize,
 ) -> BenchResult {
-    // Warm-up: 1 run, discard
-    let warmup = client.query_readonly("default", query.cypher).await;
+    let is_update = query.category == "update";
+    // Warm-up: 1 run, discard (skip for updates — they mutate state)
+    let warmup = if is_update {
+        client.query("default", query.cypher).await
+    } else {
+        client.query_readonly("default", query.cypher).await
+    };
     if let Err(e) = &warmup {
         return BenchResult {
             id: query.id,
@@ -350,9 +441,15 @@ async fn run_benchmark(
     let mut timings = Vec::with_capacity(runs);
     let mut row_count = 0;
 
-    for _ in 0..runs {
+    let actual_runs = if is_update { 1 } else { runs }; // updates run once
+    for _ in 0..actual_runs {
         let start = Instant::now();
-        match client.query_readonly("default", query.cypher).await {
+        let run_result = if is_update {
+            client.query("default", query.cypher).await
+        } else {
+            client.query_readonly("default", query.cypher).await
+        };
+        match run_result {
             Ok(result) => {
                 row_count = result.records.len();
                 timings.push(start.elapsed());
@@ -412,6 +509,8 @@ async fn main() -> Result<(), Error> {
         None
     };
 
+    let include_updates = args.iter().any(|a| a == "--updates");
+
     if !data_dir.exists() {
         eprintln!("ERROR: Data directory not found: {}", data_dir.display());
         eprintln!("Download LDBC SF1 data and extract to: {}", default_dir);
@@ -444,16 +543,19 @@ async fn main() -> Result<(), Error> {
     // ========================================================================
     // Run benchmarks
     // ========================================================================
-    let queries = ldbc_queries();
+    let mut all_queries = ldbc_queries();
+    if include_updates {
+        all_queries.extend(ldbc_updates());
+    }
     let queries: Vec<&LdbcQuery> = if let Some(ref filter) = filter_query {
-        queries.iter().filter(|q| q.id == filter.as_str()).collect()
+        all_queries.iter().filter(|q| q.id == filter.as_str()).collect()
     } else {
-        queries.iter().collect()
+        all_queries.iter().collect()
     };
 
     if queries.is_empty() {
         eprintln!("ERROR: No matching query found for filter '{}'", filter_query.unwrap_or_default());
-        eprintln!("Available: IS1-IS7, IC1-IC12");
+        eprintln!("Available: IS1-IS7, IC1-IC14, INS1-INS8 (with --updates)");
         std::process::exit(1);
     }
 
@@ -475,6 +577,7 @@ async fn main() -> Result<(), Error> {
             let label = match query.category {
                 "short"   => "--- Short Reads ---",
                 "complex" => "--- Complex Reads ---",
+                "update"  => "--- Update Operations ---",
                 other     => other,
             };
             println!("{}", label);

--- a/examples/ldbc_bi_benchmark.rs
+++ b/examples/ldbc_bi_benchmark.rs
@@ -1,0 +1,647 @@
+//! LDBC SNB Business Intelligence Benchmark — Samyama Graph Database
+//!
+//! Benchmarks Samyama's query engine against 20 LDBC SNB BI workload queries
+//! (BI-1 through BI-20) on the SF1 dataset.
+//!
+//! The LDBC BI workload tests complex analytical / OLAP-style queries over the
+//! Social Network Benchmark graph.  Several queries in the official spec require
+//! features not yet available in Samyama (APOC, GDS, weighted shortest path,
+//! CASE expressions, list comprehensions).  Those queries are adapted to
+//! simplified Cypher that captures the analytical intent using supported
+//! constructs.
+//!
+//! Prerequisites:
+//!   Download and extract LDBC SF1 data to:
+//!     data/ldbc-sf1/social_network-sf1-CsvBasic-LongDateFormatter/
+//!
+//! Usage:
+//!   cargo run --release --example ldbc_bi_benchmark
+//!   cargo run --release --example ldbc_bi_benchmark -- --runs 5
+//!   cargo run --release --example ldbc_bi_benchmark -- --query BI-1
+//!   cargo run --release --example ldbc_bi_benchmark -- --data-dir /path/to/data
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use samyama_sdk::{EmbeddedClient, SamyamaClient};
+
+mod ldbc_bi_common;
+use ldbc_bi_common::{format_duration, format_num};
+
+type Error = Box<dyn std::error::Error>;
+
+// ============================================================================
+// QUERY DEFINITIONS
+// ============================================================================
+
+struct LdbcBiQuery {
+    id: &'static str,
+    name: &'static str,
+    cypher: &'static str,
+}
+
+/// Build the 20 LDBC SNB BI queries adapted for Samyama.
+///
+/// Adaptation notes:
+///   - The LDBC `:Message` supertype does not exist in the SNB CSV schema.
+///     Where the spec unions Posts and Comments we use two separate MATCH
+///     clauses combined with UNION, or query each label independently.
+///   - Queries requiring APOC/GDS procedures (e.g. shortest weighted path,
+///     triangle counting) are rewritten using pure Cypher patterns that
+///     approximate the analytical intent.
+///   - Parameter values are chosen from the SF1 dataset.
+///
+/// SF1 parameter choices:
+///   tagName       = "Hamid_Karzai"
+///   tagClassName  = "MusicalArtist"
+///   country       = "India"
+///   midDate       = 1311292800000  (2011-07-22)
+///   startDate     = 1293840000000  (2011-01-01)
+///   endDate       = 1354320000000  (2012-12-01)
+///   personId      = 933
+///   person2Id     = 4139
+fn ldbc_bi_queries() -> Vec<LdbcBiQuery> {
+    vec![
+        // ================================================================
+        // BI-1: Posting Summary
+        // Count posts and comments by creation year, grouped by message
+        // length category.
+        // Adapted: separate queries for Post and Comment combined via UNION.
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-1",
+            name: "Posting Summary",
+            cypher: "\
+MATCH (p:Post)
+WHERE p.creationDate < 1354320000000
+RETURN 'Post' AS messageType, count(p) AS messageCount
+UNION
+MATCH (c:Comment)
+WHERE c.creationDate < 1354320000000
+RETURN 'Comment' AS messageType, count(c) AS messageCount",
+        },
+
+        // ================================================================
+        // BI-2: Tag Co-occurrence
+        // Find pairs of tags that frequently co-occur on messages created
+        // in a date range.
+        // Adapted: uses Posts only (avoids Message supertype).
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-2",
+            name: "Tag Co-occurrence",
+            cypher: "\
+MATCH (p:Post)-[:HAS_TAG]->(t1:Tag), (p)-[:HAS_TAG]->(t2:Tag)
+WHERE p.creationDate >= 1293840000000 AND p.creationDate < 1354320000000
+  AND t1.name < t2.name
+RETURN t1.name, t2.name, count(p) AS cooccurrences
+ORDER BY cooccurrences DESC
+LIMIT 20",
+        },
+
+        // ================================================================
+        // BI-3: Tag Evolution
+        // Compare the popularity of a tag before and after a given date.
+        // Adapted: two separate aggregations via UNION for before/after.
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-3",
+            name: "Tag Evolution",
+            cypher: "\
+MATCH (p:Post)-[:HAS_TAG]->(t:Tag {name: \"Hamid_Karzai\"})
+WHERE p.creationDate < 1311292800000
+RETURN t.name AS tag, 'before' AS period, count(p) AS msgCount
+UNION
+MATCH (p:Post)-[:HAS_TAG]->(t:Tag {name: \"Hamid_Karzai\"})
+WHERE p.creationDate >= 1311292800000
+RETURN t.name AS tag, 'after' AS period, count(p) AS msgCount",
+        },
+
+        // ================================================================
+        // BI-4: Popular Moderators
+        // Forums with the most messages, returning moderator details.
+        // Adapted: counts posts per forum (no Message supertype).
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-4",
+            name: "Popular Moderators",
+            cypher: "\
+MATCH (f:Forum)-[:CONTAINER_OF]->(p:Post)
+WITH f, count(p) AS postCount
+ORDER BY postCount DESC
+LIMIT 20
+MATCH (f)-[:HAS_MODERATOR]->(mod:Person)
+RETURN f.id, f.title, mod.id, mod.firstName, mod.lastName, postCount
+ORDER BY postCount DESC",
+        },
+
+        // ================================================================
+        // BI-5: Most Active Posters
+        // Persons who created the most posts; return statistics.
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-5",
+            name: "Most Active Posters",
+            cypher: "\
+MATCH (person:Person)<-[:HAS_CREATOR]-(p:Post)
+RETURN person.id, person.firstName, person.lastName, count(p) AS postCount
+ORDER BY postCount DESC
+LIMIT 20",
+        },
+
+        // ================================================================
+        // BI-6: Most Authoritative Users
+        // Persons whose messages with a given tag received the most likes.
+        // Adapted: counts LIKES on Posts tagged with the target tag.
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-6",
+            name: "Most Authoritative Users",
+            cypher: "\
+MATCH (p:Post)-[:HAS_TAG]->(t:Tag {name: \"Hamid_Karzai\"})
+MATCH (p)-[:HAS_CREATOR]->(author:Person)
+MATCH (liker:Person)-[:LIKES]->(p)
+RETURN author.id, author.firstName, author.lastName, count(liker) AS likeCount
+ORDER BY likeCount DESC
+LIMIT 20",
+        },
+
+        // ================================================================
+        // BI-7: Authoritative Authors by Score
+        // Persons with the highest total message score (approximated by
+        // number of likes + replies).
+        // Adapted: counts likes on posts per author as a score proxy.
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-7",
+            name: "Authoritative Authors by Score",
+            cypher: "\
+MATCH (author:Person)<-[:HAS_CREATOR]-(p:Post)
+WITH author, count(p) AS postCount
+ORDER BY postCount DESC
+LIMIT 100
+MATCH (liker:Person)-[:LIKES]->(p2:Post)-[:HAS_CREATOR]->(author)
+RETURN author.id, author.firstName, author.lastName, postCount, count(liker) AS totalLikes
+ORDER BY totalLikes DESC
+LIMIT 20",
+        },
+
+        // ================================================================
+        // BI-8: Related Topics
+        // Tags that appear on replies to messages with a given tag.
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-8",
+            name: "Related Topics",
+            cypher: "\
+MATCH (post:Post)-[:HAS_TAG]->(t:Tag {name: \"Hamid_Karzai\"})
+MATCH (reply:Comment)-[:REPLY_OF]->(post)
+MATCH (reply)-[:HAS_TAG]->(relatedTag:Tag)
+WHERE relatedTag.name <> \"Hamid_Karzai\"
+RETURN relatedTag.name, count(reply) AS replyCount
+ORDER BY replyCount DESC
+LIMIT 20",
+        },
+
+        // ================================================================
+        // BI-9: Forum with Related Tags
+        // Forums where posts have been tagged with both of two given tags.
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-9",
+            name: "Forum with Related Tags",
+            cypher: "\
+MATCH (f:Forum)-[:CONTAINER_OF]->(p1:Post)-[:HAS_TAG]->(t1:Tag {name: \"Hamid_Karzai\"})
+MATCH (f)-[:CONTAINER_OF]->(p2:Post)-[:HAS_TAG]->(t2:Tag {name: \"Afghanistan\"})
+WHERE p1.id <> p2.id
+RETURN f.id, f.title, count(DISTINCT p1) AS tag1Posts, count(DISTINCT p2) AS tag2Posts
+ORDER BY tag1Posts DESC
+LIMIT 20",
+        },
+
+        // ================================================================
+        // BI-10: Experts in Social Circle
+        // Multi-hop friends who are experts on a given tag (posted
+        // messages with that tag).
+        // Adapted: uses 2-hop KNOWS path (full spec uses variable-length
+        // BFS which requires GDS).
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-10",
+            name: "Experts in Social Circle",
+            cypher: "\
+MATCH (p:Person {id: 933})-[:KNOWS*1..2]-(expert:Person)
+WHERE expert.id <> 933
+WITH DISTINCT expert
+MATCH (expert)<-[:HAS_CREATOR]-(post:Post)-[:HAS_TAG]->(t:Tag {name: \"Hamid_Karzai\"})
+RETURN expert.id, expert.firstName, expert.lastName, count(post) AS expertise
+ORDER BY expertise DESC
+LIMIT 20",
+        },
+
+        // ================================================================
+        // BI-11: Unrelated Replies
+        // Replies to posts where the reply shares no tags with the
+        // original post.
+        // Adapted: uses NOT EXISTS to check for shared tags.
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-11",
+            name: "Unrelated Replies",
+            cypher: "\
+MATCH (reply:Comment)-[:REPLY_OF]->(post:Post)
+WHERE NOT EXISTS {
+  MATCH (reply)-[:HAS_TAG]->(t:Tag)<-[:HAS_TAG]-(post)
+}
+RETURN count(reply) AS unrelatedReplies",
+        },
+
+        // ================================================================
+        // BI-12: Person Trending
+        // Persons whose messages received the most likes within a period.
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-12",
+            name: "Person Trending",
+            cypher: "\
+MATCH (liker:Person)-[l:LIKES]->(post:Post)-[:HAS_CREATOR]->(author:Person)
+WHERE l.creationDate >= 1293840000000 AND l.creationDate < 1354320000000
+RETURN author.id, author.firstName, author.lastName, count(l) AS likeCount
+ORDER BY likeCount DESC
+LIMIT 20",
+        },
+
+        // ================================================================
+        // BI-13: Popular Months
+        // For each person, the creation month in which they produced the
+        // most messages.
+        // Adapted: simplified — counts posts per person and returns the
+        // total (month extraction would require date functions not yet
+        // supported).
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-13",
+            name: "Popular Months",
+            cypher: "\
+MATCH (person:Person)<-[:HAS_CREATOR]-(p:Post)
+WHERE p.creationDate >= 1293840000000 AND p.creationDate < 1354320000000
+RETURN person.id, person.firstName, person.lastName, count(p) AS messageCount
+ORDER BY messageCount DESC
+LIMIT 20",
+        },
+
+        // ================================================================
+        // BI-14: Top Thread Initiators
+        // Persons who started the longest reply threads.
+        // Adapted: counts direct replies to each person's posts as a
+        // proxy for thread length (full recursive thread depth requires
+        // variable-length REPLY_OF paths).
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-14",
+            name: "Top Thread Initiators",
+            cypher: "\
+MATCH (author:Person)<-[:HAS_CREATOR]-(post:Post)<-[:REPLY_OF]-(reply:Comment)
+RETURN author.id, author.firstName, author.lastName, count(reply) AS replyCount
+ORDER BY replyCount DESC
+LIMIT 20",
+        },
+
+        // ================================================================
+        // BI-15: Social Normals
+        // Persons with the most KNOWS connections (high-degree social
+        // nodes).
+        // Adapted: the official query uses weighted shortest path; here
+        // we approximate by finding high-degree persons in the KNOWS
+        // network.
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-15",
+            name: "Social Normals",
+            cypher: "\
+MATCH (person:Person)-[:KNOWS]-(friend:Person)
+RETURN person.id, person.firstName, person.lastName, count(friend) AS friendCount
+ORDER BY friendCount DESC
+LIMIT 20",
+        },
+
+        // ================================================================
+        // BI-16: Expert Search
+        // Persons who KNOW someone who is an expert on a given tag class.
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-16",
+            name: "Expert Search",
+            cypher: "\
+MATCH (expert:Person)<-[:HAS_CREATOR]-(post:Post)-[:HAS_TAG]->(tag:Tag)-[:HAS_TYPE]->(tc:TagClass {name: \"MusicalArtist\"})
+WITH expert, count(DISTINCT post) AS expertise
+ORDER BY expertise DESC
+LIMIT 100
+MATCH (person:Person)-[:KNOWS]-(expert)
+RETURN person.id, person.firstName, person.lastName, expert.id AS expertId, expertise
+ORDER BY expertise DESC
+LIMIT 20",
+        },
+
+        // ================================================================
+        // BI-17: Friend Triangles
+        // Count triangles in the KNOWS network.
+        // Adapted: pure Cypher triangle pattern (a)--(b)--(c)--(a) with
+        // ordering constraints to avoid double-counting.
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-17",
+            name: "Friend Triangles",
+            cypher: "\
+MATCH (a:Person)-[:KNOWS]-(b:Person)-[:KNOWS]-(c:Person)-[:KNOWS]-(a)
+WHERE a.id < b.id AND b.id < c.id
+RETURN count(a) AS triangleCount",
+        },
+
+        // ================================================================
+        // BI-18: Friend Recommendation
+        // Pairs of persons who share many friends but are not directly
+        // connected.
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-18",
+            name: "Friend Recommendation",
+            cypher: "\
+MATCH (p1:Person {id: 933})-[:KNOWS]-(mutual:Person)-[:KNOWS]-(p2:Person)
+WHERE p2.id <> 933 AND NOT EXISTS { MATCH (p1)-[:KNOWS]-(p2) }
+RETURN p2.id, p2.firstName, p2.lastName, count(DISTINCT mutual) AS mutualFriends
+ORDER BY mutualFriends DESC
+LIMIT 20",
+        },
+
+        // ================================================================
+        // BI-19: Interaction Path
+        // Weighted shortest path between two persons, where edge weight
+        // is the number of interactions (replies, likes).
+        // Adapted: Samyama does not yet support weighted shortest path.
+        // We find the unweighted shortest path and count interactions
+        // along it as a proxy.
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-19",
+            name: "Interaction Path",
+            cypher: "\
+MATCH p = shortestPath((p1:Person {id: 933})-[:KNOWS*]-(p2:Person {id: 4139}))
+RETURN length(p) AS pathLength, nodes(p) AS pathNodes",
+        },
+
+        // ================================================================
+        // BI-20: High-Level Topics
+        // Distribution of tags grouped by their TagClass.
+        // ================================================================
+        LdbcBiQuery {
+            id: "BI-20",
+            name: "High-Level Topics",
+            cypher: "\
+MATCH (t:Tag)-[:HAS_TYPE]->(tc:TagClass)
+MATCH (p:Post)-[:HAS_TAG]->(t)
+RETURN tc.name AS tagClass, count(DISTINCT t) AS tagCount, count(p) AS messageCount
+ORDER BY messageCount DESC
+LIMIT 20",
+        },
+    ]
+}
+
+// ============================================================================
+// BENCHMARK RUNNER
+// ============================================================================
+
+struct BenchResult {
+    id: &'static str,
+    name: &'static str,
+    rows: usize,
+    min: Duration,
+    median: Duration,
+    max: Duration,
+    error: Option<String>,
+}
+
+fn format_ms(d: Duration) -> String {
+    let ms = d.as_secs_f64() * 1000.0;
+    if ms < 1.0 {
+        format!("{:.2}ms", ms)
+    } else if ms < 100.0 {
+        format!("{:.1}ms", ms)
+    } else if ms < 10_000.0 {
+        format!("{:.0}ms", ms)
+    } else {
+        format!("{:.1}s", d.as_secs_f64())
+    }
+}
+
+async fn run_benchmark(
+    client: &EmbeddedClient,
+    query: &LdbcBiQuery,
+    runs: usize,
+) -> BenchResult {
+    // Warm-up: 1 run, discard
+    let warmup = client.query_readonly("default", query.cypher).await;
+    if let Err(e) = &warmup {
+        return BenchResult {
+            id: query.id,
+            name: query.name,
+            rows: 0,
+            min: Duration::ZERO,
+            median: Duration::ZERO,
+            max: Duration::ZERO,
+            error: Some(e.to_string()),
+        };
+    }
+
+    let mut timings = Vec::with_capacity(runs);
+    let mut row_count = 0;
+
+    for _ in 0..runs {
+        let start = Instant::now();
+        let run_result = client.query_readonly("default", query.cypher).await;
+        match run_result {
+            Ok(result) => {
+                row_count = result.records.len();
+                timings.push(start.elapsed());
+            }
+            Err(e) => {
+                return BenchResult {
+                    id: query.id,
+                    name: query.name,
+                    rows: 0,
+                    min: Duration::ZERO,
+                    median: Duration::ZERO,
+                    max: Duration::ZERO,
+                    error: Some(e.to_string()),
+                };
+            }
+        }
+    }
+
+    timings.sort();
+
+    BenchResult {
+        id: query.id,
+        name: query.name,
+        rows: row_count,
+        min: timings[0],
+        median: timings[timings.len() / 2],
+        max: timings[timings.len() - 1],
+        error: None,
+    }
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let args: Vec<String> = std::env::args().collect();
+
+    let default_dir = "data/ldbc-sf1/social_network-sf1-CsvBasic-LongDateFormatter";
+    let data_dir = if let Some(pos) = args.iter().position(|a| a == "--data-dir") {
+        PathBuf::from(args.get(pos + 1).expect("--data-dir requires a path argument"))
+    } else {
+        PathBuf::from(default_dir)
+    };
+
+    let runs: usize = if let Some(pos) = args.iter().position(|a| a == "--runs") {
+        args.get(pos + 1)
+            .expect("--runs requires a number")
+            .parse()
+            .expect("--runs must be a positive integer")
+    } else {
+        5
+    };
+
+    let filter_query: Option<String> = if let Some(pos) = args.iter().position(|a| a == "--query") {
+        Some(
+            args.get(pos + 1)
+                .expect("--query requires a query ID (e.g. BI-1, BI-17)")
+                .to_uppercase(),
+        )
+    } else {
+        None
+    };
+
+    if !data_dir.exists() {
+        eprintln!("ERROR: Data directory not found: {}", data_dir.display());
+        eprintln!(
+            "Download LDBC SF1 data and extract to: {}",
+            default_dir
+        );
+        std::process::exit(1);
+    }
+
+    // ========================================================================
+    // Load dataset
+    // ========================================================================
+    eprintln!("LDBC SNB Business Intelligence Benchmark — Samyama v0.5.8");
+    eprintln!();
+
+    let client = EmbeddedClient::new();
+
+    let load_start = Instant::now();
+    let load_result = {
+        let mut graph = client.store_write().await;
+        ldbc_bi_common::load_dataset(&mut graph, &data_dir)?
+    };
+    let load_time = load_start.elapsed();
+
+    eprintln!();
+    eprintln!(
+        "Dataset: {} nodes, {} edges (loaded in {})",
+        format_num(load_result.total_nodes),
+        format_num(load_result.total_edges),
+        format_duration(load_time)
+    );
+    eprintln!("Runs per query: {}", runs);
+    eprintln!();
+
+    // ========================================================================
+    // Run benchmarks
+    // ========================================================================
+    let all_queries = ldbc_bi_queries();
+    let queries: Vec<&LdbcBiQuery> = if let Some(ref filter) = filter_query {
+        all_queries
+            .iter()
+            .filter(|q| q.id.to_uppercase() == *filter)
+            .collect()
+    } else {
+        all_queries.iter().collect()
+    };
+
+    if queries.is_empty() {
+        eprintln!(
+            "ERROR: No matching query found for filter '{}'",
+            filter_query.unwrap_or_default()
+        );
+        eprintln!("Available: BI-1 through BI-20");
+        std::process::exit(1);
+    }
+
+    // Print header
+    println!(
+        "{:<8}{:<36}{:>8}{:>12}{:>12}{:>12}  {}",
+        "ID", "Name", "Rows", "Min", "Median", "Max", "Status"
+    );
+    println!(
+        "{:<8}{:<36}{:>8}{:>12}{:>12}{:>12}  {}",
+        "------", "------------------------------------", "------", "----------", "----------", "----------", "------"
+    );
+
+    let mut passed = 0usize;
+    let mut errors = 0usize;
+    let bench_start = Instant::now();
+
+    for query in &queries {
+        eprint!("  Running {}...\r", query.id);
+
+        let result = run_benchmark(&client, query, runs).await;
+
+        if let Some(ref err) = result.error {
+            println!(
+                "{:<8}{:<36}{:>8}{:>12}{:>12}{:>12}  ERROR",
+                result.id, result.name, "-", "-", "-", "-"
+            );
+            eprintln!("       {}", err);
+            errors += 1;
+        } else {
+            println!(
+                "{:<8}{:<36}{:>8}{:>12}{:>12}{:>12}  OK",
+                result.id,
+                result.name,
+                result.rows,
+                format_ms(result.min),
+                format_ms(result.median),
+                format_ms(result.max)
+            );
+            passed += 1;
+        }
+    }
+
+    let bench_time = bench_start.elapsed();
+
+    // ========================================================================
+    // Summary
+    // ========================================================================
+    println!();
+    println!(
+        "Summary: {}/{} passed, {} errors (total benchmark time: {})",
+        passed,
+        queries.len(),
+        errors,
+        format_duration(bench_time)
+    );
+
+    // Cache stats
+    let stats = client.cache_stats();
+    println!("AST cache: {} hits, {} misses", stats.hits(), stats.misses());
+
+    if errors > 0 {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}

--- a/examples/ldbc_bi_common/mod.rs
+++ b/examples/ldbc_bi_common/mod.rs
@@ -1,0 +1,35 @@
+//! Shared utilities for the LDBC SNB Business Intelligence benchmark.
+//!
+//! Re-exports the data-loading infrastructure from `ldbc_common` and provides
+//! BI-specific helpers (date epoch constants, result formatting, etc.).
+
+#![allow(dead_code)]
+
+// Re-export the full dataset loader and formatting helpers from ldbc_common.
+// The BI benchmark loads the same SNB SF1 graph as the interactive benchmark.
+#[path = "../ldbc_common/mod.rs"]
+pub mod ldbc_common;
+
+pub use ldbc_common::{format_duration, format_num, load_dataset};
+
+// ============================================================================
+// LDBC BI date constants (milliseconds since epoch, LongDateFormatter)
+// ============================================================================
+
+/// 2011-07-22 — midpoint of SF1 creation window, used to split "before/after"
+pub const MIDPOINT_DATE: i64 = 1_311_292_800_000;
+
+/// 2011-01-01 — start of SF1 activity
+pub const START_DATE: i64 = 1_293_840_000_000;
+
+/// 2012-12-01 — late in the dataset
+pub const END_DATE: i64 = 1_354_320_000_000;
+
+/// 2012-07-01 — window boundary
+pub const WINDOW_END: i64 = 1_341_100_800_000;
+
+/// 2012-01-01
+pub const YEAR_2012: i64 = 1_325_376_000_000;
+
+/// 2011-06-01
+pub const MID_2011: i64 = 1_306_886_400_000;

--- a/scripts/download_finbench.sh
+++ b/scripts/download_finbench.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+#
+# LDBC FinBench Dataset Generator for Samyama Graph Database
+#
+# Since LDBC FinBench does not have a widely-available SF1 CSV download like
+# LDBC SNB, this script generates synthetic data matching the FinBench schema
+# using the Samyama finbench_loader example.
+#
+# The generated data consists of pipe-delimited CSV files for 5 node types
+# (Account, Person, Company, Loan, Medium) and 9 edge types (OWN, TRANSFER,
+# WITHDRAW, DEPOSIT, REPAY, SIGN_IN, APPLY, INVEST, GUARANTEE).
+#
+# Usage:
+#   ./scripts/download_finbench.sh                  # Generate to default location
+#   ./scripts/download_finbench.sh /custom/data/dir  # Generate to custom location
+#
+# After generation, run the benchmark:
+#   cargo run --release --example finbench_benchmark -- --data-dir data/finbench-sf1
+#
+# Or use in-memory synthetic generation (no CSV needed):
+#   cargo run --release --example finbench_benchmark
+
+set -euo pipefail
+
+DATA_DIR="${1:-data/finbench-sf1}"
+
+echo "================================================================"
+echo "  LDBC FinBench Dataset Generator — Samyama"
+echo "================================================================"
+echo ""
+echo "  Target directory: ${DATA_DIR}"
+echo ""
+
+# ── Check if data already exists ─────────────────────────────────────
+if [ -f "${DATA_DIR}/account.csv" ] && [ -f "${DATA_DIR}/transfer.csv" ]; then
+    echo "  [SKIP] FinBench data already exists at ${DATA_DIR}"
+    echo ""
+    echo "  Files found:"
+    for f in "${DATA_DIR}"/*.csv; do
+        rows=$(wc -l < "$f" | tr -d ' ')
+        name=$(basename "$f")
+        printf "    %-30s %s lines\n" "$name" "$rows"
+    done
+    echo ""
+    echo "  To regenerate, remove the directory first:"
+    echo "    rm -rf ${DATA_DIR}"
+    echo ""
+    echo "  To run the benchmark:"
+    echo "    cargo run --release --example finbench_benchmark -- --data-dir ${DATA_DIR}"
+    exit 0
+fi
+
+# ── Try to build and run the generator ───────────────────────────────
+echo "  Checking for Rust toolchain..."
+if ! command -v cargo &>/dev/null; then
+    echo "  ERROR: 'cargo' not found. Install Rust via https://rustup.rs/"
+    exit 1
+fi
+
+echo "  Building finbench_loader..."
+echo ""
+
+if cargo build --release --example finbench_loader 2>&1; then
+    echo ""
+    echo "  Generating FinBench SF1 dataset..."
+    echo ""
+    cargo run --release --example finbench_loader -- --generate --data-dir "${DATA_DIR}" 2>&1
+    echo ""
+else
+    echo ""
+    echo "  Build failed. Falling back to shell-based data generator..."
+    echo ""
+
+    # ── Fallback: Pure shell CSV generator ───────────────────────────
+    mkdir -p "${DATA_DIR}"
+
+    NUM_PERSONS=1000
+    NUM_COMPANIES=500
+    NUM_ACCOUNTS=5000
+    NUM_LOANS=1000
+    NUM_MEDIUMS=200
+    NUM_TRANSFERS=20000
+    NUM_WITHDRAWALS=5000
+    NUM_DEPOSITS=2000
+    NUM_REPAYMENTS=3000
+    NUM_SIGN_INS=8000
+
+    ACCOUNT_TYPES=("checking" "savings" "investment" "business")
+    MEDIUM_TYPES=("phone" "tablet" "laptop" "desktop" "ATM")
+    FIRST_NAMES=("Alice" "Bob" "Charlie" "Diana" "Eve" "Frank" "Grace" "Henry" "Ivy" "Jack")
+    LAST_NAMES=("Smith" "Johnson" "Williams" "Brown" "Jones" "Garcia" "Miller" "Davis" "Kumar" "Singh")
+    COMPANY_PREFIXES=("Alpha" "Beta" "Gamma" "Delta" "Epsilon" "Zeta" "Atlas" "Nova" "Apex" "Vertex")
+    COMPANY_SUFFIXES=("Corp" "Inc" "Ltd" "Group" "Holdings" "Capital" "Technologies" "Financial" "Solutions" "Global")
+
+    # Base timestamp: 2020-01-01
+    BASE_TS=1577836800000
+    # 3 years in ms
+    TIME_RANGE=94608000000
+
+    random_ts() {
+        echo $(( BASE_TS + RANDOM * RANDOM % TIME_RANGE ))
+    }
+
+    echo "  Generating person.csv..."
+    {
+        echo "id|name|isBlocked"
+        for i in $(seq 1 $NUM_PERSONS); do
+            first=${FIRST_NAMES[$((RANDOM % ${#FIRST_NAMES[@]}))]}
+            last=${LAST_NAMES[$((RANDOM % ${#LAST_NAMES[@]}))]}
+            blocked=$(( RANDOM % 50 == 0 ? 1 : 0 ))
+            echo "${i}|${first} ${last}|${blocked}"
+        done
+    } > "${DATA_DIR}/person.csv"
+
+    echo "  Generating company.csv..."
+    {
+        echo "id|name|isBlocked"
+        for i in $(seq 1 $NUM_COMPANIES); do
+            prefix=${COMPANY_PREFIXES[$((RANDOM % ${#COMPANY_PREFIXES[@]}))]}
+            suffix=${COMPANY_SUFFIXES[$((RANDOM % ${#COMPANY_SUFFIXES[@]}))]}
+            blocked=$(( RANDOM % 100 == 0 ? 1 : 0 ))
+            echo "${i}|${prefix} ${suffix}|${blocked}"
+        done
+    } > "${DATA_DIR}/company.csv"
+
+    echo "  Generating account.csv..."
+    {
+        echo "id|createTime|isBlocked|accountType"
+        for i in $(seq 1 $NUM_ACCOUNTS); do
+            acct_type=${ACCOUNT_TYPES[$((RANDOM % ${#ACCOUNT_TYPES[@]}))]}
+            blocked=$(( RANDOM % 33 == 0 ? 1 : 0 ))
+            echo "${i}|$(random_ts)|${blocked}|${acct_type}"
+        done
+    } > "${DATA_DIR}/account.csv"
+
+    echo "  Generating loan.csv..."
+    {
+        echo "id|loanAmount|balance"
+        for i in $(seq 1 $NUM_LOANS); do
+            amount=$(( 1000 + RANDOM % 499000 ))
+            balance=$(( amount * (RANDOM % 100) / 100 ))
+            echo "${i}|${amount}.00|${balance}.00"
+        done
+    } > "${DATA_DIR}/loan.csv"
+
+    echo "  Generating medium.csv..."
+    {
+        echo "id|mediumType|isBlocked"
+        for i in $(seq 1 $NUM_MEDIUMS); do
+            mtype=${MEDIUM_TYPES[$((RANDOM % ${#MEDIUM_TYPES[@]}))]}
+            blocked=$(( RANDOM % 50 == 0 ? 1 : 0 ))
+            echo "${i}|${mtype}|${blocked}"
+        done
+    } > "${DATA_DIR}/medium.csv"
+
+    echo "  Generating transfer.csv..."
+    {
+        echo "srcId|tgtId|timestamp|amount"
+        for _ in $(seq 1 $NUM_TRANSFERS); do
+            src=$(( RANDOM % NUM_ACCOUNTS + 1 ))
+            tgt=$(( RANDOM % NUM_ACCOUNTS + 1 ))
+            while [ "$tgt" -eq "$src" ]; do tgt=$(( RANDOM % NUM_ACCOUNTS + 1 )); done
+            amount=$(( 10 + RANDOM % 50000 ))
+            echo "${src}|${tgt}|$(random_ts)|${amount}.00"
+        done
+    } > "${DATA_DIR}/transfer.csv"
+
+    echo "  Generating personOwnAccount.csv..."
+    {
+        echo "srcId|tgtId|timestamp"
+        for i in $(seq 1 $NUM_PERSONS); do
+            num_accounts=$(( RANDOM % 5 + 1 ))
+            for _ in $(seq 1 $num_accounts); do
+                aid=$(( RANDOM % NUM_ACCOUNTS + 1 ))
+                echo "${i}|${aid}|$(random_ts)"
+            done
+        done
+    } > "${DATA_DIR}/personOwnAccount.csv"
+
+    echo "  Generating companyOwnAccount.csv..."
+    {
+        echo "srcId|tgtId|timestamp"
+        for i in $(seq 1 $NUM_COMPANIES); do
+            num_accounts=$(( RANDOM % 3 + 1 ))
+            for _ in $(seq 1 $num_accounts); do
+                aid=$(( RANDOM % NUM_ACCOUNTS + 1 ))
+                echo "${i}|${aid}|$(random_ts)"
+            done
+        done
+    } > "${DATA_DIR}/companyOwnAccount.csv"
+
+    echo "  Generating withdraw.csv..."
+    {
+        echo "srcId|tgtId|timestamp|amount"
+        for _ in $(seq 1 $NUM_WITHDRAWALS); do
+            src=$(( RANDOM % NUM_ACCOUNTS + 1 ))
+            tgt=$(( RANDOM % NUM_ACCOUNTS + 1 ))
+            while [ "$tgt" -eq "$src" ]; do tgt=$(( RANDOM % NUM_ACCOUNTS + 1 )); done
+            amount=$(( 50 + RANDOM % 20000 ))
+            echo "${src}|${tgt}|$(random_ts)|${amount}.00"
+        done
+    } > "${DATA_DIR}/withdraw.csv"
+
+    echo "  Generating deposit.csv..."
+    {
+        echo "srcId|tgtId|timestamp|amount"
+        for _ in $(seq 1 $NUM_DEPOSITS); do
+            lid=$(( RANDOM % NUM_LOANS + 1 ))
+            aid=$(( RANDOM % NUM_ACCOUNTS + 1 ))
+            amount=$(( 500 + RANDOM % 100000 ))
+            echo "${lid}|${aid}|$(random_ts)|${amount}.00"
+        done
+    } > "${DATA_DIR}/deposit.csv"
+
+    echo "  Generating repay.csv..."
+    {
+        echo "srcId|tgtId|timestamp|amount"
+        for _ in $(seq 1 $NUM_REPAYMENTS); do
+            aid=$(( RANDOM % NUM_ACCOUNTS + 1 ))
+            lid=$(( RANDOM % NUM_LOANS + 1 ))
+            amount=$(( 100 + RANDOM % 50000 ))
+            echo "${aid}|${lid}|$(random_ts)|${amount}.00"
+        done
+    } > "${DATA_DIR}/repay.csv"
+
+    echo "  Generating signIn.csv..."
+    {
+        echo "srcId|tgtId|timestamp"
+        for _ in $(seq 1 $NUM_SIGN_INS); do
+            aid=$(( RANDOM % NUM_ACCOUNTS + 1 ))
+            mid=$(( RANDOM % NUM_MEDIUMS + 1 ))
+            echo "${aid}|${mid}|$(random_ts)"
+        done
+    } > "${DATA_DIR}/signIn.csv"
+
+    echo "  Generating personApplyLoan.csv..."
+    {
+        echo "srcId|tgtId|timestamp"
+        for i in $(seq 1 $NUM_LOANS); do
+            if [ $(( RANDOM % 10 )) -lt 6 ]; then
+                pid=$(( RANDOM % NUM_PERSONS + 1 ))
+                echo "${pid}|${i}|$(random_ts)"
+            fi
+        done
+    } > "${DATA_DIR}/personApplyLoan.csv"
+
+    echo "  Generating companyApplyLoan.csv..."
+    {
+        echo "srcId|tgtId|timestamp"
+        for i in $(seq 1 $NUM_LOANS); do
+            if [ $(( RANDOM % 10 )) -ge 6 ]; then
+                cid=$(( RANDOM % NUM_COMPANIES + 1 ))
+                echo "${cid}|${i}|$(random_ts)"
+            fi
+        done
+    } > "${DATA_DIR}/companyApplyLoan.csv"
+
+    echo "  Generating companyInvestCompany.csv..."
+    {
+        echo "srcId|tgtId|timestamp|ratio"
+        num_investments=$(( NUM_COMPANIES / 2 ))
+        for _ in $(seq 1 $num_investments); do
+            src=$(( RANDOM % NUM_COMPANIES + 1 ))
+            tgt=$(( RANDOM % NUM_COMPANIES + 1 ))
+            while [ "$tgt" -eq "$src" ]; do tgt=$(( RANDOM % NUM_COMPANIES + 1 )); done
+            ratio=$(( RANDOM % 100 ))
+            echo "${src}|${tgt}|$(random_ts)|0.${ratio}"
+        done
+    } > "${DATA_DIR}/companyInvestCompany.csv"
+
+    echo "  Generating personInvestCompany.csv..."
+    {
+        echo "srcId|tgtId|timestamp|ratio"
+        num_investments=$(( NUM_COMPANIES / 4 ))
+        for _ in $(seq 1 $num_investments); do
+            pid=$(( RANDOM % NUM_PERSONS + 1 ))
+            cid=$(( RANDOM % NUM_COMPANIES + 1 ))
+            ratio=$(( RANDOM % 100 ))
+            echo "${pid}|${cid}|$(random_ts)|0.${ratio}"
+        done
+    } > "${DATA_DIR}/personInvestCompany.csv"
+
+    echo "  Generating companyGuaranteeCompany.csv..."
+    {
+        echo "srcId|tgtId|timestamp"
+        num_guarantees=$(( NUM_PERSONS / 8 ))
+        for _ in $(seq 1 $num_guarantees); do
+            src=$(( RANDOM % NUM_COMPANIES + 1 ))
+            tgt=$(( RANDOM % NUM_COMPANIES + 1 ))
+            while [ "$tgt" -eq "$src" ]; do tgt=$(( RANDOM % NUM_COMPANIES + 1 )); done
+            echo "${src}|${tgt}|$(random_ts)"
+        done
+    } > "${DATA_DIR}/companyGuaranteeCompany.csv"
+
+    echo "  Generating personGuaranteePerson.csv..."
+    {
+        echo "srcId|tgtId|timestamp"
+        num_guarantees=$(( NUM_PERSONS / 12 ))
+        for _ in $(seq 1 $num_guarantees); do
+            src=$(( RANDOM % NUM_PERSONS + 1 ))
+            tgt=$(( RANDOM % NUM_PERSONS + 1 ))
+            while [ "$tgt" -eq "$src" ]; do tgt=$(( RANDOM % NUM_PERSONS + 1 )); done
+            echo "${src}|${tgt}|$(random_ts)"
+        done
+    } > "${DATA_DIR}/personGuaranteePerson.csv"
+
+    echo ""
+fi
+
+# ── Verify ───────────────────────────────────────────────────────────
+echo "================================================================"
+echo "  Dataset Summary"
+echo "================================================================"
+echo ""
+
+total_rows=0
+for f in "${DATA_DIR}"/*.csv; do
+    rows=$(( $(wc -l < "$f" | tr -d ' ') - 1 ))  # subtract header
+    total_rows=$(( total_rows + rows ))
+    name=$(basename "$f")
+    printf "  %-34s %'8d rows\n" "$name" "$rows"
+done
+
+echo ""
+printf "  %-34s %'8d total rows\n" "TOTAL" "$total_rows"
+echo ""
+echo "================================================================"
+echo "  Generation complete!"
+echo ""
+echo "  Run the benchmark:"
+echo "    cargo run --release --example finbench_benchmark -- --data-dir ${DATA_DIR}"
+echo ""
+echo "  Or use in-memory synthetic data (faster, no CSV needed):"
+echo "    cargo run --release --example finbench_benchmark"
+echo ""
+echo "  Include write operations:"
+echo "    cargo run --release --example finbench_benchmark -- --writes"
+echo "================================================================"

--- a/scripts/download_graphalytics.sh
+++ b/scripts/download_graphalytics.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Download LDBC Graphalytics example datasets.
+#
+# These are tiny (XS) datasets suitable for development and correctness testing.
+# For larger scale factors, visit: https://ldbcouncil.org/benchmarks/graphalytics/
+#
+# Usage:
+#   ./scripts/download_graphalytics.sh
+#   ./scripts/download_graphalytics.sh /custom/data/dir
+
+set -euo pipefail
+
+DATA_DIR="${1:-data/graphalytics}"
+
+echo "================================================================"
+echo "  LDBC Graphalytics Dataset Downloader"
+echo "================================================================"
+echo ""
+echo "  Target directory: ${DATA_DIR}"
+echo ""
+
+mkdir -p "${DATA_DIR}"
+
+# ── Helper ───────────────────────────────────────────────────────────
+download_dataset() {
+    local name="$1"
+    local dir="${DATA_DIR}/${name}"
+
+    if [ -f "${dir}/${name}.v" ] && [ -f "${dir}/${name}.e" ]; then
+        echo "  [SKIP] ${name} — already exists"
+        return
+    fi
+
+    echo "  [DOWNLOAD] ${name}..."
+    mkdir -p "${dir}"
+
+    local base_url="https://raw.githubusercontent.com/ldbc/ldbc_graphalytics/main/graphalytics-validation/src/main/resources/validation-graphs/example"
+
+    # Download vertex file
+    if curl -fsSL "${base_url}/${name}.v" -o "${dir}/${name}.v" 2>/dev/null; then
+        local vcount
+        vcount=$(wc -l < "${dir}/${name}.v" | tr -d ' ')
+        echo "    Vertices: ${vcount}"
+    else
+        echo "    WARNING: Could not download ${name}.v"
+    fi
+
+    # Download edge file
+    if curl -fsSL "${base_url}/${name}.e" -o "${dir}/${name}.e" 2>/dev/null; then
+        local ecount
+        ecount=$(wc -l < "${dir}/${name}.e" | tr -d ' ')
+        echo "    Edges:    ${ecount}"
+    else
+        echo "    WARNING: Could not download ${name}.e"
+    fi
+
+    # Download properties file from config-template
+    local props_url="https://raw.githubusercontent.com/ldbc/ldbc_graphalytics/main/config-template/graphs/${name}.properties"
+    if curl -fsSL "${props_url}" -o "${dir}/${name}.properties" 2>/dev/null; then
+        echo "    Properties file downloaded"
+    fi
+
+    # Download algorithm-specific input/output files for validation
+    for algo in BFS CDLP LCC PR SSSP WCC; do
+        local algo_url="${base_url}/${name}-${algo}"
+        if curl -fsSL "${algo_url}" -o "${dir}/${name}-${algo}" 2>/dev/null; then
+            : # silently download
+        fi
+    done
+
+    # Download algorithm-specific input parameters
+    local input_url="${base_url}/${name}-input"
+    if curl -fsSL "${input_url}" -o "${dir}/${name}-input" 2>/dev/null; then
+        echo "    Input parameters downloaded"
+    fi
+
+    echo "    Done: ${dir}/"
+}
+
+# ── Download datasets ────────────────────────────────────────────────
+
+echo "Downloading example datasets..."
+echo ""
+
+download_dataset "example-directed"
+download_dataset "example-undirected"
+
+echo ""
+
+# ── Verify ───────────────────────────────────────────────────────────
+echo "Verifying datasets..."
+echo ""
+
+for ds in example-directed example-undirected; do
+    dir="${DATA_DIR}/${ds}"
+    if [ -f "${dir}/${ds}.v" ] && [ -f "${dir}/${ds}.e" ]; then
+        vcount=$(wc -l < "${dir}/${ds}.v" | tr -d ' ')
+        ecount=$(wc -l < "${dir}/${ds}.e" | tr -d ' ')
+        echo "  ${ds}:"
+        echo "    Vertex file: ${dir}/${ds}.v  (${vcount} lines)"
+        echo "    Edge file:   ${dir}/${ds}.e  (${ecount} lines)"
+    else
+        echo "  ${ds}: MISSING FILES"
+    fi
+done
+
+echo ""
+echo "================================================================"
+echo "  Download complete!"
+echo ""
+echo "  Run the benchmark:"
+echo "    cargo run --release --example graphalytics_benchmark -- --all"
+echo "================================================================"

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -13,10 +13,12 @@ pub use samyama_graph_algorithms::{
     page_rank, PageRankConfig,
     weakly_connected_components, WccResult,
     strongly_connected_components, SccResult,
-    bfs, dijkstra, PathResult,
+    bfs, dijkstra, bfs_all_shortest_paths, PathResult,
     edmonds_karp, FlowResult,
     prim_mst, MSTResult,
-    count_triangles
+    count_triangles,
+    cdlp, CdlpResult, CdlpConfig,
+    local_clustering_coefficient, LccResult,
 };
 
 /// Build a GraphView from the store for algorithm execution

--- a/src/graph/property.rs
+++ b/src/graph/property.rs
@@ -29,6 +29,13 @@ pub enum PropertyValue {
     Array(Vec<PropertyValue>),
     Map(HashMap<String, PropertyValue>),
     Vector(Vec<f32>),
+    /// Duration with months, days, seconds, nanos components (ISO 8601)
+    Duration {
+        months: i64,
+        days: i64,
+        seconds: i64,
+        nanos: i32,
+    },
     Null,
 }
 
@@ -119,6 +126,16 @@ impl Ord for PropertyValue {
                 }
                 a.len().cmp(&b.len())
             }
+            (Vector(_), _) => Ordering::Less,
+            (_, Vector(_)) => Ordering::Greater,
+
+            (Duration { months: m1, days: d1, seconds: s1, nanos: n1 },
+             Duration { months: m2, days: d2, seconds: s2, nanos: n2 }) => {
+                m1.cmp(m2)
+                    .then(d1.cmp(d2))
+                    .then(s1.cmp(s2))
+                    .then(n1.cmp(n2))
+            }
         }
     }
 }
@@ -167,8 +184,15 @@ impl std::hash::Hash for PropertyValue {
                     val.to_bits().hash(state);
                 }
             }
-            PropertyValue::Null => {
+            PropertyValue::Duration { months, days, seconds, nanos } => {
                 8.hash(state);
+                months.hash(state);
+                days.hash(state);
+                seconds.hash(state);
+                nanos.hash(state);
+            }
+            PropertyValue::Null => {
+                9.hash(state);
             }
         }
     }
@@ -255,6 +279,7 @@ impl PropertyValue {
             PropertyValue::Array(_) => "Array",
             PropertyValue::Map(_) => "Map",
             PropertyValue::Vector(_) => "Vector",
+            PropertyValue::Duration { .. } => "Duration",
             PropertyValue::Null => "Null",
         }
     }
@@ -279,6 +304,14 @@ impl PropertyValue {
                 serde_json::Value::Object(json_map)
             }
             PropertyValue::Vector(v) => json!(v),
+            PropertyValue::Duration { months, days, seconds, nanos } => {
+                json!({
+                    "months": months,
+                    "days": days,
+                    "seconds": seconds,
+                    "nanos": nanos
+                })
+            }
             PropertyValue::Null => serde_json::Value::Null,
         }
     }
@@ -321,6 +354,26 @@ impl fmt::Display for PropertyValue {
                     write!(f, "{}", val)?;
                 }
                 write!(f, "])")
+            }
+            PropertyValue::Duration { months, days, seconds, nanos } => {
+                write!(f, "P")?;
+                if *months > 0 {
+                    let years = months / 12;
+                    let rem_months = months % 12;
+                    if years > 0 { write!(f, "{}Y", years)?; }
+                    if rem_months > 0 { write!(f, "{}M", rem_months)?; }
+                }
+                if *days > 0 { write!(f, "{}D", days)?; }
+                if *seconds > 0 || *nanos > 0 {
+                    write!(f, "T")?;
+                    let h = seconds / 3600;
+                    let m = (seconds % 3600) / 60;
+                    let s = seconds % 60;
+                    if h > 0 { write!(f, "{}H", h)?; }
+                    if m > 0 { write!(f, "{}M", m)?; }
+                    if s > 0 || *nanos > 0 { write!(f, "{}S", s)?; }
+                }
+                Ok(())
             }
             PropertyValue::Null => write!(f, "null"),
         }

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -109,6 +109,14 @@ pub async fn query_handler(
                         Value::Property(p) => {
                             row.push(p.to_json());
                         }
+                        Value::Path { nodes: path_nodes, edges: path_edges } => {
+                            let path_json = json!({
+                                "nodes": path_nodes.iter().map(|n| n.as_u64().to_string()).collect::<Vec<_>>(),
+                                "edges": path_edges.iter().map(|e| e.as_u64().to_string()).collect::<Vec<_>>(),
+                                "length": path_edges.len(),
+                            });
+                            row.push(path_json);
+                        }
                         Value::Null => {
                             row.push(serde_json::Value::Null);
                         }

--- a/src/protocol/command.rs
+++ b/src/protocol/command.rs
@@ -325,6 +325,10 @@ impl CommandHandler {
                     _ => RespValue::BulkString(Some(format!("{:?}", prop).into_bytes())),
                 }
             }
+            Value::Path { nodes, edges } => {
+                let path_str = format!("Path(nodes: {:?}, edges: {:?})", nodes, edges);
+                RespValue::BulkString(Some(path_str.into_bytes()))
+            }
             Value::Null => RespValue::Null,
         }
     }

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -24,6 +24,8 @@ pub struct Query {
     pub skip: Option<usize>,
     /// CALL clause (optional)
     pub call_clause: Option<CallClause>,
+    /// CALL subquery (optional)
+    pub call_subquery: Option<Box<Query>>,
     /// DELETE clause (optional)
     pub delete_clause: Option<DeleteClause>,
     /// SET clauses
@@ -101,9 +103,21 @@ pub struct Pattern {
     pub paths: Vec<PathPattern>,
 }
 
+/// Path type for path patterns (normal, shortest, allShortest)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PathType {
+    Normal,
+    Shortest,
+    AllShortest,
+}
+
 /// Path pattern: (n:Person)-[:KNOWS*1..3]->(m:Person)
 #[derive(Debug, Clone, PartialEq)]
 pub struct PathPattern {
+    /// Named path variable (e.g., `p` in `p = (a)-[:KNOWS]->(b)`)
+    pub path_variable: Option<String>,
+    /// Path type (Normal, Shortest, AllShortest)
+    pub path_type: PathType,
     /// Start node
     pub start: NodePattern,
     /// Edges and nodes
@@ -245,6 +259,41 @@ pub enum Expression {
         /// Mapping expression
         map_expr: Box<Expression>,
     },
+    /// Predicate function: all(x IN list WHERE pred), any(...), none(...), single(...)
+    PredicateFunction {
+        /// Function name (all, any, none, single)
+        name: String,
+        /// Iterator variable
+        variable: String,
+        /// List expression
+        list_expr: Box<Expression>,
+        /// Predicate expression
+        predicate: Box<Expression>,
+    },
+    /// reduce(acc = init, x IN list | expr)
+    Reduce {
+        /// Accumulator variable name
+        accumulator: String,
+        /// Initial value expression
+        init: Box<Expression>,
+        /// Iterator variable name
+        variable: String,
+        /// List expression
+        list_expr: Box<Expression>,
+        /// Body expression
+        expression: Box<Expression>,
+    },
+    /// Pattern comprehension: [(a)-[:REL]->(b) WHERE cond | expr]
+    PatternComprehension {
+        /// Pattern to match
+        pattern: Pattern,
+        /// Optional filter predicate
+        filter: Option<Box<Expression>>,
+        /// Projection expression
+        projection: Box<Expression>,
+    },
+    /// Named path reference (for Value::Path)
+    PathVariable(String),
 }
 
 /// Binary operators
@@ -445,6 +494,7 @@ impl Query {
             limit: None,
             skip: None,
             call_clause: None,
+            call_subquery: None,
             delete_clause: None,
             set_clauses: Vec::new(),
             remove_clauses: Vec::new(),

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -16,8 +16,11 @@ create_index_stmt = { ^"CREATE" ~ ^"INDEX" ~ ^"ON" ~ ":" ~ label ~ "(" ~ propert
 options = { ^"OPTIONS" ~ "{" ~ property_list? ~ "}" }
 
 // CALL statement (Standalone or followed by MATCH)
-call_stmt = { call_clause ~ match_stmt_partial? ~ return_clause? }
+call_stmt = { (call_subquery | call_clause) ~ match_stmt_partial? ~ return_clause? }
 match_stmt_partial = { ^"MATCH" ~ pattern ~ where_clause? }
+
+// CALL subquery: CALL { MATCH ... RETURN ... }
+call_subquery = { ^"CALL" ~ "{" ~ statement ~ "}" }
 
 // CALL clause
 call_clause = { ^"CALL" ~ procedure_name ~ "(" ~ (expression ~ ("," ~ expression)*)? ~ ")" ~ (^"YIELD" ~ yield_items)? }
@@ -56,8 +59,12 @@ limit_clause = { ^"LIMIT" ~ integer }
 create_stmt = { ^"CREATE" ~ pattern }
 
 // Pattern matching
-pattern = { path ~ ("," ~ path)* }
+pattern = { named_path ~ ("," ~ named_path)* }
+named_path = { (variable ~ "=" ~ shortest_path_call) | (variable ~ "=" ~ path) | shortest_path_call | path }
 path = { node ~ (edge_pattern ~ node)* }
+
+// shortestPath / allShortestPaths wrapping a pattern
+shortest_path_call = { (^"allShortestPaths" | ^"shortestPath") ~ "(" ~ path ~ ")" }
 
 // Node pattern: (n:Person {name: "Alice"})
 node = { "(" ~ variable? ~ labels? ~ properties? ~ ")" }
@@ -101,6 +108,9 @@ index_op = { "[" ~ expression ~ "]" }
 primary = {
     case_expression |
     exists_subquery |
+    reduce_expression |
+    predicate_function |
+    pattern_comprehension |
     list_comprehension |
     function_call |
     property_access |
@@ -108,6 +118,16 @@ primary = {
     variable |
     "(" ~ expression ~ ")"
 }
+
+// Predicate functions: all(x IN list WHERE pred), any(...), none(...), single(...)
+predicate_function = { predicate_function_name ~ "(" ~ variable ~ in_op ~ expression ~ ^"WHERE" ~ expression ~ ")" }
+predicate_function_name = @{ (^"all" | ^"any" | ^"none" | ^"single") ~ !(ASCII_ALPHANUMERIC | "_") }
+
+// reduce(acc = init, x IN list | expr)
+reduce_expression = { ^"reduce" ~ "(" ~ variable ~ "=" ~ expression ~ "," ~ variable ~ in_op ~ expression ~ "|" ~ expression ~ ")" }
+
+// Pattern comprehension: [(a)-[:REL]->(b) WHERE cond | expr]
+pattern_comprehension = { "[" ~ path ~ where_clause? ~ "|" ~ expression ~ "]" }
 
 // EXISTS { MATCH pattern WHERE condition }
 exists_subquery = { ^"EXISTS" ~ "{" ~ ^"MATCH" ~ pattern ~ where_clause? ~ "}" }

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -51,6 +51,16 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
             (PropertyValue::Integer(l), PropertyValue::Float(r)) => PropertyValue::Float(*l as f64 + r),
             (PropertyValue::Float(l), PropertyValue::Integer(r)) => PropertyValue::Float(l + *r as f64),
             (PropertyValue::String(l), PropertyValue::String(r)) => PropertyValue::String(format!("{}{}", l, r)),
+            // DateTime + Duration
+            (PropertyValue::DateTime(dt), PropertyValue::Duration { months, days, seconds, .. }) |
+            (PropertyValue::Duration { months, days, seconds, .. }, PropertyValue::DateTime(dt)) => {
+                add_duration_to_datetime(*dt, *months, *days, *seconds)
+            }
+            // Duration + Duration
+            (PropertyValue::Duration { months: m1, days: d1, seconds: s1, nanos: n1 },
+             PropertyValue::Duration { months: m2, days: d2, seconds: s2, nanos: n2 }) => {
+                PropertyValue::Duration { months: m1 + m2, days: d1 + d2, seconds: s1 + s2, nanos: n1 + n2 }
+            }
             _ => return Err(ExecutionError::TypeError("Add requires numeric or string operands".to_string())),
         },
         BinaryOp::Sub => match (&left_prop, &right_prop) {
@@ -58,6 +68,21 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
             (PropertyValue::Float(l), PropertyValue::Float(r)) => PropertyValue::Float(l - r),
             (PropertyValue::Integer(l), PropertyValue::Float(r)) => PropertyValue::Float(*l as f64 - r),
             (PropertyValue::Float(l), PropertyValue::Integer(r)) => PropertyValue::Float(l - *r as f64),
+            // DateTime - Duration
+            (PropertyValue::DateTime(dt), PropertyValue::Duration { months, days, seconds, .. }) => {
+                add_duration_to_datetime(*dt, -*months, -*days, -*seconds)
+            }
+            // DateTime - DateTime = Duration
+            (PropertyValue::DateTime(a), PropertyValue::DateTime(b)) => {
+                let diff_ms = a - b;
+                let total_seconds = diff_ms / 1000;
+                PropertyValue::Duration { months: 0, days: total_seconds / 86400, seconds: total_seconds % 86400, nanos: ((diff_ms % 1000) * 1_000_000) as i32 }
+            }
+            // Duration - Duration
+            (PropertyValue::Duration { months: m1, days: d1, seconds: s1, nanos: n1 },
+             PropertyValue::Duration { months: m2, days: d2, seconds: s2, nanos: n2 }) => {
+                PropertyValue::Duration { months: m1 - m2, days: d1 - d2, seconds: s1 - s2, nanos: n1 - n2 }
+            }
             _ => return Err(ExecutionError::TypeError("Sub requires numeric operands".to_string())),
         },
         BinaryOp::Mul => match (&left_prop, &right_prop) {
@@ -188,6 +213,19 @@ fn eval_expression(expr: &Expression, record: &Record, store: &GraphStore) -> Ex
         }
         Expression::ListComprehension { variable, list_expr, filter, map_expr } => {
             eval_list_comprehension(variable, list_expr, filter.as_deref(), map_expr, record, store)
+        }
+        Expression::PredicateFunction { name, variable, list_expr, predicate } => {
+            eval_predicate_function(name, variable, list_expr, predicate, record, store)
+        }
+        Expression::Reduce { accumulator, init, variable, list_expr, expression } => {
+            eval_reduce(accumulator, init, variable, list_expr, expression, record, store)
+        }
+        Expression::PatternComprehension { pattern, filter, projection } => {
+            eval_pattern_comprehension(pattern, filter.as_deref(), projection, record, store)
+        }
+        Expression::PathVariable(var) => {
+            record.get(var).cloned()
+                .ok_or_else(|| ExecutionError::VariableNotFound(var.clone()))
         }
     }
 }
@@ -321,6 +359,174 @@ fn eval_list_comprehension(
     Ok(Value::Property(PropertyValue::Array(result)))
 }
 
+/// Evaluate predicate functions: all(x IN list WHERE pred), any(...), none(...), single(...)
+fn eval_predicate_function(
+    name: &str,
+    variable: &str,
+    list_expr: &Expression,
+    predicate: &Expression,
+    record: &Record,
+    store: &GraphStore,
+) -> ExecutionResult<Value> {
+    let list_val = eval_expression(list_expr, record, store)?;
+    let items = match list_val {
+        Value::Property(PropertyValue::Array(arr)) => arr,
+        _ => return Ok(Value::Property(PropertyValue::Boolean(false))),
+    };
+
+    let mut true_count = 0usize;
+    for item in &items {
+        let mut inner_record = record.clone();
+        inner_record.bind(variable.to_string(), Value::Property(item.clone()));
+        let result = eval_expression(predicate, &inner_record, store)?;
+        if matches!(result, Value::Property(PropertyValue::Boolean(true))) {
+            true_count += 1;
+        }
+    }
+
+    let result = match name {
+        "all" => true_count == items.len(),
+        "any" => true_count > 0,
+        "none" => true_count == 0,
+        "single" => true_count == 1,
+        _ => false,
+    };
+    Ok(Value::Property(PropertyValue::Boolean(result)))
+}
+
+/// Evaluate reduce(acc = init, x IN list | expr)
+fn eval_reduce(
+    accumulator: &str,
+    init: &Expression,
+    variable: &str,
+    list_expr: &Expression,
+    expression: &Expression,
+    record: &Record,
+    store: &GraphStore,
+) -> ExecutionResult<Value> {
+    let init_val = eval_expression(init, record, store)?;
+    let list_val = eval_expression(list_expr, record, store)?;
+    let items = match list_val {
+        Value::Property(PropertyValue::Array(arr)) => arr,
+        _ => return Ok(init_val),
+    };
+
+    let mut acc = init_val;
+    for item in items {
+        let mut inner_record = record.clone();
+        inner_record.bind(accumulator.to_string(), acc);
+        inner_record.bind(variable.to_string(), Value::Property(item));
+        acc = eval_expression(expression, &inner_record, store)?;
+    }
+    Ok(acc)
+}
+
+/// Evaluate pattern comprehension: [(a)-[:REL]->(b) | expr]
+fn eval_pattern_comprehension(
+    pattern: &Pattern,
+    filter: Option<&Expression>,
+    projection: &Expression,
+    record: &Record,
+    store: &GraphStore,
+) -> ExecutionResult<Value> {
+    let mut results = Vec::new();
+
+    for path in &pattern.paths {
+        let start_var = path.start.variable.as_deref();
+        let start_labels = &path.start.labels;
+
+        // Get candidate start nodes
+        let start_node_ids: Vec<NodeId> = if let Some(var) = start_var {
+            if let Some(val) = record.get(var) {
+                match val {
+                    Value::NodeRef(id) | Value::Node(id, _) => vec![*id],
+                    _ => vec![],
+                }
+            } else if let Some(first_label) = start_labels.first() {
+                store.get_nodes_by_label(first_label).iter().map(|n| n.id).collect()
+            } else {
+                store.all_nodes().iter().map(|n| n.id).collect()
+            }
+        } else if let Some(first_label) = start_labels.first() {
+            store.get_nodes_by_label(first_label).iter().map(|n| n.id).collect()
+        } else {
+            store.all_nodes().iter().map(|n| n.id).collect()
+        };
+
+        for node_id in &start_node_ids {
+            let node = match store.get_node(*node_id) {
+                Some(n) => n,
+                None => continue,
+            };
+            let has_all_labels = start_labels.iter().all(|l| node.labels.contains(l));
+            if !has_all_labels { continue; }
+
+            if path.segments.is_empty() {
+                let mut temp_record = record.clone();
+                if let Some(var) = start_var {
+                    temp_record.bind(var.to_string(), Value::NodeRef(*node_id));
+                }
+                if let Some(f) = filter {
+                    let cond = eval_expression(f, &temp_record, store)?;
+                    if !matches!(cond, Value::Property(PropertyValue::Boolean(true))) { continue; }
+                }
+                let val = eval_expression(projection, &temp_record, store)?;
+                match val {
+                    Value::Property(pv) => results.push(pv),
+                    _ => results.push(PropertyValue::Null),
+                }
+            } else {
+                // One-hop traversal for pattern comprehension
+                for segment in &path.segments {
+                    let edge_types: Vec<&str> = segment.edge.types.iter().map(|t| t.as_str()).collect();
+                    let edges = match segment.edge.direction {
+                        Direction::Outgoing => store.get_outgoing_edges(*node_id),
+                        Direction::Incoming => store.get_incoming_edges(*node_id),
+                        Direction::Both => {
+                            let mut all = store.get_outgoing_edges(*node_id);
+                            all.extend(store.get_incoming_edges(*node_id));
+                            all
+                        }
+                    };
+                    for edge in &edges {
+                        if !edge_types.is_empty() && !edge_types.contains(&edge.edge_type.as_str()) {
+                            continue;
+                        }
+                        let target_id = if edge.source == *node_id { edge.target } else { edge.source };
+                        if !segment.node.labels.is_empty() {
+                            if let Some(target) = store.get_node(target_id) {
+                                let matches = segment.node.labels.iter().all(|l| target.labels.contains(l));
+                                if !matches { continue; }
+                            } else { continue; }
+                        }
+                        let mut temp_record = record.clone();
+                        if let Some(var) = start_var {
+                            temp_record.bind(var.to_string(), Value::NodeRef(*node_id));
+                        }
+                        if let Some(ref var) = segment.node.variable {
+                            temp_record.bind(var.clone(), Value::NodeRef(target_id));
+                        }
+                        if let Some(ref var) = segment.edge.variable {
+                            temp_record.bind(var.clone(), Value::EdgeRef(edge.id, edge.source, edge.target, edge.edge_type.clone()));
+                        }
+                        if let Some(f) = filter {
+                            let cond = eval_expression(f, &temp_record, store)?;
+                            if !matches!(cond, Value::Property(PropertyValue::Boolean(true))) { continue; }
+                        }
+                        let val = eval_expression(projection, &temp_record, store)?;
+                        match val {
+                            Value::Property(pv) => results.push(pv),
+                            _ => results.push(PropertyValue::Null),
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(Value::Property(PropertyValue::Array(results)))
+}
+
 /// Shared function evaluation for scalar functions (not aggregates)
 fn eval_function(name: &str, args: &[Value]) -> ExecutionResult<Value> {
     match name.to_lowercase().as_str() {
@@ -423,7 +629,31 @@ fn eval_function(name: &str, args: &[Value]) -> ExecutionResult<Value> {
             match &args[0] {
                 Value::Property(PropertyValue::String(s)) => Ok(Value::Property(PropertyValue::Integer(s.len() as i64))),
                 Value::Property(PropertyValue::Array(a)) => Ok(Value::Property(PropertyValue::Integer(a.len() as i64))),
-                _ => Err(ExecutionError::TypeError("size() requires string or list".to_string())),
+                Value::Path { edges, .. } => Ok(Value::Property(PropertyValue::Integer(edges.len() as i64))),
+                _ => Err(ExecutionError::TypeError("size() requires string, list, or path".to_string())),
+            }
+        }
+        // Path functions
+        "nodes" => {
+            match &args[0] {
+                Value::Path { nodes, .. } => {
+                    let arr: Vec<PropertyValue> = nodes.iter()
+                        .map(|id| PropertyValue::Integer(id.as_u64() as i64))
+                        .collect();
+                    Ok(Value::Property(PropertyValue::Array(arr)))
+                }
+                _ => Err(ExecutionError::TypeError("nodes() requires a path".to_string())),
+            }
+        }
+        "relationships" | "rels" => {
+            match &args[0] {
+                Value::Path { edges, .. } => {
+                    let arr: Vec<PropertyValue> = edges.iter()
+                        .map(|id| PropertyValue::Integer(id.as_u64() as i64))
+                        .collect();
+                    Ok(Value::Property(PropertyValue::Array(arr)))
+                }
+                _ => Err(ExecutionError::TypeError("relationships() requires a path".to_string())),
             }
         }
         // Math functions
@@ -551,6 +781,139 @@ fn eval_function(name: &str, args: &[Value]) -> ExecutionResult<Value> {
             let is_null = matches!(&args[0], Value::Null | Value::Property(PropertyValue::Null));
             Ok(Value::Property(PropertyValue::Boolean(!is_null)))
         }
+        // startNode/endNode — return source/target node of an edge
+        "startnode" => {
+            match &args[0] {
+                Value::Edge(_, edge) => Ok(Value::NodeRef(edge.source)),
+                Value::EdgeRef(_, src, _, _) => Ok(Value::NodeRef(*src)),
+                _ => Err(ExecutionError::TypeError("startNode() requires an edge".to_string())),
+            }
+        }
+        "endnode" => {
+            match &args[0] {
+                Value::Edge(_, edge) => Ok(Value::NodeRef(edge.target)),
+                Value::EdgeRef(_, _, tgt, _) => Ok(Value::NodeRef(*tgt)),
+                _ => Err(ExecutionError::TypeError("endNode() requires an edge".to_string())),
+            }
+        }
+        // range() — generate integer list
+        "range" => {
+            if args.len() < 2 { return Err(ExecutionError::RuntimeError("range() requires at least 2 arguments".to_string())); }
+            let start = extract_int(&args[0])?;
+            let end = extract_int(&args[1])?;
+            let step = if args.len() >= 3 { extract_int(&args[2])? } else { 1 };
+            if step == 0 { return Err(ExecutionError::RuntimeError("range() step cannot be 0".to_string())); }
+            let mut result = Vec::new();
+            let mut i = start;
+            if step > 0 {
+                while i <= end {
+                    result.push(PropertyValue::Integer(i));
+                    i += step;
+                }
+            } else {
+                while i >= end {
+                    result.push(PropertyValue::Integer(i));
+                    i += step;
+                }
+            }
+            Ok(Value::Property(PropertyValue::Array(result)))
+        }
+        // date/datetime/duration constructors
+        "date" => {
+            if args.is_empty() {
+                // date() — current date as DateTime
+                let now = chrono::Utc::now().timestamp_millis();
+                Ok(Value::Property(PropertyValue::DateTime(now)))
+            } else {
+                match &args[0] {
+                    Value::Property(PropertyValue::String(s)) => {
+                        // Parse ISO date string
+                        if let Ok(dt) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+                            let millis = dt.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp_millis();
+                            Ok(Value::Property(PropertyValue::DateTime(millis)))
+                        } else {
+                            Err(ExecutionError::RuntimeError(format!("Cannot parse date: {}", s)))
+                        }
+                    }
+                    Value::Property(PropertyValue::Map(map)) => {
+                        let year = map.get("year").and_then(|v| v.as_integer()).unwrap_or(1970) as i32;
+                        let month = map.get("month").and_then(|v| v.as_integer()).unwrap_or(1) as u32;
+                        let day = map.get("day").and_then(|v| v.as_integer()).unwrap_or(1) as u32;
+                        if let Some(dt) = chrono::NaiveDate::from_ymd_opt(year, month, day) {
+                            let millis = dt.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp_millis();
+                            Ok(Value::Property(PropertyValue::DateTime(millis)))
+                        } else {
+                            Err(ExecutionError::RuntimeError(format!("Invalid date: {}-{}-{}", year, month, day)))
+                        }
+                    }
+                    _ => Err(ExecutionError::TypeError("date() requires string or map argument".to_string())),
+                }
+            }
+        }
+        "datetime" => {
+            if args.is_empty() {
+                let now = chrono::Utc::now().timestamp_millis();
+                Ok(Value::Property(PropertyValue::DateTime(now)))
+            } else {
+                match &args[0] {
+                    Value::Property(PropertyValue::String(s)) => {
+                        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+                            Ok(Value::Property(PropertyValue::DateTime(dt.timestamp_millis())))
+                        } else if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
+                            Ok(Value::Property(PropertyValue::DateTime(dt.and_utc().timestamp_millis())))
+                        } else {
+                            Err(ExecutionError::RuntimeError(format!("Cannot parse datetime: {}", s)))
+                        }
+                    }
+                    _ => Err(ExecutionError::TypeError("datetime() requires string argument".to_string())),
+                }
+            }
+        }
+        "duration" => {
+            if args.is_empty() {
+                return Err(ExecutionError::RuntimeError("duration() requires an argument".to_string()));
+            }
+            match &args[0] {
+                Value::Property(PropertyValue::String(s)) => {
+                    parse_iso_duration(s)
+                }
+                Value::Property(PropertyValue::Map(map)) => {
+                    let months = map.get("months").and_then(|v| v.as_integer()).unwrap_or(0);
+                    let days = map.get("days").and_then(|v| v.as_integer()).unwrap_or(0);
+                    let hours = map.get("hours").and_then(|v| v.as_integer()).unwrap_or(0);
+                    let minutes = map.get("minutes").and_then(|v| v.as_integer()).unwrap_or(0);
+                    let seconds = map.get("seconds").and_then(|v| v.as_integer()).unwrap_or(0);
+                    let years = map.get("years").and_then(|v| v.as_integer()).unwrap_or(0);
+                    let total_months = years * 12 + months;
+                    let total_seconds = hours * 3600 + minutes * 60 + seconds;
+                    Ok(Value::Property(PropertyValue::Duration {
+                        months: total_months,
+                        days,
+                        seconds: total_seconds,
+                        nanos: 0,
+                    }))
+                }
+                _ => Err(ExecutionError::TypeError("duration() requires string or map argument".to_string())),
+            }
+        }
+        // duration component accessors
+        "duration_between" | "duration.between" => {
+            if args.len() < 2 { return Err(ExecutionError::RuntimeError("duration.between() requires 2 arguments".to_string())); }
+            match (&args[0], &args[1]) {
+                (Value::Property(PropertyValue::DateTime(a)), Value::Property(PropertyValue::DateTime(b))) => {
+                    let diff_ms = b - a;
+                    let total_seconds = diff_ms / 1000;
+                    let remaining_days = total_seconds / 86400;
+                    Ok(Value::Property(PropertyValue::Duration {
+                        months: 0,
+                        days: remaining_days,
+                        seconds: total_seconds % 86400,
+                        nanos: ((diff_ms % 1000) * 1_000_000) as i32,
+                    }))
+                }
+                _ => Err(ExecutionError::TypeError("duration.between() requires two datetime arguments".to_string())),
+            }
+        }
         _ => Err(ExecutionError::RuntimeError(format!("Unknown function: {}", name))),
     }
 }
@@ -569,6 +932,93 @@ fn extract_int(val: &Value) -> ExecutionResult<i64> {
         Value::Property(PropertyValue::Integer(i)) => Ok(*i),
         _ => Err(ExecutionError::TypeError("Expected integer argument".to_string())),
     }
+}
+
+/// Add duration components to a DateTime (millis timestamp)
+fn add_duration_to_datetime(dt_millis: i64, months: i64, days: i64, seconds: i64) -> PropertyValue {
+    use chrono::{Datelike, Months, Duration, TimeZone};
+    let dt = chrono::Utc.timestamp_millis_opt(dt_millis).single();
+    match dt {
+        Some(mut datetime) => {
+            // Add months
+            if months > 0 {
+                if let Some(d) = datetime.checked_add_months(Months::new(months as u32)) {
+                    datetime = d;
+                }
+            } else if months < 0 {
+                if let Some(d) = datetime.checked_sub_months(Months::new((-months) as u32)) {
+                    datetime = d;
+                }
+            }
+            // Add days and seconds
+            let total_secs = days * 86400 + seconds;
+            if let Some(d) = datetime.checked_add_signed(Duration::seconds(total_secs)) {
+                datetime = d;
+            }
+            PropertyValue::DateTime(datetime.timestamp_millis())
+        }
+        None => PropertyValue::Null,
+    }
+}
+
+/// Parse ISO 8601 duration string (e.g. "P1Y2M3DT4H5M6S")
+fn parse_iso_duration(s: &str) -> ExecutionResult<Value> {
+    let s = s.trim();
+    if !s.starts_with('P') && !s.starts_with('p') {
+        return Err(ExecutionError::RuntimeError(format!("Invalid duration format: {}", s)));
+    }
+    let rest = &s[1..];
+    let mut months: i64 = 0;
+    let mut days: i64 = 0;
+    let mut seconds: i64 = 0;
+    let mut nanos: i32 = 0;
+    let _ = nanos; // suppress warning
+
+    let (date_part, time_part) = if let Some(idx) = rest.find(|c: char| c == 'T' || c == 't') {
+        (&rest[..idx], &rest[idx + 1..])
+    } else {
+        (rest, "")
+    };
+
+    // Parse date part: Y, M, D
+    let mut num_buf = String::new();
+    for ch in date_part.chars() {
+        if ch.is_ascii_digit() || ch == '.' {
+            num_buf.push(ch);
+        } else {
+            let val: f64 = num_buf.parse().unwrap_or(0.0);
+            num_buf.clear();
+            match ch {
+                'Y' | 'y' => months += (val * 12.0) as i64,
+                'M' | 'm' => months += val as i64,
+                'W' | 'w' => days += (val * 7.0) as i64,
+                'D' | 'd' => days += val as i64,
+                _ => {}
+            }
+        }
+    }
+
+    // Parse time part: H, M, S
+    num_buf.clear();
+    for ch in time_part.chars() {
+        if ch.is_ascii_digit() || ch == '.' {
+            num_buf.push(ch);
+        } else {
+            let val: f64 = num_buf.parse().unwrap_or(0.0);
+            num_buf.clear();
+            match ch {
+                'H' | 'h' => seconds += (val * 3600.0) as i64,
+                'M' | 'm' => seconds += (val * 60.0) as i64,
+                'S' | 's' => {
+                    seconds += val as i64;
+                    nanos = ((val - val.floor()) * 1_000_000_000.0) as i32;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Ok(Value::Property(PropertyValue::Duration { months, days, seconds, nanos }))
 }
 
 /// Shared CASE expression evaluation
@@ -1033,6 +1483,19 @@ impl FilterOperator {
             }
             Expression::ListComprehension { variable, list_expr, filter, map_expr } => {
                 eval_list_comprehension(variable, list_expr, filter.as_deref(), map_expr, record, store)
+            }
+            Expression::PredicateFunction { name, variable, list_expr, predicate } => {
+                eval_predicate_function(name, variable, list_expr, predicate, record, store)
+            }
+            Expression::Reduce { accumulator, init, variable, list_expr, expression } => {
+                eval_reduce(accumulator, init, variable, list_expr, expression, record, store)
+            }
+            Expression::PatternComprehension { pattern, filter, projection } => {
+                eval_pattern_comprehension(pattern, filter.as_deref(), projection, record, store)
+            }
+            Expression::PathVariable(var) => {
+                record.get(var).cloned()
+                    .ok_or_else(|| ExecutionError::VariableNotFound(var.clone()))
             }
         }
     }
@@ -1614,6 +2077,19 @@ impl ProjectOperator {
             Expression::ListComprehension { variable, list_expr, filter, map_expr } => {
                 eval_list_comprehension(variable, list_expr, filter.as_deref(), map_expr, record, store)
             }
+            Expression::PredicateFunction { name, variable, list_expr, predicate } => {
+                eval_predicate_function(name, variable, list_expr, predicate, record, store)
+            }
+            Expression::Reduce { accumulator, init, variable, list_expr, expression } => {
+                eval_reduce(accumulator, init, variable, list_expr, expression, record, store)
+            }
+            Expression::PatternComprehension { pattern, filter, projection } => {
+                eval_pattern_comprehension(pattern, filter.as_deref(), projection, record, store)
+            }
+            Expression::PathVariable(var) => {
+                record.get(var).cloned()
+                    .ok_or_else(|| ExecutionError::VariableNotFound(var.clone()))
+            }
         }
     }
 }
@@ -1739,6 +2215,9 @@ impl AggregatorState {
                     Value::EdgeRef(id, ..) | Value::Edge(id, _) => {
                         set.insert(PropertyValue::Integer(id.0 as i64));
                     }
+                    Value::Path { .. } => {
+                        // Paths are not countable as distinct — ignore
+                    }
                     Value::Null => {}
                 }
             }
@@ -1855,6 +2334,19 @@ impl AggregateOperator {
             }
             Expression::ListComprehension { variable, list_expr, filter, map_expr } => {
                 eval_list_comprehension(variable, list_expr, filter.as_deref(), map_expr, record, store)
+            }
+            Expression::PredicateFunction { name, variable, list_expr, predicate } => {
+                eval_predicate_function(name, variable, list_expr, predicate, record, store)
+            }
+            Expression::Reduce { accumulator, init, variable, list_expr, expression } => {
+                eval_reduce(accumulator, init, variable, list_expr, expression, record, store)
+            }
+            Expression::PatternComprehension { pattern, filter, projection } => {
+                eval_pattern_comprehension(pattern, filter.as_deref(), projection, record, store)
+            }
+            Expression::PathVariable(var) => {
+                record.get(var).cloned()
+                    .ok_or_else(|| ExecutionError::VariableNotFound(var.clone()))
             }
         }
     }
@@ -2087,6 +2579,19 @@ impl SortOperator {
             }
             Expression::ListComprehension { variable, list_expr, filter, map_expr } => {
                 eval_list_comprehension(variable, list_expr, filter.as_deref(), map_expr, record, store)
+            }
+            Expression::PredicateFunction { name, variable, list_expr, predicate } => {
+                eval_predicate_function(name, variable, list_expr, predicate, record, store)
+            }
+            Expression::Reduce { accumulator, init, variable, list_expr, expression } => {
+                eval_reduce(accumulator, init, variable, list_expr, expression, record, store)
+            }
+            Expression::PatternComprehension { pattern, filter, projection } => {
+                eval_pattern_comprehension(pattern, filter.as_deref(), projection, record, store)
+            }
+            Expression::PathVariable(var) => {
+                record.get(var).cloned()
+                    .ok_or_else(|| ExecutionError::VariableNotFound(var.clone()))
             }
         }
     }
@@ -4450,6 +4955,185 @@ impl PhysicalOperator for ForeachOperator {
 
     fn reset(&mut self) {
         self.input.reset();
+    }
+}
+
+/// ShortestPathOperator - finds shortest path(s) between two nodes using BFS
+pub struct ShortestPathOperator {
+    input: OperatorBox,
+    source_var: String,
+    target_var: String,
+    path_var: Option<String>,
+    edge_types: Vec<String>,
+    direction: Direction,
+    all_paths: bool,  // false = shortestPath, true = allShortestPaths
+    results: std::vec::IntoIter<Record>,
+    executed: bool,
+}
+
+impl ShortestPathOperator {
+    pub fn new(
+        input: OperatorBox,
+        source_var: String,
+        target_var: String,
+        path_var: Option<String>,
+        edge_types: Vec<String>,
+        direction: Direction,
+        all_paths: bool,
+    ) -> Self {
+        Self {
+            input,
+            source_var,
+            target_var,
+            path_var,
+            edge_types,
+            direction,
+            all_paths,
+            results: Vec::new().into_iter(),
+            executed: false,
+        }
+    }
+
+    fn execute_all(&mut self, store: &GraphStore) -> ExecutionResult<()> {
+        let mut all_results = Vec::new();
+
+        while let Some(record) = self.input.next(store)? {
+            let source_id = record.get(&self.source_var)
+                .and_then(|v| v.node_id())
+                .ok_or_else(|| ExecutionError::RuntimeError("shortestPath source not a node".to_string()))?;
+            let target_id = record.get(&self.target_var)
+                .and_then(|v| v.node_id())
+                .ok_or_else(|| ExecutionError::RuntimeError("shortestPath target not a node".to_string()))?;
+
+            // BFS to find shortest path(s)
+            let paths = self.bfs_shortest(store, source_id, target_id);
+
+            if self.all_paths {
+                for path in paths {
+                    let mut new_record = record.clone();
+                    if let Some(ref pv) = self.path_var {
+                        new_record.bind(pv.clone(), Value::Path {
+                            nodes: path.0,
+                            edges: path.1,
+                        });
+                    }
+                    all_results.push(new_record);
+                }
+            } else if let Some(path) = paths.into_iter().next() {
+                let mut new_record = record.clone();
+                if let Some(ref pv) = self.path_var {
+                    new_record.bind(pv.clone(), Value::Path {
+                        nodes: path.0,
+                        edges: path.1,
+                    });
+                }
+                all_results.push(new_record);
+            }
+        }
+
+        self.results = all_results.into_iter();
+        self.executed = true;
+        Ok(())
+    }
+
+    fn bfs_shortest(&self, store: &GraphStore, source: NodeId, target: NodeId) -> Vec<(Vec<NodeId>, Vec<crate::graph::EdgeId>)> {
+        use std::collections::VecDeque;
+
+        if source == target {
+            return vec![(vec![source], vec![])];
+        }
+
+        let mut queue: VecDeque<(NodeId, Vec<NodeId>, Vec<crate::graph::EdgeId>)> = VecDeque::new();
+        let mut visited: HashSet<NodeId> = HashSet::new();
+        let mut results = Vec::new();
+        let mut found_distance: Option<usize> = None;
+
+        queue.push_back((source, vec![source], vec![]));
+        visited.insert(source);
+
+        while let Some((current, path_nodes, path_edges)) = queue.pop_front() {
+            if let Some(max_dist) = found_distance {
+                if path_nodes.len() > max_dist {
+                    break;
+                }
+            }
+
+            let edges = match self.direction {
+                Direction::Outgoing => store.get_outgoing_edges(current),
+                Direction::Incoming => store.get_incoming_edges(current),
+                Direction::Both => {
+                    let mut all = store.get_outgoing_edges(current);
+                    all.extend(store.get_incoming_edges(current));
+                    all
+                }
+            };
+
+            for edge in &edges {
+                if !self.edge_types.is_empty() && !self.edge_types.iter().any(|t| t == edge.edge_type.as_str()) {
+                    continue;
+                }
+                let next_node = if edge.source == current { edge.target } else { edge.source };
+
+                if next_node == target {
+                    let mut new_nodes = path_nodes.clone();
+                    new_nodes.push(target);
+                    let mut new_edges = path_edges.clone();
+                    new_edges.push(edge.id);
+
+                    if found_distance.is_none() {
+                        found_distance = Some(new_nodes.len());
+                    }
+                    results.push((new_nodes, new_edges));
+
+                    if !self.all_paths {
+                        return results;
+                    }
+                    continue;
+                }
+
+                if !visited.contains(&next_node) || self.all_paths {
+                    if !self.all_paths {
+                        visited.insert(next_node);
+                    }
+                    let mut new_nodes = path_nodes.clone();
+                    new_nodes.push(next_node);
+                    let mut new_edges = path_edges.clone();
+                    new_edges.push(edge.id);
+                    queue.push_back((next_node, new_nodes, new_edges));
+                }
+            }
+        }
+
+        results
+    }
+}
+
+impl PhysicalOperator for ShortestPathOperator {
+    fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        if !self.executed {
+            self.execute_all(store)?;
+        }
+        Ok(self.results.next())
+    }
+
+    fn next_batch(&mut self, store: &GraphStore, batch_size: usize) -> ExecutionResult<Option<RecordBatch>> {
+        if !self.executed {
+            self.execute_all(store)?;
+        }
+        let mut records = Vec::new();
+        for _ in 0..batch_size {
+            match self.results.next() {
+                Some(r) => records.push(r),
+                None => break,
+            }
+        }
+        if records.is_empty() { Ok(None) } else { Ok(Some(RecordBatch { records, columns: vec![] })) }
+    }
+
+    fn reset(&mut self) {
+        self.input.reset();
+        self.executed = false;
+        self.results = Vec::new().into_iter();
     }
 }
 

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -8,7 +8,7 @@ use crate::query::ast::*;
 use crate::query::executor::{
     ExecutionError, ExecutionResult, OperatorBox,
     // Added CreateNodeOperator and CreateNodesAndEdgesOperator for CREATE statement support
-    operator::{NodeScanOperator, FilterOperator, ExpandOperator, ProjectOperator, LimitOperator, SkipOperator, CreateNodeOperator, CreateNodesAndEdgesOperator, CartesianProductOperator, VectorSearchOperator, JoinOperator, LeftOuterJoinOperator, CreateVectorIndexOperator, CreateIndexOperator, AlgorithmOperator, IndexScanOperator, AggregateOperator, AggregateType, AggregateFunction, SortOperator, DeleteOperator, SetPropertyOperator, RemovePropertyOperator, UnwindOperator, MergeOperator, ForeachOperator},
+    operator::{NodeScanOperator, FilterOperator, ExpandOperator, ProjectOperator, LimitOperator, SkipOperator, CreateNodeOperator, CreateNodesAndEdgesOperator, CartesianProductOperator, VectorSearchOperator, JoinOperator, LeftOuterJoinOperator, CreateVectorIndexOperator, CreateIndexOperator, AlgorithmOperator, IndexScanOperator, AggregateOperator, AggregateType, AggregateFunction, SortOperator, DeleteOperator, SetPropertyOperator, RemovePropertyOperator, UnwindOperator, MergeOperator, ForeachOperator, ShortestPathOperator},
 };
 use crate::graph::EdgeType;  // Added for CREATE edge support
 use std::collections::{HashMap, HashSet};  // Added for CREATE properties and JOIN logic
@@ -570,43 +570,84 @@ impl QueryPlanner {
                 }
             }
 
-            // Add expand operators for each segment in this path
-            let mut current_var = start_var.clone();
-            for segment in &path.segments {
-                let target_var = segment.node.variable.as_ref()
-                    .ok_or_else(|| ExecutionError::PlanningError("Target node must have a variable".to_string()))?
+            // Check for shortestPath / allShortestPaths
+            if matches!(path.path_type, PathType::Shortest | PathType::AllShortest) && !path.segments.is_empty() {
+                // shortestPath: use BFS-based ShortestPathOperator
+                let last_segment = path.segments.last().unwrap();
+                let target_var = last_segment.node.variable.as_ref()
+                    .ok_or_else(|| ExecutionError::PlanningError("shortestPath target must have a variable".to_string()))?
                     .clone();
-
-                let edge_var = segment.edge.variable.clone();
-                let edge_types: Vec<String> = segment.edge.types.iter()
+                let edge_types: Vec<String> = last_segment.edge.types.iter()
                     .map(|t| t.as_str().to_string())
                     .collect();
+                let all_paths = matches!(path.path_type, PathType::AllShortest);
 
-                let expand = ExpandOperator::new(
-                    path_operator,
-                    current_var.clone(),
+                // We need the target node to be scanned too — create a CartesianProduct with target scan
+                let target_scan: OperatorBox = Box::new(NodeScanOperator::new(
                     target_var.clone(),
-                    edge_var,
-                    edge_types,
-                    segment.edge.direction.clone(),
-                );
-
-                // Add target label filter if labels specified on target node
-                path_operator = if !segment.node.labels.is_empty() {
-                    Box::new(expand.with_target_labels(segment.node.labels.clone()))
-                } else {
-                    Box::new(expand)
-                };
-
-                // Add property filter for target node if properties specified
-                if let Some(ref props) = segment.node.properties {
+                    last_segment.node.labels.clone(),
+                ));
+                // Add property filter for target node
+                let target_op = if let Some(ref props) = last_segment.node.properties {
                     if !props.is_empty() {
                         let filter_expr = self.build_property_filter(&target_var, props);
-                        path_operator = Box::new(FilterOperator::new(path_operator, filter_expr));
+                        Box::new(FilterOperator::new(target_scan, filter_expr)) as OperatorBox
+                    } else {
+                        target_scan
                     }
-                }
+                } else {
+                    target_scan
+                };
 
-                current_var = target_var;
+                let combined = Box::new(CartesianProductOperator::new(path_operator, target_op));
+                path_operator = Box::new(ShortestPathOperator::new(
+                    combined,
+                    start_var.clone(),
+                    target_var.clone(),
+                    path.path_variable.clone(),
+                    edge_types,
+                    last_segment.edge.direction.clone(),
+                    all_paths,
+                ));
+            } else {
+                // Normal path: use ExpandOperator for each segment
+                let mut current_var = start_var.clone();
+                for segment in &path.segments {
+                    let target_var = segment.node.variable.as_ref()
+                        .ok_or_else(|| ExecutionError::PlanningError("Target node must have a variable".to_string()))?
+                        .clone();
+
+                    let edge_var = segment.edge.variable.clone();
+                    let edge_types: Vec<String> = segment.edge.types.iter()
+                        .map(|t| t.as_str().to_string())
+                        .collect();
+
+                    let expand = ExpandOperator::new(
+                        path_operator,
+                        current_var.clone(),
+                        target_var.clone(),
+                        edge_var,
+                        edge_types,
+                        segment.edge.direction.clone(),
+                    );
+
+                    // Add target label filter if labels specified on target node
+                    path_operator = if !segment.node.labels.is_empty() {
+                        Box::new(expand.with_target_labels(segment.node.labels.clone()))
+                    } else {
+                        Box::new(expand)
+                    };
+
+                    // Add property filter for target node if properties specified
+                    if let Some(ref props) = segment.node.properties {
+                        if !props.is_empty() {
+                            let filter_expr = self.build_property_filter(&target_var, props);
+                            path_operator = Box::new(FilterOperator::new(path_operator, filter_expr));
+                        }
+                    }
+
+                    current_var = target_var;
+                }
             }
 
             // Collect variables used in this path for join detection

--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -26,6 +26,11 @@ pub enum Value {
     EdgeRef(EdgeId, NodeId, NodeId, EdgeType),
     /// A property value
     Property(PropertyValue),
+    /// A path (ordered sequence of node/edge IDs)
+    Path {
+        nodes: Vec<NodeId>,
+        edges: Vec<EdgeId>,
+    },
     /// Null
     Null,
 }
@@ -44,6 +49,8 @@ impl PartialEq for Value {
             (Value::Edge(id1, _), Value::EdgeRef(id2, ..)) | (Value::EdgeRef(id2, ..), Value::Edge(id1, _)) => id1 == id2,
             // Property and Null
             (Value::Property(p1), Value::Property(p2)) => p1 == p2,
+            // Path
+            (Value::Path { nodes: n1, edges: e1 }, Value::Path { nodes: n2, edges: e2 }) => n1 == n2 && e1 == e2,
             (Value::Null, Value::Null) => true,
             _ => false,
         }
@@ -59,7 +66,8 @@ impl Hash for Value {
             Value::Node(id, _) | Value::NodeRef(id) => { 0u8.hash(state); id.hash(state); }
             Value::Edge(id, _) | Value::EdgeRef(id, ..) => { 1u8.hash(state); id.hash(state); }
             Value::Property(p) => { 2u8.hash(state); p.hash(state); }
-            Value::Null => { 3u8.hash(state); }
+            Value::Path { nodes, edges } => { 3u8.hash(state); nodes.hash(state); edges.hash(state); }
+            Value::Null => { 4u8.hash(state); }
         }
     }
 }

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -183,6 +183,16 @@ fn parse_call_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) ->
             Rule::call_clause => {
                 query.call_clause = Some(parse_call_clause(inner)?);
             }
+            Rule::call_subquery => {
+                // CALL { subquery }
+                for sub_inner in inner.into_inner() {
+                    if sub_inner.as_rule() == Rule::statement {
+                        let mut sub_query = Query::new();
+                        parse_statement(sub_inner, &mut sub_query)?;
+                        query.call_subquery = Some(Box::new(sub_query));
+                    }
+                }
+            }
             Rule::match_stmt_partial => {
                 parse_match_statement_partial(inner, query)?;
             }
@@ -631,12 +641,64 @@ fn parse_pattern(pair: pest::iterators::Pair<Rule>) -> ParseResult<Pattern> {
     let mut paths = Vec::new();
 
     for inner in pair.into_inner() {
-        if inner.as_rule() == Rule::path {
-            paths.push(parse_path(inner)?);
+        match inner.as_rule() {
+            Rule::named_path => {
+                paths.push(parse_named_path(inner)?);
+            }
+            Rule::path => {
+                paths.push(parse_path(inner)?);
+            }
+            _ => {}
         }
     }
 
     Ok(Pattern { paths })
+}
+
+fn parse_named_path(pair: pest::iterators::Pair<Rule>) -> ParseResult<PathPattern> {
+    let mut path_variable: Option<String> = None;
+    let mut path_pattern: Option<PathPattern> = None;
+
+    for inner in pair.into_inner() {
+        match inner.as_rule() {
+            Rule::variable => {
+                if path_variable.is_none() {
+                    path_variable = Some(inner.as_str().to_string());
+                }
+            }
+            Rule::path => {
+                path_pattern = Some(parse_path(inner)?);
+            }
+            Rule::shortest_path_call => {
+                path_pattern = Some(parse_shortest_path_call(inner)?);
+            }
+            _ => {}
+        }
+    }
+
+    let mut pp = path_pattern.ok_or_else(|| ParseError::SemanticError("Named path missing path pattern".to_string()))?;
+    pp.path_variable = path_variable;
+    Ok(pp)
+}
+
+fn parse_shortest_path_call(pair: pest::iterators::Pair<Rule>) -> ParseResult<PathPattern> {
+    let text = pair.as_str();
+    let path_type = if text.to_lowercase().starts_with("allshortestpaths") {
+        PathType::AllShortest
+    } else {
+        PathType::Shortest
+    };
+
+    let mut pp = None;
+    for inner in pair.into_inner() {
+        if inner.as_rule() == Rule::path {
+            pp = Some(parse_path(inner)?);
+        }
+    }
+
+    let mut path = pp.ok_or_else(|| ParseError::SemanticError("shortestPath() missing inner path".to_string()))?;
+    path.path_type = path_type;
+    Ok(path)
 }
 
 fn parse_path(pair: pest::iterators::Pair<Rule>) -> ParseResult<PathPattern> {
@@ -666,7 +728,7 @@ fn parse_path(pair: pest::iterators::Pair<Rule>) -> ParseResult<PathPattern> {
         segments.push(PathSegment { edge, node });
     }
 
-    Ok(PathPattern { start, segments })
+    Ok(PathPattern { path_variable: None, path_type: PathType::Normal, start, segments })
 }
 
 fn parse_node(pair: pest::iterators::Pair<Rule>) -> ParseResult<NodePattern> {
@@ -1112,6 +1174,15 @@ fn parse_primary(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
             Rule::exists_subquery => {
                 return parse_exists_subquery(inner);
             }
+            Rule::reduce_expression => {
+                return parse_reduce_expression(inner);
+            }
+            Rule::predicate_function => {
+                return parse_predicate_function(inner);
+            }
+            Rule::pattern_comprehension => {
+                return parse_pattern_comprehension(inner);
+            }
             Rule::list_comprehension => {
                 return parse_list_comprehension(inner);
             }
@@ -1229,6 +1300,94 @@ fn parse_list_comprehension(pair: pest::iterators::Pair<Rule>) -> ParseResult<Ex
         list_expr: Box::new(list_expr.ok_or_else(|| ParseError::SemanticError("List comprehension missing list expression".to_string()))?),
         filter: filter.map(Box::new),
         map_expr: Box::new(map_expr.ok_or_else(|| ParseError::SemanticError("List comprehension missing map expression".to_string()))?),
+    })
+}
+
+fn parse_predicate_function(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
+    let mut name = String::new();
+    let mut variable = None;
+    let mut expressions = Vec::new();
+
+    for inner in pair.into_inner() {
+        match inner.as_rule() {
+            Rule::predicate_function_name => name = inner.as_str().to_lowercase(),
+            Rule::variable => variable = Some(inner.as_str().to_string()),
+            Rule::in_op => {}
+            Rule::expression => expressions.push(parse_expression(inner)?),
+            _ => {}
+        }
+    }
+
+    // expressions: [list_expr, predicate]
+    if expressions.len() < 2 {
+        return Err(ParseError::SemanticError("Predicate function requires list and predicate".to_string()));
+    }
+    let list_expr = expressions.remove(0);
+    let predicate = expressions.remove(0);
+
+    Ok(Expression::PredicateFunction {
+        name,
+        variable: variable.ok_or_else(|| ParseError::SemanticError("Predicate function missing variable".to_string()))?,
+        list_expr: Box::new(list_expr),
+        predicate: Box::new(predicate),
+    })
+}
+
+fn parse_pattern_comprehension(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
+    let mut pattern_path = None;
+    let mut filter = None;
+    let mut projection = None;
+    let mut expressions = Vec::new();
+
+    for inner in pair.into_inner() {
+        match inner.as_rule() {
+            Rule::path => pattern_path = Some(parse_path(inner)?),
+            Rule::where_clause => {
+                let wc = parse_where_clause(inner)?;
+                filter = Some(wc.predicate);
+            }
+            Rule::expression => expressions.push(parse_expression(inner)?),
+            _ => {}
+        }
+    }
+
+    // The last expression is the projection
+    projection = expressions.pop();
+
+    let path = pattern_path.ok_or_else(|| ParseError::SemanticError("Pattern comprehension missing pattern".to_string()))?;
+
+    Ok(Expression::PatternComprehension {
+        pattern: Pattern { paths: vec![path] },
+        filter: filter.map(Box::new),
+        projection: Box::new(projection.ok_or_else(|| ParseError::SemanticError("Pattern comprehension missing projection".to_string()))?),
+    })
+}
+
+fn parse_reduce_expression(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
+    let mut variables = Vec::new();
+    let mut expressions = Vec::new();
+
+    for inner in pair.into_inner() {
+        match inner.as_rule() {
+            Rule::variable => variables.push(inner.as_str().to_string()),
+            Rule::in_op => {}
+            Rule::expression => expressions.push(parse_expression(inner)?),
+            _ => {}
+        }
+    }
+
+    // variables: [accumulator, iterator]
+    // expressions: [init, list, body]
+    if variables.len() < 2 || expressions.len() < 3 {
+        return Err(ParseError::SemanticError("reduce() requires (acc = init, x IN list | expr)".to_string()));
+    }
+
+    Ok(Expression::Reduce {
+        accumulator: variables[0].clone(),
+        init: Box::new(expressions[0].clone()),
+        variable: variables[1].clone(),
+        list_expr: Box::new(expressions[1].clone()),
+        expression: Box::new(expressions[2].clone()),
     })
 }
 


### PR DESCRIPTION
## Summary

- Add 9 Cypher engine features: `startNode/endNode`, `all/any/none/single` predicates, `reduce()`, `duration()` with DateTime arithmetic, named paths, `nodes()`/`relationships()`, `shortestPath`/`allShortestPaths`, pattern comprehension, CALL subqueries
- Add 2 new algorithms: CDLP (Label Propagation), LCC (Local Clustering Coefficient), plus `bfs_all_shortest_paths()`
- Complete SNB Interactive: IC13/IC14 + 8 update operations (INS1-INS8)
- Add SNB BI benchmark: 20 analytical queries (BI-1..BI-20)
- Add Graphalytics benchmark: 6 algorithms (BFS, PR, WCC, CDLP, LCC, SSSP) with dataset downloader and LDBC validation
- Add FinBench benchmark: 40 queries (12 CR + 6 SR + 3 RW + 19 W) with synthetic data generator

## Test plan

- [x] 288 unit tests pass (`cargo test`)
- [x] All examples build (`cargo build --examples`)
- [x] SNB Interactive: 19/19 passed on Mac Mini SF1 (3.18M nodes, 17.26M edges)
- [ ] SNB BI: 20 queries on SF1 data
- [ ] Graphalytics: 6 algorithms on XS datasets
- [ ] FinBench: 40 queries on synthetic data