### PR TITLE
docs: ADR status review — update all 15 ADRs

### DIFF
--- a/docs/ADR/ADR-005-use-capnproto-serialization.md
+++ b/docs/ADR/ADR-005-use-capnproto-serialization.md
@@ -1,10 +1,10 @@
 # ADR-005: Use Cap'n Proto for Zero-Copy Serialization
 
 ## Status
-**Accepted**
+**Superseded** — Never adopted. Replaced by bincode for snapshots/internal and JSON for HTTP/API. See update notes below.
 
 ## Date
-2025-10-14
+2025-10-14 (Superseded 2026-03-23)
 
 ## Context
 
@@ -513,5 +513,26 @@ Cap'n Proto is mature and proven.
 
 ---
 
-**Last Updated**: 2025-10-14
-**Status**: Accepted and Implemented
+**Last Updated**: 2026-03-23
+**Status**: Superseded
+
+---
+
+## Supersession Note (2026-03-23)
+
+This ADR was accepted in October 2025 but **never implemented**. In practice, Samyama uses:
+
+| Use Case | Actual Format | Why |
+|----------|---------------|-----|
+| Snapshots (.sgsnap) | **bincode** + custom binary format | Fast, Rust-native, no schema compilation step |
+| RocksDB persistence | **bincode** | Internal Rust-only path, simplicity wins |
+| HTTP API | **JSON** | Universal client compatibility |
+| Raft log entries | **bincode** | Internal Rust-only, performance-critical |
+| HNSW vector persistence | **bincode** | Serialized Vec<f32> arrays |
+
+Cap'n Proto's zero-copy advantage is real but the integration overhead (schema compilation, build.rs, capnp dependency) was not justified given that:
+1. Samyama's hot path is in-memory (HashMap + adjacency lists), not serialization-bound
+2. bincode is fast enough (sub-millisecond for typical snapshots)
+3. The project prioritized query engine features over serialization optimization
+
+**If revisited**: Consider only for the Raft inter-node communication path where zero-copy network reads would eliminate a deserialize step. Not needed for persistence (RocksDB read path is already fast with bincode).

--- a/docs/ADR/ADR-009-graph-partitioning-strategy.md
+++ b/docs/ADR/ADR-009-graph-partitioning-strategy.md
@@ -1,10 +1,10 @@
 # ADR-009: Graph-Aware Partitioning for Distributed Mode
 
 ## Status
-**Proposed** (Phase 4+)
+**Proposed** (Phase 4+) — Stub implementation only (188 LOC in `src/sharding/`). Not production-ready.
 
 ## Date
-2025-10-14
+2025-10-14 (Updated 2026-03-23)
 
 ## Context
 

--- a/docs/ADR/ADR-010-observability-stack.md
+++ b/docs/ADR/ADR-010-observability-stack.md
@@ -1,10 +1,10 @@
 # ADR-010: Use Prometheus + OpenTelemetry for Observability
 
 ## Status
-**Accepted**
+**Accepted** — Implemented in Enterprise only. OSS has structured logging (tracing) but no Prometheus metrics.
 
 ## Date
-2025-10-14
+2025-10-14 (Updated 2026-03-23)
 
 ## Context
 

--- a/docs/ADR/ADR-011-cypher-crud-operations.md
+++ b/docs/ADR/ADR-011-cypher-crud-operations.md
@@ -1,10 +1,10 @@
 # ADR-011: Implement Cypher CRUD Operations (DELETE, SET, REMOVE)
 
 ## Status
-**Proposed**
+**Implemented** — DELETE, SET, REMOVE, MERGE all fully operational since v0.5.x. MutQueryExecutor handles all write operations.
 
 ## Date
-2025-12-27
+2025-12-27 (Implemented v0.5.x, updated 2026-03-23)
 
 ## Context
 

--- a/docs/ADR/ADR-015-graph-native-query-planning.md
+++ b/docs/ADR/ADR-015-graph-native-query-planning.md
@@ -1,10 +1,10 @@
 # ADR-015: Graph-Native Query Planning
 
 ## Status
-**Accepted**
+**Implemented** — Core planner operational since v0.6.0. Enhanced 2026-03-20: EXPLAIN shows candidate plan diagnostics (count, costs, alternatives), fallback to legacy planner for label-free patterns, 21 regression tests, `SAMYAMA_GRAPH_NATIVE=true` env var.
 
 ## Date
-2026-03-06
+2026-03-06 (Implemented v0.6.0, enhanced 2026-03-20)
 
 ## Context
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -35,20 +35,21 @@ Links to related ADRs
 
 | ADR | Title | Status | Date |
 |-----|-------|--------|------|
