### PR TITLE
feat: TypeScript SDK schema, explain, profile, import methods

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -58,6 +58,101 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /api/schema:
+    get:
+      operationId: getSchema
+      summary: Get graph schema
+      description: |
+        Returns the full schema of the graph database including node types with
+        property keys/types, edge types with source/target labels, indexes,
+        constraints, and basic statistics.
+      responses:
+        '200':
+          description: Graph schema
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SchemaResponse'
+
+  /api/import/csv:
+    post:
+      operationId: importCsv
+      summary: Import nodes from CSV
+      description: |
+        Upload a CSV file to create nodes. The first row is treated as column headers
+        (property names). Each subsequent row creates one node with the specified label.
+        Property types are auto-detected (integer → float → boolean → string).
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+                - label
+              properties:
+                file:
+                  type: string
+                  description: CSV file content
+                label:
+                  type: string
+                  description: Node label to assign to all created nodes
+                id_column:
+                  type: string
+                  description: Column to use as node ID mapping (optional)
+                delimiter:
+                  type: string
+                  description: "CSV delimiter character (default: ',')"
+      responses:
+        '200':
+          description: Import successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CsvImportResponse'
+        '400':
+          description: Import error (missing fields, parse error)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/import/json:
+    post:
+      operationId: importJson
+      summary: Import nodes from JSON
+      description: |
+        Create nodes from an array of JSON objects. Each object becomes one node
+        with the specified label. Object keys become property names; values must be
+        string, number, or boolean (other types are silently skipped).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JsonImportRequest'
+            example:
+              label: Person
+              nodes:
+                - name: Alice
+                  age: 30
+                - name: Bob
+                  age: 25
+      responses:
+        '200':
+          description: Import successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonImportResponse'
+        '400':
+          description: Import error (missing label, invalid data)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /api/status:
     get:
       operationId: getStatus
@@ -173,6 +268,120 @@ components:
             edges:
               type: integer
               description: Number of edges in the graph
+
+    SchemaResponse:
+      type: object
+      properties:
+        node_types:
+          type: array
+          items:
+            type: object
+            properties:
+              label:
+                type: string
+              count:
+                type: integer
+              properties:
+                type: object
+                additionalProperties:
+                  type: string
+                  description: "Property type: String, Integer, Float, Boolean, Vector, Unknown"
+        edge_types:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+              count:
+                type: integer
+              source_labels:
+                type: array
+                items:
+                  type: string
+              target_labels:
+                type: array
+                items:
+                  type: string
+              properties:
+                type: object
+                additionalProperties:
+                  type: string
+        indexes:
+          type: array
+          items:
+            type: object
+            properties:
+              label:
+                type: string
+              property:
+                type: string
+              type:
+                type: string
+        constraints:
+          type: array
+          items:
+            type: object
+            properties:
+              label:
+                type: string
+              property:
+                type: string
+              type:
+                type: string
+        statistics:
+          type: object
+          properties:
+            total_nodes:
+              type: integer
+            total_edges:
+              type: integer
+            avg_out_degree:
+              type: number
+
+    JsonImportRequest:
+      type: object
+      required:
+        - label
+        - nodes
+      properties:
+        label:
+          type: string
+          description: Node label to assign to all created nodes
+        nodes:
+          type: array
+          description: Array of JSON objects, each becoming a node
+          items:
+            type: object
+            additionalProperties: true
+
+    CsvImportResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          examples:
+            - ok
+        nodes_created:
+          type: integer
+        label:
+          type: string
+        columns:
+          type: array
+          items:
+            type: string
+
+    JsonImportResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          examples:
+            - ok
+        nodes_created:
+          type: integer
+        label:
+          type: string
 
     ErrorResponse:
       type: object

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samyama-sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "TypeScript SDK for the Samyama Graph Database",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,4 +1,11 @@
-import type { QueryResult, ServerStatus, ClientOptions } from "./types";
+import type {
+  QueryResult,
+  ServerStatus,
+  ClientOptions,
+  GraphSchema,
+  CsvImportResult,
+  JsonImportResult,
+} from "./types";
 import { HttpTransport } from "./http-client";
 
 const DEFAULT_URL = "http://localhost:8080";
