### PR TITLE
chore: add files field to TypeScript SDK for npm publish

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -4,6 +4,10 @@
   "description": "TypeScript SDK for the Samyama Graph Database",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
+  "files": [
+    "dist/src/**/*.js",
+    "dist/src/**/*.d.ts"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "node --test dist/tests/*.test.js",


### PR DESCRIPTION
## Summary

- Add `files` field to `sdk/typescript/package.json` so `dist/` compiled JS and d.ts files are included in the npm tarball
- Without this, `.gitignore` excludes `dist/` and the published package is missing its compiled output
- `samyama-sdk@0.6.0` published to npm successfully with this fix

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 5/5 tests pass
- [x] `npm publish --dry-run` shows all 9 files (4 .js + 4 .d.ts + package.json)
- [x] Published and verified: `npm view samyama-sdk`