-| [001](./ADR-001-use-rust-as-primary-language.md) | Use Rust as Primary Programming Language | Accepted | 2025-10-14 |
-| [002](./ADR-002-use-rocksdb-for-persistence.md) | Use RocksDB for Persistence Layer | Accepted | 2025-10-14 |
-| [003](./ADR-003-use-resp-protocol.md) | Use RESP Protocol for Network Communication | Accepted | 2025-10-14 |
-| [004](./ADR-004-use-raft-consensus.md) | Use Raft Consensus for Distributed Coordination | Accepted | 2025-10-14 |
-| [005](./ADR-005-use-capnproto-serialization.md) | Use Cap'n Proto for Zero-Copy Serialization | Accepted | 2025-10-14 |
-| [006](./ADR-006-use-tokio-async-runtime.md) | Use Tokio as Async Runtime | Accepted | 2025-10-14 |
-| [007](./ADR-007-volcano-iterator-execution.md) | Use Volcano Iterator Model for Query Execution | Accepted | 2025-10-14 |
-| [008](./ADR-008-multi-tenancy-namespace-isolation.md) | Use Namespace Isolation for Multi-Tenancy | Accepted | 2025-10-14 |
-| [009](./ADR-009-graph-partitioning-strategy.md) | Graph-Aware Partitioning for Distributed Mode | Proposed | 2025-10-14 |
-| [010](./ADR-010-observability-stack.md) | Use Prometheus + OpenTelemetry for Observability | Accepted | 2025-10-14 |
-| [011](./ADR-011-cypher-crud-operations.md) | Implement Cypher CRUD Operations (DELETE, SET, REMOVE) | Proposed | 2025-12-27 |
-| [012](./ADR-012-late-materialization.md) | Late Materialization with NodeRef/EdgeRef | Accepted | 2025-12-15 |
-| [013](./ADR-013-peg-grammar-atomic-keywords.md) | PEG Grammar with Atomic Keyword Rules | Accepted | 2025-12-20 |
-| [014](./ADR-014-explain-profile-queries.md) | EXPLAIN and PROFILE Query Plan Visualization | Accepted | 2026-02-16 |
+| [001](./ADR-001-use-rust-as-primary-language.md) | Use Rust as Primary Programming Language | Implemented | 2025-10-14 |
+| [002](./ADR-002-use-rocksdb-for-persistence.md) | Use RocksDB for Persistence Layer | Implemented | 2025-10-14 |
+| [003](./ADR-003-use-resp-protocol.md) | Use RESP Protocol for Network Communication | Implemented | 2025-10-14 |
+| [004](./ADR-004-use-raft-consensus.md) | Use Raft Consensus for Distributed Coordination | Implemented | 2025-10-14 |
+| [005](./ADR-005-use-capnproto-serialization.md) | Use Cap'n Proto for Zero-Copy Serialization | **Superseded** | 2025-10-14 |
+| [006](./ADR-006-use-tokio-async-runtime.md) | Use Tokio as Async Runtime | Implemented | 2025-10-14 |
+| [007](./ADR-007-volcano-iterator-execution.md) | Use Volcano Iterator Model for Query Execution | Implemented | 2025-10-14 |
+| [008](./ADR-008-multi-tenancy-namespace-isolation.md) | Use Namespace Isolation for Multi-Tenancy | Implemented | 2025-10-14 |
+| [009](./ADR-009-graph-partitioning-strategy.md) | Graph-Aware Partitioning for Distributed Mode | Proposed (stub) | 2025-10-14 |
+| [010](./ADR-010-observability-stack.md) | Use Prometheus + OpenTelemetry for Observability | Enterprise only | 2025-10-14 |
+| [011](./ADR-011-cypher-crud-operations.md) | Implement Cypher CRUD Operations (DELETE, SET, REMOVE) | Implemented | 2025-12-27 |
+| [012](./ADR-012-late-materialization.md) | Late Materialization with NodeRef/EdgeRef | Implemented | 2025-12-15 |
+| [013](./ADR-013-peg-grammar-atomic-keywords.md) | PEG Grammar with Atomic Keyword Rules | Implemented | 2025-12-20 |
+| [014](./ADR-014-explain-profile-queries.md) | EXPLAIN and PROFILE Query Plan Visualization | Implemented | 2026-02-16 |
+| [015](./ADR-015-graph-native-query-planning.md) | Graph-Native Query Planning | Implemented | 2026-03-06 |
 
 ## Decision Process
 
@@ -60,4 +61,4 @@ Links to related ADRs
 ---
 
 **Maintained by**: Samyama Graph Database Team
-**Last Updated**: 2026-02-16
+**Last Updated**: 2026-03-23


### PR DESCRIPTION
## Summary
- ADR-005 (Cap'n Proto): **Superseded** — never adopted, using bincode/JSON
- ADR-009 (Partitioning): Stub only, not production-ready
- ADR-010 (Prometheus): Enterprise only
- ADR-011 (Cypher CRUD): Proposed → **Implemented**
- ADR-015 (Graph-Native Planning): Updated with recent enhancements
- README index: all statuses current, ADR-015 added

## Test plan
- [x] 1842 tests pass, 0 failures