### PR TITLE
feat: add PCA algorithm with power iteration + demo (v0.5.11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Samyama is a high-performance distributed graph database written in Rust with ~90% OpenCypher query support, Redis protocol (RESP) compatibility, multi-tenancy, vector search, NLQ, and graph algorithms. Currently at Phase 4 (High Availability Foundation), version v0.5.10.
+Samyama is a high-performance distributed graph database written in Rust with ~90% OpenCypher query support, Redis protocol (RESP) compatibility, multi-tenancy, vector search, NLQ, and graph algorithms. Currently at Phase 4 (High Availability Foundation), version v0.5.11.
 
 ## Build & Development Commands
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "samyama"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "samyama-cli"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2660,14 +2660,15 @@ dependencies = [
 
 [[package]]
 name = "samyama-graph-algorithms"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
+ "ndarray",
  "serde",
 ]
 
 [[package]]
 name = "samyama-optimization"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "criterion",
  "ndarray",
@@ -2680,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "samyama-sdk"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "async-trait",
  "ndarray",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["sdk/python"]
 
 [package]
 name = "samyama"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "High-performance distributed graph database with OpenCypher support"
@@ -69,15 +69,15 @@ regex = "1"
 lru = "0.12"
 
 # Optimization Engine (Phase 7)
-samyama-optimization = { path = "crates/samyama-optimization", version = "0.5.10" }
-samyama-graph-algorithms = { path = "crates/samyama-graph-algorithms", version = "0.5.10" }
+samyama-optimization = { path = "crates/samyama-optimization", version = "0.5.11" }
+samyama-graph-algorithms = { path = "crates/samyama-graph-algorithms", version = "0.5.11" }
 ndarray = "0.15"
 reqwest = { version = "0.13.1", features = ["json"] }
 
 [dev-dependencies]
 tempfile = "3.8"
 criterion = "0.5"
-samyama-sdk = { path = "crates/samyama-sdk", version = "0.5.10" }
+samyama-sdk = { path = "crates/samyama-sdk", version = "0.5.11" }
 
 [[bench]]
 name = "graph_benchmarks"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Samyama Graph Database API
-  version: 0.5.10
+  version: 0.5.11
   description: |
     HTTP API for the Samyama high-performance distributed graph database.
     Supports OpenCypher queries, graph status, and CRUD operations.
@@ -72,7 +72,7 @@ paths:
                 $ref: '#/components/schemas/StatusResponse'
               example:
                 status: healthy
-                version: 0.5.10
+                version: 0.5.11
                 storage:
                   nodes: 2000
                   edges: 11000
@@ -163,7 +163,7 @@ components:
           type: string
           description: Server version
           examples:
-            - 0.5.10
+            - 0.5.11
         storage:
           type: object
           properties:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-cli"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "CLI for Samyama Graph Database"
@@ -12,7 +12,7 @@ name = "samyama-cli"
 path = "src/main.rs"
 
 [dependencies]
-samyama-sdk = { path = "../crates/samyama-sdk", version = "0.5.10" }
+samyama-sdk = { path = "../crates/samyama-sdk", version = "0.5.11" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/crates/samyama-graph-algorithms/Cargo.toml
+++ b/crates/samyama-graph-algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-graph-algorithms"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Graph algorithms (PageRank, WCC, BFS, Dijkstra) for Samyama Graph Database"
@@ -13,3 +13,4 @@ readme = "README.md"
 [dependencies]
 # No heavy dependencies needed for pure topology
 serde = { version = "1.0", features = ["derive"], optional = true }
+ndarray = "0.15"

--- a/crates/samyama-graph-algorithms/src/lib.rs
+++ b/crates/samyama-graph-algorithms/src/lib.rs
@@ -7,6 +7,7 @@ pub mod mst;
 pub mod topology;
 pub mod cdlp;
 pub mod lcc;
+pub mod pca;
 
 pub use common::{GraphView, NodeId};
 pub use pagerank::{page_rank, PageRankConfig};
@@ -17,3 +18,4 @@ pub use mst::{prim_mst, MSTResult};
 pub use topology::count_triangles;
 pub use cdlp::{cdlp, CdlpResult, CdlpConfig};
 pub use lcc::{local_clustering_coefficient, local_clustering_coefficient_directed, LccResult};
+pub use pca::{pca, PcaConfig, PcaResult};

--- a/crates/samyama-graph-algorithms/src/pca.rs
+++ b/crates/samyama-graph-algorithms/src/pca.rs
@@ -1,0 +1,426 @@
+//! Principal Component Analysis (PCA) via power iteration
+//!
+//! Implements dimensionality reduction for node feature matrices.
+//! Uses the deflation method: extract one eigenvector at a time from the
+//! covariance matrix using power iteration, then deflate and repeat.
+
+use ndarray::{Array1, Array2};
+
+/// PCA configuration
+pub struct PcaConfig {
+    /// Number of principal components to extract
+    pub n_components: usize,
+    /// Maximum power iterations per component (default: 100)
+    pub max_iterations: usize,
+    /// Convergence tolerance for power iteration (default: 1e-6)
+    pub tolerance: f64,
+    /// Subtract column means before PCA (default: true)
+    pub center: bool,
+    /// Divide by column std dev before PCA (default: false)
+    pub scale: bool,
+}
+
+impl Default for PcaConfig {
+    fn default() -> Self {
+        Self {
+            n_components: 2,
+            max_iterations: 100,
+            tolerance: 1e-6,
+            center: true,
+            scale: false,
+        }
+    }
+}
+
+/// PCA result containing components and explained variance
+pub struct PcaResult {
+    /// Principal component vectors (n_components x n_features), row-major
+    pub components: Vec<Vec<f64>>,
+    /// Variance explained by each component (eigenvalues)
+    pub explained_variance: Vec<f64>,
+    /// Proportion of total variance explained by each component
+    pub explained_variance_ratio: Vec<f64>,
+    /// Feature means used for centering (needed to project new data)
+    pub mean: Vec<f64>,
+    /// Feature standard deviations (if scaling was used)
+    pub std_dev: Vec<f64>,
+    /// Number of samples in the input data
+    pub n_samples: usize,
+    /// Number of features in the input data
+    pub n_features: usize,
+    /// Number of power iterations used for the last component
+    pub iterations_used: usize,
+}
+
+impl PcaResult {
+    /// Project multiple data points into the reduced PCA space.
+    ///
+    /// Each input row is centered (and optionally scaled) using the stored
+    /// mean/std_dev, then multiplied by the component matrix.
+    pub fn transform(&self, data: &[Vec<f64>]) -> Vec<Vec<f64>> {
+        data.iter().map(|row| self.transform_one(row)).collect()
+    }
+
+    /// Project a single data point into the reduced PCA space.
+    pub fn transform_one(&self, point: &[f64]) -> Vec<f64> {
+        let k = self.components.len();
+        let d = self.n_features;
+        let mut result = vec![0.0; k];
+
+        for (c, component) in self.components.iter().enumerate() {
+            let mut dot = 0.0;
+            for j in 0..d {
+                let mut val = point[j] - self.mean[j];
+                if self.std_dev[j] > 0.0 {
+                    val /= self.std_dev[j];
+                }
+                dot += val * component[j];
+            }
+            result[c] = dot;
+        }
+        result
+    }
+}
+
+/// Run PCA on a feature matrix using power iteration with deflation.
+///
+/// # Arguments
+/// - `data`: slice of rows, each row is a feature vector of equal length
+/// - `config`: PCA parameters
+///
+/// # Panics
+/// Panics if `data` is empty or rows have inconsistent lengths.
+pub fn pca(data: &[Vec<f64>], config: PcaConfig) -> PcaResult {
+    let n = data.len();
+    assert!(n > 0, "PCA requires at least one data point");
+    let d = data[0].len();
+    assert!(d > 0, "PCA requires at least one feature");
+
+    let k = config.n_components.min(d).min(n);
+
+    // Build ndarray matrix
+    let mut mat = Array2::<f64>::zeros((n, d));
+    for (i, row) in data.iter().enumerate() {
+        assert_eq!(row.len(), d, "All rows must have the same number of features");
+        for (j, &val) in row.iter().enumerate() {
+            mat[[i, j]] = val;
+        }
+    }
+
+    // Compute column means
+    let mut mean = vec![0.0; d];
+    if config.center {
+        for j in 0..d {
+            let mut s = 0.0;
+            for i in 0..n {
+                s += mat[[i, j]];
+            }
+            mean[j] = s / n as f64;
+        }
+        // Center the data
+        for i in 0..n {
+            for j in 0..d {
+                mat[[i, j]] -= mean[j];
+            }
+        }
+    }
+
+    // Compute column std devs and scale
+    let mut std_dev = vec![1.0; d];
+    if config.scale {
+        for j in 0..d {
+            let mut ss = 0.0;
+            for i in 0..n {
+                ss += mat[[i, j]] * mat[[i, j]];
+            }
+            let s = (ss / (n.max(2) - 1) as f64).sqrt();
+            std_dev[j] = s;
+            if s > 0.0 {
+                for i in 0..n {
+                    mat[[i, j]] /= s;
+                }
+            }
+        }
+    }
+
+    // Compute covariance matrix: C = X^T X / (n-1)
+    let xt = mat.t();
+    let denom = if n > 1 { (n - 1) as f64 } else { 1.0 };
+    let mut cov = xt.dot(&mat) / denom;
+
+    // Power iteration with deflation
+    let mut components: Vec<Vec<f64>> = Vec::with_capacity(k);
+    let mut eigenvalues: Vec<f64> = Vec::with_capacity(k);
+    let mut last_iters = 0;
+
+    for _ in 0..k {
+        let (eigvec, eigval, iters) = power_iteration(&cov, config.max_iterations, config.tolerance);
+        last_iters = iters;
+
+        // Deflate: C = C - lambda * v * v^T
+        for r in 0..d {
+            for c in 0..d {
+                cov[[r, c]] -= eigval * eigvec[r] * eigvec[c];
+            }
+        }
+
+        components.push(eigvec);
+        eigenvalues.push(eigval);
+    }
+
+    // Compute explained variance ratios
+    let total_variance: f64 = eigenvalues.iter().sum::<f64>()
+        + (0..d).map(|i| cov[[i, i]]).sum::<f64>(); // remaining diagonal = remaining eigenvalues
+    let explained_variance_ratio: Vec<f64> = eigenvalues
+        .iter()
+        .map(|&ev| if total_variance > 0.0 { ev / total_variance } else { 0.0 })
+        .collect();
+
+    PcaResult {
+        components,
+        explained_variance: eigenvalues,
+        explained_variance_ratio,
+        mean,
+        std_dev,
+        n_samples: n,
+        n_features: d,
+        iterations_used: last_iters,
+    }
+}
+
+/// Power iteration: find the dominant eigenvector of a symmetric matrix.
+///
+/// Returns (eigenvector, eigenvalue, iterations_used).
+fn power_iteration(
+    matrix: &Array2<f64>,
+    max_iters: usize,
+    tolerance: f64,
+) -> (Vec<f64>, f64, usize) {
+    let d = matrix.nrows();
+
+    // Initialize with a vector that has some structure to avoid degenerate starts
+    let mut v = Array1::<f64>::zeros(d);
+    for i in 0..d {
+        v[i] = ((i + 1) as f64).sqrt();
+    }
+    let norm = v.dot(&v).sqrt();
+    if norm > 0.0 {
+        v /= norm;
+    }
+
+    let mut iters = 0;
+    for iter in 0..max_iters {
+        iters = iter + 1;
+
+        // w = C * v
+        let w = matrix.dot(&v);
+
+        // Normalize
+        let w_norm = w.dot(&w).sqrt();
+        if w_norm < 1e-15 {
+            // Matrix has zero eigenvalue in this direction
+            break;
+        }
+        let v_new = &w / w_norm;
+
+        // Check convergence: |v_new - v| or |v_new + v| (sign may flip)
+        let diff_pos: f64 = v_new.iter().zip(v.iter()).map(|(a, b)| (a - b).powi(2)).sum();
+        let diff_neg: f64 = v_new.iter().zip(v.iter()).map(|(a, b)| (a + b).powi(2)).sum();
+        let diff = diff_pos.min(diff_neg).sqrt();
+
+        v = v_new;
+
+        if diff < tolerance {
+            break;
+        }
+    }
+
+    // Eigenvalue: v^T C v
+    let cv = matrix.dot(&v);
+    let eigenvalue = v.dot(&cv);
+
+    (v.to_vec(), eigenvalue, iters)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pca_basic() {
+        // 2D data with clear primary direction along x=y
+        let data: Vec<Vec<f64>> = (0..100)
+            .map(|i| {
+                let x = i as f64;
+                let y = x + (i as f64 * 0.1).sin() * 2.0; // strong correlation
+                vec![x, y]
+            })
+            .collect();
+
+        let result = pca(&data, PcaConfig {
+            n_components: 2,
+            ..Default::default()
+        });
+
+        assert_eq!(result.components.len(), 2);
+        assert_eq!(result.explained_variance.len(), 2);
+
+        // First component should capture most variance
+        assert!(result.explained_variance_ratio[0] > 0.9,
+            "First component should explain >90% variance, got {}",
+            result.explained_variance_ratio[0]);
+
+        // First component should be roughly along [1, 1] / sqrt(2) direction
+        let c0 = &result.components[0];
+        let angle = (c0[0].abs() - c0[1].abs()).abs();
+        assert!(angle < 0.2, "First component should be near diagonal, got {:?}", c0);
+    }
+
+    #[test]
+    fn test_pca_identity() {
+        // When n_components == n_features, explained_variance_ratio sums to ~1.0
+        let data: Vec<Vec<f64>> = (0..50)
+            .map(|i| {
+                vec![
+                    i as f64,
+                    (i as f64 * 0.5).sin() * 10.0,
+                    (i * i) as f64 % 17.0,
+                ]
+            })
+            .collect();
+
+        let result = pca(&data, PcaConfig {
+            n_components: 3,
+            ..Default::default()
+        });
+
+        let total: f64 = result.explained_variance_ratio.iter().sum();
+        assert!((total - 1.0).abs() < 0.01,
+            "Total explained variance ratio should be ~1.0, got {}", total);
+    }
+
+    #[test]
+    fn test_pca_explained_variance_ratios_sum() {
+        let data: Vec<Vec<f64>> = (0..200)
+            .map(|i| {
+                let x = i as f64 * 0.1;
+                vec![x, x * 2.0 + 1.0, x.sin(), x.cos(), (x * 0.3).exp().min(100.0)]
+            })
+            .collect();
+
+        let result = pca(&data, PcaConfig {
+            n_components: 5,
+            ..Default::default()
+        });
+
+        let total: f64 = result.explained_variance_ratio.iter().sum();
+        assert!((total - 1.0).abs() < 0.05,
+            "Ratios should sum to ~1.0, got {}", total);
+
+        // Ratios should be in descending order
+        for i in 1..result.explained_variance_ratio.len() {
+            assert!(result.explained_variance_ratio[i] <= result.explained_variance_ratio[i - 1] + 1e-10,
+                "Ratios should be descending");
+        }
+    }
+
+    #[test]
+    fn test_pca_transform() {
+        // Create correlated 3D data
+        let data: Vec<Vec<f64>> = (0..100)
+            .map(|i| {
+                let x = i as f64;
+                vec![x, x * 1.5 + 3.0, x * 0.8 - 2.0]
+            })
+            .collect();
+
+        let result = pca(&data, PcaConfig {
+            n_components: 1,
+            ..Default::default()
+        });
+
+        // Project and check that reconstructing from 1 component preserves most info
+        let projected = result.transform(&data);
+        assert_eq!(projected.len(), 100);
+        assert_eq!(projected[0].len(), 1);
+
+        // First component should explain nearly all variance (perfectly correlated data)
+        assert!(result.explained_variance_ratio[0] > 0.99,
+            "Should explain >99% variance for perfectly correlated data, got {}",
+            result.explained_variance_ratio[0]);
+    }
+
+    #[test]
+    fn test_pca_centering() {
+        // Data with large offset should give same components as centered data
+        let offset = 1000.0;
+        let data: Vec<Vec<f64>> = (0..50)
+            .map(|i| vec![i as f64 + offset, (i as f64 * 2.0) + offset])
+            .collect();
+
+        let result = pca(&data, PcaConfig {
+            n_components: 2,
+            center: true,
+            ..Default::default()
+        });
+
+        // Mean should be approximately offset + 24.5 for x, offset + 49 for y
+        assert!((result.mean[0] - (offset + 24.5)).abs() < 0.01);
+        assert!((result.mean[1] - (offset + 49.0)).abs() < 0.01);
+
+        // Components should still capture the correlation direction
+        assert!(result.explained_variance_ratio[0] > 0.99);
+    }
+
+    #[test]
+    fn test_pca_convergence() {
+        // Simple data that should converge quickly
+        let data: Vec<Vec<f64>> = (0..20)
+            .map(|i| vec![i as f64, 0.0])
+            .collect();
+
+        let result = pca(&data, PcaConfig {
+            n_components: 1,
+            max_iterations: 100,
+            tolerance: 1e-10,
+            ..Default::default()
+        });
+
+        // Should converge well before 100 iterations for such simple data
+        assert!(result.iterations_used < 50,
+            "Should converge quickly, used {} iterations", result.iterations_used);
+
+        // First component should be [1, 0] (all variance along x)
+        let c0 = &result.components[0];
+        assert!(c0[0].abs() > 0.99, "Should be along x axis, got {:?}", c0);
+        assert!(c0[1].abs() < 0.1, "Should have near-zero y component, got {:?}", c0);
+    }
+
+    #[test]
+    fn test_pca_scaling() {
+        // Two features with very different scales
+        let data: Vec<Vec<f64>> = (0..100)
+            .map(|i| vec![i as f64, i as f64 * 1000.0])
+            .collect();
+
+        // Without scaling, second feature dominates
+        let result_no_scale = pca(&data, PcaConfig {
+            n_components: 2,
+            scale: false,
+            ..Default::default()
+        });
+        // First component should align with second feature (larger variance)
+        assert!(result_no_scale.components[0][1].abs() > result_no_scale.components[0][0].abs());
+
+        // With scaling, features are treated equally
+        let result_scaled = pca(&data, PcaConfig {
+            n_components: 2,
+            scale: true,
+            ..Default::default()
+        });
+        // Both features should contribute roughly equally to first component
+        let ratio = result_scaled.components[0][0].abs() / result_scaled.components[0][1].abs();
+        assert!(ratio > 0.5 && ratio < 2.0,
+            "Scaled components should be balanced, ratio = {}", ratio);
+    }
+}

--- a/crates/samyama-optimization/Cargo.toml
+++ b/crates/samyama-optimization/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-optimization"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 authors = ["Sandeep Kunkunuru <sandeep@samyama.ai>"]
 description = "High-performance metaheuristic optimization algorithms (Jaya, Rao, TLBO, BMR, BWR, QOJaya, ITLBO) in Rust."

--- a/crates/samyama-sdk/Cargo.toml
+++ b/crates/samyama-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-sdk"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Client SDK for Samyama Graph Database — embedded and remote modes"
@@ -25,13 +25,13 @@ reqwest = { version = "0.13.1", features = ["json"] }
 thiserror = "1.0"
 
 # Core graph database (for EmbeddedClient)
-samyama = { path = "../..", version = "0.5.10" }
+samyama = { path = "../..", version = "0.5.11" }
 
 # Graph algorithms (for AlgorithmClient)
-samyama-graph-algorithms = { path = "../samyama-graph-algorithms", version = "0.5.10" }
+samyama-graph-algorithms = { path = "../samyama-graph-algorithms", version = "0.5.11" }
 
 # Optimization engine (re-exported for examples)
-samyama-optimization = { path = "../samyama-optimization", version = "0.5.10" }
+samyama-optimization = { path = "../samyama-optimization", version = "0.5.11" }
 
 # Numeric arrays (re-exported for optimization problems)
 ndarray = "0.15"

--- a/crates/samyama-sdk/src/algo.rs
+++ b/crates/samyama-sdk/src/algo.rs
@@ -10,9 +10,9 @@ use std::collections::HashMap;
 use samyama::algo::{
     build_view, page_rank, weakly_connected_components, strongly_connected_components,
     bfs, dijkstra, bfs_all_shortest_paths, edmonds_karp, prim_mst, count_triangles,
-    cdlp, local_clustering_coefficient,
+    cdlp, local_clustering_coefficient, pca,
     PageRankConfig, PathResult, WccResult, SccResult, FlowResult, MSTResult,
-    CdlpConfig, CdlpResult, LccResult,
+    CdlpConfig, CdlpResult, LccResult, PcaConfig, PcaResult,
 };
 use samyama_graph_algorithms::GraphView;
 
@@ -121,6 +121,17 @@ pub trait AlgorithmClient {
         label: Option<&str>,
         edge_type: Option<&str>,
     ) -> LccResult;
+
+    /// Principal Component Analysis on node numeric properties.
+    ///
+    /// Extracts the specified numeric properties from nodes matching `label`,
+    /// builds a feature matrix, and runs PCA with the given config.
+    async fn pca(
+        &self,
+        label: Option<&str>,
+        properties: &[&str],
+        config: PcaConfig,
+    ) -> PcaResult;
 }
 
 #[async_trait]
@@ -255,6 +266,54 @@ impl AlgorithmClient for EmbeddedClient {
         let store = self.store.read().await;
         let view = build_view(&store, label, edge_type, None);
         local_clustering_coefficient(&view)
+    }
+
+    async fn pca(
+        &self,
+        label: Option<&str>,
+        properties: &[&str],
+        config: PcaConfig,
+    ) -> PcaResult {
+        let store = self.store.read().await;
+        use samyama::graph::{Label, PropertyValue};
+
+        // Collect nodes matching the label filter
+        let nodes: Vec<_> = if let Some(label_str) = label {
+            let l = Label::new(label_str);
+            store.get_nodes_by_label(&l).into_iter().collect()
+        } else {
+            store.all_nodes().into_iter().collect()
+        };
+
+        // Build feature matrix: extract numeric properties from each node
+        let mut data: Vec<Vec<f64>> = Vec::with_capacity(nodes.len());
+        for node in &nodes {
+            let mut row = Vec::with_capacity(properties.len());
+            for &prop in properties {
+                let val = match node.get_property(prop) {
+                    Some(PropertyValue::Integer(i)) => *i as f64,
+                    Some(PropertyValue::Float(f)) => *f,
+                    _ => 0.0,
+                };
+                row.push(val);
+            }
+            data.push(row);
+        }
+
+        if data.is_empty() {
+            return PcaResult {
+                components: vec![],
+                explained_variance: vec![],
+                explained_variance_ratio: vec![],
+                mean: vec![0.0; properties.len()],
+                std_dev: vec![1.0; properties.len()],
+                n_samples: 0,
+                n_features: properties.len(),
+                iterations_used: 0,
+            };
+        }
+
+        pca(&data, config)
     }
 }
 

