### PR TITLE
feat: consolidate benchmarks with enterprise feature enablement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,18 @@ samyama-sdk = { path = "crates/samyama-sdk", version = "0.5.8" }
 name = "graph_benchmarks"
 harness = false
 
+[[bench]]
+name = "full_benchmark"
+harness = false
+
+[[bench]]
+name = "vector_benchmark"
+harness = false
+
+[[bench]]
+name = "graphalytics_benchmark"
+harness = false
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/benches/bench_setup.rs
+++ b/benches/bench_setup.rs
@@ -1,0 +1,97 @@
+//! Shared benchmark setup: license loading and GPU enablement.
+//!
+//! Each benchmark includes this via `#[path = "bench_setup.rs"] mod bench_setup;`
+//! and calls `bench_setup::init()` at the top of `main()`.
+//!
+//! License resolution order (same as src/main.rs in enterprise):
+//!   1. `SAMYAMA_LICENSE_KEY` env var (raw token)
+//!   2. `SAMYAMA_LICENSE_FILE` env var (path to file)
+//!   3. `./samyama.license` default file
+//!
+//! No license = Community mode (CPU only, no error).
+
+/// Initialize enterprise features for benchmarks.
+///
+/// In the open-source build (no `license` module, no `gpu` feature),
+/// this is a no-op that prints a community-mode message.
+pub fn init() {
+    #[cfg(feature = "gpu")]
+    {
+        init_enterprise();
+    }
+
+    #[cfg(not(feature = "gpu"))]
+    {
+        println!("[bench] Community edition — GPU acceleration not available.");
+        println!("[bench] Build with --features gpu and provide a license for GPU benchmarks.");
+    }
+}
+
+#[cfg(feature = "gpu")]
+fn init_enterprise() {
+    // Step 1: Resolve license token
+    let license_token = resolve_license_token();
+
+    // Step 2: Validate license
+    match license_token {
+        Some(token) => {
+            match samyama::license::License::from_token(&token) {
+                Ok(lic) => {
+                    if lic.is_valid() {
+                        println!("[bench] License: {}", lic.status_summary());
+
+                        // Step 3: Enable GPU if licensed
+                        if lic.feature_enabled("gpu") {
+                            samyama_gpu::GpuContext::enable_licensed();
+                            if samyama_gpu::GpuContext::is_available() {
+                                println!("[bench] GPU acceleration: ENABLED");
+                            } else {
+                                println!("[bench] GPU acceleration: licensed but no GPU hardware detected");
+                            }
+                        } else {
+                            println!("[bench] GPU feature not included in license. Running CPU only.");
+                        }
+                    } else {
+                        println!("[bench] License invalid or expired. Running in Community mode (CPU only).");
+                    }
+                }
+                Err(e) => {
+                    println!("[bench] Invalid license: {}. Running in Community mode (CPU only).", e);
+                }
+            }
+        }
+        None => {
+            println!("[bench] No license found. Running in Community mode (CPU only).");
+        }
+    }
+}
+
+#[cfg(feature = "gpu")]
+fn resolve_license_token() -> Option<String> {
+    // 1. SAMYAMA_LICENSE_KEY env var (raw token)
+    if let Ok(key) = std::env::var("SAMYAMA_LICENSE_KEY") {
+        if !key.is_empty() {
+            return Some(key);
+        }
+    }
+
+    // 2. SAMYAMA_LICENSE_FILE env var (path to file)
+    if let Ok(path) = std::env::var("SAMYAMA_LICENSE_FILE") {
+        if let Ok(contents) = std::fs::read_to_string(&path) {
+            let token = contents.trim().to_string();
+            if !token.is_empty() {
+                return Some(token);
+            }
+        }
+    }
+
+    // 3. Default file: ./samyama.license
+    if let Ok(contents) = std::fs::read_to_string("samyama.license") {
+        let token = contents.trim().to_string();
+        if !token.is_empty() {
+            return Some(token);
+        }
+    }
+
+    None
+}

