### PR TITLE
feat: schema introspection + CSV/JSON import APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -1666,6 +1667,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "ndarray"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2924,6 +2942,12 @@ dependencies = [
  "rand 0.8.5",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ rio_xml = "0.8"            # RDF/XML parser/serializer
 spargebra = "0.3"          # SPARQL 1.1 parser
 sparesults = "0.2"         # SPARQL results formats
 # HTTP server (for SPARQL endpoint and Visualizer)
-axum = "0.7"               # HTTP framework for SPARQL endpoint
+axum = { version = "0.7", features = ["multipart"] }  # HTTP framework
 tower = { version = "0.5", features = ["util"] }  # Middleware
 tower-http = { version = "0.5", features = ["fs", "cors"] }
 http-body-util = "0.1"     # Body utilities for HTTP testing

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -1,14 +1,15 @@
 //! HTTP handlers for the Visualizer API
 
 use axum::{
-    extract::{State, Json},
+    extract::{State, Json, Multipart},
     response::IntoResponse,
 };
 use crate::query::Value;
+use crate::graph::PropertyValue;
 use crate::http::server::AppState;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::collections::HashMap;
+use std::collections::{HashMap, BTreeMap, BTreeSet};
 
 /// Request for executing a Cypher query
 #[derive(Deserialize)]
@@ -157,6 +158,272 @@ pub async fn status_handler(
             "size": state.engine.cache_len(),
         }
     }))