--- a/crates/samyama-sdk/src/lib.rs
+++ b/crates/samyama-sdk/src/lib.rs
@@ -76,8 +76,9 @@ pub use samyama::query::{QueryEngine, RecordBatch, CacheStats};
 
 pub use samyama::algo::{
     build_view, page_rank, weakly_connected_components, strongly_connected_components,
-    bfs, dijkstra, edmonds_karp, prim_mst, count_triangles,
+    bfs, dijkstra, edmonds_karp, prim_mst, count_triangles, pca,
     PageRankConfig, PathResult, WccResult, SccResult, FlowResult, MSTResult,
+    PcaConfig, PcaResult,
 };
 pub use samyama_graph_algorithms::GraphView;
 

--- a/examples/pca_demo.rs
+++ b/examples/pca_demo.rs
@@ -1,0 +1,551 @@
+//! PCA Demo: Research Paper Citation Network
+//!
+//! Demonstrates Samyama's PCA (Principal Component Analysis) capabilities:
+//! - **Graph Model:** Research papers with 8 numeric properties
+//! - **PCA:** Reduce 8-dimensional feature space to 3 principal components
+//! - **Vector Search:** HNSW index on reduced PCA vectors for efficient similarity
+//! - **Comparison:** Full-dimensional vs PCA-reduced similarity rankings
+//!
+//! No API keys required. All data is synthetic and deterministic.
+
+use samyama_sdk::{
+    EmbeddedClient, SamyamaClient, AlgorithmClient, VectorClient,
+    NodeId, DistanceMetric, PcaConfig, PropertyValue,
+};
+use std::collections::HashMap;
+
+/// Research paper fields (domain, title_seed)
+const DOMAINS: &[&str] = &[
+    "Machine Learning",
+    "Computer Vision",
+    "Natural Language Processing",
+    "Robotics",
+    "Systems",
+    "Databases",
+    "Security",
+    "Networks",
+    "Theory",
+    "HCI",
+];
+
+/// Feature names for our paper nodes
+const FEATURES: &[&str] = &[
+    "citation_count",
+    "year",
+    "h_index",
+    "impact_factor",
+    "page_count",
+    "reference_count",
+    "download_count",
+    "author_count",
+];
+
+/// Deterministic pseudo-random number from seed
+fn pseudo_random(seed: usize, salt: usize) -> f64 {
+    let h = seed.wrapping_mul(2654435761) ^ salt.wrapping_mul(40503);
+    (h % 10000) as f64 / 10000.0
+}
+
+/// Generate synthetic paper properties based on domain and index
+fn paper_properties(domain_idx: usize, paper_idx: usize) -> Vec<(String, f64)> {
+    let seed = domain_idx * 1000 + paper_idx;
+
+    // ML/CV/NLP papers tend to have higher citations and downloads
+    let domain_boost = if domain_idx < 3 { 1.5 } else { 1.0 };
+
+    let citation_count = (pseudo_random(seed, 1) * 500.0 * domain_boost + 5.0).round();
+    let year = 2015.0 + (pseudo_random(seed, 2) * 11.0).round(); // 2015-2026
+    let h_index = (pseudo_random(seed, 3) * 80.0 * domain_boost + 5.0).round();
+    let impact_factor = pseudo_random(seed, 4) * 15.0 * domain_boost + 1.0;
+    let page_count = (pseudo_random(seed, 5) * 20.0 + 4.0).round();
+    let reference_count = (pseudo_random(seed, 6) * 60.0 + 10.0).round();
+    let download_count = citation_count * (pseudo_random(seed, 7) * 20.0 + 5.0);
+    let author_count = (pseudo_random(seed, 8) * 8.0 + 1.0).round();
+
+    vec![
+        ("citation_count".into(), citation_count),
+        ("year".into(), year),
+        ("h_index".into(), h_index),
+        ("impact_factor".into(), impact_factor),
+        ("page_count".into(), page_count),
+        ("reference_count".into(), reference_count),
+        ("download_count".into(), download_count),
+        ("author_count".into(), author_count),
+    ]
+}
+
+fn separator() {
+    println!("{}", "-".repeat(90));
+}
+
+#[tokio::main]
+async fn main() {
+    println!();
+    println!("============================================================================================");
+    println!("              PCA Demo: Research Paper Citation Network");
+    println!("              Powered by Samyama Graph Database");
+    println!("============================================================================================");
+    println!();
+
+    let client = EmbeddedClient::new();
+
+    // ====================================================================
+    // Step 1: Build the Research Paper Graph
+    // ====================================================================
+    println!("Step 1: Building Research Paper Graph");
+    separator();
+
+    let papers_per_domain = 100;
+    let total_papers = DOMAINS.len() * papers_per_domain;
+
+    let mut paper_ids: Vec<u64> = Vec::with_capacity(total_papers);
+    let mut paper_domains: HashMap<u64, String> = HashMap::new();
+    let mut paper_titles: HashMap<u64, String> = HashMap::new();
+    let mut edge_count = 0u64;
+
+    {
+        let mut store = client.store_write().await;
+
+        // Create paper nodes
+        for (d_idx, &domain) in DOMAINS.iter().enumerate() {
+            for p_idx in 0..papers_per_domain {
+                let node_id = store.create_node("Paper");
+                let global_idx = d_idx * papers_per_domain + p_idx;
+                let title = format!("{} Paper #{}", domain, p_idx + 1);
+
+                if let Some(node) = store.get_node_mut(node_id) {
+                    node.set_property("title", PropertyValue::String(title.clone()));
+                    node.set_property("domain", PropertyValue::String(domain.to_string()));
+
+                    let props = paper_properties(d_idx, p_idx);
+                    for (key, val) in &props {
+                        node.set_property(key, PropertyValue::Float(*val));
+                    }
+                }
+
+                paper_ids.push(node_id.as_u64());
+                paper_domains.insert(node_id.as_u64(), domain.to_string());
+                paper_titles.insert(node_id.as_u64(), title);
+
+                // Progress
+                if global_idx % 200 == 0 && global_idx > 0 {
+                    println!("  Created {} papers...", global_idx);
+                }
+            }
+        }
+
+        // Create CITES edges: papers cite earlier papers, with domain affinity
+        for i in 0..total_papers {
+            let src_domain = i / papers_per_domain;
+            let num_refs = (pseudo_random(i, 100) * 8.0 + 2.0) as usize;
+
+            for r in 0..num_refs {
+                // 70% chance to cite within same domain, 30% cross-domain
+                let target_domain = if pseudo_random(i * 100 + r, 200) < 0.7 {
+                    src_domain
+                } else {
+                    (pseudo_random(i * 100 + r, 300) * DOMAINS.len() as f64) as usize % DOMAINS.len()
+                };
+                let target_paper = (pseudo_random(i * 100 + r, 400) * papers_per_domain as f64) as usize % papers_per_domain;
+                let target_idx = target_domain * papers_per_domain + target_paper;
+
+                if target_idx != i && target_idx < total_papers {
+                    let src_nid = NodeId::new(paper_ids[i]);
+                    let tgt_nid = NodeId::new(paper_ids[target_idx]);
+                    if store.create_edge(src_nid, tgt_nid, "CITES").is_ok() {
+                        edge_count += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    println!("  Created {} papers across {} domains", total_papers, DOMAINS.len());
+    println!("  Created {} CITES edges", edge_count);
+    println!();
+
+    // ====================================================================
+    // Step 2: Run PCA on Paper Features
+    // ====================================================================
+    println!("Step 2: Running PCA (8D -> 3D)");
+    separator();
+
+    let n_components = 3;
+
+    let pca_result = client.pca(
+        Some("Paper"),
+        &FEATURES.iter().map(|s| *s).collect::<Vec<_>>(),
+        PcaConfig {
+            n_components,
+            max_iterations: 200,
+            tolerance: 1e-8,
+            center: true,
+            scale: true, // Scale since features have very different ranges
+            ..Default::default()
+        },
+    ).await;
+
+    println!("  Samples: {}, Features: {}", pca_result.n_samples, pca_result.n_features);
+    println!("  Components extracted: {}", pca_result.components.len());
+    println!("  Converged in {} iterations", pca_result.iterations_used);
+    println!();
+
+    // Print explained variance
+    println!("  Explained Variance:");
+    let mut cumulative = 0.0;
+    for (i, ratio) in pca_result.explained_variance_ratio.iter().enumerate() {
+        cumulative += ratio;
+        println!(
+            "    PC{}: {:.4} ({:.1}% variance, cumulative {:.1}%)",
+            i + 1,
+            pca_result.explained_variance[i],
+            ratio * 100.0,
+            cumulative * 100.0,
+        );
+    }
+    println!();
+
+    // Print component loadings
+    println!("  Component Loadings (which features contribute to each PC):");
+    for (i, component) in pca_result.components.iter().enumerate() {
+        println!("    PC{}:", i + 1);
+        let mut loadings: Vec<(usize, f64)> = component.iter().enumerate().map(|(j, &v)| (j, v)).collect();
+        loadings.sort_by(|a, b| b.1.abs().partial_cmp(&a.1.abs()).unwrap());
+        for (j, val) in loadings.iter().take(4) {
+            let bar_len = (val.abs() * 30.0) as usize;
+            let bar = if *val >= 0.0 {
+                format!("+{}", "=".repeat(bar_len.min(30)))
+            } else {
+                format!("-{}", "=".repeat(bar_len.min(30)))
+            };
+            println!("      {:18} {:+.4}  {}", FEATURES[*j], val, bar);
+        }
+    }
+    println!();
+
+    // ====================================================================
+    // Step 3: Project Papers into PCA Space
+    // ====================================================================
+    println!("Step 3: Projecting Papers into 3D PCA Space");
+    separator();
+
+    // Extract feature matrix again for projection
+    let mut feature_matrix: Vec<Vec<f64>> = Vec::with_capacity(total_papers);
+    {
+        let store = client.store_read().await;
+        for &pid in &paper_ids {
+            let nid = NodeId::new(pid);
+            if let Some(node) = store.get_node(nid) {
+                let row: Vec<f64> = FEATURES.iter().map(|&f| {
+                    match node.get_property(f) {
+                        Some(samyama_sdk::PropertyValue::Float(v)) => *v,
+                        Some(samyama_sdk::PropertyValue::Integer(v)) => *v as f64,
+                        _ => 0.0,
+                    }
+                }).collect();
+                feature_matrix.push(row);
+            }
+        }
+    }
+
+    let projected = pca_result.transform(&feature_matrix);
+
+    // Show sample projections
+    println!("  Sample projections (first 5 papers per domain):");
+    for (d_idx, &domain) in DOMAINS.iter().enumerate().take(3) {
+        println!("    {}:", domain);
+        for p in 0..5 {
+            let idx = d_idx * papers_per_domain + p;
+            let coords = &projected[idx];
+            println!(
+                "      Paper #{}: ({:+.3}, {:+.3}, {:+.3})",
+                p + 1,
+                coords[0],
+                coords[1],
+                coords[2],
+            );
+        }
+    }
+    println!("    ... ({} domains total)", DOMAINS.len());
+    println!();
+
+    // ====================================================================
+    // Step 4: Build HNSW Index with PCA Vectors
+    // ====================================================================
+    println!("Step 4: Building HNSW Index with 3D PCA Vectors");
+    separator();
+
+    client.create_vector_index("Paper", "pca_embedding", n_components, DistanceMetric::L2)
+        .await
+        .expect("Failed to create PCA vector index");
+
+    for (i, &pid) in paper_ids.iter().enumerate() {
+        let nid = NodeId::new(pid);
+        let embedding: Vec<f32> = projected[i].iter().map(|&x| x as f32).collect();
+        client.add_vector("Paper", "pca_embedding", nid, &embedding)
+            .await
+            .expect("Failed to add PCA vector");
+    }
+
+    println!("  Created HNSW index: dimension={}, metric=L2", n_components);
+    println!("  Indexed {} papers with PCA vectors", total_papers);
+    println!();
+
+    // ====================================================================
+    // Step 5: Similarity Search Using PCA Vectors
+    // ====================================================================
+    println!("Step 5: Similarity Search -- Finding Related Papers");
+    separator();
+
+    // Pick a query paper from Machine Learning domain
+    let query_idx = 0; // First ML paper
+    let query_id = paper_ids[query_idx];
+    let query_title = paper_titles.get(&query_id).unwrap();
+    let query_domain = paper_domains.get(&query_id).unwrap();
+
+    println!("  Query paper: \"{}\" ({})", query_title, query_domain);
+    println!();
+
+    // Search using PCA vectors
+    let query_vec: Vec<f32> = projected[query_idx].iter().map(|&x| x as f32).collect();
+    let pca_neighbors = client.vector_search("Paper", "pca_embedding", &query_vec, 10)
+        .await
+        .expect("PCA vector search failed");
+
+    println!("  Top 10 similar papers (PCA 3D Euclidean distance):");
+    for (rank, (nid, distance)) in pca_neighbors.iter().enumerate() {
+        let pid = nid.as_u64();
+        let title = paper_titles.get(&pid).map(|s| s.as_str()).unwrap_or("?");
+        let domain = paper_domains.get(&pid).map(|s| s.as_str()).unwrap_or("?");
+        let marker = if domain == query_domain.as_str() { "*" } else { " " };
+        println!(
+            "    {:2}. [dist={:.4}] {} \"{}\" ({})",
+            rank + 1,
+            distance,
+            marker,
+            title,
+            domain,
+        );
+    }
+    println!("  (* = same domain as query)");
+    println!();
+
+    // ====================================================================
+    // Step 6: Compare Full-Dimensional vs PCA-Reduced Similarity
+    // ====================================================================
+    println!("Step 6: Full-Dimensional vs PCA-Reduced Similarity Comparison");
+    separator();
+
+    // Build full-dimensional HNSW index for comparison
+    client.create_vector_index("Paper", "full_embedding", FEATURES.len(), DistanceMetric::L2)
+        .await
+        .expect("Failed to create full vector index");
+
+    for (i, &pid) in paper_ids.iter().enumerate() {
+        let nid = NodeId::new(pid);
+        // Standardize features for fair comparison (use PCA mean/std_dev)
+        let embedding: Vec<f32> = feature_matrix[i]
+            .iter()
+            .enumerate()
+            .map(|(j, &x)| {
+                let centered = x - pca_result.mean[j];
+                let scaled = if pca_result.std_dev[j] > 0.0 {
+                    centered / pca_result.std_dev[j]
+                } else {
+                    centered
+                };
+                scaled as f32
+            })
+            .collect();
+        client.add_vector("Paper", "full_embedding", nid, &embedding)
+            .await
+            .expect("Failed to add full vector");
+    }
+
+    // Search with full-dimensional vectors
+    let query_full: Vec<f32> = feature_matrix[query_idx]
+        .iter()
+        .enumerate()
+        .map(|(j, &x)| {
+            let centered = x - pca_result.mean[j];
+            let scaled = if pca_result.std_dev[j] > 0.0 {
+                centered / pca_result.std_dev[j]
+            } else {
+                centered
+            };
+            scaled as f32
+        })
+        .collect();
+
+    let full_neighbors = client.vector_search("Paper", "full_embedding", &query_full, 10)
+        .await
+        .expect("Full vector search failed");
+
+    // Compute overlap
+    let pca_set: std::collections::HashSet<u64> =
+        pca_neighbors.iter().map(|(nid, _)| nid.as_u64()).collect();
+    let full_set: std::collections::HashSet<u64> =
+        full_neighbors.iter().map(|(nid, _)| nid.as_u64()).collect();
+    let overlap = pca_set.intersection(&full_set).count();
+
+    println!("  Full 8D neighbors vs PCA 3D neighbors:");
+    println!("    Overlap in top-10: {}/10 ({:.0}%)", overlap, overlap as f64 * 10.0);
+    println!();
+
+    // Side-by-side comparison
+    println!("  {:40}  |  {:40}", "Full 8D", "PCA 3D");
+    println!("  {:40}  |  {:40}", "-".repeat(40), "-".repeat(40));
+    for rank in 0..10 {
+        let (f_nid, f_dist) = &full_neighbors[rank];
+        let f_title = paper_titles.get(&f_nid.as_u64()).map(|s| s.as_str()).unwrap_or("?");
+        let f_domain = paper_domains.get(&f_nid.as_u64()).map(|s| s.as_str()).unwrap_or("?");
+
+        let (p_nid, p_dist) = &pca_neighbors[rank];
+        let p_title = paper_titles.get(&p_nid.as_u64()).map(|s| s.as_str()).unwrap_or("?");
+        let p_domain = paper_domains.get(&p_nid.as_u64()).map(|s| s.as_str()).unwrap_or("?");
+
+        let f_label = format!("{}. {:.3} {}", rank + 1, f_dist, truncate(f_title, 20));
+        let p_label = format!("{}. {:.3} {}", rank + 1, p_dist, truncate(p_title, 20));
+        println!("  {:40}  |  {:40}", f_label, p_label);
+    }
+    println!();
+
+    // ====================================================================
+    // Step 7: Domain Clustering Analysis with PCA
+    // ====================================================================
+    println!("Step 7: Domain Clustering Analysis via PCA");
+    separator();
+
+    // Compute centroid per domain in PCA space
+    let mut domain_centroids: HashMap<String, Vec<f64>> = HashMap::new();
+    let mut domain_counts: HashMap<String, usize> = HashMap::new();
+
+    for (i, &pid) in paper_ids.iter().enumerate() {
+        let domain = paper_domains.get(&pid).unwrap().clone();
+        let coords = &projected[i];
+
+        let centroid = domain_centroids.entry(domain.clone()).or_insert_with(|| vec![0.0; n_components]);
+        for (j, &c) in coords.iter().enumerate() {
+            centroid[j] += c;
+        }
+        *domain_counts.entry(domain).or_insert(0) += 1;
+    }
+
+    // Normalize centroids
+    for (domain, centroid) in &mut domain_centroids {
+        let count = domain_counts[domain] as f64;
+        for c in centroid.iter_mut() {
+            *c /= count;
+        }
+    }
+
+    // Print domain centroids sorted by PC1
+    let mut sorted_domains: Vec<_> = domain_centroids.iter().collect();
+    sorted_domains.sort_by(|a, b| a.1[0].partial_cmp(&b.1[0]).unwrap());
+
+    println!("  Domain centroids in PCA space (sorted by PC1):");
+    println!("  {:25} {:>10} {:>10} {:>10}", "Domain", "PC1", "PC2", "PC3");
+    println!("  {:25} {:>10} {:>10} {:>10}", "-".repeat(25), "-".repeat(10), "-".repeat(10), "-".repeat(10));
+    for (domain, centroid) in &sorted_domains {
+        println!(
+            "  {:25} {:>10.3} {:>10.3} {:>10.3}",
+            domain,
+            centroid[0],
+            centroid[1],
+            centroid[2],
+        );
+    }
+    println!();
+
+    // Compute inter-domain distances
+    println!("  Inter-domain distances (Euclidean in PCA space):");
+    let domains_vec: Vec<&String> = sorted_domains.iter().map(|(d, _)| *d).collect();
+    println!("  Closest domain pairs:");
+    let mut all_pairs: Vec<(f64, &str, &str)> = Vec::new();
+    for i in 0..domains_vec.len() {
+        for j in (i + 1)..domains_vec.len() {
+            let c1 = &domain_centroids[domains_vec[i]];
+            let c2 = &domain_centroids[domains_vec[j]];
+            let dist: f64 = c1.iter().zip(c2.iter()).map(|(a, b)| (a - b).powi(2)).sum::<f64>().sqrt();
+            all_pairs.push((dist, domains_vec[i], domains_vec[j]));
+        }
+    }
+    all_pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+    for (dist, d1, d2) in all_pairs.iter().take(5) {
+        println!("    {:.4}  {} <-> {}", dist, d1, d2);
+    }
+    println!("  Most distant domain pairs:");
+    for (dist, d1, d2) in all_pairs.iter().rev().take(3) {
+        println!("    {:.4}  {} <-> {}", dist, d1, d2);
+    }
+    println!();
+
+    // ====================================================================
+    // Step 8: Cypher Queries on the Paper Network
+    // ====================================================================
+    println!("Step 8: Cypher Queries on Paper Network");
+    separator();
+
+    // Top cited papers
+    let result = client
+        .query_readonly(
+            "default",
+            "MATCH (p:Paper) RETURN p.title, p.citation_count, p.domain ORDER BY p.citation_count DESC LIMIT 5",
+        )
+        .await
+        .unwrap();
+    println!("  Top 5 papers by citation count:");
+    for row in &result.records {
+        if row.len() >= 3 {
+            let title = row[0].as_str().unwrap_or("?");
+            let cites = &row[1];
+            let domain = row[2].as_str().unwrap_or("?");
+            println!("    {} (citations: {}, domain: {})", truncate(title, 40), cites, domain);
+        }
+    }
+    println!();
+
+    // Count papers per domain
+    let result = client
+        .query_readonly(
+            "default",
+            "MATCH (p:Paper) RETURN p.domain, count(p) AS paper_count ORDER BY paper_count DESC",
+        )
+        .await
+        .unwrap();
+    println!("  Papers per domain:");
+    for row in &result.records {
+        if row.len() >= 2 {
+            let domain = row[0].as_str().unwrap_or("?");
+            let count = &row[1];
+            println!("    {:25} {}", domain, count);
+        }
+    }
+    println!();
+
+    // ====================================================================
+    // Summary
+    // ====================================================================
+    println!("============================================================================================");
+    println!("  Summary");
+    println!("============================================================================================");
+    println!("  Graph: {} papers, {} citations across {} domains", total_papers, edge_count, DOMAINS.len());
+    println!("  PCA: Reduced {}D features -> {}D components", FEATURES.len(), n_components);
+    let total_var: f64 = pca_result.explained_variance_ratio.iter().sum();
+    println!(
+        "  Explained variance: {:.1}% in {} components",
+        total_var * 100.0,
+        n_components,
+    );
+    println!("  Top-10 neighbor overlap (full vs PCA): {}/10", overlap);
+    println!("  HNSW index: {}D vectors, {} papers indexed", n_components, total_papers);
+    println!();
+}
+
+fn truncate(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max_len - 3])
+    }
+}

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "samyama-python"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Python bindings for the Samyama Graph Database SDK"
@@ -14,6 +14,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.22", features = ["extension-module"] }
-samyama-sdk = { path = "../../crates/samyama-sdk", version = "0.5.10" }
+samyama-sdk = { path = "../../crates/samyama-sdk", version = "0.5.11" }
 tokio = { version = "1.35", features = ["rt-multi-thread"] }
 serde_json = "1.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "samyama"
-version = "0.5.10"
+version = "0.5.11"
 description = "Python SDK for the Samyama Graph Database"
 requires-python = ">=3.8"
 license = {text = "Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "samyama-sdk",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "samyama-sdk",
-      "version": "0.5.10",
+      "version": "0.5.11",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samyama-sdk",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "TypeScript SDK for the Samyama Graph Database",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -19,6 +19,7 @@ pub use samyama_graph_algorithms::{
     count_triangles,
     cdlp, CdlpResult, CdlpConfig,
     local_clustering_coefficient, local_clustering_coefficient_directed, LccResult,
+    pca, PcaConfig, PcaResult,
 };
 
 /// Build a GraphView from the store for algorithm execution

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,6 @@ mod tests {
     fn test_version() {
         let ver = version();
         assert!(!ver.is_empty());
-        assert_eq!(ver, "0.5.10");
+        assert_eq!(ver, "0.5.11");
     }
 }


### PR DESCRIPTION
## Summary

- Add PCA (Principal Component Analysis) algorithm to `samyama-graph-algorithms` crate using power iteration with deflation — no LAPACK dependency, just `ndarray`
- Expose PCA via `AlgorithmClient` trait in SDK with `pca()` method that extracts numeric node properties and runs dimensionality reduction
- Add research paper citation network demo (`examples/pca_demo.rs`): 1000 papers, 8 numeric features → 3D PCA projection with HNSW similarity search
- Bump version to v0.5.11 across all 13 version locations

## Details

**Algorithm**: Power iteration extracts one eigenvector at a time from the covariance matrix, deflates, and repeats. Supports centering, scaling, configurable tolerance and max iterations.

**Types**: `PcaConfig`, `PcaResult` with `transform()` / `transform_one()` projection methods.

**Tests**: 7 unit tests (basic, identity, variance ratios, transform, centering, convergence, scaling) — all passing.

## Test plan

- [x] `cargo test --lib` — 255 tests pass
- [x] `cargo test -p samyama-graph-algorithms` — 24 tests pass (7 PCA)
- [x] `cargo test -p samyama-sdk` — 13 tests pass
- [x] `cargo run --example pca_demo` — runs end-to-end