### PR TITLE
fix: add cli/ to Dockerfile for workspace build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,11 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 
-# Copy all source files
+# Copy all workspace source files
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 COPY crates ./crates
+COPY cli ./cli
 COPY benches ./benches
 COPY examples ./examples
 


### PR DESCRIPTION
## Summary
- Dockerfile was missing the `cli/` workspace member directory, causing `cargo build` to fail inside Docker with "failed to load manifest for workspace member"

## Test plan
- [x] Docker build succeeds on Mac Mini