### PR TITLE
docs: embed demo video in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@
 
 **Samyama** is a high-performance, distributed, AI-native graph database written in **Rust**. It combines a **property graph engine**, **vector search**, **graph analytics**, and **natural language querying** in a single binary.
 
+### See it in action
+
+> Dashboard → Cypher Queries → Graph Simulation (Cricket KG — 36K nodes, 1.4M edges)
+
+https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v2/samyama-cricket-demo.mp4
+
 ### LDBC Benchmark Results (v0.6.0, Mac Mini M4)
 
 | Benchmark | Queries | Pass Rate | Dataset |


### PR DESCRIPTION
## Summary
- Adds cricket demo video (1:56, 1080p) at the top of README
- Video shows Dashboard, Cypher queries, and Graph Simulation
- Hosted on kg-snapshots-v2 release

Visitors see a compelling demo before anything else.