### PR TITLE
docs: fix Mac Mini specs (M4 10-core, 16GB)

### DIFF
--- a/docs/ldbc/GRAPHALYTICS.md
+++ b/docs/ldbc/GRAPHALYTICS.md
@@ -10,8 +10,8 @@ All 6 algorithms execute correctly across 5 datasets (2 XS + 3 S-size).
 
 ## Test Environment
 
-- **Hardware:** Mac Mini M4, 24GB RAM
-- **OS:** macOS Sequoia
+- **Hardware:** Mac Mini M4 (10-core: 4P+6E), 16GB RAM
+- **OS:** macOS Tahoe 26.2
 - **Build:** `cargo build --release` (Rust 1.83, LTO enabled)
 - **Date:** 2026-02-27
 

--- a/docs/ldbc/README.md
+++ b/docs/ldbc/README.md
@@ -2,7 +2,7 @@
 
 Samyama's query engine benchmarked against all four [LDBC Council](https://ldbcouncil.org/) benchmark suites.
 
-**Test Environment:** Mac Mini M4 (24GB RAM), macOS Sequoia, Rust 1.83 release build
+**Test Environment:** Mac Mini M4 (10-core, 16GB RAM), macOS Tahoe 26.2, Rust 1.83 release build
 
 **Date:** 2026-02-27
 


### PR DESCRIPTION
Fix hardware specs: M4 (not M4 Pro), 16GB (not 24GB), macOS Tahoe 26.2 (not Sequoia).