### PR TITLE
feat: rayon parallel graph algorithms

### DIFF
--- a/crates/samyama-graph-algorithms/Cargo.toml
+++ b/crates/samyama-graph-algorithms/Cargo.toml
@@ -15,3 +15,4 @@ readme = "README.md"
 serde = { version = "1.0", features = ["derive"], optional = true }
 ndarray = "0.15"
 rand = "0.8"
+rayon = "1.10"

--- a/crates/samyama-graph-algorithms/src/cdlp.rs
+++ b/crates/samyama-graph-algorithms/src/cdlp.rs
@@ -6,6 +6,7 @@
 
 use super::common::{GraphView, NodeId};
 use std::collections::HashMap;
+use rayon::prelude::*;
 
 /// Result of CDLP algorithm
 #[derive(Debug, Clone)]
@@ -46,37 +47,62 @@ pub fn cdlp(view: &GraphView, config: &CdlpConfig) -> CdlpResult {
     let mut converged = false;
     let mut iterations = 0;
 
+    let use_parallel = n >= 1000;
+
     for _iter in 0..config.max_iterations {
-        converged = true;
         iterations += 1;
 
-        for idx in 0..n {
-            // Collect neighbor labels (undirected)
-            let mut label_counts: HashMap<NodeId, usize> = HashMap::new();
-            for &neighbor in view.successors(idx) {
-                *label_counts.entry(labels[neighbor]).or_insert(0) += 1;
-            }
-            for &neighbor in view.predecessors(idx) {
-                *label_counts.entry(labels[neighbor]).or_insert(0) += 1;
-            }
+        if use_parallel {
+            let results: Vec<(NodeId, bool)> = (0..n).into_par_iter().map(|idx| {
+                let mut label_counts: HashMap<NodeId, usize> = HashMap::new();
+                for &neighbor in view.successors(idx) {
+                    *label_counts.entry(labels[neighbor]).or_insert(0) += 1;
+                }
+                for &neighbor in view.predecessors(idx) {
+                    *label_counts.entry(labels[neighbor]).or_insert(0) += 1;
+                }
+                if label_counts.is_empty() {
+                    return (labels[idx], true);
+                }
+                let max_count = *label_counts.values().max().unwrap();
+                let best_label = label_counts.into_iter()
+                    .filter(|(_, count)| *count == max_count)
+                    .map(|(label, _)| label)
+                    .min()
+                    .unwrap();
+                (best_label, best_label == labels[idx])
+            }).collect();
 
-            if label_counts.is_empty() {
-                new_labels[idx] = labels[idx];
-                continue;
+            converged = true;
+            for (idx, (label, same)) in results.into_iter().enumerate() {
+                new_labels[idx] = label;
+                if !same { converged = false; }
             }
-
-            // Pick the most frequent label; break ties by choosing smallest label
-            let max_count = *label_counts.values().max().unwrap();
-            let best_label = label_counts.into_iter()
-                .filter(|(_, count)| *count == max_count)
-                .map(|(label, _)| label)
-                .min()
-                .unwrap();
-
-            if best_label != labels[idx] {
-                converged = false;
+        } else {
+            converged = true;
+            for idx in 0..n {
+                let mut label_counts: HashMap<NodeId, usize> = HashMap::new();
+                for &neighbor in view.successors(idx) {
+                    *label_counts.entry(labels[neighbor]).or_insert(0) += 1;
+                }
+                for &neighbor in view.predecessors(idx) {
+                    *label_counts.entry(labels[neighbor]).or_insert(0) += 1;
+                }
+                if label_counts.is_empty() {
+                    new_labels[idx] = labels[idx];
+                    continue;
+                }
+                let max_count = *label_counts.values().max().unwrap();
+                let best_label = label_counts.into_iter()
+                    .filter(|(_, count)| *count == max_count)
+                    .map(|(label, _)| label)
+                    .min()
+                    .unwrap();
+                if best_label != labels[idx] {
+                    converged = false;
+                }
+                new_labels[idx] = best_label;
             }
-            new_labels[idx] = best_label;
         }
 
         std::mem::swap(&mut labels, &mut new_labels);

--- a/crates/samyama-graph-algorithms/src/lcc.rs
+++ b/crates/samyama-graph-algorithms/src/lcc.rs
@@ -11,6 +11,7 @@
 
 use super::common::{GraphView, NodeId};
 use std::collections::{HashMap, HashSet};
+use rayon::prelude::*;
 
 /// Result of LCC computation
 #[derive(Debug, Clone)]
@@ -44,73 +45,114 @@ pub fn local_clustering_coefficient_directed(view: &GraphView, directed: bool) -
         return LccResult { coefficients: HashMap::new(), average: 0.0 };
     }
 
-    // Build undirected neighbor sets for each node (used for neighborhood)
-    let mut neighbors: Vec<HashSet<usize>> = Vec::with_capacity(n);
-    for idx in 0..n {
-        let mut set = HashSet::new();
-        for &s in view.successors(idx) {
-            if s != idx { set.insert(s); }
-        }
-        for &p in view.predecessors(idx) {
-            if p != idx { set.insert(p); }
-        }
-        neighbors.push(set);
-    }
+    // Build undirected neighbor sets for each node (parallel for large graphs)
+    let use_parallel = n >= 1000;
 
-    // For directed mode, also build successor sets for fast directed edge lookup
-    let successor_sets: Option<Vec<HashSet<usize>>> = if directed {
-        let mut sets = Vec::with_capacity(n);
-        for idx in 0..n {
-            let set: HashSet<usize> = view.successors(idx).iter().copied().collect();
-            sets.push(set);
-        }
-        Some(sets)
+    let neighbors: Vec<HashSet<usize>> = if use_parallel {
+        (0..n).into_par_iter().map(|idx| {
+            let mut set = HashSet::new();
+            for &s in view.successors(idx) { if s != idx { set.insert(s); } }
+            for &p in view.predecessors(idx) { if p != idx { set.insert(p); } }
+            set
+        }).collect()
     } else {
-        None
+        (0..n).map(|idx| {
+            let mut set = HashSet::new();
+            for &s in view.successors(idx) { if s != idx { set.insert(s); } }
+            for &p in view.predecessors(idx) { if p != idx { set.insert(p); } }
+            set
+        }).collect()
+    };
+
+    // For directed mode, build successor sets for directed edge checking
+    let successor_sets: Vec<HashSet<usize>> = if directed {
+        if use_parallel {
+            (0..n).into_par_iter().map(|idx| {
+                let mut set = HashSet::new();
+                for &s in view.successors(idx) { if s != idx { set.insert(s); } }
+                set
+            }).collect()
+        } else {
+            (0..n).map(|idx| {
+                let mut set = HashSet::new();
+                for &s in view.successors(idx) { if s != idx { set.insert(s); } }
+                set
+            }).collect()
+        }
+    } else {
+        Vec::new()
+    };
+
+    // Compute LCC per node in parallel
+    let per_node: Vec<(NodeId, f64)> = if use_parallel {
+        (0..n).into_par_iter().map(|idx| {
+            let deg = neighbors[idx].len();
+            if deg < 2 {
+                return (view.index_to_node[idx], 0.0);
+            }
+            let neighbor_vec: Vec<usize> = neighbors[idx].iter().cloned().collect();
+
+            let cc = if directed {
+                let mut directed_edges = 0usize;
+                for i in 0..neighbor_vec.len() {
+                    for j in 0..neighbor_vec.len() {
+                        if i != j && successor_sets[neighbor_vec[i]].contains(&neighbor_vec[j]) {
+                            directed_edges += 1;
+                        }
+                    }
+                }
+                directed_edges as f64 / (deg * (deg - 1)) as f64
+            } else {
+                let mut triangle_edges = 0usize;
+                for i in 0..neighbor_vec.len() {
+                    for j in (i + 1)..neighbor_vec.len() {
+                        if neighbors[neighbor_vec[i]].contains(&neighbor_vec[j]) {
+                            triangle_edges += 1;
+                        }
+                    }
+                }
+                triangle_edges as f64 / (deg * (deg - 1) / 2) as f64
+            };
+            (view.index_to_node[idx], cc)
+        }).collect()
+    } else {
+        (0..n).map(|idx| {
+            let deg = neighbors[idx].len();
+            if deg < 2 {
+                return (view.index_to_node[idx], 0.0);
+            }
+            let neighbor_vec: Vec<usize> = neighbors[idx].iter().cloned().collect();
+
+            let cc = if directed {
+                let mut directed_edges = 0usize;
+                for i in 0..neighbor_vec.len() {
+                    for j in 0..neighbor_vec.len() {
+                        if i != j && successor_sets[neighbor_vec[i]].contains(&neighbor_vec[j]) {
+                            directed_edges += 1;
+                        }
+                    }
+                }
+                directed_edges as f64 / (deg * (deg - 1)) as f64
+            } else {
+                let mut triangle_edges = 0usize;
+                for i in 0..neighbor_vec.len() {
+                    for j in (i + 1)..neighbor_vec.len() {
+                        if neighbors[neighbor_vec[i]].contains(&neighbor_vec[j]) {
+                            triangle_edges += 1;
+                        }
+                    }
+                }
+                triangle_edges as f64 / (deg * (deg - 1) / 2) as f64
+            };
+            (view.index_to_node[idx], cc)
+        }).collect()
     };
 
     let mut coefficients = HashMap::with_capacity(n);
     let mut sum = 0.0;
-
-    for idx in 0..n {
-        let deg = neighbors[idx].len();
-        if deg < 2 {
-            coefficients.insert(view.index_to_node[idx], 0.0);
-            continue;
-        }
-
-        let neighbor_vec: Vec<usize> = neighbors[idx].iter().cloned().collect();
-
-        if directed {
-            // Directed mode: count directed edges u→w among neighbors
-            let succ_sets = successor_sets.as_ref().unwrap();
-            let mut directed_edges = 0usize;
-            for i in 0..neighbor_vec.len() {
-                for j in 0..neighbor_vec.len() {
-                    if i != j && succ_sets[neighbor_vec[i]].contains(&neighbor_vec[j]) {
-                        directed_edges += 1;
-                    }
-                }
-            }
-            let max_edges = deg * (deg - 1); // d*(d-1) for directed
-            let cc = directed_edges as f64 / max_edges as f64;
-            coefficients.insert(view.index_to_node[idx], cc);
-            sum += cc;
-        } else {
-            // Undirected mode: count undirected edges among neighbors
-            let mut triangle_edges = 0usize;
-            for i in 0..neighbor_vec.len() {
-                for j in (i + 1)..neighbor_vec.len() {
-                    if neighbors[neighbor_vec[i]].contains(&neighbor_vec[j]) {
-                        triangle_edges += 1;
-                    }
-                }
-            }
-            let max_edges = deg * (deg - 1) / 2; // d*(d-1)/2 for undirected
-            let cc = triangle_edges as f64 / max_edges as f64;
-            coefficients.insert(view.index_to_node[idx], cc);
-            sum += cc;
-        }
+    for (node_id, cc) in per_node {
+        sum += cc;
+        coefficients.insert(node_id, cc);
     }
 
     let average = if n > 0 { sum / n as f64 } else { 0.0 };

--- a/crates/samyama-graph-algorithms/src/pagerank.rs
+++ b/crates/samyama-graph-algorithms/src/pagerank.rs
@@ -4,6 +4,7 @@
 
 use super::common::{GraphView, NodeId};
 use std::collections::HashMap;
+use rayon::prelude::*;
 
 /// PageRank configuration
 pub struct PageRankConfig {
@@ -52,34 +53,55 @@ pub fn page_rank(
     let d = config.damping_factor;
     let base_score = (1.0 - d) / n as f64;
 
-    for _ in 0..config.iterations {
-        let mut total_diff = 0.0;
+    // Use parallel iteration for graphs with 1000+ nodes
+    let use_parallel = n >= 1000;
 
+    for _ in 0..config.iterations {
         // Compute dangling node mass if enabled
         let dangling_contrib = if config.dangling_redistribution {
-            let dangling_sum: f64 = (0..n)
-                .filter(|&i| view.out_degree(i) == 0)
-                .map(|i| scores[i])
-                .sum();
+            let dangling_sum: f64 = if use_parallel {
+                (0..n).into_par_iter()
+                    .filter(|&i| view.out_degree(i) == 0)
+                    .map(|i| scores[i])
+                    .sum()
+            } else {
+                (0..n).filter(|&i| view.out_degree(i) == 0)
+                    .map(|i| scores[i])
+                    .sum()
+            };
             dangling_sum / n as f64
         } else {
             0.0
         };
 
-        for i in 0..n {
-            let mut sum_incoming = 0.0;
-
-            // Iterate over incoming edges
-            for &source_idx in view.predecessors(i) {
-                let out_degree = view.out_degree(source_idx);
-                if out_degree > 0 {
-                    sum_incoming += scores[source_idx] / out_degree as f64;
+        // Compute new scores and convergence diff in parallel
+        let total_diff = if use_parallel {
+            next_scores.par_iter_mut().enumerate().map(|(i, next_score)| {
+                let mut sum_incoming = 0.0;
+                for &source_idx in view.predecessors(i) {
+                    let out_degree = view.out_degree(source_idx);
+                    if out_degree > 0 {
+                        sum_incoming += scores[source_idx] / out_degree as f64;
+                    }
                 }
+                *next_score = base_score + d * (sum_incoming + dangling_contrib);
+                (*next_score - scores[i]).abs()
+            }).sum::<f64>()
+        } else {
+            let mut diff = 0.0;
+            for i in 0..n {
+                let mut sum_incoming = 0.0;
+                for &source_idx in view.predecessors(i) {
+                    let out_degree = view.out_degree(source_idx);
+                    if out_degree > 0 {
+                        sum_incoming += scores[source_idx] / out_degree as f64;
+                    }
+                }
+                next_scores[i] = base_score + d * (sum_incoming + dangling_contrib);
+                diff += (next_scores[i] - scores[i]).abs();
             }
-
-            next_scores[i] = base_score + d * (sum_incoming + dangling_contrib);
-            total_diff += (next_scores[i] - scores[i]).abs();
-        }
+            diff
+        };
 
         // Swap buffers
         scores.copy_from_slice(&next_scores);

--- a/crates/samyama-graph-algorithms/src/topology.rs
+++ b/crates/samyama-graph-algorithms/src/topology.rs
@@ -4,6 +4,7 @@
 
 use super::common::GraphView;
 use std::collections::HashSet;
+use rayon::prelude::*;
 
 /// Triangle Counting
 ///
@@ -11,37 +12,55 @@ use std::collections::HashSet;
 /// For undirected graphs, each triangle is counted once.
 /// For directed, we treat as undirected for counting.
 pub fn count_triangles(view: &GraphView) -> usize {
-    let mut triangle_count = 0;
-    
-    // Using simple algorithm: for each edge (u, v), find common neighbors of u and v.
-    // To avoid overcounting, we only consider nodes with indices i < j < k.
-    
-    for u in 0..view.node_count {
-        let u_neighbors: HashSet<_> = view.successors(u).iter()
-            .chain(view.predecessors(u).iter())
-            .cloned()
-            .collect();
-            
-        for &v in &u_neighbors {
-            if v <= u { continue; } // Order u < v
-            
-            let v_neighbors: HashSet<_> = view.successors(v).iter()
-                .chain(view.predecessors(v).iter())
+    let n = view.node_count;
+
+    // Parallel outer loop: each node computes its partial triangle count
+    if n >= 1000 {
+        (0..n).into_par_iter().map(|u| {
+            let u_neighbors: HashSet<_> = view.successors(u).iter()
+                .chain(view.predecessors(u).iter())
                 .cloned()
                 .collect();
-                
-            for &w in &v_neighbors {
-                if w <= v { continue; } // Order v < w
-                
-                // Check if w is also neighbor of u
-                if u_neighbors.contains(&w) {
-                    triangle_count += 1;
+
+            let mut count = 0;
+            for &v in &u_neighbors {
+                if v <= u { continue; }
+                let v_neighbors: HashSet<_> = view.successors(v).iter()
+                    .chain(view.predecessors(v).iter())
+                    .cloned()
+                    .collect();
+                for &w in &v_neighbors {
+                    if w <= v { continue; }
+                    if u_neighbors.contains(&w) {
+                        count += 1;
+                    }
+                }
+            }
+            count
+        }).sum()
+    } else {
+        let mut triangle_count = 0;
+        for u in 0..n {
+            let u_neighbors: HashSet<_> = view.successors(u).iter()
+                .chain(view.predecessors(u).iter())
+                .cloned()
+                .collect();
+            for &v in &u_neighbors {
+                if v <= u { continue; }
+                let v_neighbors: HashSet<_> = view.successors(v).iter()
+                    .chain(view.predecessors(v).iter())
+                    .cloned()
+                    .collect();
+                for &w in &v_neighbors {
+                    if w <= v { continue; }
+                    if u_neighbors.contains(&w) {
+                        triangle_count += 1;
+                    }
                 }
             }
         }
+        triangle_count
     }
-    
-    triangle_count
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Add rayon data-parallelism to PageRank, LCC, CDLP, Triangle Count
- Parallel for 1000+ nodes, sequential fallback for small graphs

## Benchmark (i9, 8c/16t)
| Algo | 1 thread | 16 threads | Speedup |
|------|----------|------------|--------|
| PageRank 100K | 119ms | 38ms | **3.1x** |
| LCC 50K | 316ms | 35ms | **9.1x** |
| CDLP 50K | 447ms | 78ms | **5.7x** |
| TriCount 10K | 76ms | 13ms | **6.0x** |

## Tests
- 38/38 algorithm tests pass
- 1855/1855 lib tests pass