--- a/benches/full_benchmark.rs
+++ b/benches/full_benchmark.rs
@@ -1,0 +1,366 @@
+//! Comprehensive Benchmark Suite for Samyama Graph Database
+//!
+//! Measures performance of:
+//! 1. Data Ingestion (Nodes & Edges)
+//! 2. Vector Indexing & Search (HNSW)
+//! 3. K-Hop Traversal (1-hop, 2-hop, 3-hop)
+//! 4. Graph Algorithm Performance (PageRank, WCC, BFS)
+//! 5. Mixed Workload (80% read, 20% write)
+
+use samyama::{GraphStore, Label, PropertyValue, QueryEngine, DistanceMetric};
+use samyama::algo::{build_view, page_rank, weakly_connected_components, bfs, PageRankConfig};
+use samyama::persistence::TenantManager;
+use std::time::Instant;
+use std::sync::Arc;
+use rand::Rng;
+
+#[path = "bench_setup.rs"]
+mod bench_setup;
+
+const VECTOR_DIM: usize = 128;
+const NUM_NODES: usize = 10_000;
+const EDGES_PER_NODE: usize = 5;
+const SEARCH_K: usize = 10;
+
+fn format_number(n: usize) -> String {
+    let s = n.to_string();
+    let mut result = String::new();
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+    bench_setup::init();
+
+    println!("╔══════════════════════════════════════════════════════════════════╗");
+    println!("║   SAMYAMA Comprehensive Benchmark Suite                         ║");
+    println!("╚══════════════════════════════════════════════════════════════════╝");
+    println!();
+    println!("  Configuration:");
+    println!("  - Nodes:      {:>10}", format_number(NUM_NODES));
+    println!("  - Edges:      ~{:>9}", format_number(NUM_NODES * EDGES_PER_NODE));
+    println!("  - Vector dim: {:>10}", VECTOR_DIM);
+    println!("  - Search k:   {:>10}", SEARCH_K);
+    println!();
+
+    let total_start = Instant::now();
+
+    // Setup
+    let (mut store, rx) = GraphStore::with_async_indexing();
+    let engine = QueryEngine::new();
+    let tenant_manager = Arc::new(TenantManager::new());
+
+    // Start background indexer
+    let v_idx = Arc::clone(&store.vector_index);
+    let p_idx = Arc::clone(&store.property_index);
+    tokio::spawn(async move {
+        GraphStore::start_background_indexer(rx, v_idx, p_idx, tenant_manager).await;
+    });
+
+    // 1. Ingestion Benchmark
+    let node_ids = benchmark_ingestion(&mut store).await;
+
+    // 2. Vector Search Benchmark
+    benchmark_vector_search(&store);
+
+    // 3. K-Hop Traversal
+    benchmark_k_hop(&store, &engine);
+
+    // 4. Graph Algorithms
+    benchmark_graph_algorithms(&store);
+
+    // 5. Mixed Workload
+    benchmark_mixed_workload(&mut store, &engine);
+
+    // Summary
+    let total = total_start.elapsed();
+    println!("╔══════════════════════════════════════════════════════════════════╗");
+    println!("║   Benchmark Summary                                            ║");
+    println!("╠══════════════════════════════════════════════════════════════════╣");
+    println!("║  Total duration: {:>10.2?}                                   ║", total);
+    println!("║  Nodes:          {:>10}                                   ║", format_number(NUM_NODES));
+    println!("║  Edges:         ~{:>10}                                   ║", format_number(NUM_NODES * EDGES_PER_NODE));
+    println!("║  Vector dim:     {:>10}                                   ║", VECTOR_DIM);
+    println!("╚══════════════════════════════════════════════════════════════════╝");
+}
+
+async fn benchmark_ingestion(store: &mut GraphStore) -> Vec<samyama::graph::NodeId> {
+    println!("┌──────────────────────────────────────────────────────────────────┐");
+    println!("│ Benchmark 1: Data Ingestion                                     │");
+    println!("└──────────────────────────────────────────────────────────────────┘");
+
+    store.create_vector_index("Entity", "embedding", VECTOR_DIM, DistanceMetric::Cosine).unwrap();
+
+    let mut rng = rand::thread_rng();
+    let mut node_ids = Vec::with_capacity(NUM_NODES);
+
+    // Node ingestion
+    let start = Instant::now();
+    let labels = ["Server", "User", "Document", "Event", "Metric"];
+
+    for i in 0..NUM_NODES {
+        let label = labels[i % labels.len()];
+        let vec: Vec<f32> = (0..VECTOR_DIM).map(|_| rng.gen::<f32>()).collect();
+        let mut props = samyama::PropertyMap::new();
+        props.insert("id".to_string(), PropertyValue::Integer(i as i64));
+        props.insert("name".to_string(), PropertyValue::String(format!("{}-{}", label, i)));
+        props.insert("embedding".to_string(), PropertyValue::Vector(vec));
+        props.insert("score".to_string(), PropertyValue::Float(rng.gen::<f64>()));
+        props.insert("active".to_string(), PropertyValue::Boolean(rng.gen_bool(0.9)));
+
+        let id = store.create_node_with_properties("default", vec![Label::new(label), Label::new("Entity")], props);
+        node_ids.push(id);
+    }
+    let node_time = start.elapsed();
+
+    // Edge ingestion
+    let edge_types = ["LINKS_TO", "MANAGES", "MONITORS", "DEPENDS_ON", "TRIGGERS"];
+    let start_edge = Instant::now();
+    let mut edge_count = 0;
+
+    for i in 0..NUM_NODES {
+        for e in 0..EDGES_PER_NODE {
+            let target_idx = rng.gen_range(0..NUM_NODES);
+            if i != target_idx {
+                let edge_type = edge_types[e % edge_types.len()];
+                let _ = store.create_edge(node_ids[i], node_ids[target_idx], edge_type);
+                edge_count += 1;
+            }
+        }
+    }
+    let edge_time = start_edge.elapsed();
+
+    println!("  Node ingestion:");
+    println!("    Nodes:      {:>10}", format_number(NUM_NODES));
+    println!("    Duration:   {:>10.2?}", node_time);
+    println!("    Throughput: {:>10.0} nodes/sec", NUM_NODES as f64 / node_time.as_secs_f64());
+    println!();
+    println!("  Edge ingestion:");
+    println!("    Edges:      {:>10}", format_number(edge_count));
+    println!("    Duration:   {:>10.2?}", edge_time);
+    println!("    Throughput: {:>10.0} edges/sec", edge_count as f64 / edge_time.as_secs_f64());
+    println!();
+
+    // Wait for background indexing
+    println!("  Waiting for background indexing...");
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    println!("  Done.");
+    println!();
+
+    node_ids
+}
+
+fn benchmark_vector_search(store: &GraphStore) {
+    println!("┌──────────────────────────────────────────────────────────────────┐");
+    println!("│ Benchmark 2: Vector Search (HNSW)                               │");
+    println!("└──────────────────────────────────────────────────────────────────┘");
+
+    let mut rng = rand::thread_rng();
+    let k_values = [1, 5, 10, 20, 50];
+    let num_searches = 1000;
+
+    println!("  {:>6} {:>12} {:>14} {:>10}", "k", "Avg Latency", "QPS", "p99");
+    println!("  {:>6} {:>12} {:>14} {:>10}", "-", "-----------", "---", "---");
+
+    for &k in &k_values {
+        let mut latencies = Vec::with_capacity(num_searches);
+
+        for _ in 0..num_searches {
+            let query: Vec<f32> = (0..VECTOR_DIM).map(|_| rng.gen::<f32>()).collect();
+            let t = Instant::now();
+            let _ = store.vector_search("Entity", "embedding", &query, k).unwrap();
+            latencies.push(t.elapsed());
+        }
+
+        latencies.sort();
+        let total: std::time::Duration = latencies.iter().sum();
+        let avg = total / num_searches as u32;
+        let p99 = latencies[(num_searches as f64 * 0.99) as usize];
+        let qps = num_searches as f64 / total.as_secs_f64();
+
+        println!("  {:>6} {:>10.2?} {:>12.0}/s {:>8.2?}", k, avg, qps, p99);
+    }
+    println!();
+}
+
+fn benchmark_k_hop(store: &GraphStore, engine: &QueryEngine) {
+    println!("┌──────────────────────────────────────────────────────────────────┐");
+    println!("│ Benchmark 3: K-Hop Traversal                                    │");
+    println!("└──────────────────────────────────────────────────────────────────┘");
+
+    let mut rng = rand::thread_rng();
+    let num_queries = 100;
+
+    let queries = [
+        ("1-hop", "MATCH (a:Entity)-[:LINKS_TO]->(b:Entity) WHERE a.id = {} RETURN b.id"),
+        ("2-hop", "MATCH (a:Entity)-[:LINKS_TO]->(b)-[:LINKS_TO]->(c:Entity) WHERE a.id = {} RETURN c.id"),
+    ];
+
+    println!("  {:>8} {:>12} {:>14} {:>12}", "Hops", "Avg Latency", "QPS", "Queries");
+    println!("  {:>8} {:>12} {:>14} {:>12}", "----", "-----------", "---", "-------");
+
+    for (name, query_template) in &queries {
+        let start = Instant::now();
+        let mut success = 0;
+
+        for _ in 0..num_queries {
+            let id = rng.gen_range(0..NUM_NODES);
+            let q = query_template.replace("{}", &id.to_string());
+            if engine.execute(&q, store).is_ok() {
+                success += 1;
+            }
+        }
+
+        let duration = start.elapsed();
+        let avg = duration / num_queries as u32;
+        let qps = num_queries as f64 / duration.as_secs_f64();
+
+        println!("  {:>8} {:>10.2?} {:>12.0}/s {:>12}", name, avg, qps, success);
+    }
+
+    // Multi-hop via graph API (3-hop BFS)
+    let start = Instant::now();
+    for _ in 0..num_queries {
+        let start_node = rng.gen_range(0..NUM_NODES);
+        let mut visited = std::collections::HashSet::new();
+        let mut frontier = vec![samyama::graph::NodeId::new((start_node + 1) as u64)];
+
+        for _hop in 0..3 {
+            let mut next_frontier = Vec::new();
+            for &nid in &frontier {
+                if visited.insert(nid.as_u64()) {
+                    for edge in store.get_outgoing_edges(nid) {
+                        if !visited.contains(&edge.target.as_u64()) {
+                            next_frontier.push(edge.target);
+                        }
+                    }
+                }
+            }
+            frontier = next_frontier;
+        }
+    }
+    let hop3_time = start.elapsed();
+    println!("  {:>8} {:>10.2?} {:>12.0}/s {:>12}",
+        "3-hop", hop3_time / num_queries as u32,
+        num_queries as f64 / hop3_time.as_secs_f64(), num_queries);
+
+    println!();
+}
+
+fn benchmark_graph_algorithms(store: &GraphStore) {
+    println!("┌──────────────────────────────────────────────────────────────────┐");
+    println!("│ Benchmark 4: Graph Algorithms                                   │");
+    println!("└──────────────────────────────────────────────────────────────────┘");
+
+    println!("  Building graph view...");
+    let view_start = Instant::now();
+    let view = build_view(store, Some("Entity"), Some("LINKS_TO"), None);
+    let view_time = view_start.elapsed();
+    println!("  View built in {:?} ({} nodes, {} edges)",
+        view_time, view.node_count,
+        view.out_offsets.last().copied().unwrap_or(0));
+    println!();
+
+    println!("  {:>15} {:>12} {:>20}", "Algorithm", "Duration", "Result");
+    println!("  {:>15} {:>12} {:>20}", "---------", "--------", "------");
+
+    // PageRank
+    let start = Instant::now();
+    let scores = page_rank(&view, PageRankConfig::default());
+    let pr_time = start.elapsed();
+    let max_score = scores.values().cloned().fold(0.0f64, f64::max);
+    println!("  {:>15} {:>10.2?} {:>20}",
+        "PageRank", pr_time, format!("max={:.6}", max_score));
+
+    // WCC
+    let start = Instant::now();
+    let wcc = weakly_connected_components(&view);
+    let wcc_time = start.elapsed();
+    println!("  {:>15} {:>10.2?} {:>20}",
+        "WCC", wcc_time, format!("{} components", wcc.components.len()));
+
+    // BFS from node 0 to a random target
+    if view.node_count > 1 {
+        let start = Instant::now();
+        let target = (view.node_count - 1) as u64;
+        let bfs_result = bfs(&view, 0, target);
+        let bfs_time = start.elapsed();
+        let (depth, found) = match &bfs_result {
+            Some(path) => (path.path.len(), true),
+            None => (0, false),
+        };
+        println!("  {:>15} {:>10.2?} {:>20}",
+            "BFS", bfs_time, format!("found={}, depth={}", found, depth));
+    }
+
+    // Multiple PageRank iterations benchmark
+    let start = Instant::now();
+    let iterations = 10;
+    for _ in 0..iterations {
+        let _ = page_rank(&view, PageRankConfig::default());
+    }
+    let multi_pr_time = start.elapsed();
+    println!("  {:>15} {:>10.2?} {:>20}",
+        "PageRank x10", multi_pr_time, format!("{:.2?}/iter", multi_pr_time / iterations as u32));
+
+    println!();
+}
+
+fn benchmark_mixed_workload(store: &mut GraphStore, engine: &QueryEngine) {
+    println!("┌──────────────────────────────────────────────────────────────────┐");
+    println!("│ Benchmark 5: Mixed Workload (80% Read / 20% Write)              │");
+    println!("└──────────────────────────────────────────────────────────────────┘");
+
+    let mut rng = rand::thread_rng();
+    let total_ops = 10_000;
+    let mut reads = 0usize;
+    let mut writes = 0usize;
+    let mut read_time = std::time::Duration::default();
+    let mut write_time = std::time::Duration::default();
+
+    let start = Instant::now();
+
+    for _ in 0..total_ops {
+        if rng.gen_bool(0.8) {
+            // Read operation: random label scan or property lookup
+            let t = Instant::now();
+            let labels = ["Server", "User", "Document", "Event", "Metric"];
+            let label = labels[rng.gen_range(0..labels.len())];
+            let nodes = store.get_nodes_by_label(&Label::new(label));
+            std::hint::black_box(nodes.len());
+            read_time += t.elapsed();
+            reads += 1;
+        } else {
+            // Write operation: create a new node
+            let t = Instant::now();
+            let id = store.create_node("MixedWorkload");
+            if let Some(node) = store.get_node_mut(id) {
+                node.set_property("timestamp", writes as i64);
+                node.set_property("source", "benchmark");
+            }
+            write_time += t.elapsed();
+            writes += 1;
+        }
+    }
+
+    let total_time = start.elapsed();
+
+    println!("  Total operations: {:>10}", format_number(total_ops));
+    println!("  Duration:         {:>10.2?}", total_time);
+    println!("  Overall QPS:      {:>10.0}", total_ops as f64 / total_time.as_secs_f64());
+    println!();
+    println!("  {:>8} {:>10} {:>12} {:>14}", "Type", "Count", "Total Time", "Avg Latency");
+    println!("  {:>8} {:>10} {:>12} {:>14}", "----", "-----", "----------", "-----------");
+    println!("  {:>8} {:>10} {:>10.2?} {:>12.2?}",
+        "Read", format_number(reads), read_time, read_time / reads as u32);
+    println!("  {:>8} {:>10} {:>10.2?} {:>12.2?}",
+        "Write", format_number(writes), write_time, write_time / writes as u32);
+    println!();
+}

