### PR TITLE
fix: migrate get_edge_mut() calls to v1.0 API

### DIFF
--- a/benches/finbench_common/mod.rs
+++ b/benches/finbench_common/mod.rs
@@ -160,9 +160,9 @@ where
             Ok(edge_id) => {
                 let props = parse_props(&headers, &fields);
                 if !props.is_empty() {
-                    if let Some(edge) = graph.get_edge_mut(edge_id) {
+                    if let Some(edge_props) = graph.get_edge_properties_mut(edge_id) {
                         for (key, val) in props {
-                            edge.set_property(key, val);
+                            edge_props.insert(key.to_string(), val);
                         }
                     }
                 }
@@ -744,9 +744,7 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
             let src = ids.person[&pid];
             let tgt = ids.account[&aid];
             if let Ok(eid) = graph.create_edge(src, tgt, "OWN") {
-                if let Some(edge) = graph.get_edge_mut(eid) {
-                    edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                }
+                graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
                 own_count += 1;
                 owned_accounts.insert(aid);
             }
@@ -760,9 +758,7 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
             let src = ids.company[&cid];
             let tgt = ids.account[&aid];
             if let Ok(eid) = graph.create_edge(src, tgt, "OWN") {
-                if let Some(edge) = graph.get_edge_mut(eid) {
-                    edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                }
+                graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
                 own_count += 1;
                 owned_accounts.insert(aid);
             }
@@ -783,11 +779,9 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
         let src = ids.account[&src_aid];
         let tgt = ids.account[&tgt_aid];
         if let Ok(eid) = graph.create_edge(src, tgt, "TRANSFER") {
-            if let Some(edge) = graph.get_edge_mut(eid) {
-                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                let amount = 10.0 + rng.next_f64() * 50_000.0;
-                edge.set_property("amount", PropertyValue::Float(amount));
-            }
+            graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+            let amount = 10.0 + rng.next_f64() * 50_000.0;
+            graph.set_edge_property_sparse(eid, "amount", PropertyValue::Float(amount));
             transfer_count += 1;
         }
     }
@@ -806,11 +800,9 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
         let src = ids.account[&src_aid];
         let tgt = ids.account[&tgt_aid];
         if let Ok(eid) = graph.create_edge(src, tgt, "WITHDRAW") {
-            if let Some(edge) = graph.get_edge_mut(eid) {
-                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                let amount = 50.0 + rng.next_f64() * 20_000.0;
-                edge.set_property("amount", PropertyValue::Float(amount));
-            }
+            graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+            let amount = 50.0 + rng.next_f64() * 20_000.0;
+            graph.set_edge_property_sparse(eid, "amount", PropertyValue::Float(amount));
             withdraw_count += 1;
         }
     }
@@ -826,11 +818,9 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
         let src = ids.loan[&lid];
         let tgt = ids.account[&aid];
         if let Ok(eid) = graph.create_edge(src, tgt, "DEPOSIT") {
-            if let Some(edge) = graph.get_edge_mut(eid) {
-                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                let amount = 500.0 + rng.next_f64() * 100_000.0;
-                edge.set_property("amount", PropertyValue::Float(amount));
-            }
+            graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+            let amount = 500.0 + rng.next_f64() * 100_000.0;
+            graph.set_edge_property_sparse(eid, "amount", PropertyValue::Float(amount));
             deposit_count += 1;
         }
     }
@@ -846,11 +836,9 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
         let src = ids.account[&aid];
         let tgt = ids.loan[&lid];
         if let Ok(eid) = graph.create_edge(src, tgt, "REPAY") {
-            if let Some(edge) = graph.get_edge_mut(eid) {
-                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                let amount = 100.0 + rng.next_f64() * 50_000.0;
-                edge.set_property("amount", PropertyValue::Float(amount));
-            }
+            graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+            let amount = 100.0 + rng.next_f64() * 50_000.0;
+            graph.set_edge_property_sparse(eid, "amount", PropertyValue::Float(amount));
             repay_count += 1;
         }
     }
