### PR TITLE
fix: pass graph/tenant parameter through SDK and CLI

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -48,7 +48,11 @@ enum Commands {
     /// Ping the server
     Ping,
     /// Start an interactive REPL
-    Shell,
+    Shell {
+        /// Graph/tenant name
+        #[arg(long, default_value = "default")]
+        graph: String,
+    },
 }
 
 #[tokio::main]
@@ -62,7 +66,7 @@ async fn main() {
         }
         Commands::Status => run_status(&client, &cli.format).await,
         Commands::Ping => run_ping(&client).await,
-        Commands::Shell => run_shell(&client, &cli.format).await,
+        Commands::Shell { graph } => run_shell(&client, &graph, &cli.format).await,
     };
 
     if let Err(e) = result {
@@ -149,9 +153,10 @@ async fn run_ping(client: &RemoteClient) -> Result<(), Box<dyn std::error::Error
 
 async fn run_shell(
     client: &RemoteClient,
+    graph: &str,
     format: &OutputFormat,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    println!("Samyama Interactive Shell");
+    println!("Samyama Interactive Shell (graph: {})", graph);
     println!("Type Cypher queries, or :help for commands. :quit to exit.\n");
 
     let stdin = std::io::stdin();
@@ -190,7 +195,7 @@ async fn run_shell(
                 }
             }
             cypher => {
-                if let Err(e) = run_query(client, "default", cypher, false, format).await {
+                if let Err(e) = run_query(client, graph, cypher, false, format).await {
                     eprintln!("Error: {}", e);
                 }
             }

--- a/crates/samyama-sdk/src/remote.rs
+++ b/crates/samyama-sdk/src/remote.rs
@@ -33,9 +33,9 @@ impl RemoteClient {
     }
 
     /// Execute a POST request to /api/query
-    async fn post_query(&self, cypher: &str) -> SamyamaResult<QueryResult> {
+    async fn post_query(&self, graph: &str, cypher: &str) -> SamyamaResult<QueryResult> {
         let url = format!("{}/api/query", self.http_base_url);
-        let body = serde_json::json!({ "query": cypher });
+        let body = serde_json::json!({ "query": cypher, "graph": graph });
 
         let response = self.http_client.post(&url)
             .json(&body)
@@ -59,18 +59,18 @@ impl RemoteClient {
 
 #[async_trait]
 impl SamyamaClient for RemoteClient {
-    async fn query(&self, _graph: &str, cypher: &str) -> SamyamaResult<QueryResult> {
-        self.post_query(cypher).await
+    async fn query(&self, graph: &str, cypher: &str) -> SamyamaResult<QueryResult> {
+        self.post_query(graph, cypher).await
     }
 
-    async fn query_readonly(&self, _graph: &str, cypher: &str) -> SamyamaResult<QueryResult> {
-        self.post_query(cypher).await
+    async fn query_readonly(&self, graph: &str, cypher: &str) -> SamyamaResult<QueryResult> {
+        self.post_query(graph, cypher).await
     }
 
-    async fn delete_graph(&self, _graph: &str) -> SamyamaResult<()> {
+    async fn delete_graph(&self, graph: &str) -> SamyamaResult<()> {
         // The HTTP API doesn't expose GRAPH.DELETE directly.
         // We can execute a Cypher that deletes all nodes/edges.
-        self.post_query("MATCH (n) DELETE n").await?;
+        self.post_query(graph, "MATCH (n) DELETE n").await?;
         Ok(())
     }
 

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -2,7 +2,9 @@
   "name": "samyama-sdk",
   "version": "0.6.1",
   "description": "TypeScript SDK for the Samyama Graph Database",
+  "type": "module",
   "main": "dist/src/index.js",
+  "module": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [
     "dist/src/**/*.js",

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -5,8 +5,8 @@ import type {
   GraphSchema,
   CsvImportResult,
   JsonImportResult,
-} from "./types";
-import { HttpTransport } from "./http-client";
+} from "./types.js";
+import { HttpTransport } from "./http-client.js";
 
 const DEFAULT_URL = "http://localhost:8080";
 
@@ -50,40 +50,40 @@ export class SamyamaClient {
   }
 
   /** Execute a read-write Cypher query */
-  async query(cypher: string, _graph: string = "default"): Promise<QueryResult> {
-    return this.http.query(cypher);
+  async query(cypher: string, graph: string = "default"): Promise<QueryResult> {
+    return this.http.query(cypher, graph);
   }
 
   /** Execute a read-only Cypher query */
-  async queryReadonly(cypher: string, _graph: string = "default"): Promise<QueryResult> {
-    return this.http.query(cypher);
+  async queryReadonly(cypher: string, graph: string = "default"): Promise<QueryResult> {
+    return this.http.query(cypher, graph);
   }
 
   /**
    * Return the EXPLAIN plan for a Cypher query without executing it.
    * Returns the plan as text rows in the QueryResult records.
    */
-  async explain(cypher: string): Promise<QueryResult> {
+  async explain(cypher: string, graph: string = "default"): Promise<QueryResult> {
     const prefixed = cypher.trimStart().toUpperCase().startsWith("EXPLAIN")
       ? cypher
       : `EXPLAIN ${cypher}`;
-    return this.http.query(prefixed);
+    return this.http.query(prefixed, graph);
   }
 
   /**
    * Execute a Cypher query with PROFILE instrumentation.
    * Returns plan text with actual row counts and timing per operator.
    */
-  async profile(cypher: string): Promise<QueryResult> {
+  async profile(cypher: string, graph: string = "default"): Promise<QueryResult> {
     const prefixed = cypher.trimStart().toUpperCase().startsWith("PROFILE")
       ? cypher
       : `PROFILE ${cypher}`;
-    return this.http.query(prefixed);
+    return this.http.query(prefixed, graph);
   }
 
   /** Delete a graph (executes MATCH (n) DELETE n) */
-  async deleteGraph(_graph: string = "default"): Promise<void> {
-    await this.http.query("MATCH (n) DELETE n");
+  async deleteGraph(graph: string = "default"): Promise<void> {
+    await this.http.query("MATCH (n) DELETE n", graph);
   }
 
   /** List graphs (OSS: always returns ["default"]) */

--- a/sdk/typescript/src/http-client.ts
+++ b/sdk/typescript/src/http-client.ts
@@ -5,7 +5,7 @@ import type {
   GraphSchema,
   CsvImportResult,
   JsonImportResult,
-} from "./types";
+} from "./types.js";
 
 /**
  * HTTP transport for the Samyama SDK.
@@ -19,11 +19,11 @@ export class HttpTransport {
   }
 
   /** Execute a Cypher query via POST /api/query */
-  async query(cypher: string): Promise<QueryResult> {
+  async query(cypher: string, graph: string = "default"): Promise<QueryResult> {
     const response = await fetch(`${this.baseUrl}/api/query`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ query: cypher }),
+      body: JSON.stringify({ query: cypher, graph }),
     });
 
     if (!response.ok) {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,5 +1,5 @@
-export { SamyamaClient } from "./client";
-export { HttpTransport } from "./http-client";
+export { SamyamaClient } from "./client.js";
+export { HttpTransport } from "./http-client.js";
 export type {
   SdkNode,
   SdkEdge,
@@ -14,4 +14,4 @@ export type {
   ConstraintInfo,
   CsvImportResult,
   JsonImportResult,
-} from "./types";
+} from "./types.js";

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import * as assert from "node:assert/strict";
-import { SamyamaClient, HttpTransport } from "../src/index";
+import { SamyamaClient, HttpTransport } from "../src/index.js";
 import type {
   QueryResult,
   ServerStatus,
@@ -11,7 +11,7 @@ import type {
   ConstraintInfo,
   CsvImportResult,
   JsonImportResult,
-} from "../src/index";
+} from "../src/index.js";
 
 describe("SamyamaClient", () => {
   it("should create a client with default URL", () => {

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "ES2020",
     "lib": ["ES2020", "DOM"],
     "declaration": true,
     "strict": true,
@@ -9,6 +9,7 @@
     "strictNullChecks": true,
     "outDir": "dist",
     "rootDir": ".",
+    "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary
- **Rust SDK** (`RemoteClient`): `query()`, `query_readonly()`, `delete_graph()` now pass `graph` parameter in POST body instead of ignoring it
- **TypeScript SDK**: `HttpTransport.query()` includes `graph` in POST body; SDK switched from CommonJS to ESM for Vite compatibility
- **CLI**: `shell` subcommand accepts `--graph` flag for querying specific tenants (e.g. `samyama-cli shell --graph cricket`)

## Test plan
- [x] `samyama-cli query --graph cricket "MATCH (n) RETURN labels(n), count(n)"` returns cricket tenant data
- [x] `samyama-cli shell --graph cricket` REPL queries correct tenant
- [x] samyama-insight UI tenant switching works after SDK update