### PR TITLE
fix: separate pre-WITH and post-WITH WHERE clauses

### DIFF
--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -63,6 +63,8 @@ pub struct Query {
     /// Index into match_clauses where WITH clause splits pre-WITH from post-WITH.
     /// match_clauses[..split] belong to pre-WITH, match_clauses[split..] to post-WITH.
     pub with_split_index: Option<usize>,
+    /// Post-WITH WHERE clause (second WHERE after WITH ... MATCH ... WHERE ...)
+    pub post_with_where_clause: Option<WhereClause>,
 }
 
 /// CREATE VECTOR INDEX clause
@@ -547,6 +549,7 @@ impl Query {
             union_queries: Vec::new(),
             explain: false,
             with_split_index: None,
+            post_with_where_clause: None,
         }
     }
 

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -330,8 +330,8 @@ impl QueryPlanner {
 
         // 1c. Handle post-WITH MATCH clauses (join on variables from WITH output)
         for match_clause in post_with_clauses {
-            // Post-WITH clauses do NOT use the original WHERE (it was applied before WITH)
-            let match_op = self.plan_match(match_clause, None, _store)?;
+            // Post-WITH clauses use the post-WITH WHERE clause (not the pre-WITH one)
+            let match_op = self.plan_match(match_clause, query.post_with_where_clause.as_ref(), _store)?;
 
             let mut clause_vars = HashSet::new();
             for path in &match_clause.pattern.paths {

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -369,7 +369,12 @@ fn parse_match_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
                 }
             }
             Rule::where_clause => {
-                query.where_clause = Some(parse_where_clause(inner)?);
+                if query.with_split_index.is_some() {
+                    // Second WHERE clause (after WITH ... MATCH ... WHERE ...)
+                    query.post_with_where_clause = Some(parse_where_clause(inner)?);
+                } else {
+                    query.where_clause = Some(parse_where_clause(inner)?);
+                }
             }
             Rule::with_clause => {
                 // Record where WITH splits pre-WITH from post-WITH match clauses


### PR DESCRIPTION
## Summary
- Fixed parser overwriting pre-WITH WHERE clause when encountering post-WITH WHERE
- Added `post_with_where_clause` field to Query AST
- Planner now passes correct WHERE clause to post-WITH MATCH planning
- Fixes LDBC SNB IC3 "Variable not found: m" error (last remaining failure)

## Test plan
- [x] All 257 unit tests pass
- [ ] Re-run LDBC SNB benchmark — expect 21/21 queries to pass