### PR TITLE
docs: add educational code-level documentation

### DIFF
--- a/src/graph/edge.rs
+++ b/src/graph/edge.rs
@@ -1,6 +1,37 @@
-//! Edge implementation for property graph
+//! # Edge Implementation -- Directed, Typed Relationships in a Multigraph
 //!
-//! Implements:
+//! An [`Edge`] represents a **directed relationship** between two nodes. In graph
+//! theory, a directed edge (also called an *arc*) `(u, v)` is distinct from `(v, u)` --
+//! the edge has a source and a target, establishing an asymmetric relationship.
+//! For example, `(Alice)-[:FOLLOWS]->(Bob)` does not imply `(Bob)-[:FOLLOWS]->(Alice)`.
+//!
+//! ## Edge types as first-class citizens
+//!
+//! Every edge carries an [`EdgeType`] (e.g., `"KNOWS"`,
+//! `"WORKS_AT"`, `"PURCHASED"`) that classifies the relationship. This is analogous
+//! to labels on nodes but for relationships. The type is used by the query engine
+//! to filter traversals: `MATCH (a)-[:KNOWS]->(b)` only follows edges of type `KNOWS`.
+//! Edge types are indexed in [`GraphStore`](super::store::GraphStore) via a secondary
+//! `HashMap<EdgeType, HashSet<EdgeId>>` for fast type-filtered scans.
+//!
+//! ## Multigraph semantics
+//!
+//! Samyama supports **multigraphs**: multiple edges can exist between the same pair
+//! of nodes, even with the same type. This contrasts with a **simple graph**, which
+//! allows at most one edge between any pair. Multigraph support is essential for
+//! real-world modeling -- for instance, a person may have multiple financial
+//! transactions with the same counterparty, or multiple flights between the same
+//! airports. Each edge has a unique [`EdgeId`], so they remain
+//! individually addressable.
+//!
+//! ## MVCC and identity
+//!
+//! Like nodes, edges carry a `version: u64` for MVCC concurrency control, and
+//! `PartialEq`/`Hash` are defined on `id` alone -- two edges with the same ID
+//! are considered equal regardless of other fields.
+//!
+//! ## Requirements coverage
+//!
 //! - REQ-GRAPH-003: Edges with types
 //! - REQ-GRAPH-004: Properties on edges
 //! - REQ-GRAPH-007: Directed edges

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -1,10 +1,56 @@
-//! Core graph database implementation
+//! # Property Graph Model -- Core Graph Database Implementation
 //!
-//! This module implements the property graph data model with:
-//! - Nodes with multiple labels and properties (REQ-GRAPH-001 through REQ-GRAPH-006)
-//! - Directed edges with types and properties (REQ-GRAPH-003, REQ-GRAPH-007)
-//! - Multiple edges between same nodes (REQ-GRAPH-008)
-//! - In-memory storage with hash-based indices (REQ-MEM-001, REQ-MEM-003)
+//! This module implements the **property graph data model**, the most expressive
+//! of the three major graph data models used in practice.
+//!
+//! ## What is a property graph?
+//!
+//! A property graph consists of:
+//! - **Nodes** (vertices) that carry zero or more **labels** (e.g., `:Person`, `:Employee`)
+//!   and a set of key-value **properties** (e.g., `name: "Alice"`, `age: 30`).
+//! - **Edges** (relationships) that are **directed**, carry exactly one **type**
+//!   (e.g., `:KNOWS`, `:WORKS_AT`), and may also carry properties
+//!   (e.g., `since: 2020`, `strength: 0.95`).
+//! - Multiple edges may exist between the same pair of nodes (a **multigraph**),
+//!   even with the same type -- this is essential for modeling real-world data
+//!   where, for instance, two people can have multiple distinct interactions.
+//!
+//! ## How does this differ from a relational database?
+//!
+//! In an RDBMS, relationships are represented via foreign keys and resolved at
+//! query time through **JOIN operations**, which become increasingly expensive
+//! as the number of hops grows (each hop is another JOIN). A property graph
+//! stores relationships as first-class objects with direct pointers between
+//! adjacent nodes (**index-free adjacency**), making multi-hop traversals O(k)
+//! where k is the number of edges traversed -- independent of total graph size.
+//!
+//! ## How does this differ from RDF triple stores?
+//!
+//! RDF models data as (subject, predicate, object) triples -- a simpler but
+//! less expressive model. RDF edges cannot carry properties (you need
+//! **reification** to attach metadata to a relationship, which is verbose and
+//! breaks query ergonomics). RDF also lacks the concept of node identity beyond
+//! URIs, and has no native multi-label support. The property graph model trades
+//! RDF's global-web-of-data orientation for richer local modeling, which is why
+//! most application-facing graph databases (Neo4j, TigerGraph, Samyama) choose it.
+//!
+//! ## Rust patterns used in this module
+//!
+//! - **Newtype wrappers** ([`NodeId`], [`EdgeId`], [`Label`], [`EdgeType`]):
+//!   wrap `u64` or `String` in single-field structs for compile-time type safety
+//!   at zero runtime cost (see [`types`]).
+//! - **Algebraic data types**: [`PropertyValue`] is a Rust `enum` (tagged union)
+//!   whose variants carry different payload types, with exhaustive `match`
+//!   enforced by the compiler (see [`property`]).
+//! - **HashMap-based indices**: secondary indices in [`GraphStore`] map labels
+//!   and edge types to entity sets for O(1) filtered lookups (see [`store`]).
+//!
+//! ## Requirements coverage
+//!
+//! - REQ-GRAPH-001 through REQ-GRAPH-006: property graph data model
+//! - REQ-GRAPH-007: directed edges
+//! - REQ-GRAPH-008: multiple edges between same nodes
+//! - REQ-MEM-001, REQ-MEM-003: in-memory storage with optimized data structures
 
 pub mod catalog;
 pub mod edge;

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -1,6 +1,38 @@
-//! Node implementation for property graph
+//! # Node Implementation -- Multi-Label Vertices with MVCC Versioning
 //!
-//! Implements:
+//! A [`Node`] is the fundamental entity in the property graph. Unlike a row in a
+//! relational database -- which belongs to exactly one table -- a graph node can
+//! carry **multiple labels** simultaneously (e.g., a node can be both `:Person`
+//! and `:Employee`). This is stored as a `HashSet<Label>`, giving O(1)
+//! membership checks when the query engine filters by label.
+//!
+//! ## Schema-free properties
+//!
+//! Each node owns a [`PropertyMap`] (`HashMap<String, PropertyValue>`) that acts
+//! as a schema-free attribute store. Any node can have any set of properties
+//! regardless of its labels -- there is no rigid column schema to satisfy. This
+//! flexibility is one of the key advantages of graph databases over RDBMS for
+//! heterogeneous, evolving data models.
+//!
+//! ## MVCC (Multi-Version Concurrency Control)
+//!
+//! Each node carries a `version: u64` field that is incremented on mutation.
+//! In the storage layer ([`GraphStore`](super::store::GraphStore)), nodes are
+//! stored in a `Vec<Vec<Node>>` arena where the inner `Vec` holds successive
+//! versions of the same node. This enables **snapshot isolation**: a reader
+//! operating at version V sees only node versions <= V, and is never blocked by
+//! a concurrent writer creating version V+1. MVCC is the same concurrency
+//! strategy used by PostgreSQL, Oracle, and most modern databases.
+//!
+//! ## Identity semantics
+//!
+//! `PartialEq` and `Hash` are implemented on `id` alone (not properties or
+//! labels). Two `Node` values with the same `NodeId` are considered equal
+//! regardless of their other fields -- this is consistent with graph database
+//! semantics where identity is determined by the node's unique identifier.
+//!
+//! ## Requirements coverage
+//!
 //! - REQ-GRAPH-002: Nodes with labels
 //! - REQ-GRAPH-004: Properties on nodes
 //! - REQ-GRAPH-006: Multiple labels per node

--- a/src/graph/property.rs
+++ b/src/graph/property.rs
@@ -1,4 +1,63 @@
-//! Property value types for graph nodes and edges
+//! # Property Value Types -- Schema-Free, Dynamically Typed Properties
+//!
+//! This module defines [`PropertyValue`], the dynamic type system that allows
+//! nodes and edges to carry arbitrary key-value properties without a fixed schema.
+//!
+//! ## Type systems in databases
+//!
+//! Relational databases enforce a rigid schema: every row in a table must have
+//! the same columns with the same types. Graph databases take a **schema-free**
+//! (or schema-optional) approach -- any node can have any set of properties,
+//! and two nodes with the same label may have entirely different property keys.
+//! This flexibility is modeled in Rust via an `enum` (algebraic data type) where
+//! each variant represents a different value type.
+//!
+//! ## Algebraic data types (tagged unions)
+//!
+//! Rust's `enum` is a **tagged union** (also called a *sum type* or *discriminated
+//! union*). Unlike C's `union`, which is unsafe because the programmer must track
+//! which variant is active, Rust's enum carries a hidden discriminant tag and the
+//! compiler enforces exhaustive `match` -- you cannot forget to handle a variant.
+//! This makes `PropertyValue` both type-safe and extensible: adding a new variant
+//! (e.g., `Duration`) causes a compiler error at every unhandled `match` site.
+//!
+//! ## Three-valued logic (3VL) and NULL semantics
+//!
+//! The `Null` variant follows SQL/Cypher NULL semantics, which implement
+//! **three-valued logic**: NULL represents an *unknown* value, not an *empty* one.
+//! Under 3VL, `NULL = NULL` evaluates to NULL (not `true`), `NULL <> 5` evaluates
+//! to NULL (not `true`), and `NULL AND true` evaluates to NULL. This propagation
+//! of unknowns through expressions is critical for correct query evaluation and
+//! is one of the most common sources of bugs in database applications.
+//!
+//! ## Type coercion
+//!
+//! The query engine performs **implicit type coercion** (widening) when comparing
+//! values of different numeric types: an `Integer(i64)` is promoted to `Float(f64)`
+//! for comparison with a `Float`. String-to-number and boolean conversions are
+//! also supported via explicit functions (`toInteger()`, `toFloat()`, `toString()`).
+//! This mirrors the behavior of OpenCypher and SQL CAST operations.
+//!
+//! ## `PartialOrd` vs `Ord`
+//!
+//! IEEE 754 floating-point numbers are only `PartialOrd` because `NaN != NaN`
+//! and `NaN` is incomparable with every value. However, databases need a **total
+//! ordering** for `ORDER BY` and indexing. This module implements `Ord` by using
+//! `f64::total_cmp()`, which defines a total order where `-0.0 < +0.0` and `NaN`
+//! sorts after all other values. `PartialOrd` delegates to `Ord` so the two are
+//! always consistent.
+//!
+//! ## Hashing floats (`Hash` for `f64`)
+//!
+//! Hashing floating-point values is notoriously tricky because IEEE 754 has
+//! multiple bit representations for the same logical value (`+0.0` and `-0.0`
+//! compare equal but have different bits, while `NaN != NaN` but may have
+//! identical bits). The `to_bits()` approach used here converts the `f64` to
+//! its raw `u64` bit pattern and hashes that. This is correct for use with our
+//! `Eq` implementation (derived `PartialEq` compares variant-by-variant) because
+//! we treat each bit pattern as distinct. The discriminant tag (0, 1, 2, ...)
+//! hashed before each value prevents cross-type collisions (e.g., `Integer(42)`
+//! vs `String("42")`).
 //!
 //! Implements REQ-GRAPH-005: Support for multiple property data types
 
