### PR TITLE
chore: bump version to v0.5.10

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Samyama is a high-performance distributed graph database written in Rust with ~90% OpenCypher query support, Redis protocol (RESP) compatibility, multi-tenancy, vector search, NLQ, and graph algorithms. Currently at Phase 4 (High Availability Foundation), version v0.5.8.
+Samyama is a high-performance distributed graph database written in Rust with ~90% OpenCypher query support, Redis protocol (RESP) compatibility, multi-tenancy, vector search, NLQ, and graph algorithms. Currently at Phase 4 (High Availability Foundation), version v0.5.10.
 
 ## Build & Development Commands
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "samyama"
-version = "0.5.8"
+version = "0.5.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "samyama-cli"
-version = "0.5.8"
+version = "0.5.10"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2660,14 +2660,14 @@ dependencies = [
 
 [[package]]
 name = "samyama-graph-algorithms"
-version = "0.5.8"
+version = "0.5.10"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "samyama-optimization"
-version = "0.5.8"
+version = "0.5.10"
 dependencies = [
  "criterion",
  "ndarray",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "samyama-sdk"
-version = "0.5.8"
+version = "0.5.10"
 dependencies = [
  "async-trait",
  "ndarray",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["sdk/python"]
 
 [package]
 name = "samyama"
-version = "0.5.8"
+version = "0.5.10"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "High-performance distributed graph database with OpenCypher support"
@@ -69,15 +69,15 @@ regex = "1"
 lru = "0.12"
 
 # Optimization Engine (Phase 7)
-samyama-optimization = { path = "crates/samyama-optimization", version = "0.5.8" }
-samyama-graph-algorithms = { path = "crates/samyama-graph-algorithms", version = "0.5.8" }
+samyama-optimization = { path = "crates/samyama-optimization", version = "0.5.10" }
+samyama-graph-algorithms = { path = "crates/samyama-graph-algorithms", version = "0.5.10" }
 ndarray = "0.15"
 reqwest = { version = "0.13.1", features = ["json"] }
 
 [dev-dependencies]
 tempfile = "3.8"
 criterion = "0.5"
-samyama-sdk = { path = "crates/samyama-sdk", version = "0.5.8" }
+samyama-sdk = { path = "crates/samyama-sdk", version = "0.5.10" }
 
 [[bench]]
 name = "graph_benchmarks"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Samyama Graph Database API
-  version: 0.5.8
+  version: 0.5.10
   description: |
     HTTP API for the Samyama high-performance distributed graph database.
     Supports OpenCypher queries, graph status, and CRUD operations.
@@ -72,7 +72,7 @@ paths:
                 $ref: '#/components/schemas/StatusResponse'
               example:
                 status: healthy
-                version: 0.5.8
+                version: 0.5.10
                 storage:
                   nodes: 2000
                   edges: 11000
@@ -163,7 +163,7 @@ components:
           type: string
           description: Server version
           examples:
-            - 0.5.8
+            - 0.5.10
         storage:
           type: object
           properties:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-cli"
-version = "0.5.8"
+version = "0.5.10"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "CLI for Samyama Graph Database"
@@ -12,7 +12,7 @@ name = "samyama-cli"
 path = "src/main.rs"
 
 [dependencies]
-samyama-sdk = { path = "../crates/samyama-sdk", version = "0.5.8" }
+samyama-sdk = { path = "../crates/samyama-sdk", version = "0.5.10" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/crates/samyama-graph-algorithms/Cargo.toml
+++ b/crates/samyama-graph-algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-graph-algorithms"
-version = "0.5.8"
+version = "0.5.10"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Graph algorithms (PageRank, WCC, BFS, Dijkstra) for Samyama Graph Database"

--- a/crates/samyama-optimization/Cargo.toml
+++ b/crates/samyama-optimization/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-optimization"
-version = "0.5.8"
+version = "0.5.10"
 edition = "2021"
 authors = ["Sandeep Kunkunuru <sandeep@samyama.ai>"]
 description = "High-performance metaheuristic optimization algorithms (Jaya, Rao, TLBO, BMR, BWR, QOJaya, ITLBO) in Rust."

--- a/crates/samyama-sdk/Cargo.toml
+++ b/crates/samyama-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-sdk"
-version = "0.5.8"
+version = "0.5.10"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Client SDK for Samyama Graph Database — embedded and remote modes"
@@ -25,13 +25,13 @@ reqwest = { version = "0.13.1", features = ["json"] }
 thiserror = "1.0"
 
 # Core graph database (for EmbeddedClient)
-samyama = { path = "../..", version = "0.5.8" }
+samyama = { path = "../..", version = "0.5.10" }
 
 # Graph algorithms (for AlgorithmClient)
-samyama-graph-algorithms = { path = "../samyama-graph-algorithms", version = "0.5.8" }
+samyama-graph-algorithms = { path = "../samyama-graph-algorithms", version = "0.5.10" }
 
 # Optimization engine (re-exported for examples)
-samyama-optimization = { path = "../samyama-optimization", version = "0.5.8" }
+samyama-optimization = { path = "../samyama-optimization", version = "0.5.10" }
 
 # Numeric arrays (re-exported for optimization problems)
 ndarray = "0.15"

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "samyama-python"
-version = "0.5.8"
+version = "0.5.10"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Python bindings for the Samyama Graph Database SDK"
@@ -14,6 +14,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.22", features = ["extension-module"] }
-samyama-sdk = { path = "../../crates/samyama-sdk", version = "0.5.8" }
+samyama-sdk = { path = "../../crates/samyama-sdk", version = "0.5.10" }
 tokio = { version = "1.35", features = ["rt-multi-thread"] }
 serde_json = "1.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "samyama"
-version = "0.5.8"
+version = "0.5.10"
 description = "Python SDK for the Samyama Graph Database"
 requires-python = ">=3.8"
 license = {text = "Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "samyama-sdk",
-  "version": "0.5.8",
+  "version": "0.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "samyama-sdk",
-      "version": "0.5.8",
+      "version": "0.5.10",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samyama-sdk",
-  "version": "0.5.8",
+  "version": "0.5.10",
   "description": "TypeScript SDK for the Samyama Graph Database",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,6 @@ mod tests {
     fn test_version() {
         let ver = version();
         assert!(!ver.is_empty());
-        assert_eq!(ver, "0.5.8");
+        assert_eq!(ver, "0.5.10");
     }
 }


### PR DESCRIPTION
## Summary
- Version bump from 0.5.8 to 0.5.10 across all 13 version locations
- Release for LDBC benchmark completeness work (PR #80)

## Changes
All version strings updated: Cargo.toml (root + workspace deps), cli, SDK, optimization, algorithms, Python SDK, TypeScript SDK, OpenAPI spec, lib.rs test, CLAUDE.md

## Release highlights (v0.5.10)
- PageRank LDBC Graphalytics spec compliance (1/N normalization, dangling node redistribution)
- Directed LCC support for directed graphs
- WITH projection barrier operator for complex BI queries
- BI timeout guard preventing benchmark hangs
- SNB Interactive DEL-1..DEL-8 delete operations
- S-size dataset support (wiki-Talk 2.4M V, cit-Patents 3.8M V, datagen-7_5-fb 633K V)
- All 27/27 Graphalytics validations pass (12 XS + 15 S-size)