### PR TITLE
fix: preserve expand direction in logical optimizer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Samyama is a high-performance distributed graph database written in Rust with ~9
 cargo build                    # Debug build
 cargo build --release          # Release build (optimized)
 
-# Run tests (1671 unit tests)
+# Run tests (1746 unit tests)
 cargo test                     # All tests
 cargo test graph::node         # Specific module tests
 cargo test -- --nocapture      # Tests with output
@@ -161,7 +161,7 @@ graph.create_edge(source_id, target_id, "KNOWS")?;
 
 ## Testing
 
-- **1671 unit tests** across all modules (90.8% coverage)
+- **1746 unit tests** across all modules (89.7% coverage)
 - **10 benchmark binaries** in `benches/` (Criterion micro-benchmarks + domain benchmarks)
 - **Integration tests**: Python scripts in `tests/integration/`
 - **8 domain-specific example demos** with NLQ integration

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ![Version](https://img.shields.io/badge/version-0.6.0-blue)
 ![Rust](https://img.shields.io/badge/rust-1.85-orange)
-![Tests](https://img.shields.io/badge/tests-1671_passing-brightgreen)
-![Coverage](https://img.shields.io/badge/coverage-90.8%25-brightgreen)
+![Tests](https://img.shields.io/badge/tests-1746_passing-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-89.7%25-brightgreen)
 ![Bugs](https://img.shields.io/badge/bugs-0-brightgreen)
 ![Vulnerabilities](https://img.shields.io/badge/vulnerabilities-0-brightgreen)
 ![Quality Gate](https://img.shields.io/badge/quality_gate-passed-brightgreen)
@@ -168,7 +168,7 @@ Run with `cargo bench`. See [docs/performance/](docs/performance/) for detailed 
 
 ## Testing
 
-248 unit tests, integration tests via Python scripts, and 8 domain-specific example demos.
+1746 unit tests, integration tests via Python scripts, and 8 domain-specific example demos.
 
 ```bash
 cargo test                     # Run all tests

--- a/src/query/executor/logical_optimizer.rs
+++ b/src/query/executor/logical_optimizer.rs
@@ -115,12 +115,12 @@ fn push_filters_down(plan: LogicalPlanNode) -> LogicalPlanNode {
 /// convert Expand to ExpandInto.
 fn insert_expand_into(plan: LogicalPlanNode) -> LogicalPlanNode {
     match plan {
-        LogicalPlanNode::Expand { input, source_var, target_var, edge_var, edge_types, direction: _ } => {
+        LogicalPlanNode::Expand { input, source_var, target_var, edge_var, edge_types, direction } => {
             let optimized_input = insert_expand_into(*input);
             let input_vars = optimized_input.bound_variables();
 
             if input_vars.contains(&source_var) && input_vars.contains(&target_var) {
-                // Both endpoints bound → use ExpandInto
+                // Both endpoints bound → use ExpandInto (direction not needed)
                 LogicalPlanNode::ExpandInto {
                     input: Box::new(optimized_input),
                     source_var,
@@ -129,14 +129,14 @@ fn insert_expand_into(plan: LogicalPlanNode) -> LogicalPlanNode {
                     edge_var,
                 }
             } else {
+                // Preserve original direction
                 LogicalPlanNode::Expand {
                     input: Box::new(optimized_input),
                     source_var,
                     target_var,
                     edge_var,
                     edge_types,
-                    // Direction doesn't matter for ExpandInto, keep Forward for Expand
-                    direction: ExpandDirection::Forward,
+                    direction,
                 }
             }
         }

--- a/src/query/executor/plan_enumerator.rs
+++ b/src/query/executor/plan_enumerator.rs
@@ -44,8 +44,12 @@ pub fn enumerate_plans(
         .map(|wc| flatten_and_predicates(&wc.predicate))
         .unwrap_or_default();
 
+    // Collect node names in deterministic order for reproducible plan enumeration
+    let mut node_names: Vec<&String> = pattern.nodes.keys().collect();
+    node_names.sort();
+
     // For each node as a potential starting point
-    for (var_name, node) in &pattern.nodes {
+    for var_name in node_names {
         if candidates.len() >= config.max_candidate_plans {
             break;
         }

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2337,7 +2337,7 @@ mod tests {
 
     #[test]
     fn test_ab_correctness_expand() {
-        // A/B: expand pattern with data
+        // A/B: ALL candidate plans must produce identical results to legacy
         let mut store = GraphStore::new();
         let a = store.create_node("Person");
         store.get_node_mut(a).unwrap().set_property("name", PropertyValue::String("Alice".to_string()));
@@ -2350,12 +2350,9 @@ mod tests {
 
         let query = parse_query("MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a.name, b.name").unwrap();
 
+        // Legacy planner results
         let legacy = QueryPlanner::new();
-        let native = QueryPlanner::with_config(PlannerConfig { graph_native: true, max_candidate_plans: 64 });
-
         let legacy_plan = legacy.plan(&query, &store).unwrap();
-        let native_plan = native.plan(&query, &store).unwrap();
-
         let mut legacy_results: Vec<String> = Vec::new();
         let mut op = legacy_plan.root;
         while let Some(record) = op.next(&store).unwrap() {
@@ -2365,17 +2362,38 @@ mod tests {
         }
         legacy_results.sort();
 
-        let mut native_results: Vec<String> = Vec::new();
-        let mut op = native_plan.root;
-        while let Some(record) = op.next(&store).unwrap() {
-            let a_name = record.get("a.name").map(|v| format!("{:?}", v)).unwrap_or_default();
-            let b_name = record.get("b.name").map(|v| format!("{:?}", v)).unwrap_or_default();
-            native_results.push(format!("{}->{}", a_name, b_name));
-        }
-        native_results.sort();
+        // Graph-native planner — verify ALL candidate plans produce correct results
+        use super::super::logical_plan::PatternGraph;
+        use super::super::plan_enumerator::{enumerate_plans, EnumerationConfig};
+        use super::super::physical_planner::logical_to_physical;
 
-        assert_eq!(legacy_results, native_results,
-            "Expand results differ.\nLegacy: {:?}\nNative: {:?}", legacy_results, native_results);
+        let match_clause = &query.match_clauses[0];
+        let pg = PatternGraph::from_match_clause(match_clause);
+        let catalog = store.catalog();
+        let config = EnumerationConfig { max_candidate_plans: 64 };
+        let candidates = enumerate_plans(&pg, query.where_clause.as_ref(), catalog, &config);
+        assert!(candidates.len() >= 2, "Should have at least 2 candidate plans");
+
+        for (plan_idx, (logical_plan, cost)) in candidates.iter().enumerate() {
+            let physical = logical_to_physical(logical_plan);
+            let projections = vec![
+                (Expression::Property { variable: "a".to_string(), property: "name".to_string() }, "a.name".to_string()),
+                (Expression::Property { variable: "b".to_string(), property: "name".to_string() }, "b.name".to_string()),
+            ];
+            let mut op: OperatorBox = Box::new(super::super::operator::ProjectOperator::new(physical, projections));
+
+            let mut native_results: Vec<String> = Vec::new();
+            while let Some(record) = op.next(&store).unwrap() {
+                let a_name = record.get("a.name").map(|v| format!("{:?}", v)).unwrap_or_default();
+                let b_name = record.get("b.name").map(|v| format!("{:?}", v)).unwrap_or_default();
+                native_results.push(format!("{}->{}", a_name, b_name));
+            }
+            native_results.sort();
+
+            assert_eq!(legacy_results, native_results,
+                "Plan candidate #{} (cost={}) produces different results.\nLegacy: {:?}\nNative: {:?}",
+                plan_idx, cost, legacy_results, native_results);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix direction preservation bug in `insert_expand_into` — was hardcoding `ExpandDirection::Forward`, destroying reverse traversals
- Sort HashMap keys in plan enumerator for deterministic plan enumeration order
- Improve A/B correctness test to verify ALL candidate plans produce identical results
- Update test count (1746) and coverage stats (89.7%) in CLAUDE.md and README

## Test plan
- [x] All 1746 tests pass
- [x] `test_ab_correctness_expand` stable across multiple runs
- [x] Direction-reversed plans produce correct results