### PR TITLE
fix: use exact LDBC iteration count for PageRank

### DIFF
--- a/benches/graphalytics_benchmark.rs
+++ b/benches/graphalytics_benchmark.rs
@@ -425,9 +425,9 @@ fn run_algorithm(
 
             let config = PageRankConfig {
                 damping_factor: damping,
-                iterations: iterations.max(1000), // Ensure enough iterations for convergence on large graphs
-                tolerance: 1e-7, // Converge to match LDBC reference outputs
-                dangling_redistribution: false, // LDBC Graphalytics reference outputs use no dangling redistribution
+                iterations, // Use exact iteration count from LDBC properties
+                tolerance: 0.0, // No early termination — run exactly num-iterations
+                dangling_redistribution: false, // LDBC Graphalytics spec: no dangling redistribution
             };
 
             let start = Instant::now();


### PR DESCRIPTION
## Summary
- Remove `.max(1000)` from PageRank iterations in benchmark
- Set tolerance to 0.0 to run exactly the specified iterations without early exit
- LDBC reference outputs are generated with exactly `num-iterations` (e.g. 10), not converged values

## Context
Running 1000 iterations caused scores to diverge from LDBC reference values (3.5x factor) because mass leaks without dangling redistribution.