@@ -866,9 +854,7 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
         let src = ids.account[&aid];
         let tgt = ids.medium[&mid];
         if let Ok(eid) = graph.create_edge(src, tgt, "SIGN_IN") {
-            if let Some(edge) = graph.get_edge_mut(eid) {
-                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-            }
+            graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
             signin_count += 1;
         }
     }
@@ -889,9 +875,7 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
         };
         let tgt = ids.loan[&lid];
         if let Ok(eid) = graph.create_edge(src, tgt, "APPLY") {
-            if let Some(edge) = graph.get_edge_mut(eid) {
-                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-            }
+            graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
             apply_count += 1;
         }
     }
@@ -914,11 +898,9 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
         };
         let tgt = ids.company[&tgt_cid];
         if let Ok(eid) = graph.create_edge(src, tgt, "INVEST") {
-            if let Some(edge) = graph.get_edge_mut(eid) {
-                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                let ratio = rng.next_f64();
-                edge.set_property("ratio", PropertyValue::Float(ratio));
-            }
+            graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+            let ratio = rng.next_f64();
+            graph.set_edge_property_sparse(eid, "ratio", PropertyValue::Float(ratio));
             invest_count += 1;
         }
     }
@@ -938,9 +920,7 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
             let src = ids.company[&src_cid];
             let tgt = ids.company[&tgt_cid];
             if let Ok(eid) = graph.create_edge(src, tgt, "GUARANTEE") {
-                if let Some(edge) = graph.get_edge_mut(eid) {
-                    edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                }
+                graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
                 guarantee_count += 1;
             }
         } else {
@@ -950,9 +930,7 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
             let src = ids.person[&src_pid];
             let tgt = ids.person[&tgt_pid];
             if let Ok(eid) = graph.create_edge(src, tgt, "GUARANTEE") {
-                if let Some(edge) = graph.get_edge_mut(eid) {
-                    edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                }
+                graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
                 guarantee_count += 1;
             }
         }