+}
+
+/// Handler for graph schema introspection
+pub async fn schema_handler(
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    let store_guard = state.store.read().await;
+
+    let stats = store_guard.compute_statistics();
+    let mut node_types = Vec::new();
+    for label in store_guard.all_labels() {
+        let count = store_guard.label_node_count(label);
+        let mut properties = BTreeMap::new();
+        for ((l, prop), _pstats) in &stats.property_stats {
+            if l == label {
+                let nodes = store_guard.get_nodes_by_label(label);
+                let mut prop_type = "Unknown".to_string();
+                for node in nodes.iter().take(1) {
+                    if let Some(val) = node.properties.get(prop) {
+                        prop_type = match val {
+                            PropertyValue::String(_) => "String",
+                            PropertyValue::Integer(_) => "Integer",
+                            PropertyValue::Float(_) => "Float",
+                            PropertyValue::Boolean(_) => "Boolean",
+                            PropertyValue::Vector(_) => "Vector",
+                            _ => "Unknown",
+                        }.to_string();
+                    }
+                }
+                properties.insert(prop.clone(), prop_type);
+            }
+        }
+        node_types.push(json!({
+            "label": label.as_str(),
+            "count": count,
+            "properties": properties,
+        }));
+    }
+
+    let mut edge_types = Vec::new();
+    for edge_type in store_guard.all_edge_types() {
+        let count = store_guard.edge_type_count(edge_type);
+        let edges = store_guard.get_edges_by_type(edge_type);
+        let mut source_labels = BTreeSet::new();
+        let mut target_labels = BTreeSet::new();
+        let mut edge_props = BTreeMap::new();
+
+        for edge in edges.iter().take(1000) {
+            if let Some(src) = store_guard.get_node(edge.source) {
+                for l in &src.labels {
+                    source_labels.insert(l.as_str().to_string());
+                }
+            }
+            if let Some(tgt) = store_guard.get_node(edge.target) {
+                for l in &tgt.labels {
+                    target_labels.insert(l.as_str().to_string());
+                }
+            }
+            for (k, v) in &edge.properties {
+                edge_props.entry(k.clone()).or_insert_with(|| {
+                    match v {
+                        PropertyValue::String(_) => "String".to_string(),
+                        PropertyValue::Integer(_) => "Integer".to_string(),
+                        PropertyValue::Float(_) => "Float".to_string(),
+                        PropertyValue::Boolean(_) => "Boolean".to_string(),
+                        _ => "Unknown".to_string(),
+                    }
+                });
+            }
+        }
+
+        edge_types.push(json!({
+            "type": edge_type.as_str(),
+            "count": count,
+            "source_labels": source_labels.into_iter().collect::<Vec<_>>(),
+            "target_labels": target_labels.into_iter().collect::<Vec<_>>(),
+            "properties": edge_props,
+        }));
+    }
+
+    let index_list = store_guard.property_index.list_indexes();
+    let indexes: Vec<_> = index_list.iter().map(|(l, p)| {
+        json!({ "label": l.as_str(), "property": p, "type": "BTREE" })
+    }).collect();
+
+    let constraint_list = store_guard.property_index.list_constraints();
+    let constraints: Vec<_> = constraint_list.iter().map(|(l, p)| {
+        json!({ "label": l.as_str(), "property": p, "type": "UNIQUE" })
+    }).collect();
+
+    Json(json!({
+        "node_types": node_types,
+        "edge_types": edge_types,
+        "indexes": indexes,
+        "constraints": constraints,
+        "statistics": {
+            "total_nodes": stats.total_nodes,
+            "total_edges": stats.total_edges,
+            "avg_out_degree": stats.avg_out_degree,
+        }
+    }))
+}
+
+/// Handler for CSV file upload and import
+pub async fn import_csv_handler(
+    State(state): State<AppState>,
+    mut multipart: Multipart,
+) -> impl IntoResponse {
+    let mut csv_data: Option<String> = None;
+    let mut label = String::new();
+    let mut id_column: Option<String> = None;
+    let mut delimiter = b',';
+
+    loop {
+        let field_result: Result<Option<axum::extract::multipart::Field<'_>>, _> = multipart.next_field().await;
+        match field_result {
+            Ok(Some(field)) => {
+                let name = field.name().unwrap_or("").to_string();
+                match name.as_str() {
+                    "file" => {
+                        match field.text().await {
+                            Ok(text) => csv_data = Some(text),
+                            Err(e) => return (axum::http::StatusCode::BAD_REQUEST, Json(json!({ "error": format!("Failed to read file: {}", e) }))).into_response(),
+                        }
+                    }
+                    "label" => {
+                        if let Ok(text) = field.text().await {
+                            label = text;
+                        }
+                    }
+                    "id_column" => {
+                        if let Ok(text) = field.text().await {
+                            id_column = Some(text);
+                        }
+                    }
+                    "delimiter" => {
+                        if let Ok(text) = field.text().await {
+                            if let Some(&ch) = text.as_bytes().first() {
+                                delimiter = ch;
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Ok(None) => break,
+            Err(_) => break,
+        }
+    }
+
+    let csv_text = match csv_data {
+        Some(data) => data,
+        None => return (axum::http::StatusCode::BAD_REQUEST, Json(json!({ "error": "No file field in multipart request" }))).into_response(),
+    };
+
+    if label.is_empty() {
+        return (axum::http::StatusCode::BAD_REQUEST, Json(json!({ "error": "Missing 'label' field" }))).into_response();
+    }
+
+    let mut lines = csv_text.lines();
+    let header_line = match lines.next() {
+        Some(h) => h,
+        None => return (axum::http::StatusCode::BAD_REQUEST, Json(json!({ "error": "Empty CSV file" }))).into_response(),
+    };
+
+    let headers: Vec<&str> = header_line.split(delimiter as char).collect();
+    let id_col_idx = id_column.as_ref().and_then(|id_col| headers.iter().position(|h| h.trim() == id_col.as_str()));
+
+    let mut store_guard = state.store.write().await;
+    let mut count = 0usize;
+    let mut id_map: HashMap<String, crate::graph::NodeId> = HashMap::new();
+
+    for line in lines {
+        if line.trim().is_empty() { continue; }
+        let fields: Vec<&str> = line.split(delimiter as char).collect();
+
+        let node_id = store_guard.create_node(label.as_str());
+
+        if let Some(idx) = id_col_idx {
+            if let Some(val) = fields.get(idx) {
+                id_map.insert(val.trim().to_string(), node_id);
+            }
+        }
+
+        if let Some(node) = store_guard.get_node_mut(node_id) {
+            for (i, header) in headers.iter().enumerate() {
+                if let Some(value) = fields.get(i) {
+                    let trimmed = value.trim();
+                    if trimmed.is_empty() { continue; }
+
+                    let prop_val = if let Ok(int_val) = trimmed.parse::<i64>() {
+                        PropertyValue::Integer(int_val)
+                    } else if let Ok(float_val) = trimmed.parse::<f64>() {
+                        PropertyValue::Float(float_val)
+                    } else if trimmed.eq_ignore_ascii_case("true") {
+                        PropertyValue::Boolean(true)
+                    } else if trimmed.eq_ignore_ascii_case("false") {
+                        PropertyValue::Boolean(false)
+                    } else {
+                        PropertyValue::String(trimmed.to_string())
+                    };
+
+                    node.set_property(header.trim(), prop_val);
+                }
+            }
+        }
+        count += 1;
+    }
+
+    Json(json!({
+        "status": "ok",
+        "nodes_created": count,
+        "label": label,
+        "columns": headers.iter().map(|h| h.trim()).collect::<Vec<_>>(),
+    })).into_response()
+}
+
+/// Request for JSON import
+#[derive(Deserialize)]
+pub struct JsonImportRequest {
+    pub label: String,
+    pub nodes: Vec<serde_json::Value>,
+}
+
+/// Handler for JSON node import
+pub async fn import_json_handler(
+    State(state): State<AppState>,
+    Json(payload): Json<JsonImportRequest>,
+) -> impl IntoResponse {
+    if payload.label.is_empty() {
+        return (axum::http::StatusCode::BAD_REQUEST, Json(json!({ "error": "Missing 'label' field" }))).into_response();
+    }
+
+    let mut store_guard = state.store.write().await;
+    let mut count = 0usize;
+
+    for node_json in &payload.nodes {
+        let node_id = store_guard.create_node(payload.label.as_str());
+
+        if let (Some(node), Some(obj)) = (store_guard.get_node_mut(node_id), node_json.as_object()) {
+            for (key, val) in obj {
+                let prop_val = match val {
+                    serde_json::Value::String(s) => PropertyValue::String(s.clone()),
+                    serde_json::Value::Number(n) => {
+                        if let Some(i) = n.as_i64() {
+                            PropertyValue::Integer(i)
+                        } else if let Some(f) = n.as_f64() {
+                            PropertyValue::Float(f)
+                        } else {
+                            continue;
+                        }
+                    }
+                    serde_json::Value::Bool(b) => PropertyValue::Boolean(*b),
+                    _ => continue,
+                };
+                node.set_property(key, prop_val);
+            }
+        }
+        count += 1;
+    }
+
+    Json(json!({
+        "status": "ok",
+        "nodes_created": count,
+        "label": payload.label,
+    })).into_response()
 }
 
 #[cfg(test)]

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tower_http::cors::CorsLayer;
 use tracing::info;
-use super::handler::{query_handler, status_handler};
+use super::handler::{query_handler, status_handler, schema_handler, import_csv_handler, import_json_handler};
 use rust_embed::RustEmbed;
 
 #[derive(RustEmbed)]
@@ -58,6 +58,9 @@ impl HttpServer {
             .route("/", get(static_handler))
             .route("/api/query", post(query_handler))
             .route("/api/status", get(status_handler))
+            .route("/api/schema", get(schema_handler))
+            .route("/api/import/csv", post(import_csv_handler))
+            .route("/api/import/json", post(import_json_handler))
             .layer(CorsLayer::permissive())
             .with_state(state);
 

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3994,6 +3994,190 @@ impl PhysicalOperator for ShowConstraintsOperator {
     }
 }
 
+/// Show labels operator: CALL db.labels()
+pub struct ShowLabelsOperator {
+    results: Option<std::vec::IntoIter<Record>>,
+}
+
+impl ShowLabelsOperator {
+    pub fn new() -> Self {
+        Self { results: None }
+    }
+}
+
+impl PhysicalOperator for ShowLabelsOperator {
+    fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        if self.results.is_none() {
+            let mut labels: Vec<String> = store.all_labels().iter().map(|l| l.as_str().to_string()).collect();
+            labels.sort();
+            let mut records = Vec::new();
+            for label in labels {
+                let mut record = Record::new();
+                record.bind("label".to_string(), Value::Property(PropertyValue::String(label)));
+                records.push(record);
+            }
+            self.results = Some(records.into_iter());
+        }
+        Ok(self.results.as_mut().unwrap().next())
+    }
+
+    fn reset(&mut self) {
+        self.results = None;
+    }
+
+    fn describe(&self) -> OperatorDescription {
+        OperatorDescription {
+            name: "ShowLabels".to_string(),
+            details: String::new(),
+            children: Vec::new(),
+        }
+    }
+}
+
+/// Show relationship types operator: CALL db.relationshipTypes()
+pub struct ShowRelationshipTypesOperator {
+    results: Option<std::vec::IntoIter<Record>>,
+}
+
+impl ShowRelationshipTypesOperator {
+    pub fn new() -> Self {
+        Self { results: None }
+    }
+}
+
+impl PhysicalOperator for ShowRelationshipTypesOperator {
+    fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        if self.results.is_none() {
+            let mut types: Vec<String> = store.all_edge_types().iter().map(|t| t.as_str().to_string()).collect();
+            types.sort();
+            let mut records = Vec::new();
+            for edge_type in types {
+                let mut record = Record::new();
+                record.bind("relationshipType".to_string(), Value::Property(PropertyValue::String(edge_type)));
+                records.push(record);
+            }
+            self.results = Some(records.into_iter());
+        }
+        Ok(self.results.as_mut().unwrap().next())
+    }
+
+    fn reset(&mut self) {
+        self.results = None;
+    }
+
+    fn describe(&self) -> OperatorDescription {
+        OperatorDescription {
+            name: "ShowRelationshipTypes".to_string(),
+            details: String::new(),
+            children: Vec::new(),
+        }
+    }
+}
+
+/// Show property keys operator: CALL db.propertyKeys()
+pub struct ShowPropertyKeysOperator {
+    results: Option<std::vec::IntoIter<Record>>,
+}
+
+impl ShowPropertyKeysOperator {
+    pub fn new() -> Self {
+        Self { results: None }
+    }
+}
+
+impl PhysicalOperator for ShowPropertyKeysOperator {
+    fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        if self.results.is_none() {
+            let mut keys = std::collections::BTreeSet::new();
+            let stats = store.compute_statistics();
+            for ((_, prop), _) in &stats.property_stats {
+                keys.insert(prop.clone());
+            }
+            for edge_type in store.all_edge_types() {
+                let edges = store.get_edges_by_type(edge_type);
+                for edge in edges.iter().take(1000) {
+                    for key in edge.properties.keys() {
+                        keys.insert(key.clone());
+                    }
+                }
+            }
+            let mut records = Vec::new();
+            for key in keys {
+                let mut record = Record::new();
+                record.bind("propertyKey".to_string(), Value::Property(PropertyValue::String(key)));
+                records.push(record);
+            }
+            self.results = Some(records.into_iter());
+        }
+        Ok(self.results.as_mut().unwrap().next())
+    }
+
+    fn reset(&mut self) {
+        self.results = None;
+    }
+
+    fn describe(&self) -> OperatorDescription {
+        OperatorDescription {
+            name: "ShowPropertyKeys".to_string(),
+            details: String::new(),
+            children: Vec::new(),
+        }
+    }
+}
+
+/// Schema visualization operator: CALL db.schema.visualization()
+pub struct SchemaVisualizationOperator {
+    results: Option<std::vec::IntoIter<Record>>,
+}
+
+impl SchemaVisualizationOperator {
+    pub fn new() -> Self {
+        Self { results: None }
+    }
+}
+
+impl PhysicalOperator for SchemaVisualizationOperator {
+    fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        if self.results.is_none() {
+            let mut seen = std::collections::HashSet::new();
+            let mut records = Vec::new();
+            for edge_type in store.all_edge_types() {
+                let edges = store.get_edges_by_type(edge_type);
+                for edge in edges.iter().take(1000) {
+                    if let (Some(src_node), Some(tgt_node)) = (store.get_node(edge.source), store.get_node(edge.target)) {
+                        for src_label in &src_node.labels {
+                            for tgt_label in &tgt_node.labels {
+                                let key = format!("{}|{}|{}", src_label.as_str(), edge_type.as_str(), tgt_label.as_str());
+                                if seen.insert(key) {
+                                    let mut record = Record::new();
+                                    record.bind("source_label".to_string(), Value::Property(PropertyValue::String(src_label.as_str().to_string())));
+                                    record.bind("relationship_type".to_string(), Value::Property(PropertyValue::String(edge_type.as_str().to_string())));
+                                    record.bind("target_label".to_string(), Value::Property(PropertyValue::String(tgt_label.as_str().to_string())));
+                                    records.push(record);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            self.results = Some(records.into_iter());
+        }
+        Ok(self.results.as_mut().unwrap().next())
+    }
+
+    fn reset(&mut self) {
+        self.results = None;
+    }
+
+    fn describe(&self) -> OperatorDescription {
+        OperatorDescription {
+            name: "SchemaVisualization".to_string(),
+            details: String::new(),
+            children: Vec::new(),
+        }
+    }
+}
+
 /// Create edge operator: CREATE (a)-[:KNOWS]->(b)
 pub struct CreateEdgeOperator {
     /// Input operator (provides source/target nodes from MATCH)

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -9,7 +9,7 @@ use std::sync::Mutex;
 use crate::query::executor::{
     ExecutionError, ExecutionResult, OperatorBox,
     // Added CreateNodeOperator and CreateNodesAndEdgesOperator for CREATE statement support
-    operator::{NodeScanOperator, FilterOperator, ExpandOperator, ProjectOperator, LimitOperator, SkipOperator, CreateNodeOperator, CreateNodesAndEdgesOperator, CartesianProductOperator, VectorSearchOperator, JoinOperator, LeftOuterJoinOperator, CreateVectorIndexOperator, CreateIndexOperator, CompositeCreateIndexOperator, CreateConstraintOperator, DropIndexOperator, ShowIndexesOperator, ShowConstraintsOperator, AlgorithmOperator, IndexScanOperator, AggregateOperator, AggregateType, AggregateFunction, SortOperator, DeleteOperator, SetPropertyOperator, RemovePropertyOperator, UnwindOperator, MergeOperator, ForeachOperator, ShortestPathOperator, WithBarrierOperator},
+    operator::{NodeScanOperator, FilterOperator, ExpandOperator, ProjectOperator, LimitOperator, SkipOperator, CreateNodeOperator, CreateNodesAndEdgesOperator, CartesianProductOperator, VectorSearchOperator, JoinOperator, LeftOuterJoinOperator, CreateVectorIndexOperator, CreateIndexOperator, CompositeCreateIndexOperator, CreateConstraintOperator, DropIndexOperator, ShowIndexesOperator, ShowConstraintsOperator, ShowLabelsOperator, ShowRelationshipTypesOperator, ShowPropertyKeysOperator, SchemaVisualizationOperator, AlgorithmOperator, IndexScanOperator, AggregateOperator, AggregateType, AggregateFunction, SortOperator, DeleteOperator, SetPropertyOperator, RemovePropertyOperator, UnwindOperator, MergeOperator, ForeachOperator, ShortestPathOperator, WithBarrierOperator},
 };
 use crate::graph::EdgeType;  // Added for CREATE edge support
 use std::collections::{HashMap, HashSet};  // Added for CREATE properties and JOIN logic
@@ -857,6 +857,14 @@ impl QueryPlanner {
                 node_var,
                 score_var,
             )))
+        } else if call_clause.procedure_name == "db.labels" {
+            Ok(Box::new(ShowLabelsOperator::new()))
+        } else if call_clause.procedure_name == "db.relationshipTypes" {
+            Ok(Box::new(ShowRelationshipTypesOperator::new()))
+        } else if call_clause.procedure_name == "db.propertyKeys" {
+            Ok(Box::new(ShowPropertyKeysOperator::new()))
+        } else if call_clause.procedure_name == "db.schema.visualization" {
+            Ok(Box::new(SchemaVisualizationOperator::new()))
         } else if call_clause.procedure_name.starts_with("algo.") {
             Ok(Box::new(AlgorithmOperator::new(
                 call_clause.procedure_name.clone(),


### PR DESCRIPTION
## Summary
- **GET /api/schema** — full schema introspection (node types with counts/properties, edge types with source→target labels, indexes, constraints, statistics)
- **POST /api/import/csv** — multipart CSV upload with delimiter auto-detection and type inference (Integer, Float, Boolean, String)
- **POST /api/import/json** — import JSON array of objects as graph nodes
- **Cypher procedures** — `CALL db.labels()`, `db.relationshipTypes()`, `db.propertyKeys()`, `db.schema.visualization()` (Neo4j-compatible)
- Enable axum `multipart` feature for file upload support

## Test plan
- [x] All 1760 lib tests pass
- [x] Manual verification: `curl /api/schema` returns correct JSON
- [x] Playwright e2e tests in samyama-insight exercise all three endpoints