### PR TITLE
feat: add --demo medium|large flag for LDBC Graphalytics loading

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ async fn main() {
 
     println!("\n=== Starting RESP Server ===");
     println!("Connect with: redis-cli");
-    println!("Example: GRAPH.QUERY sandbox \"MATCH (n:Vertex) RETURN n.vid, n.dataset LIMIT 10\"");
+    println!("Try: GRAPH.QUERY default \"MATCH (n) RETURN labels(n), count(n)\"");
     println!();
 
     start_server().await;
@@ -72,121 +72,114 @@ fn demo_cypher_queries() {
     }
 }
 
-/// Load LDBC Graphalytics datasets from data/graphalytics/ into the graph store.
+/// Load a single LDBC Graphalytics dataset into the graph store.
 ///
-/// Datasets are loaded from .v (vertex) and .e (edge) files in the standard
-/// LDBC Graphalytics format. Each vertex becomes a :Vertex node with vid and
-/// dataset properties. Edges are typed LINKS (directed) or CONNECTS (undirected).
-///
-/// Download datasets with: ./scripts/download_graphalytics.sh
-fn load_graphalytics_data(store: &mut GraphStore) -> bool {
-    println!("Loading LDBC Graphalytics data...");
-
+/// `max_vertices` caps the number of vertices loaded (edges are only created
+/// when both endpoints are in the loaded set).
+fn load_graphalytics_dataset(
+    store: &mut GraphStore,
+    dataset: &str,
+    directed: bool,
+    max_vertices: Option<usize>,
+) -> bool {
     let data_dir = std::path::Path::new("data/graphalytics");
-    if !data_dir.exists() {
-        println!("  LDBC Graphalytics data not found at data/graphalytics/");
-        println!("  Download with: ./scripts/download_graphalytics.sh");
+
+    // Try subdirectory first (XS layout), then flat (S-size tar extraction)
+    let sub_v = data_dir.join(dataset).join(format!("{}.v", dataset));
+    let sub_e = data_dir.join(dataset).join(format!("{}.e", dataset));
+    let flat_v = data_dir.join(format!("{}.v", dataset));
+    let flat_e = data_dir.join(format!("{}.e", dataset));
+
+    let (v_path, e_path) = if sub_v.exists() && sub_e.exists() {
+        (sub_v, sub_e)
+    } else if flat_v.exists() && flat_e.exists() {
+        (flat_v, flat_e)
+    } else {
+        println!("  Dataset '{}' not found in data/graphalytics/", dataset);
+        println!("  Download with: ./scripts/download_graphalytics.sh --size S");
         return false;
-    }
+    };
 
-    // Check for available datasets (XS first, then S-size)
-    let datasets: &[(&str, bool)] = &[
-        ("example-directed", true),
-        ("example-undirected", false),
-        ("wiki-Talk", true),
-        ("cit-Patents", true),
-        ("datagen-7_5-fb", false),
-    ];
+    let limit_str = match max_vertices {
+        Some(n) => format!(" (limit: {} vertices)", n),
+        None => String::new(),
+    };
+    println!("Loading LDBC Graphalytics: {}{}...", dataset, limit_str);
 
-    let mut any_loaded = false;
-
-    for &(dataset, directed) in datasets {
-        let dir = data_dir.join(dataset);
-        let v_path = dir.join(format!("{}.v", dataset));
-        let e_path = dir.join(format!("{}.e", dataset));
-
-        if !v_path.exists() || !e_path.exists() {
-            continue;
-        }
-
-        println!("  Loading {}...", dataset);
-
-        // Phase 1: Read vertices
-        let mut vid_to_node: HashMap<u64, NodeId> = HashMap::new();
-        if let Ok(file) = File::open(&v_path) {
-            let reader = BufReader::new(file);
-            for line in reader.lines().filter_map(|l| l.ok()) {
-                let trimmed = line.trim();
-                if trimmed.is_empty() || trimmed.starts_with('#') {
-                    continue;
-                }
-                if let Ok(vid) = trimmed.parse::<u64>() {
-                    let node_id = store.create_node("Vertex");
-                    if let Some(node) = store.get_node_mut(node_id) {
-                        node.set_property("vid", vid as i64);
-                        node.set_property("dataset", dataset);
-                    }
-                    vid_to_node.insert(vid, node_id);
+    // Phase 1: Read vertices
+    let mut vid_to_node: HashMap<u64, NodeId> = HashMap::new();
+    if let Ok(file) = File::open(&v_path) {
+        let reader = BufReader::new(file);
+        for line in reader.lines().filter_map(|l| l.ok()) {
+            if let Some(cap) = max_vertices {
+                if vid_to_node.len() >= cap {
+                    break;
                 }
             }
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            if let Ok(vid) = trimmed.parse::<u64>() {
+                let node_id = store.create_node("Vertex");
+                if let Some(node) = store.get_node_mut(node_id) {
+                    node.set_property("vid", vid as i64);
+                    node.set_property("dataset", dataset);
+                }
+                vid_to_node.insert(vid, node_id);
+            }
         }
+    }
 
-        // Phase 2: Read edges
-        let edge_type = if directed { "LINKS" } else { "CONNECTS" };
-        let mut edge_count: usize = 0;
-        if let Ok(file) = File::open(&e_path) {
-            let reader = BufReader::new(file);
-            for line in reader.lines().filter_map(|l| l.ok()) {
-                let trimmed = line.trim();
-                if trimmed.is_empty() || trimmed.starts_with('#') {
-                    continue;
-                }
+    // Phase 2: Read edges (only where both endpoints are loaded)
+    let edge_type = if directed { "LINKS" } else { "CONNECTS" };
+    let mut edge_count: usize = 0;
+    if let Ok(file) = File::open(&e_path) {
+        let reader = BufReader::new(file);
+        for line in reader.lines().filter_map(|l| l.ok()) {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
 
-                let parts: Vec<&str> = if trimmed.contains('|') {
-                    trimmed.split('|').collect()
-                } else {
-                    trimmed.split_whitespace().collect()
-                };
+            let parts: Vec<&str> = if trimmed.contains('|') {
+                trimmed.split('|').collect()
+            } else {
+                trimmed.split_whitespace().collect()
+            };
 
-                if parts.len() < 2 {
-                    continue;
-                }
+            if parts.len() < 2 {
+                continue;
+            }
 
-                let src = match parts[0].parse::<u64>() {
-                    Ok(v) => v,
-                    Err(_) => continue,
-                };
-                let tgt = match parts[1].parse::<u64>() {
-                    Ok(v) => v,
-                    Err(_) => continue,
-                };
+            let src = match parts[0].parse::<u64>() {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            let tgt = match parts[1].parse::<u64>() {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
 
-                if let (Some(&s), Some(&t)) = (vid_to_node.get(&src), vid_to_node.get(&tgt)) {
-                    if let Ok(eid) = store.create_edge(s, t, edge_type) {
-                        if parts.len() >= 3 {
-                            if let Ok(w) = parts[2].parse::<f64>() {
-                                if let Some(edge) = store.get_edge_mut(eid) {
-                                    edge.set_property("weight", w);
-                                }
+            if let (Some(&s), Some(&t)) = (vid_to_node.get(&src), vid_to_node.get(&tgt)) {
+                if let Ok(eid) = store.create_edge(s, t, edge_type) {
+                    if parts.len() >= 3 {
+                        if let Ok(w) = parts[2].parse::<f64>() {
+                            if let Some(edge) = store.get_edge_mut(eid) {
+                                edge.set_property("weight", w);
                             }
                         }
-                        edge_count += 1;
                     }
+                    edge_count += 1;
                 }
             }
         }
-
-        println!("    {} vertices, {} edges ({})",
-                 vid_to_node.len(), edge_count,
-                 if directed { "directed" } else { "undirected" });
-        any_loaded = true;
     }
 
-    if any_loaded {
-        println!("LDBC Graphalytics data loaded successfully!");
-    }
-
-    any_loaded
+    println!("  Loaded {} vertices, {} edges ({})",
+             vid_to_node.len(), edge_count,
+             if directed { "directed" } else { "undirected" });
+    true
 }
 
 async fn start_server() {
@@ -200,6 +193,11 @@ async fn start_server() {
         .and_then(|_| std::env::args().skip_while(|a| a != "--port").nth(1))
         .and_then(|p| p.parse().ok())
         .unwrap_or(6379);
+
+    // Parse --demo flag: medium (~100K vertices) or large (full dataset)
+    let demo_mode: Option<String> = std::env::args()
+        .position(|a| a == "--demo")
+        .and_then(|pos| std::env::args().nth(pos + 1));
 
     // Initialize persistence FIRST (before loading data)
     let persistence = if let Some(path) = &config.data_path {
@@ -244,25 +242,25 @@ async fn start_server() {
         }
     }
 
-    // Only load demo data if no persisted data was recovered
+    // Load demo data based on --demo flag (skip if persisted data was recovered)
     if !recovered {
-        println!("No persisted data found, loading demo data...");
-
-        if !load_graphalytics_data(&mut graph) {
-            // Fallback: minimal Person graph when no datasets are available
-            let alice = graph.create_node("Person");
-            if let Some(node) = graph.get_node_mut(alice) {
-                node.set_property("name", "Alice");
-                node.set_property("age", 30i64);
+        match demo_mode.as_deref() {
+            Some("medium") => {
+                // ~100K vertex subset of datagen-7_5-fb (Facebook-like social graph)
+                load_graphalytics_dataset(&mut graph, "datagen-7_5-fb", false, Some(100_000));
             }
-
-            let bob = graph.create_node("Person");
-            if let Some(node) = graph.get_node_mut(bob) {
-                node.set_property("name", "Bob");
-                node.set_property("age", 25i64);
+            Some("large") => {
+                // Full wiki-Talk dataset (2.4M vertices, 5M edges)
+                load_graphalytics_dataset(&mut graph, "wiki-Talk", true, None);
             }
-
-            graph.create_edge(alice, bob, "KNOWS").unwrap();
+            Some(other) => {
+                eprintln!("Unknown --demo mode '{}'. Use: --demo medium  or  --demo large", other);
+                eprintln!("  medium  — datagen-7_5-fb (~100K vertices, undirected social graph)");
+                eprintln!("  large   — wiki-Talk (2.4M vertices, directed discussion graph)");
+            }
+            None => {
+                // Default: empty graph
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Default startup is now empty graph (no demo data loaded)
- `--demo medium`: loads datagen-7_5-fb capped at 100K vertices + their edges
- `--demo large`: loads full wiki-Talk (2.4M vertices, 5M edges)
- Supports both subdirectory and flat file layouts from download script

## Test plan
- [x] `cargo test --lib` — 1760 tests pass
- [ ] `./target/release/samyama` — empty graph
- [ ] `./target/release/samyama --demo medium` — ~100K vertices
- [ ] `./target/release/samyama --demo large` — 2.4M vertices