@@ -16,6 +23,14 @@ const DEFAULT_URL = "http://localhost:8080";
  * // Query data
  * const result = await client.queryReadonly("MATCH (n:Person) RETURN n.name");
  * console.log(result.records);
+ *
+ * // Schema introspection
+ * const schema = await client.schema();
+ * console.log(schema.node_types);
+ *
+ * // EXPLAIN / PROFILE
+ * const plan = await client.explain("MATCH (n:Person) RETURN n");
+ * const profile = await client.profile("MATCH (n:Person) RETURN n");
  * ```
  */
 export class SamyamaClient {
@@ -44,6 +59,28 @@ export class SamyamaClient {
     return this.http.query(cypher);
   }
 
+  /**
+   * Return the EXPLAIN plan for a Cypher query without executing it.
+   * Returns the plan as text rows in the QueryResult records.
+   */
+  async explain(cypher: string): Promise<QueryResult> {
+    const prefixed = cypher.trimStart().toUpperCase().startsWith("EXPLAIN")
+      ? cypher
+      : `EXPLAIN ${cypher}`;
+    return this.http.query(prefixed);
+  }
+
+  /**
+   * Execute a Cypher query with PROFILE instrumentation.
+   * Returns plan text with actual row counts and timing per operator.
+   */
+  async profile(cypher: string): Promise<QueryResult> {
+    const prefixed = cypher.trimStart().toUpperCase().startsWith("PROFILE")
+      ? cypher
+      : `PROFILE ${cypher}`;
+    return this.http.query(prefixed);
+  }
+
   /** Delete a graph (executes MATCH (n) DELETE n) */
   async deleteGraph(_graph: string = "default"): Promise<void> {
     await this.http.query("MATCH (n) DELETE n");
@@ -57,6 +94,37 @@ export class SamyamaClient {
   /** Get server status */
   async status(): Promise<ServerStatus> {
     return this.http.status();
+  }
+
+  /** Get graph schema (node types, edge types, indexes, constraints, statistics) */
+  async schema(): Promise<GraphSchema> {
+    return this.http.schema();
+  }
+
+  /**
+   * Import nodes from CSV content.
+   * @param csvContent - Raw CSV string (first row = headers)
+   * @param label - Node label to assign
+   * @param options - Optional: idColumn, delimiter
+   */
+  async importCsv(
+    csvContent: string,
+    label: string,
+    options?: { idColumn?: string; delimiter?: string },
+  ): Promise<CsvImportResult> {
+    return this.http.importCsv(csvContent, label, options);
+  }
+
+  /**
+   * Import nodes from JSON objects.
+   * @param label - Node label to assign
+   * @param nodes - Array of objects, each becoming a node
+   */
+  async importJson(
+    label: string,
+    nodes: Record<string, unknown>[],
+  ): Promise<JsonImportResult> {
+    return this.http.importJson(label, nodes);
   }
 
   /** Ping the server */

--- a/sdk/typescript/src/http-client.ts
+++ b/sdk/typescript/src/http-client.ts
@@ -1,4 +1,11 @@
-import type { QueryResult, ServerStatus, ErrorResponse } from "./types";
+import type {
+  QueryResult,
+  ServerStatus,
+  ErrorResponse,
+  GraphSchema,
+  CsvImportResult,
+  JsonImportResult,
+} from "./types";
 
 /**
  * HTTP transport for the Samyama SDK.
@@ -38,5 +45,68 @@ export class HttpTransport {
     }
 
     return (await response.json()) as ServerStatus;
+  }
+
+  /** Get graph schema via GET /api/schema */
+  async schema(): Promise<GraphSchema> {
+    const response = await fetch(`${this.baseUrl}/api/schema`);
+
+    if (!response.ok) {
+      const body = (await response.json().catch(() => ({
+        error: `HTTP ${response.status}`,
+      }))) as ErrorResponse;
+      throw new Error(body.error || `HTTP ${response.status}`);
+    }
+
+    return (await response.json()) as GraphSchema;
+  }
+
+  /** Import nodes from CSV via POST /api/import/csv (multipart) */
+  async importCsv(
+    csvContent: string,
+    label: string,
+    options?: { idColumn?: string; delimiter?: string },
+  ): Promise<CsvImportResult> {
+    const formData = new FormData();
+    const blob = new Blob([csvContent], { type: "text/csv" });
+    formData.append("file", blob, "import.csv");
+    formData.append("label", label);
+    if (options?.idColumn) formData.append("id_column", options.idColumn);
+    if (options?.delimiter) formData.append("delimiter", options.delimiter);
+
+    const response = await fetch(`${this.baseUrl}/api/import/csv`, {
+      method: "POST",
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const body = (await response.json().catch(() => ({
+        error: `HTTP ${response.status}`,
+      }))) as ErrorResponse;
+      throw new Error(body.error || `HTTP ${response.status}`);
+    }
+
+    return (await response.json()) as CsvImportResult;
+  }
+
+  /** Import nodes from JSON via POST /api/import/json */
+  async importJson(
+    label: string,
+    nodes: Record<string, unknown>[],
+  ): Promise<JsonImportResult> {
+    const response = await fetch(`${this.baseUrl}/api/import/json`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ label, nodes }),
+    });
+
+    if (!response.ok) {
+      const body = (await response.json().catch(() => ({
+        error: `HTTP ${response.status}`,
+      }))) as ErrorResponse;
+      throw new Error(body.error || `HTTP ${response.status}`);
+    }
+
+    return (await response.json()) as JsonImportResult;
   }
 }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -7,4 +7,11 @@ export type {
   ServerStatus,
   ErrorResponse,
   ClientOptions,
+  GraphSchema,
+  NodeType,
+  EdgeType,
+  IndexInfo,
+  ConstraintInfo,
+  CsvImportResult,
+  JsonImportResult,
 } from "./types";

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -37,6 +37,64 @@ export interface ErrorResponse {
   error: string;
 }
 
+/** Node type descriptor from schema introspection */
+export interface NodeType {
+  label: string;
+  count: number;
+  properties: Record<string, string>;
+}
+
+/** Edge type descriptor from schema introspection */
+export interface EdgeType {
+  type: string;
+  count: number;
+  source_labels: string[];
+  target_labels: string[];
+  properties: Record<string, string>;
+}
+
+/** Index descriptor from schema introspection */
+export interface IndexInfo {
+  label: string;
+  property: string;
+  type: string;
+}
+
+/** Constraint descriptor from schema introspection */
+export interface ConstraintInfo {
+  label: string;
+  property: string;
+  type: string;
+}
+
+/** Graph schema returned by GET /api/schema */
+export interface GraphSchema {
+  node_types: NodeType[];
+  edge_types: EdgeType[];
+  indexes: IndexInfo[];
+  constraints: ConstraintInfo[];
+  statistics: {
+    total_nodes: number;
+    total_edges: number;
+    avg_out_degree: number;
+  };
+}
+
+/** Result of CSV import */
+export interface CsvImportResult {
+  status: string;
+  nodes_created: number;
+  label: string;
+  columns: string[];
+}
+
+/** Result of JSON import */
+export interface JsonImportResult {
+  status: string;
+  nodes_created: number;
+  label: string;
+}
+
 /** Options for creating a client */
 export interface ClientOptions {
   /** Base URL for HTTP transport (default: http://localhost:8080) */

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -1,7 +1,17 @@
 import { describe, it } from "node:test";
 import * as assert from "node:assert/strict";
 import { SamyamaClient, HttpTransport } from "../src/index";
-import type { QueryResult, ServerStatus } from "../src/index";
+import type {
+  QueryResult,
+  ServerStatus,
+  GraphSchema,
+  NodeType,
+  EdgeType,
+  IndexInfo,
+  ConstraintInfo,
+  CsvImportResult,
+  JsonImportResult,
+} from "../src/index";
 
 describe("SamyamaClient", () => {
   it("should create a client with default URL", () => {
@@ -19,6 +29,31 @@ describe("SamyamaClient", () => {
     const graphs = await client.listGraphs();
     assert.deepEqual(graphs, ["default"]);
   });
+
+  it("should have explain method", () => {
+    const client = new SamyamaClient();
+    assert.equal(typeof client.explain, "function");
+  });
+
+  it("should have profile method", () => {
+    const client = new SamyamaClient();
+    assert.equal(typeof client.profile, "function");
+  });
+
+  it("should have schema method", () => {
+    const client = new SamyamaClient();
+    assert.equal(typeof client.schema, "function");
+  });
+
+  it("should have importCsv method", () => {
+    const client = new SamyamaClient();
+    assert.equal(typeof client.importCsv, "function");
+  });
+
+  it("should have importJson method", () => {
+    const client = new SamyamaClient();
+    assert.equal(typeof client.importJson, "function");
+  });
 });
 
 describe("HttpTransport", () => {
@@ -30,5 +65,55 @@ describe("HttpTransport", () => {
   it("should strip trailing slashes from URL", () => {
     const transport = new HttpTransport("http://localhost:8080///");
     assert.ok(transport);
+  });
+
+  it("should have schema method", () => {
+    const transport = new HttpTransport("http://localhost:8080");
+    assert.equal(typeof transport.schema, "function");
+  });
+
+  it("should have importCsv method", () => {
+    const transport = new HttpTransport("http://localhost:8080");
+    assert.equal(typeof transport.importCsv, "function");
+  });
+
+  it("should have importJson method", () => {
+    const transport = new HttpTransport("http://localhost:8080");
+    assert.equal(typeof transport.importJson, "function");
+  });
+});
+
+describe("Types", () => {
+  it("should allow constructing GraphSchema objects", () => {
+    const schema: GraphSchema = {
+      node_types: [{ label: "Person", count: 10, properties: { name: "String" } }],
+      edge_types: [{ type: "KNOWS", count: 5, source_labels: ["Person"], target_labels: ["Person"], properties: {} }],
+      indexes: [{ label: "Person", property: "name", type: "BTREE" }],
+      constraints: [{ label: "Person", property: "email", type: "UNIQUE" }],
+      statistics: { total_nodes: 10, total_edges: 5, avg_out_degree: 0.5 },
+    };
+    assert.equal(schema.node_types.length, 1);
+    assert.equal(schema.edge_types[0].type, "KNOWS");
+    assert.equal(schema.indexes[0].type, "BTREE");
+    assert.equal(schema.constraints[0].type, "UNIQUE");
+  });
+
+  it("should allow constructing CsvImportResult objects", () => {
+    const result: CsvImportResult = {
+      status: "ok",
+      nodes_created: 5,
+      label: "Person",
+      columns: ["name", "age"],
+    };
+    assert.equal(result.nodes_created, 5);
+  });
+
+  it("should allow constructing JsonImportResult objects", () => {
+    const result: JsonImportResult = {
+      status: "ok",
+      nodes_created: 3,
+      label: "City",
+    };
+    assert.equal(result.nodes_created, 3);
   });
 });


### PR DESCRIPTION
## Summary
- **SK-10**: Add `explain(cypher)` and `profile(cypher)` methods to `SamyamaClient`
- **SK-11**: Add `schema()`, `importCsv()`, `importJson()` methods with full type definitions
- **SK-05**: Update OpenAPI spec with 3 new endpoints (`/api/schema`, `/api/import/csv`, `/api/import/json`)
- Published as `samyama-sdk@0.6.1` on npm
- 16 unit tests (up from 5)

## Test plan
- [x] `npx tsc` — clean build
- [x] `node --test` — 16/16 tests pass
- [x] Published to npm and verified in samyama-insight