--- a/benches/ldbc_common/mod.rs
+++ b/benches/ldbc_common/mod.rs
@@ -161,9 +161,9 @@ where
             Ok(edge_id) => {
                 let props = parse_props(&headers, &fields);
                 if !props.is_empty() {
-                    if let Some(edge) = graph.get_edge_mut(edge_id) {
+                    if let Some(edge_props) = graph.get_edge_properties_mut(edge_id) {
                         for (key, val) in props {
-                            edge.set_property(key, val);
+                            edge_props.insert(key.to_string(), val);
                         }
                     }
                 }

--- a/examples/banking_demo.rs
+++ b/examples/banking_demo.rs
@@ -441,17 +441,17 @@ fn load_relationship_file(
         if let (Some(from_id), Some(to_id)) = (from_id, to_id) {
             if let (Some(from_node), Some(to_node)) = (mappings.find(&from_id), mappings.find(&to_id)) {
                 if let Ok(edge_id) = graph.create_edge(from_node, to_node, edge_type) {
-                    if let Some(edge) = graph.get_edge_mut(edge_id) {
+                    if let Some(props) = graph.get_edge_properties_mut(edge_id) {
                         for (key, value) in &row {
                             if *key != from_col && *key != to_col && !value.is_empty() {
                                 if let Ok(n) = value.parse::<f64>() {
-                                    edge.set_property(*key, n);
+                                    props.insert((*key).into(), n.into());
                                 } else if let Ok(n) = value.parse::<i64>() {
-                                    edge.set_property(*key, n);
+                                    props.insert((*key).into(), n.into());
                                 } else if *value == "True" || *value == "False" {
-                                    edge.set_property(*key, *value == "True");
+                                    props.insert((*key).into(), (*value == "True").into());
                                 } else {
-                                    edge.set_property(*key, *value);
+                                    props.insert((*key).into(), (*value).into());
                                 }
                             }
                         }
@@ -732,7 +732,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         for node in &individual_customers {
             for edge in graph.get_outgoing_edges(node.id) {
                 if edge.edge_type.as_str() == "OWNS" {
-                    persist_mgr.persist_create_edge("retail_banking", edge)?;
+                    persist_mgr.persist_create_edge("retail_banking", &edge)?;
                     retail_edges += 1;
                 }
             }
@@ -742,7 +742,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         for node in &corporate_customers {
             for edge in graph.get_outgoing_edges(node.id) {
                 if edge.edge_type.as_str() == "OWNS" {
-                    persist_mgr.persist_create_edge("corporate_banking", edge)?;
+                    persist_mgr.persist_create_edge("corporate_banking", &edge)?;
                     corporate_edges += 1;
                 }
             }
@@ -752,7 +752,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         for node in &hnw_customers {
             for edge in graph.get_outgoing_edges(node.id) {
                 if edge.edge_type.as_str() == "OWNS" {
-                    persist_mgr.persist_create_edge("wealth_management", edge)?;
+                    persist_mgr.persist_create_edge("wealth_management", &edge)?;
                     wealth_edges += 1;
                 }
             }

--- a/examples/clinical_trials_demo.rs
+++ b/examples/clinical_trials_demo.rs
@@ -555,9 +555,7 @@ async fn main() {
         for (d1, d2, interaction_type) in drug_interaction_pairs() {
             if d1 < drug_ids.len() && d2 < drug_ids.len() {
                 let eid = store.create_edge(drug_ids[d1], drug_ids[d2], EdgeType::new("INTERACTS_WITH")).unwrap();
-                if let Some(edge) = store.get_edge_mut(eid) {
-                    edge.set_property("interaction_type", interaction_type);
-                }
+                store.set_edge_property_sparse(eid, "interaction_type", interaction_type);
                 edge_count += 1;
             }
         }

--- a/examples/druginteractions_common/mod.rs
+++ b/examples/druginteractions_common/mod.rs
@@ -339,13 +339,11 @@ fn load_drugbank_dgidb(
 
             let edge_id = graph.create_edge(drug_node, gene_node, "INTERACTS_WITH_GENE")
                 .map_err(|e| format!("Edge creation failed: {}", e))?;
-            if let Some(e) = graph.get_edge_mut(edge_id) {
-                if !int_type.is_empty() && int_type != "NULL" {
-                    e.set_property("interaction_type", PropertyValue::String(int_type));
-                }
-                if !source.is_empty() {
-                    e.set_property("source", PropertyValue::String(source));
-                }
+            if !int_type.is_empty() && int_type != "NULL" {
+                graph.set_edge_property_sparse(edge_id, "interaction_type", PropertyValue::String(int_type));
+            }
+            if !source.is_empty() {
+                graph.set_edge_property_sparse(edge_id, "source", PropertyValue::String(source));
             }
             edge_count += 1;
         }
@@ -500,10 +498,8 @@ fn load_sider(
 
             let edge_id = graph.create_edge(drug_node, ind_node, "HAS_INDICATION")
                 .map_err(|e| format!("Edge creation failed: {}", e))?;
-            if let Some(e) = graph.get_edge_mut(edge_id) {
-                if !method.is_empty() {
-                    e.set_property("method", PropertyValue::String(method.to_string()));
-                }
+            if !method.is_empty() {
+                graph.set_edge_property_sparse(edge_id, "method", PropertyValue::String(method.to_string()));
             }
             ind_edges += 1;
         }
@@ -700,9 +696,7 @@ fn load_openfda(
                 let eid = graph.create_edge(drug_node, ae_node, "HAS_ADVERSE_EVENT")
                     .map_err(|e| format!("Edge creation failed: {}", e))?;
                 if let Ok(count) = count_str.parse::<i64>() {
-                    if let Some(e) = graph.get_edge_mut(eid) {
-                        e.set_property("report_count", PropertyValue::Integer(count));
-                    }
+                    graph.set_edge_property_sparse(eid, "report_count", PropertyValue::Integer(count));
                 }
                 ae_edges += 1;
             }

--- a/examples/finbench_common/mod.rs
+++ b/examples/finbench_common/mod.rs
@@ -160,9 +160,9 @@ where
             Ok(edge_id) => {
                 let props = parse_props(&headers, &fields);
                 if !props.is_empty() {
-                    if let Some(edge) = graph.get_edge_mut(edge_id) {
+                    if let Some(edge_props) = graph.get_edge_properties_mut(edge_id) {
                         for (key, val) in props {
-                            edge.set_property(key, val);
+                            edge_props.insert(key.to_string(), val);
                         }
                     }
                 }
@@ -744,9 +744,7 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
             let src = ids.person[&pid];
             let tgt = ids.account[&aid];
             if let Ok(eid) = graph.create_edge(src, tgt, "OWN") {
-                if let Some(edge) = graph.get_edge_mut(eid) {
-                    edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                }
+                graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
                 own_count += 1;
                 owned_accounts.insert(aid);
             }
@@ -760,9 +758,7 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
             let src = ids.company[&cid];
             let tgt = ids.account[&aid];
             if let Ok(eid) = graph.create_edge(src, tgt, "OWN") {
-                if let Some(edge) = graph.get_edge_mut(eid) {
-                    edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                }
+                graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
                 own_count += 1;
                 owned_accounts.insert(aid);
             }
@@ -783,11 +779,9 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
         let src = ids.account[&src_aid];
         let tgt = ids.account[&tgt_aid];
         if let Ok(eid) = graph.create_edge(src, tgt, "TRANSFER") {
-            if let Some(edge) = graph.get_edge_mut(eid) {
-                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                let amount = 10.0 + rng.next_f64() * 50_000.0;
-                edge.set_property("amount", PropertyValue::Float(amount));
-            }
+            graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+            let amount = 10.0 + rng.next_f64() * 50_000.0;
+            graph.set_edge_property_sparse(eid, "amount", PropertyValue::Float(amount));
             transfer_count += 1;
         }
     }
@@ -806,11 +800,9 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
         let src = ids.account[&src_aid];
         let tgt = ids.account[&tgt_aid];
         if let Ok(eid) = graph.create_edge(src, tgt, "WITHDRAW") {
-            if let Some(edge) = graph.get_edge_mut(eid) {
-                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                let amount = 50.0 + rng.next_f64() * 20_000.0;
-                edge.set_property("amount", PropertyValue::Float(amount));
-            }
+            graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+            let amount = 50.0 + rng.next_f64() * 20_000.0;
+            graph.set_edge_property_sparse(eid, "amount", PropertyValue::Float(amount));
             withdraw_count += 1;
         }
     }
@@ -826,11 +818,9 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
         let src = ids.loan[&lid];
         let tgt = ids.account[&aid];
         if let Ok(eid) = graph.create_edge(src, tgt, "DEPOSIT") {
-            if let Some(edge) = graph.get_edge_mut(eid) {
-                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                let amount = 500.0 + rng.next_f64() * 100_000.0;
-                edge.set_property("amount", PropertyValue::Float(amount));
-            }
+            graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+            let amount = 500.0 + rng.next_f64() * 100_000.0;
+            graph.set_edge_property_sparse(eid, "amount", PropertyValue::Float(amount));
             deposit_count += 1;
         }
     }
@@ -846,11 +836,9 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
         let src = ids.account[&aid];
         let tgt = ids.loan[&lid];
         if let Ok(eid) = graph.create_edge(src, tgt, "REPAY") {
-            if let Some(edge) = graph.get_edge_mut(eid) {
-                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                let amount = 100.0 + rng.next_f64() * 50_000.0;
-                edge.set_property("amount", PropertyValue::Float(amount));
-            }
+            graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+            let amount = 100.0 + rng.next_f64() * 50_000.0;
+            graph.set_edge_property_sparse(eid, "amount", PropertyValue::Float(amount));
             repay_count += 1;
         }
     }
@@ -866,9 +854,7 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
         let src = ids.account[&aid];
         let tgt = ids.medium[&mid];
         if let Ok(eid) = graph.create_edge(src, tgt, "SIGN_IN") {
-            if let Some(edge) = graph.get_edge_mut(eid) {
-                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-            }
+            graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
             signin_count += 1;
         }
     }
@@ -889,9 +875,7 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
         };
         let tgt = ids.loan[&lid];
         if let Ok(eid) = graph.create_edge(src, tgt, "APPLY") {
-            if let Some(edge) = graph.get_edge_mut(eid) {
-                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-            }
+            graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
             apply_count += 1;
         }
     }
@@ -914,11 +898,9 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
         };
         let tgt = ids.company[&tgt_cid];
         if let Ok(eid) = graph.create_edge(src, tgt, "INVEST") {
-            if let Some(edge) = graph.get_edge_mut(eid) {
-                edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                let ratio = rng.next_f64();
-                edge.set_property("ratio", PropertyValue::Float(ratio));
-            }
+            graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
+            let ratio = rng.next_f64();
+            graph.set_edge_property_sparse(eid, "ratio", PropertyValue::Float(ratio));
             invest_count += 1;
         }
     }
@@ -938,9 +920,7 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
             let src = ids.company[&src_cid];
             let tgt = ids.company[&tgt_cid];
             if let Ok(eid) = graph.create_edge(src, tgt, "GUARANTEE") {
-                if let Some(edge) = graph.get_edge_mut(eid) {
-                    edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                }
+                graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
                 guarantee_count += 1;
             }
         } else {
@@ -950,9 +930,7 @@ pub fn generate_dataset(graph: &mut GraphStore, config: &GeneratorConfig) -> Loa
             let src = ids.person[&src_pid];
             let tgt = ids.person[&tgt_pid];
             if let Ok(eid) = graph.create_edge(src, tgt, "GUARANTEE") {
-                if let Some(edge) = graph.get_edge_mut(eid) {
-                    edge.set_property("timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
-                }
+                graph.set_edge_property_sparse(eid, "timestamp", PropertyValue::DateTime(random_ts(&mut rng)));
                 guarantee_count += 1;
             }
         }

--- a/examples/ldbc_common/mod.rs
+++ b/examples/ldbc_common/mod.rs
@@ -161,9 +161,9 @@ where
             Ok(edge_id) => {
                 let props = parse_props(&headers, &fields);
                 if !props.is_empty() {
-                    if let Some(edge) = graph.get_edge_mut(edge_id) {
+                    if let Some(edge_props) = graph.get_edge_properties_mut(edge_id) {
                         for (key, val) in props {
-                            edge.set_property(key, val);
+                            edge_props.insert(key.to_string(), val);
                         }
                     }
                 }

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "samyama-python"
-version = "0.9.0"
+version = "1.0.0"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Python bindings for the Samyama Graph Database SDK"
@@ -14,6 +14,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.22", features = ["extension-module"] }
-samyama-sdk = { path = "../../crates/samyama-sdk", version = "0.9.0" }
+samyama-sdk = { path = "../../crates/samyama-sdk", version = "1.0.0" }
 tokio = { version = "1.35", features = ["rt-multi-thread"] }
 serde_json = "1.0"

--- a/tests/algo_integration_test.rs
+++ b/tests/algo_integration_test.rs
@@ -21,19 +21,19 @@ fn test_max_flow_mst_integration() {
     let et = EdgeType::new("LINK");
     
     let e1 = store.create_edge(n1, n2, et.clone()).unwrap();
-    store.get_edge_mut(e1).unwrap().set_property("capacity".to_string(), PropertyValue::Float(10.0));
-    
+    store.set_edge_property_sparse(e1, "capacity", PropertyValue::Float(10.0));
+
     let e2 = store.create_edge(n1, n3, et.clone()).unwrap();
-    store.get_edge_mut(e2).unwrap().set_property("capacity".to_string(), PropertyValue::Float(10.0));
-    
+    store.set_edge_property_sparse(e2, "capacity", PropertyValue::Float(10.0));
+
     let e3 = store.create_edge(n2, n3, et.clone()).unwrap();
-    store.get_edge_mut(e3).unwrap().set_property("capacity".to_string(), PropertyValue::Float(1.0));
+    store.set_edge_property_sparse(e3, "capacity", PropertyValue::Float(1.0));
 
     let e4 = store.create_edge(n2, n4, et.clone()).unwrap();
-    store.get_edge_mut(e4).unwrap().set_property("capacity".to_string(), PropertyValue::Float(10.0));
+    store.set_edge_property_sparse(e4, "capacity", PropertyValue::Float(10.0));
 
     let e5 = store.create_edge(n3, n4, et.clone()).unwrap();
-    store.get_edge_mut(e5).unwrap().set_property("capacity".to_string(), PropertyValue::Float(10.0));
+    store.set_edge_property_sparse(e5, "capacity", PropertyValue::Float(10.0));
 
     // 1. Test Max Flow
     let query_str = format!("CALL algo.maxFlow({}, {}, 'capacity') YIELD max_flow", n1.as_u64(), n4.as_u64());

--- a/tests/comprehensive_test.rs
+++ b/tests/comprehensive_test.rs
@@ -50,16 +50,12 @@ async fn test_all_phases_comprehensive() {
 
     // Create edges with properties
     let knows_edge = graph_store.create_edge(alice_id, bob_id, "KNOWS").unwrap();
-    if let Some(edge) = graph_store.get_edge_mut(knows_edge) {
-        edge.set_property("since", 2020i64);
-        edge.set_property("strength", 0.9);
-    }
+    graph_store.set_edge_property_sparse(knows_edge, "since", 2020i64);
+    graph_store.set_edge_property_sparse(knows_edge, "strength", 0.9);
 
     let works_at_edge = graph_store.create_edge(alice_id, company_id, "WORKS_AT").unwrap();
-    if let Some(edge) = graph_store.get_edge_mut(works_at_edge) {
-        edge.set_property("position", "Senior Engineer");
-        edge.set_property("since", 2018i64);
-    }
+    graph_store.set_edge_property_sparse(works_at_edge, "position", "Senior Engineer");
+    graph_store.set_edge_property_sparse(works_at_edge, "since", 2018i64);
 
     // Verify graph structure
     assert_eq!(graph_store.node_count(), 3);


### PR DESCRIPTION
## Summary
- Migrate all `get_edge_mut()` calls to `set_edge_property_sparse()` / `get_edge_properties_mut()` after v1.0 arena removal
- Fix owned `Edge` references (`&edge`) for `persist_create_edge()` calls  
- Bump Python SDK version to 1.0.0

## Files changed (10)
- 2 integration tests (`algo_integration_test.rs`, `comprehensive_test.rs`)
- 3 examples (`banking_demo.rs`, `clinical_trials_demo.rs`, `druginteractions_common/`)
- 2 example common modules (`ldbc_common/`, `finbench_common/`)
- 2 bench common modules (`ldbc_common/`, `finbench_common/`)
- `sdk/python/Cargo.toml`

## Test plan
- [x] `cargo test --lib` — 1,933 pass
- [x] `cargo test --test comprehensive_test --test algo_integration_test` — pass
- [x] All affected examples compile
- [x] All affected benchmarks compile and run
- [x] LDBC SF1 benchmark 21/21 pass