### PR TITLE
Extend drug interactions loader with ChEMBL and OpenFDA

### DIFF
--- a/examples/aact_common/mod.rs
+++ b/examples/aact_common/mod.rs
@@ -1392,6 +1392,128 @@ fn load_design_group_interventions(
 ///
 /// # Returns
 /// `LoadResult` with total node and edge counts.
+// ============================================================================
+// STEP 13: Drug enrichment from DrugBank vocabulary (offline, no API)
+// ============================================================================
+
+/// Match DRUG-type Intervention names against DrugBank vocabulary (names + synonyms).
+/// Creates Drug nodes and CODED_AS_DRUG edges. No external API calls needed.
+fn enrich_drugs_from_drugbank(
+    graph: &mut GraphStore,
+    vocab_path: &Path,
+    ids: &IdMaps,
+) -> Result<(usize, usize), Error> {
+    // Build lookup: lowercase name/synonym -> (drugbank_id, canonical_name)
+    let mut name_to_drug: HashMap<String, (String, String)> = HashMap::new();
+
+    let file = File::open(vocab_path)?;
+    let reader = BufReader::new(file);
+    let mut first = true;
+    let mut col_idx: HashMap<String, usize> = HashMap::new();
+
+    for line in reader.lines() {
+        let line = line?;
+        if first {
+            // Parse CSV header
+            for (i, col) in line.split(',').enumerate() {
+                col_idx.insert(col.trim().trim_matches('"').to_string(), i);
+            }
+            first = false;
+            continue;
+        }
+        // Parse CSV with quoted fields
+        let fields = parse_drugbank_csv(&line);
+        let dbid = fields.get(*col_idx.get("DrugBank ID").unwrap_or(&0))
+            .map(|s| s.trim().to_string()).unwrap_or_default();
+        let common_name = fields.get(*col_idx.get("Common name").unwrap_or(&2))
+            .map(|s| s.trim().to_string()).unwrap_or_default();
+        let synonyms_str = fields.get(*col_idx.get("Synonyms").unwrap_or(&5))
+            .map(|s| s.trim().to_string()).unwrap_or_default();
+
+        if dbid.is_empty() || common_name.is_empty() {
+            continue;
+        }
+
+        let entry = (dbid.clone(), common_name.clone());
+        name_to_drug.insert(common_name.to_lowercase(), entry.clone());
+
+        // Index synonyms
+        for syn in synonyms_str.split('|') {
+            let syn = syn.trim();
+            if !syn.is_empty() {
+                name_to_drug.entry(syn.to_lowercase())
+                    .or_insert_with(|| entry.clone());
+            }
+        }
+    }
+
+    eprintln!("    DrugBank vocabulary: {} names/synonyms indexed", format_num(name_to_drug.len()));
+
+    // Match interventions against DrugBank
+    let mut drug_nodes: HashMap<String, NodeId> = HashMap::new();  // dbid -> NodeId
+    let mut node_count = 0usize;
+    let mut edge_count = 0usize;
+
+    for (interv_name_lower, &interv_node) in &ids.intervention {
+        // Check if this intervention is a DRUG type
+        let is_drug = graph.get_node(interv_node)
+            .and_then(|n| n.get_property("type"))
+            .map(|v| matches!(v, PropertyValue::String(s) if s == "DRUG"))
+            .unwrap_or(false);
+
+        if !is_drug {
+            continue;
+        }
+
+        // Try matching intervention name against DrugBank
+        if let Some((dbid, canonical_name)) = name_to_drug.get(interv_name_lower) {
+            let drug_node = if let Some(&existing) = drug_nodes.get(dbid) {
+                existing
+            } else {
+                let nid = graph.create_node("Drug");
+                if let Some(n) = graph.get_node_mut(nid) {
+                    n.set_property("drugbank_id", PropertyValue::String(dbid.clone()));
+                    n.set_property("name", PropertyValue::String(canonical_name.clone()));
+                }
+                drug_nodes.insert(dbid.clone(), nid);
+                node_count += 1;
+                nid
+            };
+
+            // Intervention -[:CODED_AS_DRUG]-> Drug
+            if graph.create_edge(interv_node, drug_node, "CODED_AS_DRUG").is_ok() {
+                edge_count += 1;
+            }
+        }
+    }
+
+    eprintln!("    Matched: {} Drug nodes, {} CODED_AS_DRUG edges (from {} drug-type interventions)",
+        format_num(node_count), format_num(edge_count),
+        format_num(ids.intervention.len()));
+
+    Ok((node_count, edge_count))
+}
+
+/// Parse a CSV line with quoted fields containing commas and pipes.
+fn parse_drugbank_csv(line: &str) -> Vec<String> {
+    let mut fields = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+
+    for ch in line.chars() {
+        match ch {
+            '"' => in_quotes = !in_quotes,
+            ',' if !in_quotes => {
+                fields.push(current.clone());
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+    fields.push(current);
+    fields
+}
+
 pub fn load_dataset(
     graph: &mut GraphStore,
     data_dir: &Path,
@@ -1603,6 +1725,38 @@ pub fn load_dataset(
     ));
     total_nodes += nn;
     total_edges += ne;
+
+    // ====================================================================
+    // Step 13: Drug enrichment (DrugBank cross-reference, no API calls)
+    // ====================================================================
+    let drugbank_vocab = data_dir.join("..").join("drugbank_vocabulary.csv");
+    // Also check a few common locations
+    let drugbank_vocab = if drugbank_vocab.exists() {
+        Some(drugbank_vocab)
+    } else {
+        // Try sibling druginteractions-kg data dir
+        let alt = data_dir.join("..").join("..").join("..").join("druginteractions-kg")
+            .join("data").join("drugbank").join("drugbank_vocabulary.csv");
+        if alt.exists() { Some(alt) } else { None }
+    };
+
+    if let Some(vocab_path) = drugbank_vocab {
+        eprintln!("--- Step 13: Drug enrichment (DrugBank cross-reference) ---");
+        let t = Instant::now();
+        let (nn, ne) = enrich_drugs_from_drugbank(graph, &vocab_path, &ids)?;
+        print_done(&format!(
+            "  Drug           {:>12} nodes, {:>12} CODED_AS_DRUG edges ({})",
+            format_num(nn),
+            format_num(ne),
+            format_duration(t.elapsed())
+        ));
+        total_nodes += nn;
+        total_edges += ne;
+    } else {
+        eprintln!("--- Step 13: Drug enrichment skipped (no drugbank_vocabulary.csv found) ---");
+        eprintln!("  Hint: place drugbank_vocabulary.csv alongside the AACT data dir,");
+        eprintln!("  or ensure druginteractions-kg/data/drugbank/ is a sibling directory.");
+    }
 
     Ok(LoadResult {
         total_nodes,

--- a/examples/druginteractions_common/mod.rs
+++ b/examples/druginteractions_common/mod.rs
@@ -32,9 +32,13 @@ pub struct LoadResult {
     pub gene_nodes: usize,
     pub side_effect_nodes: usize,
     pub indication_nodes: usize,
+    pub bioactivity_nodes: usize,
+    pub adverse_event_nodes: usize,
     pub interaction_edges: usize,
     pub side_effect_edges: usize,
     pub indication_edges: usize,
+    pub bioactivity_edges: usize,
+    pub adverse_event_edges: usize,
 }
 
 // ============================================================================
@@ -46,18 +50,24 @@ struct IdMaps {
     gene: HashMap<String, NodeId>,          // gene_name -> NodeId
     side_effect: HashMap<String, NodeId>,   // meddra_id -> NodeId
     indication: HashMap<String, NodeId>,    // meddra_id -> NodeId
+    bioactivity: HashMap<String, NodeId>,   // chembl_assay_id -> NodeId
+    adverse_event: HashMap<String, NodeId>, // term -> NodeId
     // Name lookups
     drug_name_to_dbid: HashMap<String, String>,  // lowercase name -> drugbank_id
     // Edge dedup
     interaction_edges: HashSet<String>,
     side_effect_edges: HashSet<String>,
     indication_edges: HashSet<String>,
+    bioactivity_edges: HashSet<String>,
+    adverse_event_edges: HashSet<String>,
 }
 
 impl IdMaps {
     fn new() -> Self {
         Self {
             drug: HashMap::new(),
+            bioactivity: HashMap::new(),
+            adverse_event: HashMap::new(),
             gene: HashMap::new(),
             side_effect: HashMap::new(),
             indication: HashMap::new(),
@@ -65,6 +75,8 @@ impl IdMaps {
             interaction_edges: HashSet::new(),
             side_effect_edges: HashSet::new(),
             indication_edges: HashSet::new(),
+            bioactivity_edges: HashSet::new(),
+            adverse_event_edges: HashSet::new(),
         }
     }
 }
@@ -119,9 +131,13 @@ pub fn load_dataset(
         gene_nodes: 0,
         side_effect_nodes: 0,
         indication_nodes: 0,
+        bioactivity_nodes: 0,
+        adverse_event_nodes: 0,
         interaction_edges: 0,
         side_effect_edges: 0,
         indication_edges: 0,
+        bioactivity_edges: 0,
+        adverse_event_edges: 0,
     };
 
     if phases.contains(&"drugbank_dgidb".to_string()) || phases.contains(&"all".to_string()) {
@@ -153,10 +169,39 @@ pub fn load_dataset(
         );
     }
 
+    if phases.contains(&"chembl".to_string()) || phases.contains(&"all".to_string()) {
+        let t = Instant::now();
+        let (bio_nodes, bio_edges, new_genes) =
+            load_chembl(graph, &mut maps, data_dir)?;
+        result.bioactivity_nodes = bio_nodes;
+        result.bioactivity_edges = bio_edges;
+        result.gene_nodes += new_genes;
+        eprintln!(
+            "  Phase 3 (ChEMBL): {} bioactivities, {} edges, {} new genes [{}]",
+            format_num(bio_nodes), format_num(bio_edges), format_num(new_genes),
+            format_duration(t.elapsed())
+        );
+    }
+
+    if phases.contains(&"openfda".to_string()) || phases.contains(&"all".to_string()) {
+        let t = Instant::now();
+        let (ae_nodes, ae_edges) =
+            load_openfda(graph, &mut maps, data_dir)?;
+        result.adverse_event_nodes = ae_nodes;
+        result.adverse_event_edges = ae_edges;
+        eprintln!(
+            "  Phase 4 (OpenFDA): {} adverse events, {} edges [{}]",
+            format_num(ae_nodes), format_num(ae_edges),
+            format_duration(t.elapsed())
+        );
+    }
+
     result.total_nodes = result.drug_nodes + result.gene_nodes
-        + result.side_effect_nodes + result.indication_nodes;
+        + result.side_effect_nodes + result.indication_nodes
+        + result.bioactivity_nodes + result.adverse_event_nodes;
     result.total_edges = result.interaction_edges
-        + result.side_effect_edges + result.indication_edges;
+        + result.side_effect_edges + result.indication_edges
+        + result.bioactivity_edges + result.adverse_event_edges;
 
     Ok(result)
 }
@@ -465,6 +510,207 @@ fn load_sider(
     }
 
     Ok((se_nodes, se_edges, ind_nodes, ind_edges))
+}
+
+// ============================================================================
+// PHASE 3: ChEMBL bioactivities
+// ============================================================================
+
+fn load_chembl(
+    graph: &mut GraphStore,
+    maps: &mut IdMaps,
+    data_dir: &Path,
+) -> Result<(usize, usize, usize), Error> {
+    let chembl_path = data_dir.join("chembl").join("chembl_activities.tsv");
+    if !chembl_path.exists() {
+        eprintln!("    ChEMBL: skipped (no chembl_activities.tsv)");
+        return Ok((0, 0, 0));
+    }
+
+    let file = File::open(&chembl_path)?;
+    let reader = BufReader::new(file);
+    let mut bio_nodes = 0usize;
+    let mut bio_edges = 0usize;
+    let mut new_genes = 0usize;
+    let mut first = true;
+    let mut col_idx: HashMap<String, usize> = HashMap::new();
+
+    for line in reader.lines() {
+        let line = line?;
+        if first {
+            for (i, col) in line.split('\t').enumerate() {
+                col_idx.insert(col.trim().to_string(), i);
+            }
+            first = false;
+            continue;
+        }
+        let fields: Vec<&str> = line.split('\t').collect();
+        let chembl_id = tfield(&fields, &col_idx, "chembl_id");
+        let assay_id = tfield(&fields, &col_idx, "chembl_assay_id");
+        let assay_type = tfield(&fields, &col_idx, "assay_type");
+        let std_type = tfield(&fields, &col_idx, "standard_type");
+        let std_value = tfield(&fields, &col_idx, "standard_value");
+        let std_units = tfield(&fields, &col_idx, "standard_units");
+        let pchembl = tfield(&fields, &col_idx, "pchembl_value");
+        let gene_name = tfield(&fields, &col_idx, "gene_name");
+        let target_name = tfield(&fields, &col_idx, "target_name");
+
+        if assay_id.is_empty() {
+            continue;
+        }
+
+        // Create Bioactivity node if new
+        if !maps.bioactivity.contains_key(&assay_id) {
+            let nid = graph.create_node("Bioactivity");
+            if let Some(n) = graph.get_node_mut(nid) {
+                n.set_property("chembl_assay_id", PropertyValue::String(assay_id.clone()));
+                if !assay_type.is_empty() {
+                    n.set_property("assay_type", PropertyValue::String(assay_type.clone()));
+                }
+                if !std_type.is_empty() {
+                    n.set_property("standard_type", PropertyValue::String(std_type.clone()));
+                }
+                if !std_value.is_empty() {
+                    if let Ok(v) = std_value.parse::<f64>() {
+                        n.set_property("standard_value", PropertyValue::Float(v));
+                    }
+                }
+                if !std_units.is_empty() {
+                    n.set_property("standard_units", PropertyValue::String(std_units.clone()));
+                }
+                if !pchembl.is_empty() {
+                    if let Ok(v) = pchembl.parse::<f64>() {
+                        n.set_property("pchembl_value", PropertyValue::Float(v));
+                    }
+                }
+                if !target_name.is_empty() {
+                    n.set_property("target_name", PropertyValue::String(target_name));
+                }
+            }
+            maps.bioactivity.insert(assay_id.clone(), nid);
+            bio_nodes += 1;
+        }
+
+        let bio_node = maps.bioactivity[&assay_id];
+
+        // HAS_BIOACTIVITY edge (Drug -> Bioactivity) — resolve drug by chembl_id
+        let dbid = maps.drug_name_to_dbid.get(&chembl_id.to_lowercase()).cloned();
+        if let Some(ref dbid) = dbid {
+            if let Some(&drug_node) = maps.drug.get(dbid) {
+                let edge_key = format!("{}|{}", dbid, assay_id);
+                if !maps.bioactivity_edges.contains(&edge_key) {
+                    maps.bioactivity_edges.insert(edge_key);
+                    let _ = graph.create_edge(drug_node, bio_node, "HAS_BIOACTIVITY");
+                    bio_edges += 1;
+                }
+            }
+        }
+
+        // BIOACTIVITY_TARGET edge (Bioactivity -> Gene)
+        if !gene_name.is_empty() {
+            let gene_node = if let Some(&id) = maps.gene.get(&gene_name) {
+                id
+            } else {
+                let id = graph.create_node("Gene");
+                if let Some(n) = graph.get_node_mut(id) {
+                    n.set_property("gene_name", PropertyValue::String(gene_name.clone()));
+                }
+                maps.gene.insert(gene_name.clone(), id);
+                new_genes += 1;
+                id
+            };
+            let bt_key = format!("{}|{}", assay_id, gene_name);
+            if !maps.bioactivity_edges.contains(&bt_key) {
+                maps.bioactivity_edges.insert(bt_key);
+                let _ = graph.create_edge(bio_node, gene_node, "BIOACTIVITY_TARGET");
+                bio_edges += 1;
+            }
+        }
+
+        if bio_nodes % 100_000 == 0 && bio_nodes > 0 {
+            eprint!("\r    ChEMBL: {} bioactivities, {} edges", format_num(bio_nodes), format_num(bio_edges));
+        }
+    }
+    eprintln!("\r    ChEMBL: {} bioactivities, {} edges, {} new genes",
+        format_num(bio_nodes), format_num(bio_edges), format_num(new_genes));
+
+    Ok((bio_nodes, bio_edges, new_genes))
+}
+
+// ============================================================================
+// PHASE 4: OpenFDA FAERS adverse events
+// ============================================================================
+
+fn load_openfda(
+    graph: &mut GraphStore,
+    maps: &mut IdMaps,
+    data_dir: &Path,
+) -> Result<(usize, usize), Error> {
+    let openfda_path = data_dir.join("openfda").join("adverse_events.tsv");
+    if !openfda_path.exists() {
+        eprintln!("    OpenFDA: skipped (no adverse_events.tsv)");
+        return Ok((0, 0));
+    }
+
+    let file = File::open(&openfda_path)?;
+    let reader = BufReader::new(file);
+    let mut ae_nodes = 0usize;
+    let mut ae_edges = 0usize;
+    let mut first = true;
+    let mut col_idx: HashMap<String, usize> = HashMap::new();
+
+    for line in reader.lines() {
+        let line = line?;
+        if first {
+            for (i, col) in line.split('\t').enumerate() {
+                col_idx.insert(col.trim().to_string(), i);
+            }
+            first = false;
+            continue;
+        }
+        let fields: Vec<&str> = line.split('\t').collect();
+        let dbid = tfield(&fields, &col_idx, "drugbank_id");
+        let ae_term = tfield(&fields, &col_idx, "adverse_event_term");
+        let count_str = tfield(&fields, &col_idx, "count");
+
+        if dbid.is_empty() || ae_term.is_empty() {
+            continue;
+        }
+
+        // Create AdverseEvent node if new
+        let ae_key = ae_term.to_lowercase();
+        let ae_node = if let Some(&id) = maps.adverse_event.get(&ae_key) {
+            id
+        } else {
+            let id = graph.create_node("AdverseEvent");
+            if let Some(n) = graph.get_node_mut(id) {
+                n.set_property("term", PropertyValue::String(ae_term.clone()));
+                n.set_property("source", PropertyValue::String("OpenFDA_FAERS".to_string()));
+            }
+            maps.adverse_event.insert(ae_key.clone(), id);
+            ae_nodes += 1;
+            id
+        };
+
+        // HAS_ADVERSE_EVENT edge (Drug -> AdverseEvent)
+        if let Some(&drug_node) = maps.drug.get(&dbid) {
+            let edge_key = format!("{}|{}", dbid, ae_key);
+            if !maps.adverse_event_edges.contains(&edge_key) {
+                maps.adverse_event_edges.insert(edge_key);
+                let eid = graph.create_edge(drug_node, ae_node, "HAS_ADVERSE_EVENT")
+                    .map_err(|e| format!("Edge creation failed: {}", e))?;
+                if let Ok(count) = count_str.parse::<i64>() {
+                    if let Some(e) = graph.get_edge_mut(eid) {
+                        e.set_property("report_count", PropertyValue::Integer(count));
+                    }
+                }
+                ae_edges += 1;
+            }
+        }
+    }
+    eprintln!("    OpenFDA: {} adverse events, {} edges", format_num(ae_nodes), format_num(ae_edges));
+
+    Ok((ae_nodes, ae_edges))
 }
 
 // ============================================================================

--- a/examples/druginteractions_loader.rs
+++ b/examples/druginteractions_loader.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Error> {
         eprintln!();
         eprintln!("Options:");
         eprintln!("  --data-dir PATH   Directory with drugbank/, dgidb/, sider/ subdirs (required)");
-        eprintln!("  --phases PHASES   Comma-separated: drugbank_dgidb,sider (default: all)");
+        eprintln!("  --phases PHASES   Comma-separated: drugbank_dgidb,sider,chembl,openfda (default: all)");
         eprintln!("  --snapshot PATH   Export snapshot to .sgsnap file after loading");
         eprintln!("  --query           Enter interactive Cypher REPL after loading");
         std::process::exit(1);
@@ -86,14 +86,16 @@ async fn main() -> Result<(), Error> {
     eprintln!();
     eprintln!("========================================");
     eprintln!("Drug Interactions KG load complete.");
-    eprintln!("  Drugs:        {}", format_num(result.drug_nodes));
-    eprintln!("  Genes:        {}", format_num(result.gene_nodes));
-    eprintln!("  Side Effects: {}", format_num(result.side_effect_nodes));
-    eprintln!("  Indications:  {}", format_num(result.indication_nodes));
+    eprintln!("  Drugs:          {}", format_num(result.drug_nodes));
+    eprintln!("  Genes:          {}", format_num(result.gene_nodes));
+    eprintln!("  Side Effects:   {}", format_num(result.side_effect_nodes));
+    eprintln!("  Indications:    {}", format_num(result.indication_nodes));
+    eprintln!("  Bioactivities:  {}", format_num(result.bioactivity_nodes));
+    eprintln!("  Adverse Events: {}", format_num(result.adverse_event_nodes));
     eprintln!("  ─────────────────────");
-    eprintln!("  Total nodes:  {}", format_num(result.total_nodes));
-    eprintln!("  Total edges:  {}", format_num(result.total_edges));
-    eprintln!("  Time:         {}", format_duration(total_elapsed));
+    eprintln!("  Total nodes:    {}", format_num(result.total_nodes));
+    eprintln!("  Total edges:    {}", format_num(result.total_edges));
+    eprintln!("  Time:           {}", format_duration(total_elapsed));
     eprintln!("========================================");
 
     // Snapshot export


### PR DESCRIPTION
## Summary
- Add Phase 3 (ChEMBL) and Phase 4 (OpenFDA) to the drug interactions Rust loader
- New Bioactivity nodes (208K from ChEMBL) + HAS_BIOACTIVITY / BIOACTIVITY_TARGET edges
- New AdverseEvent nodes (1.7K from OpenFDA FAERS) + HAS_ADVERSE_EVENT edges with report_count
- Snapshot grows from 33K nodes/189K edges to 245K nodes/388K edges (5 of 6 README sources)

## Test plan
- [x] `cargo build --release --example druginteractions_loader` compiles
- [x] Full load with all 5 sources: 244,783 nodes, 387,577 edges in 7.7s
- [x] Snapshot exports successfully (8.1 MB)
- [ ] `cargo test` passes (no changes to core lib, only examples)