### PR TITLE
fix: piped edge types, SET expression evaluator, HTTP write detection

### DIFF
--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -41,7 +41,14 @@ pub async fn query_handler(
     let query_upper = payload.query.trim().to_uppercase();
     let is_write = query_upper.starts_with("CREATE") ||
                    query_upper.starts_with("SET") ||
-                   query_upper.starts_with("DELETE");
+                   query_upper.starts_with("DELETE") ||
+                   query_upper.starts_with("MERGE") ||
+                   (query_upper.starts_with("MATCH") &&
+                    (query_upper.contains(" CREATE ") || query_upper.contains(" SET ") ||
+                     query_upper.contains(" DELETE ") || query_upper.contains(" MERGE ") ||
+                     query_upper.contains(" REMOVE ") ||
+                     query_upper.ends_with(" CREATE") || query_upper.ends_with(" SET") ||
+                     query_upper.ends_with(" DELETE") || query_upper.ends_with(" MERGE")));
 
     let result = if is_write {
         let mut store_guard = state.store.write().await;

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -82,7 +82,7 @@ edge_pattern = {
     ("-" ~ edge_detail ~ "-")
 }
 edge_detail = { "[" ~ variable? ~ edge_types? ~ length_pattern? ~ properties? ~ "]" }
-edge_types = { (":" ~ edge_type)+ }
+edge_types = { ":" ~ edge_type ~ (("|" | ":") ~ edge_type)* }
 edge_type = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 // Variable length: *1..5 or * or *3..

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -5334,19 +5334,25 @@ impl PhysicalOperator for SetPropertyOperator {
 
     fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
         if let Some(record) = self.input.next_mut(store, tenant_id)? {
-            for (var, prop, expr) in &self.items {
-                // Evaluate the expression
-                let val = match expr {
-                    Expression::Literal(lit) => lit.clone(),
-                    Expression::Property { variable, property } => {
-                        if let Some(v) = record.get(variable) {
-                            v.resolve_property(property, store)
-                        } else {
-                            PropertyValue::Null
-                        }
-                    }
-                    _ => PropertyValue::Null,
+            // Evaluate all SET expressions first (immutable borrow of store)
+            let evaluated: Vec<_> = self.items.iter().map(|(var, prop, expr)| {
+                let val = match eval_expression(expr, &record, store) {
+                    Ok(v) => match v {
+                        Value::Property(pv) => pv,
+                        Value::Null => PropertyValue::Null,
+                        Value::NodeRef(id) => PropertyValue::Integer(id.as_u64() as i64),
+                        Value::Node(id, _) => PropertyValue::Integer(id.as_u64() as i64),
+                        Value::EdgeRef(id, ..) => PropertyValue::Integer(id.as_u64() as i64),
+                        Value::Edge(id, _) => PropertyValue::Integer(id.as_u64() as i64),
+                        Value::Path { .. } => PropertyValue::Null,
+                    },
+                    Err(_) => PropertyValue::Null,
                 };
+                (var.clone(), prop.clone(), val)
+            }).collect();
+
+            // Apply mutations (mutable borrow of store)
+            for (var, prop, val) in &evaluated {
 
                 if let Some(node_val) = record.get(var) {
                     match node_val {


### PR DESCRIPTION
## Summary
- **Piped edge types**: `MATCH (a)-[:KNOWS|WORKS_WITH]->(b)` now parses correctly (standard Cypher syntax)
- **SET expression evaluator**: `SET n.prop = toUpper(n.name)` and other function/binary expressions now work in SET clauses (previously silently returned Null)
- **HTTP write detection**: `MATCH...SET`, `MATCH...DELETE`, `MATCH...MERGE` correctly routed to write executor via HTTP API

## Test plan
- [x] 1782 unit tests pass (cargo test on AWS VM)
- [x] Integration test: `[:KNOWS|WORKS_WITH]` matches both edge types
- [x] Integration test: `SET n.upper_name = toUpper(n.name)` persists correctly
- [x] Integration test: backward compat — single edge type `[:KNOWS]` still works
- [x] Criterion benchmarks pass — no parse performance regression
- [x] 3 examples run successfully (social_network, banking, supply_chain)

## Known issue (pre-existing, not a regression)
SET on existing properties doesn't overwrite (e.g., `SET n.age = 31` on node with age=30 still reads 30). This is a deeper issue likely related to columnar store or late materialization. New properties (SET n.new_prop = value) work fine.