--- a/benches/graphalytics_benchmark.rs
+++ b/benches/graphalytics_benchmark.rs
@@ -1,0 +1,820 @@
+//! LDBC Graphalytics Benchmark Runner for Samyama Graph Database
+//!
+//! Implements the 6 core LDBC Graphalytics algorithms:
+//!   1. BFS  — Breadth-First Search (single-source, all distances)
+//!   2. PR   — PageRank
+//!   3. WCC  — Weakly Connected Components
+//!   4. CDLP — Community Detection via Label Propagation
+//!   5. LCC  — Local Clustering Coefficient
+//!   6. SSSP — Single-Source Shortest Path (Dijkstra)
+//!
+//! Loads graphs from standard Graphalytics edge-list format and builds a
+//! `GraphView` directly for pure algorithm benchmarking.
+//!
+//! When validation output files are present (downloaded by the script),
+//! results are compared against the official LDBC expected values.
+//!
+//! Usage:
+//!   cargo bench --release --bench graphalytics_benchmark -- --all
+//!   cargo bench --release --bench graphalytics_benchmark -- --dataset example-directed --algo BFS
+//!   cargo bench --release --bench graphalytics_benchmark -- --data-dir data/graphalytics/ --all
+
+use std::collections::{HashMap, VecDeque, BinaryHeap};
+use std::cmp::Ordering;
+use std::path::Path;
+use std::time::Instant;
+
+use samyama_graph_algorithms::{
+    GraphView,
+    page_rank, PageRankConfig,
+    weakly_connected_components,
+    cdlp, CdlpConfig,
+    local_clustering_coefficient,
+};
+
+#[path = "bench_setup.rs"]
+mod bench_setup;
+
+mod graphalytics_common;
+use graphalytics_common::{
+    load_graphalytics_dataset, find_dataset_files, find_properties_file,
+    parse_properties, load_validation, DatasetProperties,
+    format_num, format_duration,
+};
+
+// ============================================================================
+// ALGORITHM IMPLEMENTATIONS (Graphalytics-specific single-source variants)
+// ============================================================================
+
+/// BFS from a single source, returning distances to all reachable nodes.
+/// Unreachable nodes get `u64::MAX` (matches Graphalytics convention of Long.MAX_VALUE).
+fn bfs_single_source(view: &GraphView, source_id: u64) -> HashMap<u64, u64> {
+    let mut result: HashMap<u64, u64> = HashMap::with_capacity(view.node_count);
+
+    // Initialize all nodes as unreachable
+    for &nid in &view.index_to_node {
+        result.insert(nid, u64::MAX);
+    }
+
+    let Some(&source_idx) = view.node_to_index.get(&source_id) else {
+        return result;
+    };
+
+    let mut distances: Vec<Option<u64>> = vec![None; view.node_count];
+    distances[source_idx] = Some(0);
+    let mut queue = VecDeque::new();
+    queue.push_back(source_idx);
+
+    while let Some(current) = queue.pop_front() {
+        let current_dist = distances[current].unwrap();
+        for &neighbor in view.successors(current) {
+            if distances[neighbor].is_none() {
+                distances[neighbor] = Some(current_dist + 1);
+                queue.push_back(neighbor);
+            }
+        }
+    }
+
+    for (idx, dist) in distances.into_iter().enumerate() {
+        if let Some(d) = dist {
+            result.insert(view.index_to_node[idx], d);
+        }
+    }
+    result
+}
+
+/// Dijkstra SSSP from a single source, returning distances to all reachable nodes.
+/// Uses edge weights if available, otherwise assumes weight 1.0.
+/// Unreachable nodes get `f64::INFINITY` (matches Graphalytics convention).
+fn sssp_single_source(view: &GraphView, source_id: u64) -> HashMap<u64, f64> {
+    let mut result: HashMap<u64, f64> = HashMap::with_capacity(view.node_count);
+
+    // Initialize all nodes as unreachable
+    for &nid in &view.index_to_node {
+        result.insert(nid, f64::INFINITY);
+    }
+
+    let Some(&source_idx) = view.node_to_index.get(&source_id) else {
+        return result;
+    };
+
+    #[derive(Copy, Clone, PartialEq)]
+    struct State {
+        cost: f64,
+        idx: usize,
+    }
+    impl Eq for State {}
+    impl Ord for State {
+        fn cmp(&self, other: &Self) -> Ordering {
+            other.cost.partial_cmp(&self.cost).unwrap_or(Ordering::Equal)
+        }
+    }
+    impl PartialOrd for State {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    let mut dist: Vec<f64> = vec![f64::INFINITY; view.node_count];
+    dist[source_idx] = 0.0;
+    let mut heap = BinaryHeap::new();
+    heap.push(State { cost: 0.0, idx: source_idx });
+
+    while let Some(State { cost, idx }) = heap.pop() {
+        if cost > dist[idx] {
+            continue;
+        }
+
+        let edges = view.successors(idx);
+        let weights = view.weights(idx);
+
+        for (i, &next_idx) in edges.iter().enumerate() {
+            let w = if let Some(ws) = weights { ws[i] } else { 1.0 };
+            if w < 0.0 {
+                continue;
+            }
+            let next_cost = cost + w;
+            if next_cost < dist[next_idx] {
+                dist[next_idx] = next_cost;
+                heap.push(State { cost: next_cost, idx: next_idx });
+            }
+        }
+    }
+
+    for (idx, &d) in dist.iter().enumerate() {
+        result.insert(view.index_to_node[idx], d);
+    }
+    result
+}
+
+// ============================================================================
+// BENCHMARK RUNNER
+// ============================================================================
+
+const ALL_ALGOS: &[&str] = &["BFS", "PR", "WCC", "CDLP", "LCC", "SSSP"];
+
+/// Default datasets to run when --all is specified without --dataset.
+const DEFAULT_DATASETS: &[&str] = &["example-directed", "example-undirected"];
+
+fn main() {
+    bench_setup::init();
+
+    let args: Vec<String> = std::env::args().collect();
+
+    let data_dir = get_arg(&args, "--data-dir")
+        .unwrap_or_else(|| "data/graphalytics".to_string());
+    let dataset_arg = get_arg(&args, "--dataset");
+    let algo_arg = get_arg(&args, "--algo");
+    let run_all = args.iter().any(|a| a == "--all");
+    let validate = !args.iter().any(|a| a == "--no-validate");
+
+    if !run_all && dataset_arg.is_none() && algo_arg.is_none() {
+        print_usage();
+        return;
+    }
+
+    // Determine which datasets to run
+    let datasets: Vec<String> = if let Some(ds) = dataset_arg {
+        vec![ds]
+    } else {
+        DEFAULT_DATASETS.iter().map(|s| s.to_string()).collect()
+    };
+
+    // Determine which algorithms to run
+    let algos: Vec<String> = if let Some(algo) = algo_arg {
+        vec![algo.to_uppercase()]
+    } else {
+        ALL_ALGOS.iter().map(|s| s.to_string()).collect()
+    };
+
+    println!();
+    println!("================================================================");
+    println!("  LDBC Graphalytics Benchmark -- Samyama Graph Database");
+    println!("================================================================");
+    println!();
+    println!("  Data directory: {}", data_dir);
+    println!("  Datasets:       {:?}", datasets);
+    println!("  Algorithms:     {:?}", algos);
+    println!("  Validation:     {}", if validate { "enabled" } else { "disabled" });
+    println!();
+
+    let data_path = Path::new(&data_dir);
+
+    let mut results: Vec<BenchmarkResult> = Vec::new();
+
+    for dataset in &datasets {
+        println!("----------------------------------------------------------------");
+        println!("  Dataset: {}", dataset);
+        println!("----------------------------------------------------------------");
+
+        // Find dataset files
+        let (vertex_path, edge_path) = match find_dataset_files(data_path, dataset) {
+            Ok(paths) => paths,
+            Err(e) => {
+                eprintln!("  ERROR: {}", e);
+                eprintln!("  Run scripts/download_graphalytics.sh to download datasets.");
+                eprintln!();
+                continue;
+            }
+        };
+
+        // Parse properties file for algorithm parameters
+        let props = if let Some(props_path) = find_properties_file(data_path, dataset) {
+            let p = parse_properties(&props_path);
+            println!("  Properties loaded from {}", props_path.display());
+            p
+        } else {
+            DatasetProperties::default()
+        };
+
+        let directed = props.directed.unwrap_or_else(|| {
+            graphalytics_common::is_directed(dataset)
+        });
+
+        // Load the graph
+        println!("  Loading {} (directed={})...", dataset, directed);
+        let load_start = Instant::now();
+        let loaded = match load_graphalytics_dataset(&vertex_path, &edge_path, directed, dataset) {
+            Ok(g) => g,
+            Err(e) => {
+                eprintln!("  ERROR loading dataset: {}", e);
+                continue;
+            }
+        };
+        let load_time = load_start.elapsed();
+
+        println!(
+            "  Loaded: {} vertices, {} edges in {}",
+            format_num(loaded.info.vertex_count),
+            format_num(loaded.info.edge_count),
+            format_duration(load_time),
+        );
+        println!();
+
+        let view = &loaded.view;
+
+        // Run each requested algorithm
+        for algo in &algos {
+            let result = run_algorithm(algo, view, dataset, &props, data_path, validate);
+            if let Some(r) = result {
+                let status = if r.validated {
+                    if r.validation_passed { "  PASS" } else { "  FAIL" }
+                } else {
+                    ""
+                };
+                println!(
+                    "  {:>6}  {:>12}  {}{}",
+                    r.algorithm,
+                    format_duration(r.duration),
+                    r.summary,
+                    status,
+                );
+                results.push(r);
+            }
+        }
+        println!();
+    }
+
+    // ── Final Summary Table ─────────────────────────────────────────────
+    if results.len() > 1 {
+        println!("================================================================");
+        println!("  SUMMARY");
+        println!("================================================================");
+        println!();
+        println!(
+            "  {:>20} {:>6} {:>10} {:>12}  {:>6}  {}",
+            "Dataset", "Algo", "Vertices", "Time", "Valid", "Result"
+        );
+        println!(
+            "  {:>20} {:>6} {:>10} {:>12}  {:>6}  {}",
+            "-------", "----", "--------", "----", "-----", "------"
+        );
+        for r in &results {
+            let valid_str = if r.validated {
+                if r.validation_passed { "PASS" } else { "FAIL" }
+            } else {
+                "-"
+            };
+            println!(
+                "  {:>20} {:>6} {:>10} {:>12}  {:>6}  {}",
+                r.dataset,
+                r.algorithm,
+                format_num(r.vertex_count),
+                format_duration(r.duration),
+                valid_str,
+                r.summary,
+            );
+        }
+        println!();
+    }
+
+    // Exit with non-zero status if any validations failed
+    let failures = results.iter().filter(|r| r.validated && !r.validation_passed).count();
+    if failures > 0 {
+        eprintln!("  {} validation(s) FAILED", failures);
+        std::process::exit(1);
+    }
+}
+
+// ============================================================================
+// ALGORITHM DISPATCH
+// ============================================================================
+
+struct BenchmarkResult {
+    dataset: String,
+    algorithm: String,
+    vertex_count: usize,
+    duration: std::time::Duration,
+    summary: String,
+    validated: bool,
+    validation_passed: bool,
+}
+
+fn run_algorithm(
+    algo: &str,
+    view: &GraphView,
+    dataset: &str,
+    props: &DatasetProperties,
+    data_dir: &Path,
+    validate: bool,
+) -> Option<BenchmarkResult> {
+    match algo {
+        "BFS" => {
+            let source_id = props.bfs_source.unwrap_or_else(|| {
+                if view.node_count > 0 { view.index_to_node[0] } else { 0 }
+            });
+
+            let start = Instant::now();
+            let distances = bfs_single_source(view, source_id);
+            let duration = start.elapsed();
+
+            let reachable = distances.values().filter(|&&d| d < u64::MAX).count();
+            let max_dist = distances.values().filter(|&&d| d < u64::MAX).max().copied().unwrap_or(0);
+
+            // Validation
+            let (validated, passed) = if validate {
+                validate_bfs(&distances, data_dir, dataset)
+            } else {
+                (false, false)
+            };
+
+            Some(BenchmarkResult {
+                dataset: dataset.to_string(),
+                algorithm: "BFS".to_string(),
+                vertex_count: view.node_count,
+                duration,
+                summary: format!(
+                    "source={}, reachable={}, max_depth={}",
+                    source_id, format_num(reachable), max_dist
+                ),
+                validated,
+                validation_passed: passed,
+            })
+        }
+
+        "PR" | "PAGERANK" => {
+            let damping = props.pr_damping.unwrap_or(0.85);
+            let iterations = props.pr_iterations.unwrap_or(20);
+
+            let config = PageRankConfig {
+                damping_factor: damping,
+                iterations,
+                tolerance: 0.0, // Use fixed iteration count
+            };
+
+            let start = Instant::now();
+            let scores = page_rank(view, config);
+            let duration = start.elapsed();
+
+            let max_score = scores.values().cloned().fold(0.0f64, f64::max);
+            let min_score = scores.values().cloned().fold(f64::MAX, f64::min);
+
+            let (validated, passed) = if validate {
+                validate_float_map(&scores, data_dir, dataset, "PR", 1e-6)
+            } else {
+                (false, false)
+            };
+
+            Some(BenchmarkResult {
+                dataset: dataset.to_string(),
+                algorithm: "PR".to_string(),
+                vertex_count: view.node_count,
+                duration,
+                summary: format!(
+                    "iters={}, d={}, min={:.6}, max={:.6}",
+                    iterations, damping, min_score, max_score
+                ),
+                validated,
+                validation_passed: passed,
+            })
+        }
+
+        "WCC" => {
+            let start = Instant::now();
+            let wcc = weakly_connected_components(view);
+            let duration = start.elapsed();
+
+            let num_components = wcc.components.len();
+            let largest = wcc.components.values().map(|v| v.len()).max().unwrap_or(0);
+
+            // WCC validation: compare component IDs (two nodes in same component
+            // should have the same component label in expected output)
+            let (validated, passed) = if validate {
+                validate_wcc(&wcc.node_component, data_dir, dataset)
+            } else {
+                (false, false)
+            };
+
+            Some(BenchmarkResult {
+                dataset: dataset.to_string(),
+                algorithm: "WCC".to_string(),
+                vertex_count: view.node_count,
+                duration,
+                summary: format!(
+                    "components={}, largest={}",
+                    format_num(num_components), format_num(largest)
+                ),
+                validated,
+                validation_passed: passed,
+            })
+        }
+
+        "CDLP" => {
+            let max_iters = props.cdlp_max_iterations.unwrap_or(100);
+            let config = CdlpConfig {
+                max_iterations: max_iters,
+            };
+
+            let start = Instant::now();
+            let result = cdlp(view, &config);
+            let duration = start.elapsed();
+
+            // Count distinct communities
+            let mut community_counts: HashMap<u64, usize> = HashMap::new();
+            for &label in result.labels.values() {
+                *community_counts.entry(label).or_insert(0) += 1;
+            }
+            let num_communities = community_counts.len();
+            let largest = community_counts.values().max().copied().unwrap_or(0);
+
+            // CDLP validation: same as WCC, compare community partitions
+            let (validated, passed) = if validate {
+                validate_cdlp(&result.labels, data_dir, dataset)
+            } else {
+                (false, false)
+            };
+
+            Some(BenchmarkResult {
+                dataset: dataset.to_string(),
+                algorithm: "CDLP".to_string(),
+                vertex_count: view.node_count,
+                duration,
+                summary: format!(
+                    "communities={}, largest={}, iters={}",
+                    format_num(num_communities), format_num(largest), result.iterations,
+                ),
+                validated,
+                validation_passed: passed,
+            })
+        }
+
+        "LCC" => {
+            let start = Instant::now();
+            let result = local_clustering_coefficient(view);
+            let duration = start.elapsed();
+
+            let non_zero = result.coefficients.values().filter(|&&cc| cc > 0.0).count();
+
+            let (validated, passed) = if validate {
+                validate_float_map(&result.coefficients, data_dir, dataset, "LCC", 1e-6)
+            } else {
+                (false, false)
+            };
+
+            Some(BenchmarkResult {
+                dataset: dataset.to_string(),
+                algorithm: "LCC".to_string(),
+                vertex_count: view.node_count,
+                duration,
+                summary: format!(
+                    "avg_cc={:.6}, non_zero={}",
+                    result.average, format_num(non_zero),
+                ),
+                validated,
+                validation_passed: passed,
+            })
+        }
+
+        "SSSP" => {
+            let source_id = props.sssp_source.unwrap_or_else(|| {
+                if view.node_count > 0 { view.index_to_node[0] } else { 0 }
+            });
+
+            let start = Instant::now();
+            let distances = sssp_single_source(view, source_id);
+            let duration = start.elapsed();
+
+            let reachable = distances.values().filter(|&&d| d < f64::INFINITY).count();
+            let max_dist = distances
+                .values()
+                .filter(|&&d| d < f64::INFINITY)
+                .cloned()
+                .fold(0.0f64, f64::max);
+
+            let (validated, passed) = if validate {
+                validate_sssp(&distances, data_dir, dataset)
+            } else {
+                (false, false)
+            };
+
+            Some(BenchmarkResult {
+                dataset: dataset.to_string(),
+                algorithm: "SSSP".to_string(),
+                vertex_count: view.node_count,
+                duration,
+                summary: format!(
+                    "source={}, reachable={}, max_dist={:.4}",
+                    source_id, format_num(reachable), max_dist,
+                ),
+                validated,
+                validation_passed: passed,
+            })
+        }
+
+        _ => {
+            eprintln!(
+                "  WARNING: Unknown algorithm '{}'. Valid: {:?}",
+                algo, ALL_ALGOS
+            );
+            None
+        }
+    }
+}
+
+// ============================================================================
+// VALIDATION FUNCTIONS
+// ============================================================================
+
+/// Validate BFS distances against expected output.
+fn validate_bfs(
+    actual: &HashMap<u64, u64>,
+    data_dir: &Path,
+    dataset: &str,
+) -> (bool, bool) {
+    let expected = match load_validation(data_dir, dataset, "BFS") {
+        Some(e) => e,
+        None => return (false, false),
+    };
+
+    let mut all_match = true;
+    let mut mismatches = 0;
+
+    for (node_id, expected_str) in &expected {
+        let expected_val: u64 = if expected_str == "9223372036854775807" {
+            u64::MAX
+        } else {
+            match expected_str.parse() {
+                Ok(v) => v,
+                Err(_) => { mismatches += 1; continue; }
+            }
+        };
+
+        let actual_val = actual.get(node_id).copied().unwrap_or(u64::MAX);
+        if actual_val != expected_val {
+            if mismatches < 3 {
+                eprintln!(
+                    "    BFS mismatch: node {} expected {} got {}",
+                    node_id, expected_val, actual_val
+                );
+            }
+            mismatches += 1;
+            all_match = false;
+        }
+    }
+
+    if mismatches > 3 {
+        eprintln!("    ... and {} more mismatches", mismatches - 3);
+    }
+
+    (true, all_match)
+}
+
+/// Validate float-valued results (PR, LCC) against expected output.
+fn validate_float_map(
+    actual: &HashMap<u64, f64>,
+    data_dir: &Path,
+    dataset: &str,
+    algo: &str,
+    tolerance: f64,
+) -> (bool, bool) {
+    let expected = match load_validation(data_dir, dataset, algo) {
+        Some(e) => e,
+        None => return (false, false),
+    };
+
+    let mut all_match = true;
+    let mut mismatches = 0;
+
+    for (node_id, expected_str) in &expected {
+        let expected_val: f64 = match expected_str.parse() {
+            Ok(v) => v,
+            Err(_) => { mismatches += 1; continue; }
+        };
+
+        let actual_val = actual.get(node_id).copied().unwrap_or(0.0);
+        let diff = (actual_val - expected_val).abs();
+        let rel_diff = if expected_val.abs() > 1e-12 {
+            diff / expected_val.abs()
+        } else {
+            diff
+        };
+
+        if diff > tolerance && rel_diff > tolerance {
+            if mismatches < 3 {
+                eprintln!(
+                    "    {} mismatch: node {} expected {:.15e} got {:.15e} (diff={:.2e})",
+                    algo, node_id, expected_val, actual_val, diff
+                );
+            }
+            mismatches += 1;
+            all_match = false;
+        }
+    }
+
+    if mismatches > 3 {
+        eprintln!("    ... and {} more mismatches", mismatches - 3);
+    }
+
+    (true, all_match)
+}
+
+/// Validate WCC results: two nodes with the same expected label should be
+/// in the same component, and vice versa.
+fn validate_wcc(
+    actual: &HashMap<u64, usize>,
+    data_dir: &Path,
+    dataset: &str,
+) -> (bool, bool) {
+    let expected = match load_validation(data_dir, dataset, "WCC") {
+        Some(e) => e,
+        None => return (false, false),
+    };
+
+    // Build expected partition: group nodes by their expected label
+    let mut expected_groups: HashMap<String, Vec<u64>> = HashMap::new();
+    for (&node_id, label) in &expected {
+        expected_groups.entry(label.clone()).or_default().push(node_id);
+    }
+
+    // Check that nodes in the same expected group share the same actual component
+    let mut all_match = true;
+    let mut mismatches = 0;
+
+    for (_label, group) in &expected_groups {
+        if group.len() < 2 {
+            continue;
+        }
+        let first_comp = actual.get(&group[0]);
+        for &node_id in &group[1..] {
+            let comp = actual.get(&node_id);
+            if comp != first_comp {
+                if mismatches < 3 {
+                    eprintln!(
+                        "    WCC mismatch: nodes {} and {} should be in same component",
+                        group[0], node_id
+                    );
+                }
+                mismatches += 1;
+                all_match = false;
+            }
+        }
+    }
+
+    if mismatches > 3 {
+        eprintln!("    ... and {} more mismatches", mismatches - 3);
+    }
+
+    (true, all_match)
+}
+
+/// Validate CDLP results by exact label comparison.
+fn validate_cdlp(
+    actual: &HashMap<u64, u64>,
+    data_dir: &Path,
+    dataset: &str,
+) -> (bool, bool) {
+    let expected = match load_validation(data_dir, dataset, "CDLP") {
+        Some(e) => e,
+        None => return (false, false),
+    };
+
+    let mut all_match = true;
+    let mut mismatches = 0;
+
+    for (node_id, expected_str) in &expected {
+        let expected_label: u64 = match expected_str.parse() {
+            Ok(v) => v,
+            Err(_) => { mismatches += 1; continue; }
+        };
+        let actual_label = actual.get(node_id).copied().unwrap_or(0);
+        if actual_label != expected_label {
+            if mismatches < 3 {
+                eprintln!(
+                    "    CDLP mismatch: node {} expected label {} got {}",
+                    node_id, expected_label, actual_label
+                );
+            }
+            mismatches += 1;
+            all_match = false;
+        }
+    }
+
+    if mismatches > 3 {
+        eprintln!("    ... and {} more mismatches", mismatches - 3);
+    }
+
+    (true, all_match)
+}
+
+/// Validate SSSP distances against expected output.
+fn validate_sssp(
+    actual: &HashMap<u64, f64>,
+    data_dir: &Path,
+    dataset: &str,
+) -> (bool, bool) {
+    let expected = match load_validation(data_dir, dataset, "SSSP") {
+        Some(e) => e,
+        None => return (false, false),
+    };
+
+    let mut all_match = true;
+    let mut mismatches = 0;
+
+    for (node_id, expected_str) in &expected {
+        let expected_val: f64 = if expected_str == "Infinity" || expected_str == "infinity" {
+            f64::INFINITY
+        } else {
+            match expected_str.parse() {
+                Ok(v) => v,
+                Err(_) => { mismatches += 1; continue; }
+            }
+        };
+
+        let actual_val = actual.get(node_id).copied().unwrap_or(f64::INFINITY);
+
+        if expected_val.is_infinite() && actual_val.is_infinite() {
+            continue; // both unreachable
+        }
+
+        let diff = (actual_val - expected_val).abs();
+        if diff > 1e-6 {
+            if mismatches < 3 {
+                eprintln!(
+                    "    SSSP mismatch: node {} expected {:.15e} got {:.15e} (diff={:.2e})",
+                    node_id, expected_val, actual_val, diff
+                );
+            }
+            mismatches += 1;
+            all_match = false;
+        }
+    }
+
+    if mismatches > 3 {
+        eprintln!("    ... and {} more mismatches", mismatches - 3);
+    }
+
+    (true, all_match)
+}
+
+// ============================================================================
+// CLI HELPERS
+// ============================================================================
+
+fn get_arg(args: &[String], flag: &str) -> Option<String> {
+    args.iter()
+        .position(|a| a == flag)
+        .and_then(|i| args.get(i + 1))
+        .cloned()
+}
+
+fn print_usage() {
+    println!("LDBC Graphalytics Benchmark for Samyama Graph Database");
+    println!();
+    println!("Usage:");
+    println!("  cargo bench --release --bench graphalytics_benchmark -- --all");
+    println!("  cargo bench --release --bench graphalytics_benchmark -- --dataset example-directed --algo BFS");
+    println!("  cargo bench --release --bench graphalytics_benchmark -- --data-dir data/graphalytics/ --all");
+    println!();
+    println!("Options:");
+    println!("  --all              Run all algorithms on all default datasets");
+    println!("  --dataset <name>   Specify a dataset (e.g., example-directed)");
+    println!("  --algo <name>      Run a specific algorithm: BFS, PR, WCC, CDLP, LCC, SSSP");
+    println!("  --data-dir <path>  Dataset directory (default: data/graphalytics/)");
+    println!("  --no-validate      Skip result validation against expected outputs");
+    println!();
+    println!("Datasets are expected in Graphalytics edge-list format:");
+    println!("  <data-dir>/<dataset>/<dataset>.v   -- one vertex ID per line");
+    println!("  <data-dir>/<dataset>/<dataset>.e   -- source|target[|weight] per line");
+    println!();
+    println!("Download datasets with: scripts/download_graphalytics.sh");
+}

--- a/benches/graphalytics_common/mod.rs
+++ b/benches/graphalytics_common/mod.rs
@@ -1,0 +1,402 @@
+//! LDBC Graphalytics edge-list dataset loader.
+//!
+//! Parses the standard Graphalytics file format:
+//!   - Vertex file:  one vertex ID per line
+//!   - Edge file:    "source|target" or "source|target|weight" per line
+//!     (also supports space-delimited, as used by official example datasets)
+//!
+//! Builds a `samyama_graph_algorithms::GraphView` directly without going through
+//! the main GraphStore, so the benchmark measures pure algorithm time.
+
+use samyama_graph_algorithms::GraphView;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+/// Metadata about a loaded graph.
+pub struct GraphInfo {
+    pub name: String,
+    pub directed: bool,
+    pub vertex_count: usize,
+    pub edge_count: usize,
+}
+
+/// Result of loading a Graphalytics dataset.
+pub struct LoadedGraph {
+    pub view: GraphView,
+    pub info: GraphInfo,
+}
+
+/// Algorithm parameters parsed from a `.properties` file.
+pub struct DatasetProperties {
+    pub directed: Option<bool>,
+    pub bfs_source: Option<u64>,
+    pub sssp_source: Option<u64>,
+    pub pr_damping: Option<f64>,
+    pub pr_iterations: Option<usize>,
+    pub cdlp_max_iterations: Option<usize>,
+}
+
+impl Default for DatasetProperties {
+    fn default() -> Self {
+        Self {
+            directed: None,
+            bfs_source: None,
+            sssp_source: None,
+            pr_damping: None,
+            pr_iterations: None,
+            cdlp_max_iterations: None,
+        }
+    }
+}
+
+/// Parse a Graphalytics `.properties` file for algorithm parameters.
+pub fn parse_properties(path: &Path) -> DatasetProperties {
+    let mut props = DatasetProperties::default();
+
+    let file = match File::open(path) {
+        Ok(f) => f,
+        Err(_) => return props,
+    };
+
+    let reader = BufReader::new(file);
+    for line_result in reader.lines() {
+        let line = match line_result {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let line = line.trim().to_string();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        if let Some((key, value)) = line.split_once('=') {
+            let key = key.trim();
+            let value = value.trim();
+
+            if key.ends_with(".directed") {
+                props.directed = value.parse().ok();
+            } else if key.ends_with(".bfs.source-vertex") {
+                props.bfs_source = value.parse().ok();
+            } else if key.ends_with(".sssp.source-vertex") {
+                props.sssp_source = value.parse().ok();
+            } else if key.ends_with(".pr.damping-factor") {
+                props.pr_damping = value.parse().ok();
+            } else if key.ends_with(".pr.num-iterations") {
+                props.pr_iterations = value.parse().ok();
+            } else if key.ends_with(".cdlp.max-iterations") {
+                props.cdlp_max_iterations = value.parse().ok();
+            }
+        }
+    }
+
+    props
+}
+
+/// Load expected validation output for an algorithm.
+/// Returns a map from vertex ID to the expected value string.
+pub fn load_validation(
+    data_dir: &Path,
+    dataset: &str,
+    algo: &str,
+) -> Option<HashMap<u64, String>> {
+    // Try: <data_dir>/<dataset>/<dataset>-<ALGO>
+    let dataset_dir = data_dir.join(dataset);
+    let path = dataset_dir.join(format!("{}-{}", dataset, algo));
+
+    if !path.exists() {
+        return None;
+    }
+
+    let file = File::open(&path).ok()?;
+    let reader = BufReader::new(file);
+    let mut result = HashMap::new();
+
+    for line_result in reader.lines() {
+        let line = match line_result {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let line = line.trim().to_string();
+        if line.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() >= 2 {
+            if let Ok(id) = parts[0].parse::<u64>() {
+                result.insert(id, parts[1].to_string());
+            }
+        }
+    }
+
+    if result.is_empty() { None } else { Some(result) }
+}
+
+/// Load a Graphalytics dataset from vertex and edge files.
+///
+/// The vertex file contains one vertex ID (u64) per line.
+/// The edge file contains rows: `source|target[|weight]` or `source target [weight]`.
+///
+/// If `directed` is false, each edge is stored in both directions.
+pub fn load_graphalytics_dataset(
+    vertex_path: &Path,
+    edge_path: &Path,
+    directed: bool,
+    dataset_name: &str,
+) -> Result<LoadedGraph, Box<dyn std::error::Error>> {
+    // ── Phase 1: Load vertices ──────────────────────────────────────────
+    let mut node_ids: Vec<u64> = Vec::new();
+
+    if vertex_path.exists() {
+        let file = File::open(vertex_path)?;
+        let reader = BufReader::new(file);
+        for line_result in reader.lines() {
+            let line = line_result?;
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') || line.starts_with('%') {
+                continue;
+            }
+            let id: u64 = line.parse().map_err(|e| {
+                format!("Failed to parse vertex ID '{}': {}", line, e)
+            })?;
+            node_ids.push(id);
+        }
+    }
+
+    // ── Phase 2: Load edges ─────────────────────────────────────────────
+    struct RawEdge {
+        source: u64,
+        target: u64,
+        weight: f64,
+    }
+
+    let mut raw_edges: Vec<RawEdge> = Vec::new();
+    let mut has_weights = false;
+
+    if edge_path.exists() {
+        let file = File::open(edge_path)?;
+        let reader = BufReader::new(file);
+        for line_result in reader.lines() {
+            let line = line_result?;
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') || line.starts_with('%') {
+                continue;
+            }
+
+            // Try pipe delimiter first, then whitespace
+            let parts: Vec<&str> = if line.contains('|') {
+                line.split('|').collect()
+            } else {
+                line.split_whitespace().collect()
+            };
+
+            if parts.len() < 2 {
+                continue;
+            }
+
+            let source: u64 = parts[0].parse().map_err(|e| {
+                format!("Failed to parse source ID '{}': {}", parts[0], e)
+            })?;
+            let target: u64 = parts[1].parse().map_err(|e| {
+                format!("Failed to parse target ID '{}': {}", parts[1], e)
+            })?;
+
+            let weight = if parts.len() >= 3 {
+                has_weights = true;
+                parts[2].parse::<f64>().unwrap_or(1.0)
+            } else {
+                1.0
+            };
+
+            raw_edges.push(RawEdge { source, target, weight });
+        }
+    }
+
+    // ── Phase 3: Discover all vertex IDs ────────────────────────────────
+    // If vertex file was empty or missing, infer vertices from edges.
+    if node_ids.is_empty() {
+        let mut seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        for e in &raw_edges {
+            seen.insert(e.source);
+            seen.insert(e.target);
+        }
+        node_ids = seen.into_iter().collect();
+        node_ids.sort();
+    }
+
+    // ── Phase 4: Build index mappings ───────────────────────────────────
+    let node_count = node_ids.len();
+    let mut node_to_index: HashMap<u64, usize> = HashMap::with_capacity(node_count);
+    let mut index_to_node: Vec<u64> = Vec::with_capacity(node_count);
+
+    for (idx, &nid) in node_ids.iter().enumerate() {
+        node_to_index.insert(nid, idx);
+        index_to_node.push(nid);
+    }
+
+    // ── Phase 5: Build adjacency lists ──────────────────────────────────
+    let mut outgoing: Vec<Vec<usize>> = vec![Vec::new(); node_count];
+    let mut incoming: Vec<Vec<usize>> = vec![Vec::new(); node_count];
+    let mut weights_out: Vec<Vec<f64>> = if has_weights {
+        vec![Vec::new(); node_count]
+    } else {
+        Vec::new()
+    };
+
+    let mut edge_count = 0usize;
+
+    for e in &raw_edges {
+        let Some(&src_idx) = node_to_index.get(&e.source) else { continue };
+        let Some(&tgt_idx) = node_to_index.get(&e.target) else { continue };
+
+        outgoing[src_idx].push(tgt_idx);
+        incoming[tgt_idx].push(src_idx);
+        if has_weights {
+            weights_out[src_idx].push(e.weight);
+        }
+        edge_count += 1;
+
+        if !directed {
+            // Add reverse edge for undirected graphs
+            outgoing[tgt_idx].push(src_idx);
+            incoming[src_idx].push(tgt_idx);
+            if has_weights {
+                weights_out[tgt_idx].push(e.weight);
+            }
+            edge_count += 1;
+        }
+    }
+
+    // ── Phase 6: Build GraphView via from_adjacency_list ────────────────
+    let weight_vecs = if has_weights { Some(weights_out) } else { None };
+
+    let view = GraphView::from_adjacency_list(
+        node_count,
+        index_to_node,
+        node_to_index,
+        outgoing,
+        incoming,
+        weight_vecs,
+    );
+
+    let info = GraphInfo {
+        name: dataset_name.to_string(),
+        directed,
+        vertex_count: node_count,
+        edge_count,
+    };
+
+    Ok(LoadedGraph { view, info })
+}
+
+/// Attempt to auto-detect whether a dataset is directed or undirected
+/// based on the dataset name convention or properties file.
+pub fn is_directed(dataset_name: &str) -> bool {
+    let lower = dataset_name.to_lowercase();
+    if lower.contains("undirected") {
+        false
+    } else if lower.contains("directed") {
+        true
+    } else {
+        // Default to directed
+        true
+    }
+}
+
+/// Find the vertex, edge, and properties file paths for a given dataset.
+///
+/// Looks for standard Graphalytics naming:
+///   - `<dataset>.v`  or `<dataset>.vertices`
+///   - `<dataset>.e`  or `<dataset>.edges`
+///   - `<dataset>.properties`
+pub fn find_dataset_files(
+    data_dir: &Path,
+    dataset: &str,
+) -> Result<(std::path::PathBuf, std::path::PathBuf), Box<dyn std::error::Error>> {
+    let dataset_dir = data_dir.join(dataset);
+
+    // Try inside a subdirectory named after the dataset
+    let candidates_v = [
+        dataset_dir.join(format!("{}.v", dataset)),
+        dataset_dir.join(format!("{}.vertices", dataset)),
+        // Also try directly in data_dir
+        data_dir.join(format!("{}.v", dataset)),
+        data_dir.join(format!("{}.vertices", dataset)),
+    ];
+
+    let candidates_e = [
+        dataset_dir.join(format!("{}.e", dataset)),
+        dataset_dir.join(format!("{}.edges", dataset)),
+        data_dir.join(format!("{}.e", dataset)),
+        data_dir.join(format!("{}.edges", dataset)),
+    ];
+
+    let vertex_path = candidates_v
+        .iter()
+        .find(|p| p.exists())
+        .cloned()
+        .ok_or_else(|| {
+            format!(
+                "Vertex file not found. Tried:\n  {}",
+                candidates_v
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n  ")
+            )
+        })?;
+
+    let edge_path = candidates_e
+        .iter()
+        .find(|p| p.exists())
+        .cloned()
+        .ok_or_else(|| {
+            format!(
+                "Edge file not found. Tried:\n  {}",
+                candidates_e
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n  ")
+            )
+        })?;
+
+    Ok((vertex_path, edge_path))
+}
+
+/// Find the properties file for a dataset (if it exists).
+pub fn find_properties_file(data_dir: &Path, dataset: &str) -> Option<std::path::PathBuf> {
+    let candidates = [
+        data_dir.join(dataset).join(format!("{}.properties", dataset)),
+        data_dir.join(format!("{}.properties", dataset)),
+    ];
+    candidates.iter().find(|p| p.exists()).cloned()
+}
+
+// ============================================================================
+// FORMATTING HELPERS
+// ============================================================================
+
+pub fn format_num(n: usize) -> String {
+    let s = n.to_string();
+    let mut result = String::new();
+    for (i, ch) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(ch);
+    }
+    result.chars().rev().collect()
+}
+
+pub fn format_duration(d: std::time::Duration) -> String {
+    let secs = d.as_secs_f64();
+    if secs < 0.001 {
+        format!("{:.0}us", secs * 1_000_000.0)
+    } else if secs < 1.0 {
+        format!("{:.2}ms", secs * 1000.0)
+    } else {
+        format!("{:.3}s", secs)
+    }
+}

