### PR TITLE
fix: increase PageRank max iterations to 1000

### DIFF
--- a/benches/graphalytics_benchmark.rs
+++ b/benches/graphalytics_benchmark.rs
@@ -425,7 +425,7 @@ fn run_algorithm(
 
             let config = PageRankConfig {
                 damping_factor: damping,
-                iterations: iterations.max(100), // Ensure enough iterations for convergence on large graphs
+                iterations: iterations.max(1000), // Ensure enough iterations for convergence on large graphs
                 tolerance: 1e-7, // Converge to match LDBC reference outputs
             };
 


### PR DESCRIPTION
100 iterations insufficient for 3.7M-node S-size graphs.