### PR TITLE
fix: upgrade Dockerfile Rust to 1.85

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.83-bookworm AS builder
+FROM rust:1.85-bookworm AS builder
 
 # Install build dependencies for RocksDB
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
base64ct 1.8.3 requires edition2024 (Rust >= 1.85)