--- a/benches/vector_benchmark.rs
+++ b/benches/vector_benchmark.rs
@@ -1,0 +1,316 @@
+//! Vector Search Benchmark Suite
+//!
+//! Comprehensive benchmarks for Samyama's HNSW vector index:
+//! 1. Index build time across dimensions
+//! 2. Search latency by distance metric (Cosine, L2, Dot)
+//! 3. Recall@k measurement
+//! 4. Dimension scaling (64, 128, 384, 768)
+//! 5. Dataset size scaling
+
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::vector::DistanceMetric;
+use std::collections::HashSet;
+use std::time::Instant;
+use rand::Rng;
+
+#[path = "bench_setup.rs"]
+mod bench_setup;
+
+fn format_number(n: usize) -> String {
+    let s = n.to_string();
+    let mut result = String::new();
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
+}
+
+fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
+    let mut dot = 0.0f32;
+    let mut norm_a = 0.0f32;
+    let mut norm_b = 0.0f32;
+    for i in 0..a.len() {
+        dot += a[i] * b[i];
+        norm_a += a[i] * a[i];
+        norm_b += b[i] * b[i];
+    }
+    let denom = norm_a.sqrt() * norm_b.sqrt();
+    if denom == 0.0 { 1.0 } else { 1.0 - dot / denom }
+}
+
+fn benchmark_index_build(dimensions: &[usize], num_vectors: usize) {
+    println!("┌──────────────────────────────────────────────────────────────────┐");
+    println!("│ Benchmark 1: Index Build Time ({} vectors)             │", format_number(num_vectors));
+    println!("└──────────────────────────────────────────────────────────────────┘");
+
+    let mut rng = rand::thread_rng();
+
+    println!("  {:>6} {:>12} {:>14} {:>14}", "Dim", "Duration", "Vectors/sec", "MB est.");
+    println!("  {:>6} {:>12} {:>14} {:>14}", "---", "--------", "-----------", "-------");
+
+    for &dim in dimensions {
+        let mut store = GraphStore::new();
+        store.create_vector_index("Item", "embedding", dim, DistanceMetric::Cosine).unwrap();
+
+        let start = Instant::now();
+        for i in 0..num_vectors {
+            let vec: Vec<f32> = (0..dim).map(|_| rng.gen::<f32>()).collect();
+            let mut props = std::collections::HashMap::new();
+            props.insert("id".to_string(), PropertyValue::Integer(i as i64));
+            props.insert("embedding".to_string(), PropertyValue::Vector(vec));
+            store.create_node_with_properties("default", vec![Label::new("Item")], props);
+        }
+        let duration = start.elapsed();
+
+        let rate = num_vectors as f64 / duration.as_secs_f64();
+        let mb = (num_vectors * dim * 4) as f64 / (1024.0 * 1024.0);
+
+        println!("  {:>6} {:>10.2?} {:>12.0}/s {:>12.1}MB",
+            dim, duration, rate, mb);
+    }
+    println!();
+}
+
+fn benchmark_distance_metrics(num_vectors: usize, dim: usize, k: usize) {
+    println!("┌──────────────────────────────────────────────────────────────────┐");
+    println!("│ Benchmark 2: Distance Metrics ({} vectors, {} dim, k={})   │",
+        format_number(num_vectors), dim, k);
+    println!("└──────────────────────────────────────────────────────────────────┘");
+
+    let metrics = [
+        ("Cosine", DistanceMetric::Cosine),
+        ("L2", DistanceMetric::L2),
+        ("InnerProduct", DistanceMetric::InnerProduct),
+    ];
+
+    let mut rng = rand::thread_rng();
+    let num_searches = 500;
+
+    println!("  {:>12} {:>12} {:>14} {:>10}", "Metric", "Avg Latency", "QPS", "p99 est.");
+    println!("  {:>12} {:>12} {:>14} {:>10}", "------", "-----------", "---", "--------");
+
+    for (name, metric) in &metrics {
+        let mut store = GraphStore::new();
+        store.create_vector_index("Item", "embedding", dim, *metric).unwrap();
+
+        for i in 0..num_vectors {
+            let vec: Vec<f32> = (0..dim).map(|_| rng.gen::<f32>()).collect();
+            let mut props = std::collections::HashMap::new();
+            props.insert("id".to_string(), PropertyValue::Integer(i as i64));
+            props.insert("embedding".to_string(), PropertyValue::Vector(vec));
+            store.create_node_with_properties("default", vec![Label::new("Item")], props);
+        }
+
+        let mut latencies = Vec::with_capacity(num_searches);
+
+        for _ in 0..num_searches {
+            let query: Vec<f32> = (0..dim).map(|_| rng.gen::<f32>()).collect();
+            let t = Instant::now();
+            let _ = store.vector_search("Item", "embedding", &query, k).unwrap();
+            latencies.push(t.elapsed());
+        }
+
+        latencies.sort();
+        let total: std::time::Duration = latencies.iter().sum();
+        let avg = total / num_searches as u32;
+        let p99 = latencies[(num_searches as f64 * 0.99) as usize];
+        let qps = num_searches as f64 / total.as_secs_f64();
+
+        println!("  {:>12} {:>10.2?} {:>12.0}/s {:>8.2?}",
+            name, avg, qps, p99);
+    }
+    println!();
+}
+
+fn benchmark_recall(num_vectors: usize, dim: usize) {
+    println!("┌──────────────────────────────────────────────────────────────────┐");
+    println!("│ Benchmark 3: Recall@k ({} vectors, {} dim)              │",
+        format_number(num_vectors), dim);
+    println!("└──────────────────────────────────────────────────────────────────┘");
+
+    let mut rng = rand::thread_rng();
+    let mut store = GraphStore::new();
+    store.create_vector_index("Item", "embedding", dim, DistanceMetric::Cosine).unwrap();
+
+    let mut all_vectors: Vec<Vec<f32>> = Vec::with_capacity(num_vectors);
+    let mut node_ids = Vec::with_capacity(num_vectors);
+
+    for i in 0..num_vectors {
+        let vec: Vec<f32> = (0..dim).map(|_| rng.gen::<f32>()).collect();
+        all_vectors.push(vec.clone());
+        let mut props = std::collections::HashMap::new();
+        props.insert("id".to_string(), PropertyValue::Integer(i as i64));
+        props.insert("embedding".to_string(), PropertyValue::Vector(vec));
+        let id = store.create_node_with_properties("default", vec![Label::new("Item")], props);
+        node_ids.push(id);
+    }
+
+    let k_values = [1, 5, 10, 20, 50];
+    let num_queries = 100;
+
+    println!("  {:>6} {:>10} {:>12} {:>12}", "k", "Recall@k", "Avg Latency", "Results");
+    println!("  {:>6} {:>10} {:>12} {:>12}", "-", "--------", "-----------", "-------");
+
+    for &k in &k_values {
+        if k > num_vectors { continue; }
+
+        let mut total_recall = 0.0;
+        let mut total_time = std::time::Duration::default();
+
+        for _ in 0..num_queries {
+            let query: Vec<f32> = (0..dim).map(|_| rng.gen::<f32>()).collect();
+
+            // Brute-force ground truth
+            let mut distances: Vec<(usize, f32)> = all_vectors.iter()
+                .enumerate()
+                .map(|(i, v)| (i, cosine_distance(&query, v)))
+                .collect();
+            distances.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+            let ground_truth: HashSet<u64> = distances[..k].iter()
+                .map(|(i, _)| node_ids[*i].as_u64())
+                .collect();
+
+            // HNSW search
+            let t = Instant::now();
+            let results = store.vector_search("Item", "embedding", &query, k).unwrap();
+            total_time += t.elapsed();
+
+            let found: HashSet<u64> = results.iter().map(|(id, _)| id.as_u64()).collect();
+            let intersection = ground_truth.intersection(&found).count();
+            total_recall += intersection as f64 / k as f64;
+        }
+
+        let avg_recall = total_recall / num_queries as f64;
+        let avg_latency = total_time / num_queries as u32;
+
+        println!("  {:>6} {:>9.1}% {:>10.2?} {:>12}",
+            k, avg_recall * 100.0, avg_latency, k);
+    }
+    println!();
+}
+
+fn benchmark_dimension_scaling(num_vectors: usize, k: usize) {
+    println!("┌──────────────────────────────────────────────────────────────────┐");
+    println!("│ Benchmark 4: Dimension Scaling ({} vectors, k={})        │",
+        format_number(num_vectors), k);
+    println!("└──────────────────────────────────────────────────────────────────┘");
+
+    let dimensions = [32, 64, 128, 256, 384, 768];
+    let mut rng = rand::thread_rng();
+    let num_searches = 200;
+
+    println!("  {:>6} {:>12} {:>12} {:>14} {:>10}", "Dim", "Build Time", "Search Avg", "Search QPS", "MB/index");
+    println!("  {:>6} {:>12} {:>12} {:>14} {:>10}", "---", "----------", "----------", "----------", "--------");
+
+    for &dim in &dimensions {
+        let mut store = GraphStore::new();
+        store.create_vector_index("Item", "embedding", dim, DistanceMetric::Cosine).unwrap();
+
+        let build_start = Instant::now();
+        for i in 0..num_vectors {
+            let vec: Vec<f32> = (0..dim).map(|_| rng.gen::<f32>()).collect();
+            let mut props = std::collections::HashMap::new();
+            props.insert("id".to_string(), PropertyValue::Integer(i as i64));
+            props.insert("embedding".to_string(), PropertyValue::Vector(vec));
+            store.create_node_with_properties("default", vec![Label::new("Item")], props);
+        }
+        let build_time = build_start.elapsed();
+
+        let mut total_search = std::time::Duration::default();
+        for _ in 0..num_searches {
+            let query: Vec<f32> = (0..dim).map(|_| rng.gen::<f32>()).collect();
+            let t = Instant::now();
+            let _ = store.vector_search("Item", "embedding", &query, k).unwrap();
+            total_search += t.elapsed();
+        }
+
+        let avg_search = total_search / num_searches as u32;
+        let qps = num_searches as f64 / total_search.as_secs_f64();
+        let mb = (num_vectors * dim * 4) as f64 / (1024.0 * 1024.0);
+
+        println!("  {:>6} {:>10.2?} {:>10.2?} {:>12.0}/s {:>8.1}MB",
+            dim, build_time, avg_search, qps, mb);
+    }
+    println!();
+}
+
+fn benchmark_dataset_scaling(dim: usize, k: usize) {
+    println!("┌──────────────────────────────────────────────────────────────────┐");
+    println!("│ Benchmark 5: Dataset Size Scaling ({} dim, k={})            │", dim, k);
+    println!("└──────────────────────────────────────────────────────────────────┘");
+
+    let sizes = [1_000, 5_000, 10_000, 25_000, 50_000];
+    let mut rng = rand::thread_rng();
+    let num_searches = 100;
+
+    println!("  {:>8} {:>12} {:>12} {:>14}", "Vectors", "Build Time", "Search Avg", "Search QPS");
+    println!("  {:>8} {:>12} {:>12} {:>14}", "-------", "----------", "----------", "----------");
+
+    for &n in &sizes {
+        let mut store = GraphStore::new();
+        store.create_vector_index("Item", "embedding", dim, DistanceMetric::Cosine).unwrap();
+
+        let build_start = Instant::now();
+        for i in 0..n {
+            let vec: Vec<f32> = (0..dim).map(|_| rng.gen::<f32>()).collect();
+            let mut props = std::collections::HashMap::new();
+            props.insert("id".to_string(), PropertyValue::Integer(i as i64));
+            props.insert("embedding".to_string(), PropertyValue::Vector(vec));
+            store.create_node_with_properties("default", vec![Label::new("Item")], props);
+        }
+        let build_time = build_start.elapsed();
+
+        let mut total_search = std::time::Duration::default();
+        for _ in 0..num_searches {
+            let query: Vec<f32> = (0..dim).map(|_| rng.gen::<f32>()).collect();
+            let t = Instant::now();
+            let _ = store.vector_search("Item", "embedding", &query, k).unwrap();
+            total_search += t.elapsed();
+        }
+
+        let avg_search = total_search / num_searches as u32;
+        let qps = num_searches as f64 / total_search.as_secs_f64();
+
+        println!("  {:>8} {:>10.2?} {:>10.2?} {:>12.0}/s",
+            format_number(n), build_time, avg_search, qps);
+    }
+    println!();
+}
+
+fn main() {
+    bench_setup::init();
+
+    println!("╔══════════════════════════════════════════════════════════════════╗");
+    println!("║   SAMYAMA Vector Search Benchmark Suite (HNSW)                  ║");
+    println!("╚══════════════════════════════════════════════════════════════════╝");
+    println!();
+
+    let total_start = Instant::now();
+
+    let standard_dims = [64, 128, 384, 768];
+    let standard_n = 10_000;
+    let standard_k = 10;
+
+    benchmark_index_build(&standard_dims, standard_n);
+    benchmark_distance_metrics(standard_n, 128, standard_k);
+    benchmark_recall(5_000, 128);
+    benchmark_dimension_scaling(standard_n, standard_k);
+    benchmark_dataset_scaling(128, standard_k);
+
+    let total = total_start.elapsed();
+
+    println!("╔══════════════════════════════════════════════════════════════════╗");
+    println!("║   Benchmark Complete                                            ║");
+    println!("╠══════════════════════════════════════════════════════════════════╣");
+    println!("║  Total duration: {:>10.2?}                                   ║", total);
+    println!("║                                                                ║");
+    println!("║  Configuration:                                                ║");
+    println!("║  - HNSW index with default parameters                          ║");
+    println!("║  - Random float32 vectors                                      ║");
+    println!("║  - Metrics: Cosine, L2, InnerProduct                           ║");
+    println!("║  - Dimensions: 64, 128, 384, 768                               ║");
+    println!("╚══════════════════════════════════════════════════════════════════╝");
+}


### PR DESCRIPTION
## Summary
- Move `full_benchmark`, `vector_benchmark`, and `graphalytics_benchmark` from `examples/` into `benches/` as `harness = false` benchmark targets
- Add shared `benches/bench_setup.rs` that handles license loading and GPU enablement via `#[cfg(feature = "gpu")]` — no-op in community builds, enables GPU acceleration in enterprise builds with a valid license
- Original `examples/` files remain untouched for standalone use

## Test plan
- [x] `cargo build --benches` — all 4 benchmarks compile cleanly
- [x] `cargo test` — all existing tests pass (no src/ changes)
- [x] `cargo bench --bench graph_benchmarks -- --list` — existing Criterion benchmarks unaffected
- [ ] `cargo bench --release --bench full_benchmark` — runs with CPU, prints community mode message
- [ ] `cargo bench --release --bench vector_benchmark` — runs HNSW benchmarks
- [ ] `cargo bench --release --bench graphalytics_benchmark -- --all` — loads datasets, runs 6 algorithms
- [ ] Enterprise: `SAMYAMA_LICENSE_FILE=... cargo bench --release --bench full_benchmark --features gpu` — enables GPU