@@ -16,9 +75,9 @@ use std::cmp::Ordering;
 /// - Float (f64)
 /// - Boolean
 /// - DateTime (as i64 timestamp)
-/// - Array (Vec<PropertyValue>)
+/// - Array (`Vec<PropertyValue>`)
 /// - Map (HashMap<String, PropertyValue>)
-/// - Vector (Vec<f32>) for AI/Vector search
+/// - Vector (`Vec<f32>`) for AI/Vector search
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum PropertyValue {
     String(String),

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -1,6 +1,78 @@
-//! In-memory graph storage implementation
+//! # In-Memory Graph Storage -- Adjacency Lists, Indices, and Statistics
 //!
-//! Implements:
+//! [`GraphStore`] is the central data structure of the Samyama graph engine. It
+//! holds all nodes, edges, indices, and metadata in memory, optimized for the
+//! access patterns of a graph query engine.
+//!
+//! ## Why adjacency lists, not adjacency matrices?
+//!
+//! An adjacency matrix for V vertices requires O(V^2) space and O(V) time to
+//! find a node's neighbors. Real-world graphs are overwhelmingly **sparse** --
+//! a social network with 1 million users might have 100 million edges, but a
+//! matrix would need 10^12 cells. Adjacency lists use O(V + E) space and give
+//! O(degree) neighbor iteration -- a far better fit.
+//!
+//! ## Arena allocation with MVCC versioning
+//!
+//! Nodes and edges are stored in `Vec<Vec<T>>` structures (arena allocation).
+//! The outer `Vec` is indexed by entity ID (acting as a dense array), and the
+//! inner `Vec` holds successive **MVCC versions** of that entity. This layout
+//! gives O(1) lookup by ID (direct indexing, no hash computation), excellent
+//! cache locality for sequential scans, and natural support for snapshot reads
+//! at any historical version. This is similar to how PostgreSQL stores tuple
+//! versions in heap pages, but without the overhead of disk I/O.
+//!
+//! ## Sorted adjacency lists and `edge_between()`
+//!
+//! The `outgoing` and `incoming` adjacency lists store `Vec<(NodeId, EdgeId)>`
+//! tuples **sorted by NodeId**. This enables `edge_between(a, b)` to use
+//! **binary search** with O(log d) complexity (where d = degree of the node),
+//! which is critical for the `ExpandIntoOperator` that checks edge existence
+//! between two already-bound nodes in triangle-pattern queries.
+//!
+//! ## Secondary indices: label and edge-type
+//!
+//! `label_index: HashMap<Label, HashSet<NodeId>>` and
+//! `edge_type_index: HashMap<EdgeType, HashSet<EdgeId>>` act as secondary
+//! indices, analogous to B-tree indices in an RDBMS. When a Cypher query
+//! specifies `MATCH (n:Person)`, the engine looks up the `Person` entry in
+//! `label_index` and scans only matching nodes, avoiding a full table scan.
+//! We use `HashMap` (not `BTreeMap`) because we only need equality lookups
+//! on labels, not range scans.
+//!
+//! ## ColumnStore integration (late materialization)
+//!
+//! `node_columns` and `edge_columns` provide **columnar storage** for
+//! frequently accessed properties. In the traditional row store (`PropertyMap`
+//! on each node), reading one property from 1000 nodes touches 1000 scattered
+//! `HashMap`s. The columnar store groups all values of the same property
+//! contiguously, enabling vectorized reads and better CPU cache utilization.
+//! The query engine uses **late materialization**: scan operators produce
+//! lightweight `Value::NodeRef(id)` references instead of cloning full nodes,
+//! and properties are resolved on demand from the column store.
+//!
+//! ## GraphStatistics for cost-based optimization
+//!
+//! The query planner uses [`GraphStatistics`] to estimate the cardinality
+//! (number of rows) at each stage of a query plan, choosing the plan with
+//! the lowest estimated cost. See the struct documentation for details.
+//!
+//! ## Key Rust patterns
+//!
+//! - **`Vec<Vec<T>>` arena**: dense ID-indexed storage avoids HashMap overhead;
+//!   inner Vec holds MVCC versions.
+//! - **`HashMap` vs `BTreeMap`**: `HashMap` is used for indices because we need
+//!   O(1) point lookups (label equality), not ordered iteration. `BTreeMap`
+//!   would add an unnecessary O(log n) factor.
+//! - **`Arc`**: `vector_index` and `property_index` are wrapped in `Arc`
+//!   (atomic reference counting) for shared ownership across the query engine
+//!   and background index-maintenance tasks.
+//! - **`thiserror`**: the [`GraphError`] enum uses the `thiserror` crate's
+//!   derive macro to auto-generate `Display` and `Error` implementations,
+//!   reducing boilerplate for error types.
+//!
+//! ## Requirements coverage
+//!
 //! - REQ-GRAPH-001: Property graph data model
 //! - REQ-MEM-001: In-memory storage
 //! - REQ-MEM-003: Memory-optimized data structures
@@ -63,7 +135,35 @@ pub enum GraphError {
 
 pub type GraphResult<T> = Result<T, GraphError>;
 
-/// Statistics about graph contents for cost-based query optimization
+/// Statistics about graph contents for **cost-based query optimization**.
+///
+/// # What is cardinality estimation?
+///
+/// Every query plan is a tree of operators (scan, filter, join, sort, ...).
+/// The query planner must choose among many possible orderings of these
+/// operators. To compare plans, it estimates the **cardinality** (number of
+/// rows) flowing through each operator. For example, if `:Person` has 10,000
+/// nodes and `:Company` has 500, the planner should scan `:Company` first in
+/// a join -- fewer rows means less work at every subsequent stage.
+///
+/// # How selectivity works
+///
+/// **Selectivity** is the probability that a predicate evaluates to `true`
+/// for a randomly chosen row. A selectivity of 0.01 on a 10,000-row scan
+/// means the filter will pass approximately 100 rows. Selectivity is
+/// estimated as `1 / distinct_count` for equality predicates (assuming a
+/// uniform distribution). The `null_fraction` is subtracted before
+/// estimation because NULL values never match equality predicates.
+///
+/// # Sampling approach for property stats
+///
+/// Computing exact statistics for every property on every label would be
+/// expensive in a large graph. Instead, `compute_statistics()` samples the
+/// first 1,000 nodes per label and extrapolates `distinct_count`,
+/// `null_fraction`, and `selectivity`. This is similar to PostgreSQL's
+/// `ANALYZE` command, which samples a configurable fraction of each table.
+/// The trade-off is speed vs. accuracy -- sampling may miss rare values,
+/// but is sufficient for plan selection in practice.
 #[derive(Debug, Clone)]
 pub struct GraphStatistics {
     /// Total number of nodes
@@ -136,14 +236,29 @@ impl GraphStatistics {
     }
 }
 
-/// In-memory graph storage
+/// In-memory graph storage engine.
 ///
-/// Uses hash maps for O(1) lookup performance:
-/// - nodes: NodeId -> Node
-/// - edges: EdgeId -> Edge
-/// - outgoing: NodeId -> Vec<EdgeId> (adjacency list for outgoing edges)
-/// - incoming: NodeId -> Vec<EdgeId> (adjacency list for incoming edges)
-/// - label_index: Label -> Vec<NodeId> (index for fast label lookups)
+/// `GraphStore` is the authoritative source of truth for all graph data.
+/// Its data structure layout is designed for the access patterns of a
+/// Cypher query engine:
+///
+/// | Field | Type | Purpose | Lookup cost |
+/// |---|---|---|---|
+/// | `nodes` | `Vec<Vec<Node>>` | Arena-allocated node versions, indexed by `NodeId` | O(1) |
+/// | `edges` | `Vec<Vec<Edge>>` | Arena-allocated edge versions, indexed by `EdgeId` | O(1) |
+/// | `outgoing` | `Vec<Vec<(NodeId, EdgeId)>>` | Sorted adjacency list per node (outgoing) | O(log d) binary search |
+/// | `incoming` | `Vec<Vec<(NodeId, EdgeId)>>` | Sorted adjacency list per node (incoming) | O(log d) binary search |
+/// | `label_index` | `HashMap<Label, HashSet<NodeId>>` | Secondary index: label -> node set | O(1) lookup, O(n) scan |
+/// | `edge_type_index` | `HashMap<EdgeType, HashSet<EdgeId>>` | Secondary index: type -> edge set | O(1) lookup, O(n) scan |
+/// | `node_columns` | `ColumnStore` | Columnar property storage for late materialization | O(1) per cell |
+/// | `catalog` | `GraphCatalog` | Triple-level statistics for graph-native planning (ADR-015) | O(1) |
+///
+/// The `free_node_ids` / `free_edge_ids` vectors enable **ID reuse** after
+/// deletions, avoiding unbounded growth of the arena vectors.
+///
+/// Thread safety: `GraphStore` is not `Sync` by itself. Concurrent access
+/// is managed by the server layer, which wraps it in `Arc<RwLock<GraphStore>>`
+/// for shared-nothing read parallelism with exclusive write access.
 #[derive(Debug)]
 pub struct GraphStore {
     /// Node storage (Arena with versioning: NodeId -> [Versions])

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -1,4 +1,36 @@
-//! Core type definitions for the graph database
+//! # Core Type Definitions -- Newtype Wrappers for Type Safety
+//!
+//! This module defines the fundamental identifier and label types used throughout
+//! the graph engine. Every type here follows Rust's **newtype pattern**: wrapping
+//! a primitive (`u64` for identifiers, `String` for names) in a single-field
+//! tuple struct.
+//!
+//! ## The newtype pattern
+//!
+//! Without newtypes, a function signature like `fn create_edge(u64, u64, u64)`
+//! is ambiguous -- which argument is the edge ID, which is the source, which is
+//! the target? Newtypes make the compiler reject `create_edge(edge_id, target, source)`
+//! when the signature expects `(EdgeId, NodeId, NodeId)`. This is a **zero-cost
+//! abstraction**: the Rust compiler erases the wrapper at compile time, generating
+//! the same machine code as if you had used raw `u64` values directly.
+//!
+//! ## `Display` vs `Debug`
+//!
+//! Each type implements both traits, serving different audiences:
+//! - [`Display`](std::fmt::Display) (`{}`) produces user-facing output
+//!   (e.g., `"NodeId(42)"`), used in error messages and query results.
+//! - [`Debug`](std::fmt::Debug) (`{:?}`) produces programmer-facing output
+//!   with full structural detail, used in logs, test failures, and `dbg!()`.
+//!
+//! The `#[derive(Debug)]` attribute auto-generates `Debug`; we implement
+//! `Display` manually to control the format.
+//!
+//! ## Derived traits
+//!
+//! All types derive `Clone`, `Copy` (identifiers are trivially copyable since
+//! they are just `u64`), `PartialEq`, `Eq`, `Hash` (for use as `HashMap` keys),
+//! `PartialOrd`, `Ord` (for sorted adjacency lists and `BTreeMap` usage),
+//! and `Serialize`/`Deserialize` (for persistence and network transport).
 
 use serde::{Deserialize, Serialize};
 use std::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,68 +1,89 @@
-//! Samyama Graph Database
+//! # Samyama Graph Database
 //!
-//! A high-performance, distributed graph database with OpenCypher query support,
-//! Redis protocol compatibility, and multi-tenancy.
+//! A high-performance graph database written in Rust with ~90% OpenCypher query support,
+//! RESP (Redis protocol) compatibility, multi-tenancy, HNSW vector search, natural language
+//! queries, and graph algorithms. Currently at v0.6.0.
 //!
-//! # Architecture
+//! ## How a Graph Database Works
 //!
-//! This implementation follows the Architecture Decision Records (ADRs):
-//! - ADR-001: Rust for memory safety and performance
-//! - ADR-002: RocksDB for persistence (future)
-//! - ADR-003: RESP protocol for Redis compatibility (future)
-//! - ADR-005: Cap'n Proto for serialization (future)
-//! - ADR-006: Tokio for async runtime (future)
+//! Unlike relational databases (PostgreSQL, MySQL) that store data in tables with rows and
+//! columns, a graph database stores data as **nodes** (entities) and **edges** (relationships).
+//! This model is natural for connected data: social networks, knowledge graphs, fraud detection.
 //!
-//! # Requirements Implemented
+//! ```text
+//! Relational:                          Graph:
+//! ┌──────────┐  ┌──────────────┐       (Alice)──KNOWS──>(Bob)
+//! │ persons  │  │ friendships  │          │                │
+//! │──────────│  │──────────────│       WORKS_AT        WORKS_AT
+//! │ id│ name │  │ from │ to   │          │                │
+//! │ 1 │Alice │  │  1   │  2   │       (Acme)           (Globex)
+//! │ 2 │ Bob  │  │  2   │  3   │
+//! └──────────┘  └──────────────┘
+//! ```
 //!
-//! ## Phase 1 - Core Features (Current)
+//! The key advantage: traversing relationships is O(1) per hop (follow a pointer) instead of
+//! O(n log n) per JOIN in SQL. This is called **index-free adjacency**.
 //!
-//! - ✅ REQ-GRAPH-001: Property graph data model
-//! - ✅ REQ-GRAPH-002: Nodes with labels
-//! - ✅ REQ-GRAPH-003: Edges with types
-//! - ✅ REQ-GRAPH-004: Properties on nodes and edges
-//! - ✅ REQ-GRAPH-005: Multiple property data types
-//! - ✅ REQ-GRAPH-006: Multiple labels per node
-//! - ✅ REQ-GRAPH-007: Directed edges
-//! - ✅ REQ-GRAPH-008: Multiple edges between nodes
-//! - ✅ REQ-MEM-001: In-memory storage
-//! - ✅ REQ-MEM-003: Memory-optimized data structures
+//! ## Architecture Overview
 //!
-//! ## Phase 2 - Query Engine & RESP Protocol (Current)
+//! ```text
+//! ┌─────────────────────────────────────────────────────────┐
+//! │                    Client Layer                         │
+//! │   RESP (Redis)         HTTP/REST         SDK (Rust/TS)  │
+//! ├─────────────────────────────────────────────────────────┤
+//! │                  Query Pipeline                         │
+//! │   Cypher Text ──> PEG Parser ──> AST ──> Planner ──>   │
+//! │   ──> Physical Operators (Volcano Model) ──> Results   │
+//! ├─────────────────────────────────────────────────────────┤
+//! │                  Storage Layer                          │
+//! │   In-Memory GraphStore    RocksDB Persistence    WAL   │
+//! │   Vec<Vec<Node>> arena    Column families        fsync  │
+//! │   Adjacency lists         Tenant isolation       CRC32  │
+//! ├─────────────────────────────────────────────────────────┤
+//! │                  Extensions                             │
+//! │   HNSW Vector Search   Graph Algorithms   NLQ (LLM)    │
+//! │   Raft Consensus       Multi-Tenancy      Agentic AI   │
+//! └─────────────────────────────────────────────────────────┘
+//! ```
 //!
-//! - ✅ REQ-CYPHER-001: OpenCypher query language
-//! - ✅ REQ-CYPHER-002: Pattern matching
-//! - ✅ REQ-CYPHER-007: WHERE clauses
-//! - ✅ REQ-CYPHER-008: ORDER BY and LIMIT
-//! - ✅ REQ-CYPHER-009: Query optimization
-//! - ✅ REQ-REDIS-001: RESP protocol implementation
-//! - ✅ REQ-REDIS-002: Redis client connections
-//! - ✅ REQ-REDIS-004: Redis-compatible graph commands
-//! - ✅ REQ-REDIS-006: Redis client library compatibility
+//! ## Key Design Decisions (ADRs)
 //!
-//! ## Phase 3 - Persistence & Multi-Tenancy (Complete)
+//! - **ADR-007 Volcano Iterator Model**: query operators are lazy, pull-based iterators.
+//!   Each operator's `next()` pulls one record at a time from its child — composable and
+//!   memory-efficient (no intermediate materialization).
+//! - **ADR-012 Late Materialization**: scan operators produce `NodeRef(id)` (8 bytes) instead
+//!   of cloning full nodes. Properties are resolved on-demand. This reduces memory bandwidth
+//!   during traversals by ~60%.
+//! - **ADR-013 Atomic Keyword Rules**: PEG grammar uses atomic rules (`@{}`) for keywords
+//!   to prevent implicit whitespace consumption before word-boundary checks.
+//! - **ADR-015 Graph-Native Planning**: cost-based query optimizer using triple-level statistics
+//!   for cardinality estimation and join ordering.
 //!
-//! - ✅ REQ-PERSIST-001: RocksDB persistence
-//! - ✅ REQ-PERSIST-002: Write-Ahead Logging
-//! - ✅ REQ-TENANT-001 through REQ-TENANT-008: Multi-tenancy with resource quotas
+//! ## Modules
 //!
-//! ## Phase 4 - High Availability (Complete)
+//! | Module | Purpose |
+//! |--------|---------|
+//! | [`graph`] | Property graph data model (nodes, edges, properties, adjacency lists) |
+//! | [`query`] | OpenCypher parser, AST, planner, and Volcano execution engine |
+//! | [`protocol`] | RESP (Redis) wire protocol for client compatibility |
+//! | [`persistence`] | RocksDB storage, WAL, and multi-tenant isolation |
+//! | [`raft`] | Raft consensus for high availability (leader election, log replication) |
+//! | [`vector`] | HNSW approximate nearest neighbor search for vector embeddings |
+//! | [`algo`] | Graph algorithms (PageRank, WCC, SCC, BFS, Dijkstra, etc.) |
+//! | [`nlq`] | Natural language to Cypher translation via LLM providers |
+//! | [`agent`] | Agentic AI enrichment (GAK: Generation-Augmented Knowledge) |
+//! | [`rdf`] | RDF triple store (foundation for SPARQL support) |
 //!
-//! - ✅ REQ-HA-001: Raft consensus protocol
-//! - ✅ REQ-HA-002: Leader election and automatic failover
-//! - ✅ REQ-HA-003: Log replication across cluster nodes
-//! - ✅ REQ-HA-004: Cluster membership management
+//! ## Rust Concepts Used Throughout
 //!
-//! ## Phase 5 - RDF/SPARQL Support (Foundation)
-//!
-//! - ✅ REQ-RDF-001: RDF data model (triples/quads)
-//! - ✅ REQ-RDF-002: RDF triple store with indexing
-//! - ✅ REQ-RDF-004: Named graphs support
-//! - 🚧 REQ-RDF-003: RDF serialization formats (Turtle, RDF/XML, N-Triples, JSON-LD)
-//! - 🚧 REQ-RDF-005: RDFS reasoning
-//! - 🚧 REQ-RDF-006: Property graph ↔ RDF mapping
-//! - 🚧 REQ-SPARQL-001: SPARQL 1.1 query language
-//! - 🚧 REQ-SPARQL-002: SPARQL HTTP protocol
-//! - 🚧 REQ-SPARQL-003: Query forms (SELECT, CONSTRUCT, ASK, DESCRIBE)
+//! - **Ownership & Borrowing**: `QueryExecutor<'a>` borrows `&'a GraphStore` — the compiler
+//!   guarantees no data races without runtime locks for read-only queries.
+//! - **Algebraic Data Types**: `PropertyValue` enum (tagged union) with exhaustive `match` —
+//!   the compiler ensures every variant is handled.
+//! - **Trait Objects**: `Box<dyn PhysicalOperator>` for runtime polymorphism in the operator tree.
+//! - **Zero-Cost Abstractions**: newtype wrappers (`NodeId(u64)`) provide type safety with no
+//!   runtime overhead.
+//! - **Error Handling**: `thiserror` for library errors, `Result<T, E>` instead of exceptions.
 //!
 //! ## Example Usage
 //!

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -1,9 +1,40 @@
-//! Persistence layer for Samyama Graph Database
+//! # Persistence Layer
 //!
-//! Implements Phase 3 requirements:
-//! - REQ-PERSIST-001: Persistence to disk using RocksDB
-//! - REQ-PERSIST-002: Write-Ahead Logging (WAL) for durability
-//! - REQ-TENANT-001 through REQ-TENANT-008: Multi-tenancy with resource isolation
+//! ## ACID guarantees
+//!
+//! Database persistence is built around the ACID properties:
+//! - **Atomicity**: operations either fully complete or fully roll back — no partial writes
+//! - **Consistency**: the database always moves from one valid state to another
+//! - **Isolation**: concurrent transactions don't interfere with each other
+//! - **Durability**: once a write is committed, it survives crashes and power loss
+//!
+//! ## Write-Ahead Log (WAL)
+//!
+//! The WAL is the standard technique for durability. The idea: write the operation to a
+//! sequential log file BEFORE modifying the actual data. If the process crashes mid-write,
+//! the log can be replayed on recovery to reconstruct the correct state. This same pattern
+//! is used by PostgreSQL, SQLite, and RocksDB internally.
+//!
+//! ## RocksDB
+//!
+//! RocksDB is Facebook's embedded key-value store, evolved from Google's LevelDB. It uses
+//! an LSM-tree (Log-Structured Merge-tree) architecture optimized for write-heavy workloads:
+//! writes go to an in-memory buffer (memtable), which periodically flushes to sorted disk
+//! files (SSTables) that are compacted in the background. Column families provide logical
+//! separation within a single database instance — each is an independent LSM-tree.
+//!
+//! ## Multi-tenancy
+//!
+//! Multiple isolated "tenants" share one database process. Each tenant gets its own RocksDB
+//! column family (like a namespace), ensuring data isolation. Resource quotas (max nodes,
+//! max edges, storage limits) prevent any single tenant from monopolizing shared resources.
+//!
+//! ## PersistenceManager
+//!
+//! The `PersistenceManager` orchestrates WAL + RocksDB + TenantManager. All writes flow
+//! through the WAL first (for durability), then to RocksDB (for indexed storage). On
+//! startup, any WAL entries written after the last checkpoint are replayed to bring the
+//! in-memory graph state up to date.
 
 pub mod storage;
 pub mod tenant;

--- a/src/persistence/storage.rs
+++ b/src/persistence/storage.rs
@@ -1,7 +1,38 @@
-//! RocksDB storage layer implementation
+//! # RocksDB Storage Layer
 //!
-//! Implements REQ-PERSIST-001 (Persistence to disk) using RocksDB
-//! Implements REQ-TENANT-002 (Data isolation) using column families
+//! ## Column families
+//!
+//! RocksDB column families are like separate "namespaces" within one database instance.
+//! Each column family has its own memtable, SSTable files, and compaction settings. In
+//! Samyama, each tenant gets a dedicated column family, providing data isolation without
+//! the overhead of separate database instances.
+//!
+//! ## Key encoding
+//!
+//! Keys are tenant-prefixed (e.g., `tenant:node:123`, `tenant:edge:456`) so that even
+//! within a column family, data is logically partitioned. This encoding ensures tenants
+//! cannot accidentally read each other's data and enables efficient prefix scans for
+//! tenant-specific queries.
+//!
+//! ## Serialization
+//!
+//! Rust structs (nodes, edges, properties) are serialized to bytes using `bincode` — a
+//! compact binary format that is significantly faster and smaller than JSON. The trade-off
+//! is that bincode is not human-readable, but for internal storage this is the right choice.
+//!
+//! ## Write buffer tuning
+//!
+//! RocksDB's write buffer (memtable) accumulates writes in memory before flushing to disk
+//! as sorted SSTable files. Larger write buffers batch more writes per flush, improving
+//! throughput but using more memory. The default is typically 64MB per column family.
+//!
+//! ## Rust concept: `Arc<T>`
+//!
+//! `Arc` (Atomic Reference Counting) enables shared ownership across threads. Multiple
+//! parts of the system (server, query executor, persistence manager) hold `Arc` references
+//! to the same storage instance. The reference count is updated atomically, and the storage
+//! is dropped only when the last reference goes away. This is Rust's safe alternative to
+//! shared pointers in C++.
 
 use crate::graph::{Edge, EdgeId, Node, NodeId, PropertyMap};
 use rocksdb::{ColumnFamilyDescriptor, Options, DB};

--- a/src/persistence/tenant.rs
+++ b/src/persistence/tenant.rs
@@ -269,7 +269,7 @@ pub struct AutoEmbedConfig {
     pub chunk_overlap: usize,
     /// Vector dimension size
     pub vector_dimension: usize,
-    /// Embedding policies: Label -> Vec<PropertyKey>
+    /// Embedding policies: Label -> `Vec<PropertyKey>`
     pub embedding_policies: HashMap<String, Vec<String>>,
 }
 

--- a/src/persistence/wal.rs
+++ b/src/persistence/wal.rs
@@ -1,6 +1,42 @@
-//! Write-Ahead Log (WAL) implementation
+//! # Write-Ahead Log (WAL)
 //!
-//! Implements REQ-PERSIST-002 (Write-Ahead Logging for durability)
+//! ## Core theory
+//!
+//! The fundamental insight behind WAL is that **sequential writes are fast** (especially
+//! on SSDs and spinning disks), while random writes are slow. By appending each operation
+//! to a log file before modifying the in-memory data structures, we get durability without
+//! expensive random I/O. If the process crashes after writing to the log but before
+//! updating the main data, we can reconstruct the correct state from the log.
+//!
+//! ## Recovery
+//!
+//! On startup, the WAL is scanned from the beginning (or from the last checkpoint).
+//! Each entry is replayed against the in-memory graph to reconstruct state. Checkpoints
+//! record a "safe point" — all data before the checkpoint is known to be persisted to
+//! RocksDB, so the WAL can be truncated to prevent unbounded growth.
+//!
+//! ## CRC32 checksums
+//!
+//! Each WAL record includes a CRC32 checksum computed over its payload. This detects
+//! corruption from hardware errors (bit flips in storage or memory). During recovery,
+//! if a checksum mismatch is found, the corrupt entry is detected and skipped — this
+//! is safer than silently applying corrupted data.
+//!
+//! ## Sequence numbers
+//!
+//! Every WAL entry gets a monotonically increasing sequence number. These provide a
+//! total ordering of operations, which is essential for exactly-once replay during
+//! recovery (skip entries already applied) and for coordinating with checkpoints.
+//!
+//! ## Sync modes
+//!
+//! There is a fundamental trade-off between durability and performance:
+//! - **`fsync` after every write**: guarantees the data is on stable storage, but each
+//!   fsync can take 1-10ms (limits throughput to ~100-1000 writes/sec)
+//! - **Buffered writes**: the OS may cache writes in its page cache, risking loss of
+//!   the most recent writes on crash, but achieving much higher throughput
+//!
+//! Most databases offer both modes and let users choose based on their requirements.
 
 use serde::{Deserialize, Serialize};
 use std::fs::{File, OpenOptions};

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,14 +1,40 @@
-//! Network protocol module
+//! # Network Protocol (RESP)
 //!
-//! Implements RESP (Redis Serialization Protocol) support:
-//! - REQ-REDIS-001: RESP protocol implementation
-//! - REQ-REDIS-002: Redis client connections
-//! - REQ-REDIS-003: Authentication (future)
-//! - REQ-REDIS-004: Redis-compatible graph commands
-//! - REQ-REDIS-006: Redis client library compatibility
-//! - REQ-REDIS-007: Pipelining support
+//! ## What is RESP?
 //!
-//! Architecture follows ADR-003 (RESP Protocol)
+//! RESP (Redis Serialization Protocol) is a simple text/binary protocol for client-server
+//! communication, originally designed for Redis. Samyama implements RESP so that **existing
+//! Redis clients** — redis-cli, Python's `redis` library, Node.js `ioredis`, Go's
+//! `go-redis` — can connect to Samyama without any modification. This provides instant
+//! ecosystem compatibility with dozens of client libraries across every major language.
+//!
+//! ## Wire format
+//!
+//! RESP messages are prefixed with a type byte and terminated by `\r\n` (CRLF):
+//! - `+OK\r\n` — Simple string (status replies)
+//! - `-ERR message\r\n` — Error (with human-readable message)
+//! - `:42\r\n` — Integer
+//! - `$6\r\nfoobar\r\n` — Bulk string (length-prefixed, binary-safe)
+//! - `*2\r\n...\r\n...\r\n` — Array (element count prefix, then elements)
+//! - `_\r\n` — Null (RESP3)
+//!
+//! The length-prefixed bulk strings are important: they allow binary data (including
+//! `\r\n` within the payload) to be transmitted without escaping.
+//!
+//! ## Graph commands
+//!
+//! Samyama extends the RESP command set with graph-specific commands:
+//! - `GRAPH.QUERY <graph> <cypher>` — execute a read-write Cypher query
+//! - `GRAPH.RO_QUERY <graph> <cypher>` — execute a read-only Cypher query (can be
+//!   routed to replicas in a cluster)
+//! - `GRAPH.DELETE <graph>` — delete an entire graph
+//!
+//! ## Why the Redis protocol?
+//!
+//! This design was inspired by FalkorDB (formerly RedisGraph). By speaking Redis's
+//! protocol, Samyama avoids the "cold start" problem of needing custom client libraries.
+//! Users can connect with tools they already have installed (`redis-cli`) and integrate
+//! with applications using battle-tested Redis client libraries.
 
 pub mod resp;
 pub mod server;

--- a/src/protocol/resp.rs
+++ b/src/protocol/resp.rs
@@ -1,7 +1,37 @@
-//! RESP (Redis Serialization Protocol) implementation
+//! # RESP3 Encoder/Decoder
 //!
-//! Implements REQ-REDIS-001 (RESP protocol support)
-//! Based on RESP3 specification: https://redis.io/docs/reference/protocol-spec/
+//! ## RESP3 encoding and decoding
+//!
+//! The protocol uses `\r\n` (CRLF) as line terminators. Each message starts with a type
+//! byte (`+` for simple strings, `-` for errors, `:` for integers, `$` for bulk strings,
+//! `*` for arrays, `_` for null). The decoder reads the type byte, then parses the
+//! remainder according to the type-specific format.
+//!
+//! ## State machine parsing
+//!
+//! Messages arrive as byte streams over TCP. A single logical message may be split across
+//! multiple TCP packets (fragmentation), or multiple messages may arrive in one packet
+//! (pipelining). The `decode()` function handles this by returning:
+//! - `Ok(Some(value))` — a complete message was parsed and consumed from the buffer
+//! - `Ok(None)` — not enough data yet; the caller should buffer more bytes and retry
+//! - `Err(...)` — the data is malformed
+//!
+//! This pattern is standard in async network programming and integrates with Tokio's
+//! codec framework.
+//!
+//! ## `BytesMut` from the `bytes` crate
+//!
+//! `BytesMut` is a mutable byte buffer optimized for network I/O. Unlike `Vec<u8>`, it
+//! supports zero-copy slicing (`split_to()` returns the consumed bytes without copying)
+//! and efficient prepending. It is the standard buffer type in the Tokio ecosystem for
+//! reading from and writing to sockets.
+//!
+//! ## Rust concept: the `Buf` trait
+//!
+//! The `Buf` trait (from the `bytes` crate) abstracts over "a buffer with a read cursor."
+//! Methods like `chunk()` return the readable bytes, and `advance(n)` moves the cursor
+//! forward without copying data. This enables efficient sequential reads through a buffer,
+//! which is exactly what a protocol parser needs.
 
 use bytes::{Buf, BytesMut};
 use std::io::{self, Write};

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -1,11 +1,70 @@
-//! Abstract Syntax Tree for OpenCypher queries
+//! # Abstract Syntax Tree (AST) for OpenCypher Queries
 //!
-//! Implements REQ-CYPHER-001 through REQ-CYPHER-009
+//! An **Abstract Syntax Tree** is a tree-shaped data structure that represents the
+//! *semantic structure* of source code. It is "abstract" because it discards syntactic
+//! noise that matters to the parser but not to the compiler -- parentheses for grouping,
+//! semicolons, whitespace, and comments are all gone. What remains is a clean hierarchy
+//! of *language constructs*: clauses, patterns, expressions, and literals.
+//!
+//! ## Cypher AST and Graph Patterns
+//!
+//! Cypher's pattern syntax maps naturally to a tree:
+//!
+//! ```text
+//!   (a:Person)-[:KNOWS]->(b:Person)
+//!        |          |          |
+//!   PatternNode  PatternEdge  PatternNode
+//!        \__________|__________/
+//!              PatternPath
+//!                   |
+//!              MatchClause
+//!                   |
+//!                 Query   (root of the tree)
+//! ```
+//!
+//! The [`Query`] struct is the **root node** of every AST. Its fields are all optional
+//! because Cypher allows many clause combinations: `CREATE` without `MATCH`, `MATCH`
+//! without `RETURN`, standalone `MERGE`, and so on. The planner inspects which fields
+//! are populated to decide what execution plan to build.
+//!
+//! ## Recursive Types and `Box<T>` in Rust
+//!
+//! ASTs are inherently recursive -- an `Expression` can contain sub-expressions
+//! (`1 + (2 * 3)`), and a `Query` can contain sub-queries (`CALL { ... }`). Rust
+//! requires every type to have a known size at compile time, but a recursive type like
+//! `Expression { left: Expression, right: Expression }` would be infinitely large.
+//!
+//! The solution is **`Box<T>`** -- a heap-allocated pointer with a fixed size (8 bytes
+//! on 64-bit systems). By writing `Box<Expression>` instead of `Expression`, we break
+//! the infinite-size cycle. The AST nodes in this module use `Box` extensively:
+//! `Box<Expression>` in binary operations, `Box<Query>` in CALL subqueries, and
+//! `Box<WhereClause>` in EXISTS subqueries (the `Option<Box<WhereClause>>` pattern
+//! also breaks a recursive type cycle between `Expression` and `WhereClause`).
 
 use crate::graph::{EdgeType, Label, PropertyValue};
 use std::collections::HashMap;
 
-/// Complete Cypher query representation
+/// The root AST node representing a complete Cypher query.
+///
+/// Every parsed Cypher statement produces exactly one `Query`. Its fields are grouped
+/// into four logical categories:
+///
+/// 1. **Pattern matching**: `match_clauses`, `where_clause`, `post_with_where_clause` --
+///    these define *what* to find in the graph (nodes, edges, paths, filters).
+///
+/// 2. **Mutations**: `create_clause`, `delete_clause`, `set_clauses`, `remove_clauses`,
+///    `merge_clause`, `foreach_clause` -- these modify graph state. When any of these
+///    are present, the planner sets `ExecutionPlan::is_write = true`, which routes
+///    execution through `MutQueryExecutor` (requiring `&mut GraphStore`).
+///
+/// 3. **Projection and ordering**: `return_clause`, `order_by`, `skip`, `limit`,
+///    `with_clause` -- these shape the output (column selection, sorting, pagination).
+///    `WITH` acts as a pipeline barrier: it materializes intermediate results and
+///    introduces a new scope, similar to a subquery in SQL.
+///
+/// 4. **Schema and introspection**: `create_index_clause`, `drop_index_clause`,
+///    `create_constraint_clause`, `show_indexes`, `show_constraints`, `explain`,
+///    `profile` -- these are DDL/DML operations and diagnostic flags.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Query {
     /// MATCH clauses
@@ -121,7 +180,7 @@ pub struct YieldItem {
     pub alias: Option<String>,
 }
 
-/// MATCH clause: MATCH (n:Person)-[:KNOWS]->(m)
+/// MATCH clause: `MATCH (n:Person)-[:KNOWS]->(m)`
 #[derive(Debug, Clone, PartialEq)]
 pub struct MatchClause {
     /// Pattern to match
@@ -145,10 +204,10 @@ pub enum PathType {
     AllShortest,
 }
 
-/// Path pattern: (n:Person)-[:KNOWS*1..3]->(m:Person)
+/// Path pattern: `(n:Person)-[:KNOWS*1..3]->(m:Person)`
 #[derive(Debug, Clone, PartialEq)]
 pub struct PathPattern {
-    /// Named path variable (e.g., `p` in `p = (a)-[:KNOWS]->(b)`)
+    /// Named path variable (e.g., `p` in `p = (a)-\[:KNOWS\]->(b)`)
     pub path_variable: Option<String>,
     /// Path type (Normal, Shortest, AllShortest)
     pub path_type: PathType,
@@ -268,7 +327,7 @@ pub enum Expression {
         /// ELSE default
         else_result: Option<Box<Expression>>,
     },
-    /// List/map indexing: expr[index]
+    /// List/map indexing: `expr[index]`
     Index {
         /// Expression being indexed
         expr: Box<Expression>,
@@ -326,7 +385,7 @@ pub enum Expression {
         /// Body expression
         expression: Box<Expression>,
     },
-    /// Pattern comprehension: [(a)-[:REL]->(b) WHERE cond | expr]
+    /// Pattern comprehension: `[(a)-[:REL]->(b) WHERE cond | expr]`
     PatternComprehension {
         /// Pattern to match
         pattern: Pattern,
@@ -474,7 +533,7 @@ pub struct ForeachClause {
     pub create_clauses: Vec<CreateClause>,
 }
 
-/// UNWIND clause: UNWIND [1,2,3] AS x
+/// UNWIND clause: `UNWIND [1,2,3] AS x`
 #[derive(Debug, Clone, PartialEq)]
 pub struct UnwindClause {
     /// Expression to unwind (must evaluate to a list)

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -1,6 +1,80 @@
-//! Query execution engine using Volcano iterator model
+//! # Query Execution Engine: Volcano Iterator Model
 //!
-//! Implements REQ-CYPHER-009 (query optimization) and ADR-007
+//! This module implements query execution using the **Volcano iterator model**, an
+//! architecture invented by Goetz Graefe in the early 1990s that remains the foundation
+//! of nearly every relational and graph database engine today (PostgreSQL, MySQL, Neo4j,
+//! and now Samyama all use it).
+//!
+//! ## How Volcano Works
+//!
+//! An execution plan is a **tree of operators**. Each operator implements a `next()` method
+//! that returns the next [`Record`] (or `None` when exhausted). The root operator pulls
+//! from its child, which pulls from its child, and so on down to the leaf (a scan operator).
+//! Records flow **upward** through the tree, one at a time:
+//!
+//! ```text
+//!   ProjectOperator::next()          ← caller pulls from here
+//!        │
+//!        ├── calls FilterOperator::next()
+//!        │        │
+//!        │        ├── calls ExpandOperator::next()
+//!        │        │        │
+//!        │        │        └── calls NodeScanOperator::next()   ← reads from GraphStore
+//!        │        │                    returns Record { n: NodeRef(42) }
+//!        │        │            returns Record { n: NodeRef(42), m: NodeRef(99) }
+//!        │        │
+//!        │        └── checks WHERE predicate, passes or skips
+//!        │
+//!        └── extracts RETURN columns, materializes NodeRef → Node if needed
+//! ```
+//!
+//! ## Why Volcano?
+//!
+//! - **Composability**: operators are independent building blocks. Adding a new operator
+//!   (say, `UnwindOperator`) requires no changes to existing operators.
+//! - **Memory efficiency**: no intermediate result sets are fully materialized. A
+//!   `MATCH ... WHERE ... RETURN ... LIMIT 10` query can stop after 10 records without
+//!   scanning the entire graph.
+//! - **Pipelining**: records flow through the tree without buffering (except for blocking
+//!   operators like `SortOperator` and `AggregateOperator` which must see all input first).
+//!
+//! ## Physical Operators
+//!
+//! The operator zoo includes:
+//! - **Scans**: `NodeScanOperator`, `IndexScanOperator` -- leaf operators that read from the graph
+//! - **Filters**: `FilterOperator` -- evaluates WHERE predicates
+//! - **Traversal**: `ExpandOperator` (fan-out along edges), `ExpandIntoOperator` (check edge existence between two bound nodes), `ShortestPathOperator`
+//! - **Projection**: `ProjectOperator` -- evaluates RETURN expressions, materializes lazy refs
+//! - **Pagination**: `LimitOperator`, `SkipOperator`
+//! - **Grouping**: `AggregateOperator` (COUNT, SUM, AVG, etc.), `SortOperator`
+//! - **Joins**: `JoinOperator` (hash join), `LeftOuterJoinOperator` (for OPTIONAL MATCH), `CartesianProductOperator`
+//! - **Mutations**: `CreateNodeOperator`, `CreateEdgeOperator`, `DeleteOperator`, `SetPropertyOperator`, `MergeOperator`
+//! - **Misc**: `UnwindOperator`, `ForeachOperator`, `WithBarrierOperator`
+//!
+//! ## Late Materialization (ADR-012)
+//!
+//! Scan operators produce `Value::NodeRef(id)` instead of cloning the full node with all
+//! its properties. Properties are resolved **on demand** via `Value::resolve_property()`.
+//! This is the key performance optimization for traversal-heavy queries: on a 3-hop path
+//! query, most intermediate nodes are never accessed for their properties, so cloning them
+//! would be pure waste.
+//!
+//! ## Read vs Write Execution
+//!
+//! - **[`QueryExecutor`]**: read-only path. Takes `&GraphStore` (shared reference).
+//!   Operators call `next(store)` with an immutable borrow.
+//! - **[`MutQueryExecutor`]**: write path. Takes `&mut GraphStore` (exclusive reference).
+//!   Operators call `next_mut(store)` to create nodes, edges, or modify properties.
+//!
+//! ## Trait Objects: `Box<dyn PhysicalOperator>`
+//!
+//! Each operator has a different Rust type (`NodeScanOperator`, `FilterOperator`, etc.),
+//! but the planner needs to compose them into a tree without knowing the concrete types.
+//! This is where **trait objects** come in: `Box<dyn PhysicalOperator>` erases the concrete
+//! type and dispatches `next()` calls through a vtable (virtual function table), just like
+//! virtual methods in C++ or interface dispatch in Java. This is Rust's mechanism for
+//! **runtime polymorphism** -- the alternative to compile-time generics when you need
+//! heterogeneous collections of operators.
 
 pub mod cost_model;
 pub mod logical_optimizer;

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1,6 +1,68 @@
-//! Physical operators for query execution (Volcano iterator model)
+//! Physical operators for query execution using the Volcano iterator model.
 //!
-//! Implements ADR-007 (Volcano Iterator Model)
+//! # Volcano Iterator Model (ADR-007)
+//!
+//! The Volcano model (Goetz Graefe, 1990s) is the dominant query execution paradigm in
+//! relational and graph databases. Each operator implements a `next()` method that returns
+//! one record at a time, pulling from child operators on demand. This creates a pipeline
+//! where data flows from leaf operators (scans) up through filters, joins, and projections
+//! to the root operator that produces final results.
+//!
+//! # Physical Operators
+//!
+//! | Operator | Description |
+//! |---|---|
+//! | `NodeScanOperator` | Scans all nodes matching a label (like a table scan in SQL) |
+//! | `IndexScanOperator` | Uses a B-tree index to find nodes matching a predicate |
+//! | `FilterOperator` | Evaluates a WHERE predicate, discarding non-matching records |
+//! | `ExpandOperator` | Traverses edges from bound nodes to discover neighbors (graph-native; no SQL equivalent without expensive JOINs) |
+//! | `ExpandIntoOperator` | Checks if an edge exists between two already-bound nodes (a semi-join) |
+//! | `ProjectOperator` | Evaluates RETURN expressions, materializing `NodeRef` → `Node` for output |
+//! | `LimitOperator` / `SkipOperator` | LIMIT and SKIP clauses |
+//! | `SortOperator` | ORDER BY with multi-key comparison |
+//! | `AggregateOperator` | GROUP BY + aggregation functions (count, sum, avg, min, max, collect) |
+//! | `JoinOperator` | Hash join for multi-pattern MATCH queries |
+//! | `LeftOuterJoinOperator` | For OPTIONAL MATCH (preserves unmatched left rows with NULLs) |
+//! | `CartesianProductOperator` | Cross product for disconnected patterns |
+//! | `UnwindOperator` | Expands arrays into individual rows |
+//! | `MergeOperator` | MERGE (upsert): CREATE if not exists, otherwise match |
+//! | `ShortestPathOperator` | BFS/Dijkstra for `shortestPath()` function |
+//! | `VectorSearchOperator` | HNSW approximate nearest neighbor search |
+//! | `AlgorithmOperator` | Runs graph algorithms (PageRank, WCC, SCC, etc.) |
+//! | DDL operators | `CreateIndex`, `DropIndex`, `CreateConstraint`, `ShowIndexes`, etc. |
+//!
+//! # Expression Evaluation
+//!
+//! The `eval_expression()` function recursively evaluates AST expressions against a record.
+//! It handles property access (`n.name`), arithmetic (`a + b`), comparisons (`a > b`),
+//! boolean logic (`AND`/`OR`/`NOT`), function calls (`toUpper()`, `count()`), CASE
+//! expressions, list operations, and more.
+//!
+//! # Type Coercion and NULL Propagation
+//!
+//! Integer/Float automatic promotion (widening), String concatenation via `+`, and NULL
+//! propagation following three-valued logic: any operation involving NULL returns NULL,
+//! except `IS NULL` / `IS NOT NULL`.
+//!
+//! # Late Materialization
+//!
+//! Operators work with `Value::NodeRef(id)` instead of full `Value::Node(id, clone)`.
+//! Property access goes through `resolve_property()`, which looks up the property from
+//! the [`GraphStore`] on demand. Full materialization only happens at `ProjectOperator`
+//! when the query returns a node variable. See ADR-012.
+//!
+//! # Metaheuristic Optimization Solvers
+//!
+//! `AlgorithmOperator` integrates 16 solvers from `samyama-optimization` (Jaya, Rao,
+//! TLBO, Firefly, Cuckoo, GWO, GA, SA, Bat, ABC, GSA, NSGA2, MOTLBO, HS, FPA) for
+//! solving continuous optimization problems within graph queries.
+//!
+//! # Rust Patterns
+//!
+//! - `Box<dyn PhysicalOperator>` — dynamic dispatch via trait objects for operator trees
+//! - `&GraphStore` — lifetime-bounded borrow of the graph during execution
+//! - `HashMap` — build phase of hash joins in `JoinOperator`
+//! - `BTreeSet` — sorted unique results where ordering matters
 
 use crate::graph::{GraphStore, Label, NodeId, EdgeType};
 use crate::query::ast::{Expression, BinaryOp, UnaryOp, Direction, Pattern};
@@ -460,7 +522,7 @@ fn eval_reduce(
     Ok(acc)
 }
 
-/// Evaluate pattern comprehension: [(a)-[:REL]->(b) | expr]
+/// Evaluate pattern comprehension: `[(a)-[:REL]->(b) | expr]`
 fn eval_pattern_comprehension(
     pattern: &Pattern,
     filter: Option<&Expression>,
@@ -1937,7 +1999,7 @@ impl PhysicalOperator for FilterOperator {
     }
 }
 
-/// Expand operator: -[:KNOWS]->
+/// Expand operator: `-[:KNOWS]->`
 pub struct ExpandOperator {
     /// Input operator
     input: OperatorBox,
@@ -4178,7 +4240,7 @@ impl PhysicalOperator for SchemaVisualizationOperator {
     }
 }
 
-/// Create edge operator: CREATE (a)-[:KNOWS]->(b)
+/// Create edge operator: `CREATE (a)-[:KNOWS]->(b)`
 pub struct CreateEdgeOperator {
     /// Input operator (provides source/target nodes from MATCH)
     input: Option<OperatorBox>,
@@ -4287,7 +4349,7 @@ impl PhysicalOperator for CreateEdgeOperator {
 }
 
 /// Combined operator for CREATE patterns with both nodes and edges
-/// Example: CREATE (a:Person)-[:KNOWS]->(b:Person)
+/// Example: `CREATE (a:Person)-[:KNOWS]->(b:Person)`
 /// This operator first creates all nodes, then creates edges between them
 pub struct CreateNodesAndEdgesOperator {
     /// Node creation operator
@@ -4406,7 +4468,7 @@ impl PhysicalOperator for CreateNodesAndEdgesOperator {
 }
 
 /// Operator for MATCH...CREATE queries
-/// Example: MATCH (a:Trial {id: 'NCT001'}), (b:Condition {mesh_id: 'D001'}) CREATE (a)-[:STUDIES]->(b)
+/// Example: `MATCH (a:Trial {id: 'NCT001'}), (b:Condition {mesh_id: 'D001'}) CREATE (a)-[:STUDIES]->(b)`
 /// This operator takes matched nodes and creates edges between them
 pub struct MatchCreateEdgeOperator {
     /// Input operator (MATCH results)

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1,6 +1,59 @@
-//! Query planner - converts AST to execution plan
+//! # Query Planner: From Declarative Query to Imperative Execution
 //!
-//! Implements basic query optimization (REQ-CYPHER-009)
+//! The planner is the heart of the query engine. It transforms a **declarative** query
+//! ("find all people who know Alice") into an **imperative** execution plan ("scan Person
+//! nodes, expand along KNOWS edges, filter where name = 'Alice'"). This transformation is
+//! the most important optimization opportunity in any database -- the same query can have
+//! dozens of valid execution plans, and the best one can be orders of magnitude faster
+//! than the worst.
+//!
+//! ## Cost-Based Optimization (ADR-015)
+//!
+//! Like PostgreSQL, MySQL, and other mature databases, Samyama uses **cost-based
+//! optimization**. The planner:
+//! 1. **Enumerates** candidate plans (different join orders, scan strategies, traversal
+//!    directions)
+//! 2. **Estimates** the cost of each plan using **cardinality estimation** -- statistical
+//!    models that predict how many records each operator will produce (e.g., "there are
+//!    10,000 Person nodes, 0.1% have name = 'Alice', so an equality filter produces ~10
+//!    records")
+//! 3. **Picks** the cheapest plan
+//!
+//! The statistics come from [`GraphStore::compute_statistics()`] which samples property
+//! distributions, counts labels, and measures average degree.
+//!
+//! ## Key Optimization Techniques
+//!
+//! - **Predicate pushdown**: move WHERE filters as close to the scan as possible. Filtering
+//!   1 million nodes down to 100 *before* expanding edges is vastly cheaper than expanding
+//!   all edges and filtering afterward.
+//! - **Index selection**: when a WHERE clause matches an indexed property (`WHERE n.email = $x`
+//!   and an index exists on `:Person(email)`), use `IndexScanOperator` instead of
+//!   `NodeScanOperator + FilterOperator`. This turns O(n) scans into O(log n) lookups.
+//! - **Join ordering**: for multi-pattern MATCH clauses, the order in which patterns are
+//!   joined matters enormously. Joining a 10-row result with a 1M-row result is fast;
+//!   joining two 1M-row results is catastrophic.
+//! - **Early LIMIT propagation**: push LIMIT down into the operator tree so that scans
+//!   stop after producing enough records.
+//!
+//! ## Plan Cache
+//!
+//! Planning is not free -- enumerating plans and computing cost estimates takes time. For
+//! repeated queries (common in applications), the planner caches planning metadata (index
+//! hints, cost estimates) keyed by a hash of the query string. A **generation counter**
+//! (`AtomicU64`) is incremented on schema changes (CREATE INDEX, DROP INDEX) to invalidate
+//! stale cache entries. This uses `AtomicU64` with `Ordering::Relaxed` because exact
+//! ordering is not required -- a stale read just causes one extra re-plan.
+//!
+//! ## Rust Concepts
+//!
+//! - **`Mutex<HashMap<u64, PlanCacheEntry>>`**: the plan cache is shared across threads
+//!   (the query engine is `Send + Sync`). `Mutex` provides mutual exclusion -- only one
+//!   thread can read/write the cache at a time. `HashMap<u64, _>` uses a pre-computed hash
+//!   of the query string as the key.
+//! - **`AtomicU64`**: a lock-free atomic integer for the generation counter. Atomics are
+//!   cheaper than mutexes for simple counters because they use CPU-level atomic instructions
+//!   (e.g., `LOCK CMPXCHG` on x86) instead of OS-level locks.
 
 use crate::graph::GraphStore;
 use crate::graph::{Label, PropertyValue};  // Added for CREATE support
@@ -14,7 +67,19 @@ use crate::query::executor::{
 use crate::graph::EdgeType;  // Added for CREATE edge support
 use std::collections::{HashMap, HashSet};  // Added for CREATE properties and JOIN logic
 
-/// Execution plan - a tree of physical operators
+/// An execution plan: a tree of physical operators ready to execute.
+///
+/// The `root` field holds the top-level operator (typically a `ProjectOperator` or
+/// `LimitOperator`). Calling `root.next(store)` begins the Volcano pull-based execution,
+/// cascading `next()` calls down the operator tree until a leaf scan produces a record.
+///
+/// `output_columns` lists the variable names that appear in the RETURN clause, used to
+/// construct the final `RecordBatch` column headers.
+///
+/// `is_write` distinguishes read plans from write plans. When `true`, the executor must
+/// use `next_mut(&mut store)` instead of `next(&store)`, and the caller must hold an
+/// exclusive (`&mut`) reference to the `GraphStore`. This flag is set by the planner
+/// when it encounters CREATE, DELETE, SET, MERGE, or schema-modification clauses.
 pub struct ExecutionPlan {
     /// Root operator
     pub root: OperatorBox,

--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -1,6 +1,42 @@
-//! Record structures for query execution
+//! # Records: The Data Unit of Query Execution
 //!
-//! Records flow through the Volcano iterator pipeline
+//! A [`Record`] is a set of **variable bindings** -- a mapping from variable names (like
+//! `n`, `r`, `m` in `MATCH (n)-[r]->(m)`) to [`Value`]s. It is the graph-database analog
+//! of a "row" in a relational database, except that columns are named variables rather
+//! than positional indices. Records flow through the Volcano iterator pipeline one at a
+//! time, accumulating bindings as they pass through operators (e.g., `ExpandOperator` adds
+//! the target node binding to an existing record that already contains the source node).
+//!
+//! ## Late Materialization (ADR-012)
+//!
+//! The most important optimization in this module is **late materialization**. Instead of
+//! cloning an entire `Node` (with all its properties, labels, and metadata) when a scan
+//! produces a result, we store only a `Value::NodeRef(id)` -- a 64-bit integer. The full
+//! node data is resolved **on demand** via [`Value::resolve_property(prop, store)`] only
+//! when a property is actually needed (e.g., in a WHERE filter or RETURN projection).
+//!
+//! This matters enormously for traversal queries. Consider `MATCH (a)-[:KNOWS]->(b)-[:KNOWS]->(c)`:
+//! the ExpandOperator traverses through `b` nodes, but if the query only returns `c.name`,
+//! the `b` nodes never need their properties loaded. Late materialization turns what would
+//! be O(n * avg_properties) memory into O(n * 8 bytes).
+//!
+//! ## Semantic Equality: `NodeRef(id) == Node(id, _)`
+//!
+//! The [`Value`] enum has both lazy (`NodeRef`) and materialized (`Node`) variants for the
+//! same logical entity. This creates a subtle correctness requirement: the `JoinOperator`
+//! uses hash-based lookups to match records from two sides of a join. If the left side
+//! produces `NodeRef(42)` and the right side produces `Node(42, <data>)`, they must be
+//! considered **equal** and must produce the **same hash** -- otherwise the join silently
+//! drops valid matches.
+//!
+//! This is why [`PartialEq`] and [`Hash`] are implemented **manually** instead of derived.
+//! The derive macro would compare all fields (including the `Node` data), breaking the
+//! semantic equivalence. The manual implementation compares only the identity (the `NodeId`),
+//! and the hash function uses a discriminant tag (0 for nodes, 1 for edges) plus the ID,
+//! ensuring the **hash consistency invariant**: if `a == b`, then `hash(a) == hash(b)`.
+//!
+//! [`RecordBatch`] is the final output container -- a vector of [`Record`]s plus column
+//! names, returned to the caller after query execution completes.
 
 use crate::graph::{Edge, Node, NodeId, EdgeId, EdgeType, PropertyValue, GraphStore};
 use std::collections::HashMap;
@@ -13,7 +49,27 @@ pub struct Record {
     bindings: HashMap<String, Value>,
 }
 
-/// Value types that can be bound to variables
+/// Value types that can be bound to variables in a query record.
+///
+/// The key design choice here is the **late materialization hierarchy**:
+///
+/// - **`NodeRef(id)`** -- a lazy reference. Stores only the 64-bit `NodeId`. Produced by
+///   scan and expand operators. Extremely cheap to create (no heap allocation, no cloning).
+///   Properties are resolved on demand via `resolve_property(prop, store)`.
+///
+/// - **`Node(id, node)`** -- a fully materialized node. Contains a clone of the `Node`
+///   struct with all labels and properties. Produced by `ProjectOperator` when the RETURN
+///   clause requests `RETURN n` (the entire node), triggering full materialization.
+///
+/// The same lazy/eager split exists for edges: `EdgeRef(id, src, tgt, type)` carries the
+/// structural data (endpoints and type) without property clones, while `Edge(id, edge)`
+/// is fully materialized.
+///
+/// `Property(PropertyValue)` wraps scalar values (strings, integers, floats, booleans,
+/// datetimes, arrays, maps) that result from property access (`n.name`) or literal
+/// expressions. `Path` stores ordered sequences of node/edge IDs for named path patterns
+/// like `p = (a)-[]->(b)`. `Null` represents the absence of a value, following Cypher's
+/// three-valued logic (true/false/null).
 #[derive(Debug, Clone)]
 pub enum Value {
     /// A fully materialized node

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,14 +1,73 @@
-//! Query processing module
+//! # Query Processing Pipeline
 //!
-//! Implements OpenCypher query language support:
-//! - REQ-CYPHER-001: OpenCypher query language
-//! - REQ-CYPHER-002: Pattern matching
-//! - REQ-CYPHER-003: CRUD operations
-//! - REQ-CYPHER-007: WHERE clauses
-//! - REQ-CYPHER-008: ORDER BY and LIMIT
-//! - REQ-CYPHER-009: Query optimization
+//! This module implements the full **query processing pipeline** for Samyama's OpenCypher
+//! dialect, following the same staged architecture used by virtually every database engine
+//! and compiler:
 //!
-//! Architecture follows ADR-007 (Volcano Iterator Model)
+//! ```text
+//!   Source Text          Pest PEG Parser        Abstract Syntax Tree
+//!  ┌──────────┐        ┌──────────────┐        ┌──────────────────┐
+//!  │ MATCH    │──Lex──>│  cypher.pest │──AST──>│  Query struct    │
+//!  │ (n:Foo)  │ +Parse │  (PEG rules) │        │  (ast.rs)        │
+//!  │ RETURN n │        └──────────────┘        └────────┬─────────┘
+//!  └──────────┘                                         │
+//!                                                       │ plan()
+//!                                                       v
+//!                     Execution Plan             ┌──────────────┐
+//!                    ┌──────────────┐            │ QueryPlanner │
+//!                    │ Operator tree│<───────────│ (planner.rs) │
+//!                    │ (Volcano)    │            └──────────────┘
+//!                    └──────┬───────┘
+//!                           │ next() / next_mut()
+//!                           v
+//!                    ┌──────────────┐
+//!                    │  RecordBatch │  (final output)
+//!                    └──────────────┘
+//! ```
+//!
+//! This mirrors how compilers work: source code is lexed into tokens, parsed into an AST,
+//! lowered to an intermediate representation (the execution plan), and finally "executed"
+//! (in a compiler, that means code generation; here, it means pulling records through
+//! operators). The analogy is not accidental -- query languages *are* domain-specific
+//! programming languages.
+//!
+//! ## Parsing: PEG via Pest
+//!
+//! The parser uses [Pest](https://pest.rs), a Rust crate that implements **Parsing Expression
+//! Grammars (PEGs)**. Unlike context-free grammars (CFGs) used by yacc/bison, PEGs use an
+//! ordered-choice operator (`/`) that tries alternatives left-to-right and commits to the
+//! first match. This makes PEGs **always unambiguous** -- there is exactly one parse tree for
+//! any input, which eliminates an entire class of grammar debugging. The grammar lives in
+//! [`cypher.pest`](cypher.pest) and is compiled into a Rust parser at build time via a proc
+//! macro (`#[derive(Parser)]`).
+//!
+//! ## Execution: Volcano Iterator Model (ADR-007)
+//!
+//! Query execution follows the **Volcano iterator model** invented by Goetz Graefe. Each
+//! physical operator (scan, filter, expand, project, etc.) implements a `next()` method that
+//! **pulls** a single record from its child operator. Records flow upward through the
+//! operator tree one at a time, like a lazy iterator chain in Rust (`iter().filter().map()`).
+//! This is memory-efficient because intermediate results are never fully materialized -- each
+//! operator processes one record and immediately passes it upstream.
+//!
+//! ## LRU Parse Cache
+//!
+//! Parsing is expensive (PEG matching, AST construction, string allocation). Since many
+//! applications execute the same queries repeatedly with different parameters, this module
+//! maintains an **LRU (Least Recently Used) cache** of parsed ASTs. On a cache hit, we skip
+//! parsing entirely and jump straight to planning. The cache uses `Mutex<LruCache>` for
+//! thread safety, with lock-free `AtomicU64` counters for hit/miss statistics.
+//!
+//! ## Read vs Write Execution Paths
+//!
+//! Queries are split into two execution paths based on mutability:
+//! - **[`QueryExecutor`]**: read-only queries (MATCH, RETURN, EXPLAIN). Takes `&GraphStore`.
+//! - **[`MutQueryExecutor`]**: write queries (CREATE, DELETE, SET, MERGE). Takes `&mut GraphStore`.
+//!
+//! This separation mirrors Rust's ownership model -- shared references (`&T`) allow
+//! concurrent reads, while exclusive references (`&mut T`) guarantee single-writer access.
+//! The type system enforces at compile time that no read query can accidentally modify the
+//! graph.
 
 pub mod ast;
 pub mod parser;

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1,6 +1,61 @@
-//! OpenCypher query parser using Pest
+//! # OpenCypher Parser: PEG Grammar + Pratt Precedence
 //!
-//! Implements REQ-CYPHER-001, REQ-CYPHER-002
+//! This module transforms a Cypher query string into an `ast::Query` tree. It combines
+//! two parsing techniques:
+//!
+//! ## PEG (Parsing Expression Grammar)
+//!
+//! Unlike context-free grammars (CFGs) used by traditional parser generators (yacc, bison,
+//! ANTLR), **PEGs** use an **ordered choice** operator (`/`). When a PEG rule offers
+//! alternatives `A / B / C`, the parser tries `A` first; if `A` matches, `B` and `C` are
+//! never attempted. This makes PEGs **inherently unambiguous** -- there is always exactly
+//! one parse tree for any input. CFGs, by contrast, can be ambiguous (the classic
+//! "dangling else" problem), requiring precedence annotations or grammar refactoring.
+//!
+//! ## Pest: Rust's PEG Parser Generator
+//!
+//! [Pest](https://pest.rs) reads a `.pest` grammar file ([`cypher.pest`](cypher.pest)) and
+//! generates a parser at compile time using a proc macro (`#[derive(Parser)]`). The grammar
+//! defines rules like `match_clause`, `expression`, `variable`, etc. Pest produces a
+//! `Pairs` iterator of matched spans, which this module walks to construct AST nodes.
+//!
+//! ## Atomic Rules and Keyword Boundaries (ADR-013)
+//!
+//! In Pest, non-atomic rules (`rule = { ... }`) insert **implicit whitespace** between
+//! sequence elements. This is convenient for most grammar rules but dangerous for keyword
+//! detection. Consider: `rule = { ^"AND" ~ !(ASCII_ALPHA) }`. The implicit whitespace
+//! rule consumes the space after "AND", and then the negative lookahead sees the next
+//! identifier character and *fails* -- the keyword is not recognized.
+//!
+//! The fix is **atomic rules** (`rule = @{ ^"AND" ~ !(ASCII_ALPHANUMERIC | "_") }`).
+//! The `@` prefix disables implicit whitespace, so the lookahead fires immediately after
+//! the keyword text, before any space is consumed. This is critical for operators like
+//! `AND`, `OR`, `NOT`, `IN`, `CONTAINS`, and `STARTS WITH`.
+//!
+//! ## Pratt Parsing for Operator Precedence
+//!
+//! Expressions like `1 + 2 * 3` require **operator precedence** to parse correctly (the
+//! multiplication binds tighter than addition). This module uses Pest's built-in
+//! **Pratt parser**, an algorithm invented by Vaughan Pratt in 1973. Each operator is
+//! assigned a **binding power** (precedence level). The parser recursively consumes tokens,
+//! comparing binding powers to decide whether to "shift" (absorb the next operator) or
+//! "reduce" (close the current sub-expression). The result is correct associativity and
+//! precedence without rewriting the grammar into layers of precedence rules.
+//!
+//! The precedence levels (lowest to highest) are:
+//! 1. `OR`
+//! 2. `AND`
+//! 3. `IN`, comparisons (`=`, `<>`, `<`, `>`, `<=`, `>=`)
+//! 4. Addition/subtraction (`+`, `-`)
+//! 5. Multiplication/division/modulo (`*`, `/`, `%`)
+//!
+//! ## `LazyLock`: Thread-Safe One-Time Initialization
+//!
+//! The `PRATT_PARSER` static is initialized using [`std::sync::LazyLock`], Rust's
+//! built-in "once cell" pattern (stabilized in Rust 1.80). `LazyLock` guarantees that
+//! the closure runs **exactly once**, even under concurrent access from multiple threads.
+//! This avoids rebuilding the Pratt parser on every query while remaining thread-safe
+//! without explicit locking.
 
 use crate::graph::{EdgeType, Label, PropertyValue};
 use crate::query::ast::*;

--- a/src/raft/mod.rs
+++ b/src/raft/mod.rs
@@ -1,10 +1,45 @@
-//! Raft consensus implementation for high availability
+//! # Raft Consensus for High Availability
 //!
-//! Implements Phase 4 requirements:
-//! - REQ-HA-001: Raft consensus protocol
-//! - REQ-HA-002: Leader election and failover
-//! - REQ-HA-003: Log replication across nodes
-//! - REQ-HA-004: Cluster membership management
+//! ## What is Raft?
+//!
+//! Raft (Ongaro & Ousterhout, 2014) is a distributed consensus algorithm that ensures
+//! all nodes in a cluster agree on the same sequence of operations, even when some nodes
+//! fail or network partitions occur. It was designed to be **understandable** — in contrast
+//! to Paxos, which is mathematically equivalent but notoriously difficult to implement
+//! correctly.
+//!
+//! ## Key concepts
+//!
+//! - **Leader Election**: at any time, one node is the leader and all others are followers.
+//!   If the leader fails, followers detect the timeout and hold an election. A candidate
+//!   needs votes from a majority (quorum) to become the new leader.
+//! - **Log Replication**: the leader receives all write requests, appends them to its log,
+//!   and replicates log entries to followers. An entry is "committed" once a majority of
+//!   nodes have acknowledged it — committed entries are never lost.
+//! - **Safety**: Raft guarantees that if a log entry is committed, it will be present in
+//!   the logs of all future leaders. This is enforced by election restrictions (candidates
+//!   must have all committed entries to win).
+//!
+//! ## Terms
+//!
+//! Terms are Raft's logical clock — monotonically increasing integers that represent
+//! leader epochs. Each term has at most one leader. When a node sees a higher term, it
+//! knows its information is stale and updates. Terms prevent "split brain" scenarios
+//! where two nodes both think they are leader.
+//!
+//! ## Why Raft over Paxos?
+//!
+//! Paxos solves the same problem but is presented as a monolithic protocol. Raft
+//! decomposes consensus into three sub-problems (leader election, log replication, safety)
+//! that can be understood and implemented independently. This decomposition has made Raft
+//! the dominant choice for new distributed systems (etcd, CockroachDB, TiKV).
+//!
+//! ## In Samyama
+//!
+//! All write operations (CREATE, SET, DELETE, MERGE) go through the Raft leader, which
+//! replicates them to followers before committing. Reads can go to any node with relaxed
+//! consistency (may read slightly stale data) or only to the leader for strong consistency.
+//! This module uses the `openraft` crate, a Rust implementation of the Raft protocol.
 
 pub mod node;
 pub mod network;

--- a/src/vector/index.rs
+++ b/src/vector/index.rs
@@ -1,7 +1,48 @@
-//! Vector index implementation using HNSW
+//! # HNSW Vector Index Implementation
 //!
-//! This module provides a wrapper around the hnsw_rs library for
-//! high-performance approximate nearest neighbor search.
+//! ## How HNSW works
+//!
+//! HNSW (Hierarchical Navigable Small World) builds a proximity graph with multiple
+//! layers. Each node is assigned a random maximum layer (exponentially distributed —
+//! most nodes live only on layer 0, few reach the top). Insertion connects the new
+//! point to its nearest neighbors on each layer. Search starts at the top layer's
+//! entry point and greedily descends, refining the candidate set at each level.
+//!
+//! ## Key parameters
+//!
+//! - **`m`** (max connections per node): Controls graph density. Higher m = better recall
+//!   but more memory and slower insertion. Typical values: 12-48. Layer 0 uses `2*m`
+//!   connections.
+//! - **`ef_construction`** (search width during insertion): How many candidates to
+//!   consider when connecting a new node. Higher = better graph quality but slower build.
+//!   Typical values: 100-400.
+//! - **`ef_search`** (search width during query): How many candidates to track during
+//!   search. Higher = better recall but slower queries. Must be >= k (number of results).
+//!   This is the main recall-vs-speed knob at query time.
+//!
+//! ## Distance trait
+//!
+//! Rust's trait system enables polymorphic distance computation. The `hnsw_rs` crate
+//! defines a `Distance<T>` trait, and this module implements it with `CosineDistance`
+//! and `InnerProductDistance` structs. This allows the same HNSW data structure to work
+//! with different distance metrics without runtime dispatch overhead (monomorphization).
+//!
+//! ## Cosine distance formula
+//!
+//! `cosine_distance(a, b) = 1 - (a . b) / (||a|| * ||b||)`
+//!
+//! This measures angular distance between vectors:
+//! - **0** = identical direction (parallel vectors)
+//! - **1** = orthogonal (perpendicular, no similarity)
+//! - **2** = opposite direction (anti-correlated)
+//!
+//! ## Persistence strategy
+//!
+//! HNSW indices (from `hnsw_rs`) don't expose an iterator over stored vectors.
+//! To support persistence, all inserted vectors are also stored in a `Vec<StoredVector>`
+//! alongside the HNSW structure. On serialization, this vector list is saved via
+//! `bincode`. On load, a fresh HNSW index is constructed and all stored vectors are
+//! re-inserted. This trades load-time speed for implementation simplicity.
 
 use crate::graph::NodeId;
 use hnsw_rs::prelude::*;

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -1,7 +1,49 @@
-//! Vector search and AI integration (Phase 6)
+//! # Vector Search and AI Integration
 //!
-//! This module provides support for vector embeddings and
-//! approximate nearest neighbor search using HNSW.
+//! ## What are vector embeddings?
+//!
+//! Vector embeddings are dense numerical representations of data (text, images, graph
+//! nodes) in high-dimensional space — typically 128 to 1536 dimensions. The key insight
+//! is that **similar items have nearby vectors**: the sentence "happy dog" will be closer
+//! to "joyful puppy" than to "stock market crash" in embedding space. This is the
+//! foundation of modern AI search, recommendation systems, and retrieval-augmented
+//! generation (RAG).
+//!
+//! ## Approximate Nearest Neighbor (ANN) search
+//!
+//! Given a query vector, we want to find the k closest vectors in a collection. Exact
+//! (brute-force) search is O(n*d) where n = number of vectors and d = dimensions — too
+//! slow for millions of vectors. ANN algorithms trade a small amount of accuracy (recall)
+//! for dramatically faster search, often achieving 95%+ recall at 100x+ speedup.
+//!
+//! ## HNSW (Hierarchical Navigable Small World)
+//!
+//! This module uses HNSW, a graph-based ANN algorithm by Malkov & Yashunin (2018). It
+//! builds a multi-layer proximity graph:
+//! - **Upper layers** have few nodes with long-range connections for fast coarse navigation
+//! - **Lower layers** have more nodes with short-range connections for precise search
+//! - **Layer 0** contains all points
+//!
+//! Search starts at the top layer and greedily navigates to the nearest neighbor, then
+//! descends to the next layer. This yields O(log n) search time with high recall.
+//!
+//! ## Distance metrics
+//!
+//! - **L2 (Euclidean)**: straight-line distance in space. Good for dense, normalized vectors.
+//! - **Cosine**: measures the angle between vectors (direction only, ignores magnitude).
+//!   `distance = 1 - cos(theta)`. Most common for text embeddings.
+//! - **Inner Product (dot product)**: combines magnitude and direction. Used when vector
+//!   norms carry meaning (e.g., popularity-weighted embeddings).
+//!
+//! ## Integration with graph queries
+//!
+//! Vector search is exposed as a Cypher procedure:
+//! ```cypher
+//! CALL db.index.vector.queryNodes('embedding_index', 10, [0.1, 0.2, ...])
+//! YIELD node, score
+//! RETURN node.name, score
+//! ```
+//! This enables hybrid queries combining graph traversal with semantic similarity.
 
 pub mod index;
 pub mod manager;


### PR DESCRIPTION
## Summary
- Added rich `//!` module-level and `///` struct-level doc comments across 23 source files
- Explains both **Rust concepts** (ownership, trait objects, algebraic data types, newtype pattern) and **CS fundamentals** (adjacency lists, Volcano model, HNSW, Raft consensus, WAL, PEG parsing)
- 1,197 lines of documentation added, zero code changes
- All 1,820 tests pass, rustdoc builds with zero warnings

## Modules documented
| Module | Key concepts covered |
|--------|---------------------|
| `graph/` | Property graph model, adjacency lists, MVCC, three-valued logic, type coercion |
| `query/` | PEG parsing, Pratt parser, AST, Volcano iterator model, late materialization, cost-based optimization |
| `vector/` | HNSW algorithm, ANN search, distance metrics |
| `persistence/` | ACID, WAL theory, RocksDB column families, multi-tenancy |
| `raft/` | Raft consensus, leader election, log replication |
| `protocol/` | RESP wire format, state machine parsing |

## Test plan
- [x] `cargo test` — 1,820 passed, 0 failed
- [x] `cargo doc --no-deps` — zero warnings
- [ ] Browse `cargo doc` output for readability