### PR TITLE
fix: disable dangling redistribution for LDBC PageRank

### DIFF
--- a/benches/graphalytics_benchmark.rs
+++ b/benches/graphalytics_benchmark.rs
@@ -427,6 +427,7 @@ fn run_algorithm(
                 damping_factor: damping,
                 iterations: iterations.max(1000), // Ensure enough iterations for convergence on large graphs
                 tolerance: 1e-7, // Converge to match LDBC reference outputs
+                dangling_redistribution: false, // LDBC Graphalytics reference outputs use no dangling redistribution
             };
 
             let start = Instant::now();

--- a/crates/samyama-graph-algorithms/src/pagerank.rs
+++ b/crates/samyama-graph-algorithms/src/pagerank.rs
@@ -11,8 +11,12 @@ pub struct PageRankConfig {
     pub damping_factor: f64,
     /// Number of iterations
     pub iterations: usize,
-    /// Tolerance for convergence (optional - not used in fixed iteration version)
+    /// Tolerance for convergence (0.0 = run all iterations)
     pub tolerance: f64,
+    /// Whether to redistribute dangling node mass.
+    /// Set to false for LDBC Graphalytics compatibility (reference outputs
+    /// are generated without dangling redistribution).
+    pub dangling_redistribution: bool,
 }
 
 impl Default for PageRankConfig {
@@ -21,6 +25,7 @@ impl Default for PageRankConfig {
             damping_factor: 0.85,
             iterations: 20,
             tolerance: 0.0001,
+            dangling_redistribution: true,
         }
     }
 }
@@ -50,12 +55,16 @@ pub fn page_rank(
     for _ in 0..config.iterations {
         let mut total_diff = 0.0;
 
-        // Compute dangling node mass: sum of scores for nodes with out_degree == 0
-        let dangling_sum: f64 = (0..n)
-            .filter(|&i| view.out_degree(i) == 0)
-            .map(|i| scores[i])
-            .sum();
-        let dangling_contrib = dangling_sum / n as f64;
+        // Compute dangling node mass if enabled
+        let dangling_contrib = if config.dangling_redistribution {
+            let dangling_sum: f64 = (0..n)
+                .filter(|&i| view.out_degree(i) == 0)
+                .map(|i| scores[i])
+                .sum();
+            dangling_sum / n as f64
+        } else {
+            0.0
+        };
 
         for i in 0..n {
             let mut sum_incoming = 0.0;

--- a/examples/clinical_trials_demo.rs
+++ b/examples/clinical_trials_demo.rs
@@ -791,6 +791,7 @@ async fn main() {
             damping_factor: 0.85,
             iterations: 30,
             tolerance: 0.0001,
+            ..Default::default()
         },
         Some("Drug"),
         Some("INTERACTS_WITH"),

--- a/examples/smart_manufacturing_demo.rs
+++ b/examples/smart_manufacturing_demo.rs
@@ -710,6 +710,7 @@ async fn main() {
         damping_factor: 0.85,
         iterations: 30,
         tolerance: 0.0001,
+        ..Default::default()
     }, None, None).await;
     let pr_time = start.elapsed();
 

--- a/examples/supply_chain_demo.rs
+++ b/examples/supply_chain_demo.rs
@@ -939,6 +939,7 @@ async fn main() {
         damping_factor: 0.85,
         iterations: 30,
         tolerance: 0.0001,
+        ..Default::default()
     }, None, None).await;
     let pr_time = start.elapsed();
 


### PR DESCRIPTION
## Summary
- Add `dangling_redistribution: bool` field to `PageRankConfig` (default: `true` for backward compat)
- Disable for LDBC Graphalytics benchmark to match reference outputs (generated without dangling redistribution)
- Update all callers with `..Default::default()`

## Context
S-size LDBC Graphalytics PageRank validation was failing with 34,650 mismatches on cit-Patents because LDBC reference outputs don't redistribute dangling node mass, but our implementation did. This caused ~3.5x score differences on graphs with many dangling nodes.

## Test plan
- [x] `cargo test` - all tests pass
- [x] `cargo check` - compiles cleanly
- [ ] Re-run S-size Graphalytics benchmark on Mac Mini after merge