### PR TITLE
feat: randomized SVD for PCA + optimizations (v0.5.12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Samyama is a high-performance distributed graph database written in Rust with ~90% OpenCypher query support, Redis protocol (RESP) compatibility, multi-tenancy, vector search, NLQ, and graph algorithms. Currently at Phase 4 (High Availability Foundation), version v0.5.11.
+Samyama is a high-performance distributed graph database written in Rust with ~90% OpenCypher query support, Redis protocol (RESP) compatibility, multi-tenancy, vector search, NLQ, and graph algorithms. Currently at Phase 4 (High Availability Foundation), version v0.5.12.
 
 ## Build & Development Commands
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "samyama"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "samyama-cli"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2660,15 +2660,16 @@ dependencies = [
 
 [[package]]
 name = "samyama-graph-algorithms"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "ndarray",
+ "rand 0.8.5",
  "serde",
 ]
 
 [[package]]
 name = "samyama-optimization"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "criterion",
  "ndarray",
@@ -2681,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "samyama-sdk"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "async-trait",
  "ndarray",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["sdk/python"]
 
 [package]
 name = "samyama"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "High-performance distributed graph database with OpenCypher support"
@@ -69,15 +69,15 @@ regex = "1"
 lru = "0.12"
 
 # Optimization Engine (Phase 7)
-samyama-optimization = { path = "crates/samyama-optimization", version = "0.5.11" }
-samyama-graph-algorithms = { path = "crates/samyama-graph-algorithms", version = "0.5.11" }
+samyama-optimization = { path = "crates/samyama-optimization", version = "0.5.12" }
+samyama-graph-algorithms = { path = "crates/samyama-graph-algorithms", version = "0.5.12" }
 ndarray = "0.15"
 reqwest = { version = "0.13.1", features = ["json"] }
 
 [dev-dependencies]
 tempfile = "3.8"
 criterion = "0.5"
-samyama-sdk = { path = "crates/samyama-sdk", version = "0.5.11" }
+samyama-sdk = { path = "crates/samyama-sdk", version = "0.5.12" }
 
 [[bench]]
 name = "graph_benchmarks"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Samyama Graph Database API
-  version: 0.5.11
+  version: 0.5.12
   description: |
     HTTP API for the Samyama high-performance distributed graph database.
     Supports OpenCypher queries, graph status, and CRUD operations.
@@ -72,7 +72,7 @@ paths:
                 $ref: '#/components/schemas/StatusResponse'
               example:
                 status: healthy
-                version: 0.5.11
+                version: 0.5.12
                 storage:
                   nodes: 2000
                   edges: 11000
@@ -163,7 +163,7 @@ components:
           type: string
           description: Server version
           examples:
-            - 0.5.11
+            - 0.5.12
         storage:
           type: object
           properties:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-cli"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "CLI for Samyama Graph Database"
@@ -12,7 +12,7 @@ name = "samyama-cli"
 path = "src/main.rs"
 
 [dependencies]
-samyama-sdk = { path = "../crates/samyama-sdk", version = "0.5.11" }
+samyama-sdk = { path = "../crates/samyama-sdk", version = "0.5.12" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/crates/samyama-graph-algorithms/Cargo.toml
+++ b/crates/samyama-graph-algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-graph-algorithms"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Graph algorithms (PageRank, WCC, BFS, Dijkstra) for Samyama Graph Database"
@@ -14,3 +14,4 @@ readme = "README.md"
 # No heavy dependencies needed for pure topology
 serde = { version = "1.0", features = ["derive"], optional = true }
 ndarray = "0.15"
+rand = "0.8"

--- a/crates/samyama-graph-algorithms/src/lib.rs
+++ b/crates/samyama-graph-algorithms/src/lib.rs
@@ -18,4 +18,4 @@ pub use mst::{prim_mst, MSTResult};
 pub use topology::count_triangles;
 pub use cdlp::{cdlp, CdlpResult, CdlpConfig};
 pub use lcc::{local_clustering_coefficient, local_clustering_coefficient_directed, LccResult};
-pub use pca::{pca, PcaConfig, PcaResult};
+pub use pca::{pca, PcaConfig, PcaResult, PcaSolver};

--- a/crates/samyama-graph-algorithms/src/pca.rs
+++ b/crates/samyama-graph-algorithms/src/pca.rs
@@ -1,23 +1,55 @@
-//! Principal Component Analysis (PCA) via power iteration
+//! Principal Component Analysis (PCA)
 //!
 //! Implements dimensionality reduction for node feature matrices.
-//! Uses the deflation method: extract one eigenvector at a time from the
-//! covariance matrix using power iteration, then deflate and repeat.
+//!
+//! Two solvers are available:
+//! - **Randomized SVD** (default): Halko-Martinsson-Tropp algorithm. O(n·d·k),
+//!   numerically stable, automatic orthogonality. Industry standard (scikit-learn,
+//!   cuML, Spark MLlib).
+//! - **Power Iteration** (legacy): Extract one eigenvector at a time from the
+//!   covariance matrix, then deflate and repeat. With Gram-Schmidt
+//!   re-orthogonalization for stability.
 
-use ndarray::{Array1, Array2};
+use ndarray::{Array1, Array2, Axis};
+use rand::Rng;
+
+/// Solver strategy for PCA.
+#[derive(Debug, Clone)]
+pub enum PcaSolver {
+    /// Automatically select solver based on data size:
+    /// Randomized if n > 500 and k < 0.8 * min(n, d), else PowerIteration.
+    Auto,
+    /// Randomized SVD (Halko-Martinsson-Tropp).
+    Randomized {
+        /// Extra columns for accuracy (default: 10).
+        n_oversamples: usize,
+        /// Subspace power iterations for stability (default: 4).
+        n_power_iters: usize,
+    },
+    /// Legacy power iteration with deflation.
+    PowerIteration,
+}
+
+impl Default for PcaSolver {
+    fn default() -> Self {
+        PcaSolver::Auto
+    }
+}
 
 /// PCA configuration
 pub struct PcaConfig {
     /// Number of principal components to extract
     pub n_components: usize,
-    /// Maximum power iterations per component (default: 100)
+    /// Maximum power iterations per component (only used for PowerIteration solver)
     pub max_iterations: usize,
-    /// Convergence tolerance for power iteration (default: 1e-6)
+    /// Convergence tolerance for power iteration (only used for PowerIteration solver)
     pub tolerance: f64,
     /// Subtract column means before PCA (default: true)
     pub center: bool,
     /// Divide by column std dev before PCA (default: false)
     pub scale: bool,
+    /// Solver strategy (default: Auto)
+    pub solver: PcaSolver,
 }
 
 impl Default for PcaConfig {
@@ -28,6 +60,7 @@ impl Default for PcaConfig {
             tolerance: 1e-6,
             center: true,
             scale: false,
+            solver: PcaSolver::Auto,
         }
     }
 }
@@ -48,17 +81,45 @@ pub struct PcaResult {
     pub n_samples: usize,
     /// Number of features in the input data
     pub n_features: usize,
-    /// Number of power iterations used for the last component
+    /// Number of iterations used (last component for PowerIteration, power iters for Randomized)
     pub iterations_used: usize,
 }
 
 impl PcaResult {
     /// Project multiple data points into the reduced PCA space.
     ///
-    /// Each input row is centered (and optionally scaled) using the stored
-    /// mean/std_dev, then multiplied by the component matrix.
+    /// Uses ndarray matrix multiplication for efficiency.
     pub fn transform(&self, data: &[Vec<f64>]) -> Vec<Vec<f64>> {
-        data.iter().map(|row| self.transform_one(row)).collect()
+        let n = data.len();
+        if n == 0 || self.components.is_empty() {
+            return vec![];
+        }
+        let d = self.n_features;
+        let k = self.components.len();
+
+        // Build component matrix (k × d)
+        let comp_flat: Vec<f64> = self.components.iter().flat_map(|r| r.iter().copied()).collect();
+        let comp_mat = Array2::from_shape_vec((k, d), comp_flat).unwrap();
+
+        // Build centered data matrix (n × d)
+        let data_flat: Vec<f64> = data.iter().flat_map(|row| {
+            row.iter().enumerate().map(|(j, &val)| {
+                let mut v = val - self.mean[j];
+                if self.std_dev[j] > 0.0 && self.std_dev[j] != 1.0 {
+                    v /= self.std_dev[j];
+                }
+                v
+            })
+        }).collect();
+        let data_mat = Array2::from_shape_vec((n, d), data_flat).unwrap();
+
+        // projected = data_mat @ comp_mat^T → (n × k)
+        let projected = data_mat.dot(&comp_mat.t());
+
+        // Convert back to Vec<Vec<f64>>
+        projected.rows().into_iter()
+            .map(|row| row.to_vec())
+            .collect()
     }
 
     /// Project a single data point into the reduced PCA space.
@@ -71,7 +132,7 @@ impl PcaResult {
             let mut dot = 0.0;
             for j in 0..d {
                 let mut val = point[j] - self.mean[j];
-                if self.std_dev[j] > 0.0 {
+                if self.std_dev[j] > 0.0 && self.std_dev[j] != 1.0 {
                     val /= self.std_dev[j];
                 }
                 dot += val * component[j];
@@ -82,11 +143,11 @@ impl PcaResult {
     }
 }
 
-/// Run PCA on a feature matrix using power iteration with deflation.
+/// Run PCA on a feature matrix.
 ///
 /// # Arguments
 /// - `data`: slice of rows, each row is a feature vector of equal length
-/// - `config`: PCA parameters
+/// - `config`: PCA parameters (including solver selection)
 ///
 /// # Panics
 /// Panics if `data` is empty or rows have inconsistent lengths.
@@ -98,95 +159,304 @@ pub fn pca(data: &[Vec<f64>], config: PcaConfig) -> PcaResult {
 
     let k = config.n_components.min(d).min(n);
 
-    // Build ndarray matrix
-    let mut mat = Array2::<f64>::zeros((n, d));
-    for (i, row) in data.iter().enumerate() {
+    // Build ndarray matrix from flat data (cache-friendly)
+    let flat: Vec<f64> = data.iter().flat_map(|row| {
         assert_eq!(row.len(), d, "All rows must have the same number of features");
-        for (j, &val) in row.iter().enumerate() {
-            mat[[i, j]] = val;
-        }
-    }
+        row.iter().copied()
+    }).collect();
+    let mut mat = Array2::from_shape_vec((n, d), flat).unwrap();
 
-    // Compute column means
+    // Compute column means and center using ndarray operations
     let mut mean = vec![0.0; d];
     if config.center {
-        for j in 0..d {
-            let mut s = 0.0;
-            for i in 0..n {
-                s += mat[[i, j]];
-            }
-            mean[j] = s / n as f64;
-        }
-        // Center the data
-        for i in 0..n {
-            for j in 0..d {
-                mat[[i, j]] -= mean[j];
-            }
-        }
+        let mean_arr = mat.mean_axis(Axis(0)).unwrap();
+        mat -= &mean_arr;
+        mean = mean_arr.to_vec();
     }
 
     // Compute column std devs and scale
     let mut std_dev = vec![1.0; d];
     if config.scale {
         for j in 0..d {
-            let mut ss = 0.0;
-            for i in 0..n {
-                ss += mat[[i, j]] * mat[[i, j]];
-            }
+            let col = mat.column(j);
+            let ss: f64 = col.iter().map(|x| x * x).sum();
             let s = (ss / (n.max(2) - 1) as f64).sqrt();
             std_dev[j] = s;
             if s > 0.0 {
-                for i in 0..n {
-                    mat[[i, j]] /= s;
+                mat.column_mut(j).mapv_inplace(|x| x / s);
+            }
+        }
+    }
+
+    // Decide solver
+    let use_randomized = match &config.solver {
+        PcaSolver::Auto => {
+            let min_dim = n.min(d);
+            n > 500 && (k as f64) < 0.8 * min_dim as f64
+        }
+        PcaSolver::Randomized { .. } => true,
+        PcaSolver::PowerIteration => false,
+    };
+
+    let (n_oversamples, n_power_iters) = match &config.solver {
+        PcaSolver::Randomized { n_oversamples, n_power_iters } => (*n_oversamples, *n_power_iters),
+        _ => (10, 4),
+    };
+
+    if use_randomized {
+        // ── Randomized SVD path ──
+        let (components, singular_values) = randomized_svd(&mat, k, n_oversamples, n_power_iters);
+
+        // Eigenvalues (variance) = σ² / (n-1)
+        let denom = if n > 1 { (n - 1) as f64 } else { 1.0 };
+        let eigenvalues: Vec<f64> = singular_values.iter().map(|&s| s * s / denom).collect();
+
+        // Total variance from covariance diagonal
+        let total_variance = compute_total_variance(&mat, denom);
+
+        let explained_variance_ratio: Vec<f64> = eigenvalues
+            .iter()
+            .map(|&ev| if total_variance > 0.0 { ev / total_variance } else { 0.0 })
+            .collect();
+
+        PcaResult {
+            components,
+            explained_variance: eigenvalues,
+            explained_variance_ratio,
+            mean,
+            std_dev,
+            n_samples: n,
+            n_features: d,
+            iterations_used: n_power_iters,
+        }
+    } else {
+        // ── Power iteration with deflation path ──
+        let xt = mat.t();
+        let denom = if n > 1 { (n - 1) as f64 } else { 1.0 };
+        let mut cov = xt.dot(&mat) / denom;
+
+        // Capture total variance BEFORE deflation
+        let total_variance: f64 = (0..d).map(|i| cov[[i, i]]).sum();
+
+        let mut components: Vec<Vec<f64>> = Vec::with_capacity(k);
+        let mut eigenvalues: Vec<f64> = Vec::with_capacity(k);
+        let mut last_iters = 0;
+
+        for _ in 0..k {
+            let (eigvec, _eigval, iters) = power_iteration(&cov, config.max_iterations, config.tolerance);
+            last_iters = iters;
+
+            // Gram-Schmidt re-orthogonalization against previous components
+            let mut new_vec = eigvec;
+            for prev in &components {
+                let dot: f64 = new_vec.iter().zip(prev).map(|(a, b)| a * b).sum();
+                for (v, p) in new_vec.iter_mut().zip(prev) {
+                    *v -= dot * p;
                 }
             }
+            // Re-normalize after orthogonalization
+            let norm: f64 = new_vec.iter().map(|x| x * x).sum::<f64>().sqrt();
+            if norm > 1e-15 {
+                for v in &mut new_vec {
+                    *v /= norm;
+                }
+            }
+
+            // Recompute eigenvalue after orthogonalization: v^T C v
+            let v_arr = Array1::from(new_vec.clone());
+            let cv = cov.dot(&v_arr);
+            let eigval = v_arr.dot(&cv);
+
+            // Deflate: C = C - lambda * v * v^T
+            for r in 0..d {
+                for c in 0..d {
+                    cov[[r, c]] -= eigval * new_vec[r] * new_vec[c];
+                }
+            }
+
+            components.push(new_vec);
+            eigenvalues.push(eigval);
+        }
+
+        let explained_variance_ratio: Vec<f64> = eigenvalues
+            .iter()
+            .map(|&ev| if total_variance > 0.0 { ev / total_variance } else { 0.0 })
+            .collect();
+
+        PcaResult {
+            components,
+            explained_variance: eigenvalues,
+            explained_variance_ratio,
+            mean,
+            std_dev,
+            n_samples: n,
+            n_features: d,
+            iterations_used: last_iters,
         }
     }
+}
 
-    // Compute covariance matrix: C = X^T X / (n-1)
-    let xt = mat.t();
-    let denom = if n > 1 { (n - 1) as f64 } else { 1.0 };
-    let mut cov = xt.dot(&mat) / denom;
+/// Compute total variance from centered data matrix: sum of column variances.
+fn compute_total_variance(mat: &Array2<f64>, denom: f64) -> f64 {
+    let d = mat.ncols();
+    let mut total = 0.0;
+    for j in 0..d {
+        let col = mat.column(j);
+        let ss: f64 = col.iter().map(|x| x * x).sum();
+        total += ss / denom;
+    }
+    total
+}
 
-    // Power iteration with deflation
-    let mut components: Vec<Vec<f64>> = Vec::with_capacity(k);
-    let mut eigenvalues: Vec<f64> = Vec::with_capacity(k);
-    let mut last_iters = 0;
+// ============================================================
+// Randomized SVD (Halko-Martinsson-Tropp)
+// ============================================================
 
-    for _ in 0..k {
-        let (eigvec, eigval, iters) = power_iteration(&cov, config.max_iterations, config.tolerance);
-        last_iters = iters;
+/// Randomized SVD: find top-k singular vectors of a centered data matrix.
+///
+/// Algorithm (Algorithm 5.1 from Halko et al. 2011):
+/// 1. Generate random Gaussian matrix Omega (d × (k+p))
+/// 2. Y = X @ Omega
+/// 3. Power iteration for stability: Y = (X @ X^T)^q @ Y, with QR between steps
+/// 4. QR factorization of Y → Q
+/// 5. B = Q^T @ X (small: (k+p) × d)
+/// 6. SVD of B via eigendecomposition of B @ B^T
+/// 7. Return top-k right singular vectors and singular values
+fn randomized_svd(
+    mat: &Array2<f64>,       // n × d, already centered
+    k: usize,                // number of components
+    n_oversamples: usize,    // oversampling parameter
+    n_power_iters: usize,    // power iterations for accuracy
+) -> (Vec<Vec<f64>>, Vec<f64>) {
+    let n = mat.nrows();
+    let d = mat.ncols();
+    let l = (k + n_oversamples).min(n).min(d); // sketch width
 
-        // Deflate: C = C - lambda * v * v^T
+    // Stage 1: Random projection
+    let mut rng = rand::thread_rng();
+    let omega_flat: Vec<f64> = (0..d * l).map(|_| rng.sample::<f64, _>(rand::distributions::Standard)).collect();
+    let omega = Array2::from_shape_vec((d, l), omega_flat).unwrap();
+
+    // Y = X @ Omega  (n × l)
+    let mut y = mat.dot(&omega);
+
+    // Power iteration for stability: repeat q times
+    // Y = X @ (X^T @ Y), then QR factorize Y
+    for _ in 0..n_power_iters {
+        // QR factorize Y to maintain numerical stability
+        qr_modified_gram_schmidt(&mut y);
+        // Y = X @ (X^T @ Y)
+        let xty = mat.t().dot(&y); // d × l
+        y = mat.dot(&xty);         // n × l
+    }
+
+    // Final QR to get orthonormal basis Q
+    qr_modified_gram_schmidt(&mut y);
+    let q = y; // n × l, orthonormal columns
+
+    // Stage 2: Form small matrix B = Q^T @ X  (l × d)
+    let b = q.t().dot(mat);
+
+    // SVD of B via eigendecomposition of B @ B^T  (l × l, small)
+    let bbt = b.dot(&b.t());
+    let l_actual = bbt.nrows();
+
+    // Eigen-decompose the small l×l matrix using power iteration
+    // (we need all l eigenvectors, but we only keep top k)
+    let (eigvecs_left, eigvals) = symmetric_eigen(&bbt, l_actual);
+
+    // Right singular vectors of B: V_i = B^T @ U_i / σ_i
+    // Components are the right singular vectors of X (rows of V^T)
+    let mut components = Vec::with_capacity(k);
+    let mut singular_values = Vec::with_capacity(k);
+
+    for i in 0..k.min(l_actual) {
+        let sigma_sq = eigvals[i];
+        if sigma_sq < 1e-30 {
+            break;
+        }
+        let sigma = sigma_sq.sqrt();
+        singular_values.push(sigma);
+
+        // u_i = eigvecs_left column i
+        let u_i = eigvecs_left.column(i);
+        // v_i = B^T @ u_i / sigma
+        let v_i = b.t().dot(&u_i) / sigma;
+        components.push(v_i.to_vec());
+    }
+
+    (components, singular_values)
+}
+
+/// Symmetric eigendecomposition of a small matrix using power iteration + deflation.
+///
+/// Returns (eigenvectors as columns of Array2, eigenvalues sorted descending).
+fn symmetric_eigen(mat: &Array2<f64>, k: usize) -> (Array2<f64>, Vec<f64>) {
+    let d = mat.nrows();
+    let mut deflated = mat.clone();
+    let mut eigvecs = Array2::<f64>::zeros((d, k));
+    let mut eigvals = Vec::with_capacity(k);
+
+    for i in 0..k {
+        let (vec, _val, _) = power_iteration(&deflated, 200, 1e-12);
+
+        // Gram-Schmidt against previous eigenvectors
+        let mut v = Array1::from(vec);
+        for j in 0..i {
+            let prev = eigvecs.column(j);
+            let dot = prev.dot(&v);
+            v -= &(&prev * dot);
+        }
+        let norm = v.dot(&v).sqrt();
+        if norm > 1e-15 {
+            v /= norm;
+        }
+
+        // Recompute eigenvalue after orthogonalization
+        let av = deflated.dot(&v);
+        let val = v.dot(&av);
+
+        // Deflate
         for r in 0..d {
             for c in 0..d {
-                cov[[r, c]] -= eigval * eigvec[r] * eigvec[c];
+                deflated[[r, c]] -= val * v[r] * v[c];
             }
         }
 
-        components.push(eigvec);
-        eigenvalues.push(eigval);
+        eigvecs.column_mut(i).assign(&v);
+        eigvals.push(val);
     }
 
-    // Compute explained variance ratios
-    let total_variance: f64 = eigenvalues.iter().sum::<f64>()
-        + (0..d).map(|i| cov[[i, i]]).sum::<f64>(); // remaining diagonal = remaining eigenvalues
-    let explained_variance_ratio: Vec<f64> = eigenvalues
-        .iter()
-        .map(|&ev| if total_variance > 0.0 { ev / total_variance } else { 0.0 })
-        .collect();
+    (eigvecs, eigvals)
+}
 
-    PcaResult {
-        components,
-        explained_variance: eigenvalues,
-        explained_variance_ratio,
-        mean,
-        std_dev,
-        n_samples: n,
-        n_features: d,
-        iterations_used: last_iters,
+// ============================================================
+// QR factorization (Modified Gram-Schmidt)
+// ============================================================
+
+/// Modified Gram-Schmidt QR factorization in-place.
+///
+/// Replaces columns of `mat` with orthonormal vectors spanning the same space.
+fn qr_modified_gram_schmidt(mat: &mut Array2<f64>) {
+    let ncols = mat.ncols();
+    for j in 0..ncols {
+        let mut col_j = mat.column(j).to_owned();
+        for i in 0..j {
+            let col_i = mat.column(i).to_owned();
+            let r = col_i.dot(&col_j);
+            col_j -= &(&col_i * r);
+        }
+        let norm = col_j.dot(&col_j).sqrt();
+        if norm > 1e-15 {
+            col_j /= norm;
+        }
+        mat.column_mut(j).assign(&col_j);
     }
 }
+
+// ============================================================
+// Power iteration (used by both solvers and internal eigen)
+// ============================================================
 
 /// Power iteration: find the dominant eigenvector of a symmetric matrix.
 ///
@@ -383,6 +653,7 @@ mod tests {
             n_components: 1,
             max_iterations: 100,
             tolerance: 1e-10,
+            solver: PcaSolver::PowerIteration,
             ..Default::default()
         });
 
@@ -422,5 +693,158 @@ mod tests {
         let ratio = result_scaled.components[0][0].abs() / result_scaled.components[0][1].abs();
         assert!(ratio > 0.5 && ratio < 2.0,
             "Scaled components should be balanced, ratio = {}", ratio);
+    }
+
+    // ── New tests for randomized SVD ──
+
+    #[test]
+    fn test_pca_randomized_basic() {
+        // Generate data large enough to trigger randomized solver via Auto
+        let data: Vec<Vec<f64>> = (0..600)
+            .map(|i| {
+                let x = i as f64;
+                vec![x, x * 2.0 + 1.0, x.sin() * 10.0, (x * 0.01).cos() * 5.0]
+            })
+            .collect();
+
+        let result = pca(&data, PcaConfig {
+            n_components: 2,
+            solver: PcaSolver::Randomized { n_oversamples: 10, n_power_iters: 4 },
+            ..Default::default()
+        });
+
+        assert_eq!(result.components.len(), 2);
+        // First component should capture most variance (x and 2x dominate)
+        assert!(result.explained_variance_ratio[0] > 0.8,
+            "Randomized SVD: first component should explain >80% variance, got {}",
+            result.explained_variance_ratio[0]);
+    }
+
+    #[test]
+    fn test_pca_randomized_orthogonality() {
+        // Verify components from randomized SVD are orthogonal
+        let data: Vec<Vec<f64>> = (0..600)
+            .map(|i| {
+                let x = i as f64 * 0.1;
+                vec![x, x * 2.0 + 1.0, x.sin() * 10.0, x.cos() * 5.0, (x * 0.3).exp().min(100.0)]
+            })
+            .collect();
+
+        let result = pca(&data, PcaConfig {
+            n_components: 4,
+            solver: PcaSolver::Randomized { n_oversamples: 10, n_power_iters: 4 },
+            ..Default::default()
+        });
+
+        // Check pairwise orthogonality
+        for i in 0..result.components.len() {
+            for j in (i + 1)..result.components.len() {
+                let dot: f64 = result.components[i].iter()
+                    .zip(result.components[j].iter())
+                    .map(|(a, b)| a * b)
+                    .sum();
+                assert!(dot.abs() < 0.05,
+                    "Components {} and {} should be orthogonal, dot product = {}", i, j, dot);
+            }
+        }
+    }
+
+    #[test]
+    fn test_pca_auto_selects_randomized() {
+        // n=600, d=4, k=2 → k < 0.8 * min(600,4) = 3.2 → randomized
+        let data: Vec<Vec<f64>> = (0..600)
+            .map(|i| {
+                let x = i as f64;
+                vec![x, x * 2.0, x.sin(), x.cos()]
+            })
+            .collect();
+
+        let result = pca(&data, PcaConfig {
+            n_components: 2,
+            solver: PcaSolver::Auto,
+            ..Default::default()
+        });
+
+        // iterations_used should be the n_power_iters (4) for randomized, not >4
+        // (Power iteration would use many more iterations)
+        assert!(result.iterations_used <= 10,
+            "Auto should select randomized (iters={})", result.iterations_used);
+        assert_eq!(result.components.len(), 2);
+    }
+
+    #[test]
+    fn test_pca_solver_backward_compat() {
+        // Verify PowerIteration still works identically to before
+        let data: Vec<Vec<f64>> = (0..100)
+            .map(|i| {
+                let x = i as f64;
+                vec![x, x * 1.5 + 3.0, x * 0.8 - 2.0]
+            })
+            .collect();
+
+        let result = pca(&data, PcaConfig {
+            n_components: 2,
+            solver: PcaSolver::PowerIteration,
+            ..Default::default()
+        });
+
+        assert_eq!(result.components.len(), 2);
+        assert!(result.explained_variance_ratio[0] > 0.99,
+            "PowerIteration should explain >99% on correlated data, got {}",
+            result.explained_variance_ratio[0]);
+
+        // Verify orthogonality of components (improved by Gram-Schmidt)
+        let dot: f64 = result.components[0].iter()
+            .zip(result.components[1].iter())
+            .map(|(a, b)| a * b)
+            .sum();
+        assert!(dot.abs() < 0.01,
+            "PowerIteration components should be orthogonal, dot = {}", dot);
+    }
+
+    #[test]
+    fn test_pca_randomized_variance_sum() {
+        // Variance ratios from randomized SVD should sum close to 1.0 when k = d
+        let data: Vec<Vec<f64>> = (0..600)
+            .map(|i| {
+                let x = i as f64 * 0.1;
+                vec![x, x.sin() * 10.0, (x * 0.5).cos() * 5.0]
+            })
+            .collect();
+
+        let result = pca(&data, PcaConfig {
+            n_components: 3,
+            solver: PcaSolver::Randomized { n_oversamples: 10, n_power_iters: 4 },
+            ..Default::default()
+        });
+
+        let total: f64 = result.explained_variance_ratio.iter().sum();
+        assert!((total - 1.0).abs() < 0.1,
+            "Randomized SVD ratios should sum close to 1.0, got {}", total);
+    }
+
+    #[test]
+    fn test_pca_transform_batch() {
+        // Verify that batch transform matches individual transform_one calls
+        let data: Vec<Vec<f64>> = (0..100)
+            .map(|i| {
+                let x = i as f64;
+                vec![x, x * 2.0 + 1.0, x.sin() * 3.0]
+            })
+            .collect();
+
+        let result = pca(&data, PcaConfig {
+            n_components: 2,
+            ..Default::default()
+        });
+
+        let batch = result.transform(&data);
+        for (i, row) in data.iter().enumerate() {
+            let single = result.transform_one(row);
+            for (j, (&b, &s)) in batch[i].iter().zip(single.iter()).enumerate() {
+                assert!((b - s).abs() < 1e-10,
+                    "Batch[{}][{}]={} != single={}", i, j, b, s);
+            }
+        }
     }
 }

--- a/crates/samyama-optimization/Cargo.toml
+++ b/crates/samyama-optimization/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-optimization"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 authors = ["Sandeep Kunkunuru <sandeep@samyama.ai>"]
 description = "High-performance metaheuristic optimization algorithms (Jaya, Rao, TLBO, BMR, BWR, QOJaya, ITLBO) in Rust."

--- a/crates/samyama-sdk/Cargo.toml
+++ b/crates/samyama-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-sdk"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Client SDK for Samyama Graph Database — embedded and remote modes"
@@ -25,13 +25,13 @@ reqwest = { version = "0.13.1", features = ["json"] }
 thiserror = "1.0"
 
 # Core graph database (for EmbeddedClient)
-samyama = { path = "../..", version = "0.5.11" }
+samyama = { path = "../..", version = "0.5.12" }
 
 # Graph algorithms (for AlgorithmClient)
-samyama-graph-algorithms = { path = "../samyama-graph-algorithms", version = "0.5.11" }
+samyama-graph-algorithms = { path = "../samyama-graph-algorithms", version = "0.5.12" }
 
 # Optimization engine (re-exported for examples)
-samyama-optimization = { path = "../samyama-optimization", version = "0.5.11" }
+samyama-optimization = { path = "../samyama-optimization", version = "0.5.12" }
 
 # Numeric arrays (re-exported for optimization problems)
 ndarray = "0.15"

--- a/crates/samyama-sdk/src/algo.rs
+++ b/crates/samyama-sdk/src/algo.rs
@@ -12,7 +12,7 @@ use samyama::algo::{
     bfs, dijkstra, bfs_all_shortest_paths, edmonds_karp, prim_mst, count_triangles,
     cdlp, local_clustering_coefficient, pca,
     PageRankConfig, PathResult, WccResult, SccResult, FlowResult, MSTResult,
-    CdlpConfig, CdlpResult, LccResult, PcaConfig, PcaResult,
+    CdlpConfig, CdlpResult, LccResult, PcaConfig, PcaResult, PcaSolver,
 };
 use samyama_graph_algorithms::GraphView;
 
@@ -285,20 +285,20 @@ impl AlgorithmClient for EmbeddedClient {
             store.all_nodes().into_iter().collect()
         };
 
-        // Build feature matrix: extract numeric properties from each node
-        let mut data: Vec<Vec<f64>> = Vec::with_capacity(nodes.len());
-        for node in &nodes {
-            let mut row = Vec::with_capacity(properties.len());
-            for &prop in properties {
-                let val = match node.get_property(prop) {
-                    Some(PropertyValue::Integer(i)) => *i as f64,
-                    Some(PropertyValue::Float(f)) => *f,
+        // Build feature matrix: flat allocation then reshape into rows
+        let n = nodes.len();
+        let d = properties.len();
+        let mut data_flat = vec![0.0f64; n * d];
+        for (i, node) in nodes.iter().enumerate() {
+            for (j, &prop) in properties.iter().enumerate() {
+                data_flat[i * d + j] = match node.get_property(prop) {
+                    Some(PropertyValue::Integer(v)) => *v as f64,
+                    Some(PropertyValue::Float(v)) => *v,
                     _ => 0.0,
                 };
-                row.push(val);
             }
-            data.push(row);
         }
+        let data: Vec<Vec<f64>> = data_flat.chunks_exact(d).map(|c| c.to_vec()).collect();
 
         if data.is_empty() {
             return PcaResult {

--- a/crates/samyama-sdk/src/lib.rs
+++ b/crates/samyama-sdk/src/lib.rs
@@ -78,7 +78,7 @@ pub use samyama::algo::{
     build_view, page_rank, weakly_connected_components, strongly_connected_components,
     bfs, dijkstra, edmonds_karp, prim_mst, count_triangles, pca,
     PageRankConfig, PathResult, WccResult, SccResult, FlowResult, MSTResult,
-    PcaConfig, PcaResult,
+    PcaConfig, PcaResult, PcaSolver,
 };
 pub use samyama_graph_algorithms::GraphView;
 

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "samyama-python"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Python bindings for the Samyama Graph Database SDK"
@@ -14,6 +14,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.22", features = ["extension-module"] }
-samyama-sdk = { path = "../../crates/samyama-sdk", version = "0.5.11" }
+samyama-sdk = { path = "../../crates/samyama-sdk", version = "0.5.12" }
 tokio = { version = "1.35", features = ["rt-multi-thread"] }
 serde_json = "1.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "samyama"
-version = "0.5.11"
+version = "0.5.12"
 description = "Python SDK for the Samyama Graph Database"
 requires-python = ">=3.8"
 license = {text = "Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "samyama-sdk",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "samyama-sdk",
-      "version": "0.5.11",
+      "version": "0.5.12",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samyama-sdk",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "TypeScript SDK for the Samyama Graph Database",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -19,7 +19,7 @@ pub use samyama_graph_algorithms::{
     count_triangles,
     cdlp, CdlpResult, CdlpConfig,
     local_clustering_coefficient, local_clustering_coefficient_directed, LccResult,
-    pca, PcaConfig, PcaResult,
+    pca, PcaConfig, PcaResult, PcaSolver,
 };
 
 /// Build a GraphView from the store for algorithm execution

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,6 @@ mod tests {
     fn test_version() {
         let ver = version();
         assert!(!ver.is_empty());
-        assert_eq!(ver, "0.5.11");
+        assert_eq!(ver, "0.5.12");
     }
 }


### PR DESCRIPTION
## Summary
- **Randomized SVD** (Halko-Martinsson-Tropp) as default PCA solver — O(n·d·k), numerically stable, automatically orthogonal components. Industry standard matching scikit-learn, cuML, Spark MLlib.
- **`PcaSolver` enum** (`Auto`/`Randomized`/`PowerIteration`) for backward compatibility — `Auto` selects randomized for n>500, power iteration for small datasets.
- **Implementation optimizations**: flat array construction, ndarray-native centering, batch transform via matrix multiply, Gram-Schmidt re-orthogonalization, fixed variance calculation.
- **SDK**: flat allocation for feature extraction in `algo.rs`.
- **Version bump** to v0.5.12 across all 13 version locations.

## Test plan
- [x] `cargo test -p samyama-graph-algorithms` — 30/30 passed (6 new PCA tests)
- [x] `cargo test -p samyama-sdk` — 11/11 + 2 doc-tests passed
- [x] `cargo test --lib` — 255/255 passed (incl. `test_version` for 0.5.12)
- [ ] Verify `cargo run --example pca_demo` output is similar