### PR TITLE
port: ADR-017 (Phases 0/1/3a) + multi-WHERE parser fix + WithBarrier streaming LIMIT

### DIFF
--- a/docs/ADR/ADR-017-adjacency-aware-aggregation-planning.md
+++ b/docs/ADR/ADR-017-adjacency-aware-aggregation-planning.md
@@ -1,0 +1,210 @@
+# ADR-017: Adjacency-Aware Aggregation Planning
+
+## Status
+**Proposed** — design for review. Not yet implemented.
+
+## Date
+2026-04-13
+
+## Context
+
+ADR-015 shipped the graph-native planner with starting-point enumeration, direction reversal, and cost-based plan selection. That planner **correctly** handles asymmetric traversal patterns — `MATCH (a:Article)-[:AUTHORED_BY]->(au:Author {name: 'Smith'})` now drives from `Author` via the selective name filter instead of the 40M-node `Article` scan.
+
+But for **aggregation queries that touch every edge of a type**, starting-point selection cannot help. The total work is bounded below by the edge count, not by the cardinality of either endpoint.
+
+The 500-query v1.0 mega benchmark exposes this with four failures, all hitting the 300-second query timeout on PubMed (1B edges):
+
+| ID | Query | Bottleneck |
+|---|---|---|
+| MB049 | `MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal) RETURN j.title, count(a) ORDER BY count(a) DESC LIMIT 10` | 40M edges into aggregate |
+| MB054 | Same shape, `:MENTIONS_CHEMICAL` instead of `:PUBLISHED_IN` | 55M edges |
+| MB053 | Same shape with explicit `WITH m LIMIT 500` prefix | 40M post-LIMIT expansion¹ |
+| OM27 | Depression comorbidity agg on OMOP 51M Person × ConditionOccurrence | Cross-product into aggregate |
+
+¹ *PR #192 fixes MB053 and EX49 — the non-aggregation case where `WITH x LIMIT N` should short-circuit. This ADR addresses the remaining aggregation cases.*
+
+### Why Starting-Point Selection Is Not Enough
+
+Consider MB049. Two candidate plans:
+
+| Plan | Start | Expand | Aggregate input |
+|---|---|---|---|
+| A | Scan Article (40M) | Forward `:PUBLISHED_IN` (avg_out = 1) | 40M tuples |
+| B | Scan Journal (50k) | Reverse `:PUBLISHED_IN` (avg_in = 800) | 40M tuples |
+
+Both plans feed 40M tuples into the `AggregateOperator`. Starting from the smaller side doesn't reduce work — it just changes which side of the edge list is walked. **The aggregation itself must see every edge to finalize group counts.**
+
+The fundamental insight: when the aggregate is `count(neighbor)` grouped by a bound endpoint label, the count **is** the per-node in-degree (or out-degree) filtered by edge type. That quantity is already maintained in the adjacency list structure — we don't need to walk individual edges.
+
+### What's Already There
+
+The v1.0 planner has a narrow `EdgeTypeCountOperator` (planner.rs:1321-1339) that handles:
+
+```cypher
+MATCH ()-[r]->() RETURN type(r), count(*)
+```
+
+This is the **degenerate** case — global edge-type counts with no endpoint labels. Per planner.rs:1319-1326, it requires:
+- Single MATCH, single path, single segment
+- No labels on start or end nodes
+- `group by` is `type(r)`
+
+MB049 does not qualify because both endpoints have labels. The degree information is there in the adjacency lists; we just don't use it.
+
+## Decision
+
+**We will extend the planner to recognize a class of aggregation patterns where the aggregate reduces to per-node degree scans, and emit a new `AdjacencyCountAggregateOperator` that computes results in O(|nodes on the bound side|) instead of O(|edges|).**
+
+### Pattern Recognition
+
+The planner will detect this shape during logical-plan construction:
+
+```cypher
+MATCH (a[:LabelA])-[r:EdgeType]-(b:LabelB)
+RETURN b.prop [, ...], count(a) AS n  -- or count(*), count(r), count(DISTINCT a)
+[ORDER BY n DESC | ASC] [LIMIT N]
+```
+
+**Constraints for the rewrite:**
+- Single MATCH clause, single edge segment (the common pattern of MB049/54 and similar)
+- Exactly one `count()` aggregate — sum/avg/min/max over neighbor properties are a future phase
+- Group-by keys are all properties of a single endpoint (`b` in the example) plus optional expressions on `b`
+- WHERE clauses, if present, only reference that endpoint
+- Edge type is concrete (not a wildcard)
+
+The direction of the count — forward (out-degree of `a` grouped by `a`) or reverse (in-degree of `b` grouped by `b`) — is determined by which endpoint carries the group-by keys.
+
+### New Operator: AdjacencyCountAggregate
+
+Takes: source scan (the grouped side, e.g. `:Journal`), edge type, direction, group-by keys, optional ORDER BY and LIMIT.
+
+Algorithm:
+```
+for each node n in source scan:
+    let count = store.degree(n, edge_type, direction, [optional other-label filter])
+    emit (group_by_exprs, count)
+apply ORDER BY + LIMIT with bounded TopK heap
+```
+
+Cost: `O(|group_scan| × O(degree_lookup))`. For MB049: 50,000 Journals × O(1) degree lookup = 50,000 operations vs the current 40,000,000.
+
+### When the Other-Label Filter Is Cheap
+
+A subtlety: MB049 specifies `a:Article`. If `:PUBLISHED_IN` has both `:Article` and `:Book` sources, the count must filter to Article only. Three options:
+
+1. **Degree cache is edge-type only**: filter by walking adjacencies, O(degree) per node (no improvement vs full scan)
+2. **Per-(label, edge_type) degree cache**: maintain `degree_by_other_label(node, edge_type, other_label)` — additional storage, negligible per-node cost
+3. **Ignore the filter when the schema implies uniqueness**: if catalog knows `:PUBLISHED_IN` only connects `:Article` and `:Journal`, the filter is a no-op
+
+Phase 1 takes option 3 via catalog consultation; option 2 becomes a Phase 3 storage-layer enhancement if benchmarks show the schema-uniqueness check isn't covering common cases.
+
+### Phased Implementation
+
+| Phase | Scope | Delivers |
+|-------|-------|----------|
+| **0: Pattern detector** | `LogicalPlanNode::AdjacencyCountAggregate` variant; planner recognition; unit tests for detection | Zero behavioral change, new plan shape available behind env flag |
+| **1: Operator + unschema'd cases** | `AdjacencyCountAggregateOperator`; physical conversion; catalog schema-uniqueness check; integration tests with ORDER BY DESC LIMIT N | MB049, MB054 pass; ~50x speedup for qualifying queries |
+| **2: Label-filtered degree** | Extend adjacency to cache per-(edge_type, other_label) counts for hot node labels; lazy computation with invalidation | Handles mixed-source edge types correctly |
+| **3: Multi-aggregate + WITH-wrapped form** | Extend to `count(*)`, `count(r)`, and the `WITH ... ORDER BY ... LIMIT N RETURN ...` shape (addresses OM27) | Broader coverage; OM27 passes |
+| **4: Collected neighbors** | Extend to `sum(b.prop)` and `collect(b)` when b is the non-grouped side | LDBC BI query coverage |
+
+### Interaction with Other Optimizations
+
+- **`EdgeTypeCountOperator`** (the `type(r), count(*)` case): remains; it's the degenerate form of this ADR's pattern
+- **`LabelCountOperator`**: remains; covers `MATCH (n:L) RETURN count(n)`
+- **TopK fusion** (proposed in issue #190 part 2): `AdjacencyCountAggregate` emits its own TopK internally; no separate fusion needed
+- **PR #192 (WithBarrier streaming LIMIT)**: orthogonal; covers the non-aggregation case
+
+## Rationale
+
+### Why This Is The Right Abstraction
+
+The "count of things on the other side of an edge" is the most common aggregation shape in real graph workloads — degree distributions, popularity, influence. Every graph DB that's serious about this workload has a specialized plan shape for it:
+
+- **Neo4j**: `GetDegree` operator, used when the planner detects count-star with pattern matching
+- **Memgraph**: inline degree-lookup in aggregation planning since v2.4
+- **TigerGraph**: `degree()` function exposed directly in GSQL
+
+The pattern is pervasive enough to justify its own plan node rather than bolting onto the generic aggregate.
+
+### Why Not Just Fix EdgeTypeCountOperator
+
+The existing operator's constraints (planner.rs:1319) are too restrictive — they were designed for the global `type(r), count(*)` shape, not labelled-endpoint aggregations. Relaxing them mid-logic-block risks other plan paths. A new plan node with its own predicate is cleaner and separately testable.
+
+### Why Not Materialized Views
+
+A materialized view for "top-10 journals by article count" would make this specific query O(10). But:
+- Requires view definition syntax and invalidation rules (big project)
+- Hard-coded for the exact query; MB054 would need its own view
+- Write overhead scales with view count
+
+The degree-scan approach handles any `count(neighbor)` query with one code path and no view maintenance.
+
+### Performance Target
+
+For MB049 on the v1.0 mega-bench corpus:
+- Current: timeout at 300s (query doesn't complete)
+- Target: < 500 ms (50,000 Journal scans × ~10 μs per degree lookup)
+
+This is a 600x improvement lower bound (timeout → success) and a plausible further 10-100x vs a cost-optimal edge-walking plan.
+
+## Consequences
+
+### Positive
+- MB049, MB054 complete in < 1s instead of timing out (mega bench 493 → 495)
+- OM27 completes once Phase 3 ships (mega bench → 496+)
+- Pattern generalizes to all `count(neighbor)` groupby-one-endpoint queries — many LDBC BI queries benefit
+- Catalog is already there — no schema or storage changes for Phase 1
+- No query syntax changes — users keep writing standard Cypher
+
+### Negative
+- New plan node adds planner surface area to test
+- Label-filtered degree cache (Phase 2) adds per-node storage (~8 bytes per (label, edge_type) pair)
+- If the schema-uniqueness check is wrong, query returns wrong counts — must be defensive
+- Phase 2's lazy cache invalidation is subtle around DELETE under MVCC; needs attention alongside the ADR-012 late-materialization and v1.0 MVCC work
+
+### Neutral
+- EXPLAIN output gains a new operator name; users running automated test diffs on plan shapes need an update
+- Feature-flag rollout (`SAMYAMA_ADJACENCY_AGG=1`) mirrors the ADR-015 rollout pattern
+
+## Alternatives Considered
+
+### Alternative 1: Generic Streaming Aggregate With Cost-Based Early Termination
+Compute aggregates in a streaming fashion and cut off when the current heap top can no longer be beaten.
+
+**Rejected**: requires knowing the full distribution of remaining tuples to terminate early. Without pre-computed stats, we'd need to scan most of the input anyway. For MB049 specifically, the long tail of infrequent journals is exactly where we'd still be scanning.
+
+### Alternative 2: Approximate Aggregation (Count-Min Sketch)
+Use a sketch data structure to estimate group counts.
+
+**Rejected**: Cypher `count()` is exact — approximate answers would break the semantics. Could be offered as an opt-in for analytics queries, but that's a separate feature (ADR candidate later).
+
+### Alternative 3: Push Aggregate Below Scan Via Physical Pre-Aggregation
+Maintain an incrementally-updated per-(label, edge_type, other_label) counter at ingestion time.
+
+**Rejected for Phase 1**, kept as Phase 2: this is the label-filtered degree cache. Writes are in the hot path of loading; write overhead must be measured before committing to maintaining it unconditionally.
+
+### Alternative 4: Query Rewriting at the API Layer
+Recognize the pattern and rewrite the Cypher before parsing — e.g., transform MB049 into `MATCH (j:Journal) WHERE size((:Article)-[:PUBLISHED_IN]->(j)) > 0 ...`.
+
+**Rejected**: leaks into the NLQ and Cypher-SDK surfaces, inconsistent with "engine handles its own optimization", brittle across Cypher dialects.
+
+## Related Decisions
+
+- [ADR-007: Volcano Iterator Model](./ADR-007-volcano-iterator-execution.md) — new operator implements `PhysicalOperator`
+- [ADR-012: Late Materialization](./ADR-012-late-materialization.md) — new operator emits `Value::NodeRef` for grouped endpoint
+- [ADR-015: Graph-Native Query Planning](./ADR-015-graph-native-query-planning.md) — this ADR extends the logical-plan layer introduced there
+- PR #192 `perf/with-limit-streaming` — complementary; handles the non-aggregation WITH LIMIT case
+
+## References
+
+- Mega benchmark results: [`samyama-graph-book/src/data/benchmark/`](https://github.com/samyama-ai/samyama-graph-book/tree/main/src/data/benchmark) (v4 run: 493/500)
+- Issue [#190](https://git.samyama.ai/Samyama.ai/samyama-graph-enterprise/issues/190) — motivating issue
+- Issue [#191](https://git.samyama.ai/Samyama.ai/samyama-graph-enterprise/issues/191) — OM27 tracker
+- Neo4j GetDegree operator: https://neo4j.com/docs/cypher-manual/current/query-tuning/using/
+- Labelled Property Graph Model, Angles et al., 2017
+
+---
+
+**Last Updated**: 2026-04-13
+**Status**: Proposed (awaiting review)

--- a/src/query/executor/adjacency_agg_detector.rs
+++ b/src/query/executor/adjacency_agg_detector.rs
@@ -163,6 +163,15 @@ pub fn detect(query: &Query) -> Option<AdjacencyAggPattern> {
 
     let (count_alias, count_arg_var, count_distinct) = count_info?;
 
+    // Phase 1 cannot safely lower `count(DISTINCT neighbor)` — degree-on-a-node
+    // equals the raw edge count, which differs from the set-size when parallel
+    // edges exist. Reject so the planner keeps the generic aggregate path.
+    // A future phase may lift this constraint either via a parallel-edge
+    // schema check or a dedup helper in the operator.
+    if count_distinct {
+        return None;
+    }
+
     // The counted variable must be one endpoint; the grouped side must be the
     // OTHER endpoint and must provide every group-by variable.
     let (grouped_var, grouped_node, neighbor_var, neighbor_node) =
@@ -325,7 +334,9 @@ mod tests {
         assert!(detect(&q).is_none());
     }
 
-    /// DISTINCT count — set-cardinality semantics diverge from raw degree.
+    /// DISTINCT count — set-cardinality semantics diverge from raw degree
+    /// when parallel edges exist. Phase 1 rejects outright; lift in a later
+    /// phase once we have a parallel-edge check.
     #[test]
     fn rejects_count_distinct_in_phase_1() {
         let q = parse_query(
@@ -333,11 +344,7 @@ mod tests {
              RETURN j.title, count(DISTINCT a) AS articles",
         )
         .unwrap();
-        let p = detect(&q);
-        // Detector still extracts it — Phase 1's lowering will reject on the
-        // `count_distinct` flag. Make sure we faithfully record the modifier.
-        let p = p.expect("detector preserves DISTINCT info");
-        assert!(p.count_distinct);
+        assert!(detect(&q).is_none());
     }
 
     /// Property constraints on endpoints would act as filters; out of scope.

--- a/src/query/executor/adjacency_agg_detector.rs
+++ b/src/query/executor/adjacency_agg_detector.rs
@@ -1,0 +1,389 @@
+//! Detector for the adjacency-aware aggregation pattern (ADR-017 Phase 0).
+//!
+//! Recognizes queries of the form:
+//! ```text
+//! MATCH (a[:LabelA])-[r:EdgeType]-(b:LabelB)
+//! RETURN b.prop [, ...], count(a) AS n
+//!   [ORDER BY n DESC] [LIMIT N]
+//! ```
+//! where the aggregate reduces to per-node degree on the bound endpoint `b`.
+//!
+//! The detector is deliberately conservative in Phase 0: if any constraint
+//! fails, it returns `None` and the caller uses the standard plan. This
+//! guarantees zero behavior change until the physical operator ships in
+//! Phase 1.
+
+use super::logical_plan::ExpandDirection;
+use crate::graph::types::{EdgeType, Label};
+use crate::query::ast::{Direction, Expression, Query};
+
+/// Parameters extracted from a query that matches the adjacency-count pattern.
+///
+/// These are the inputs Phase 1's `AdjacencyCountAggregateOperator` will need
+/// at plan-construction time. Phase 0 produces this struct but does not yet
+/// build a `LogicalPlanNode` from it — that wiring lands in Phase 1.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AdjacencyAggPattern {
+    /// Variable bound to the endpoint the aggregate groups on.
+    pub grouped_var: String,
+    /// Label of the grouped endpoint (required — used as the NodeScan target).
+    pub grouped_label: Label,
+    /// Variable bound to the counted neighbor.
+    pub neighbor_var: String,
+    /// Optional label on the neighbor side. Phase 1 requires schema uniqueness
+    /// before using this for filtering; the detector records it for later use.
+    pub neighbor_label: Option<Label>,
+    /// Edge type connecting the two endpoints. Phase 1 requires exactly one.
+    pub edge_type: EdgeType,
+    /// Direction of the edge *relative to the grouped endpoint*.
+    /// - `Forward`  = `grouped_var -[E]-> neighbor_var` (out-degree)
+    /// - `Reverse`  = `neighbor_var -[E]-> grouped_var` (in-degree)
+    pub direction: ExpandDirection,
+    /// Alias the count result is exposed as (e.g. `"articles"`).
+    pub count_alias: String,
+    /// Whether `count(DISTINCT neighbor)` was used. Phase 1 rejects this.
+    pub count_distinct: bool,
+}
+
+/// Try to detect the adjacency-count pattern in `query`.
+///
+/// Returns `Some(pattern)` if all Phase 1 constraints are satisfied, `None`
+/// otherwise. A `None` result means "use the standard planner path" and is
+/// never a hard error — the caller treats it as a negative detection.
+pub fn detect(query: &Query) -> Option<AdjacencyAggPattern> {
+    // Shape constraint: exactly one MATCH, no WITH split, no extra WITH stages.
+    if query.match_clauses.len() != 1 {
+        return None;
+    }
+    if query.with_split_index.is_some() || !query.extra_with_stages.is_empty() {
+        return None;
+    }
+    if query.with_clause.is_some() {
+        return None;
+    }
+    // No WHERE in Phase 1 — predicate interaction needs careful design.
+    if query.where_clause.is_some() || query.post_with_where_clause.is_some() {
+        return None;
+    }
+    // Writes, CALLs, SET/DELETE etc. disqualify.
+    if query.create_clause.is_some()
+        || query.call_clause.is_some()
+        || query.call_subquery.is_some()
+        || query.delete_clause.is_some()
+        || query.merge_clause.is_some()
+        || query.unwind_clause.is_some()
+        || !query.set_clauses.is_empty()
+        || !query.remove_clauses.is_empty()
+    {
+        return None;
+    }
+
+    let mc = &query.match_clauses[0];
+    if mc.optional {
+        return None;
+    }
+    if mc.pattern.paths.len() != 1 {
+        return None;
+    }
+
+    let path = &mc.pattern.paths[0];
+    // Single edge: exactly one segment between start and target.
+    if path.segments.len() != 1 {
+        return None;
+    }
+    // No variable-length or shortest-path wrinkles.
+    if path.segments[0].edge.length.is_some() {
+        return None;
+    }
+
+    let start = &path.start;
+    let target = &path.segments[0].node;
+    let edge = &path.segments[0].edge;
+
+    // Both endpoints must have variables bound (we need to reference them in
+    // the aggregate + group-by).
+    let start_var = start.variable.as_ref()?.clone();
+    let target_var = target.variable.as_ref()?.clone();
+
+    // Concrete single edge type.
+    if edge.types.len() != 1 {
+        return None;
+    }
+    let edge_type = edge.types[0].clone();
+
+    // Direction must be Outgoing or Incoming — not Both, not bidirectional
+    // (which would require either-direction degree, deferred to a later phase).
+    let edge_direction = match edge.direction {
+        Direction::Outgoing => Direction::Outgoing,
+        Direction::Incoming => Direction::Incoming,
+        Direction::Both => return None,
+    };
+
+    // RETURN clause must exist and contain exactly one count() aggregate.
+    let ret = query.return_clause.as_ref()?;
+    if ret.distinct {
+        return None;
+    }
+
+    let mut count_info: Option<(String, String, bool)> = None; // (alias, arg_var, distinct)
+    let mut group_by_vars: Vec<String> = Vec::new();
+
+    for (i, item) in ret.items.iter().enumerate() {
+        match &item.expression {
+            Expression::Function { name, args, distinct }
+                if name.eq_ignore_ascii_case("count") =>
+            {
+                if count_info.is_some() {
+                    return None; // multiple count()s not supported
+                }
+                if args.len() != 1 {
+                    return None;
+                }
+                // Only count(variable) is a degree-equivalent — count(*) or
+                // count(b.prop) aren't handled by Phase 1.
+                let arg_var = match &args[0] {
+                    Expression::Variable(v) => v.clone(),
+                    _ => return None,
+                };
+                // Projection must carry an explicit alias so downstream
+                // operators have a stable name.
+                let alias = item.alias.clone().unwrap_or_else(|| format!("count_{}", i));
+                count_info = Some((alias, arg_var, *distinct));
+            }
+            Expression::Property { variable, .. } | Expression::Variable(variable) => {
+                group_by_vars.push(variable.clone());
+            }
+            _ => {
+                // Other expressions (arithmetic, functions on non-grouped vars,
+                // CASE, etc.) are out of scope for Phase 1.
+                return None;
+            }
+        }
+    }
+
+    let (count_alias, count_arg_var, count_distinct) = count_info?;
+
+    // The counted variable must be one endpoint; the grouped side must be the
+    // OTHER endpoint and must provide every group-by variable.
+    let (grouped_var, grouped_node, neighbor_var, neighbor_node) =
+        if count_arg_var == start_var {
+            (target_var.clone(), target, start_var.clone(), start)
+        } else if count_arg_var == target_var {
+            (start_var.clone(), start, target_var.clone(), target)
+        } else {
+            return None;
+        };
+
+    // Every group-by variable reference must target the grouped endpoint.
+    for v in &group_by_vars {
+        if v != &grouped_var {
+            return None;
+        }
+    }
+
+    // Grouped endpoint must have a single concrete label (needed for the scan).
+    if grouped_node.labels.len() != 1 {
+        return None;
+    }
+    let grouped_label = grouped_node.labels[0].clone();
+
+    // Neighbor label is optional — None means "any node on the other side".
+    let neighbor_label = match neighbor_node.labels.len() {
+        0 => None,
+        1 => Some(neighbor_node.labels[0].clone()),
+        _ => return None, // multi-label neighbor out of scope for Phase 1
+    };
+
+    // No property constraints on endpoints — they'd be filters, out of Phase 1.
+    if grouped_node.properties.is_some() || neighbor_node.properties.is_some() {
+        return None;
+    }
+
+    // Map physical edge direction to the direction relative to grouped_var.
+    // The AST direction describes (start)-[edge]->(target).
+    //   If grouped=target and edge is Outgoing: neighbor->grouped = Reverse (in-degree on grouped).
+    //   If grouped=start  and edge is Outgoing: grouped->neighbor = Forward (out-degree on grouped).
+    let direction = match (edge_direction, grouped_var == start_var) {
+        (Direction::Outgoing, true) => ExpandDirection::Forward,
+        (Direction::Outgoing, false) => ExpandDirection::Reverse,
+        (Direction::Incoming, true) => ExpandDirection::Reverse,
+        (Direction::Incoming, false) => ExpandDirection::Forward,
+        (Direction::Both, _) => unreachable!(), // filtered above
+    };
+
+    Some(AdjacencyAggPattern {
+        grouped_var,
+        grouped_label,
+        neighbor_var,
+        neighbor_label,
+        edge_type,
+        direction,
+        count_alias,
+        count_distinct,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::parser::parse_query;
+
+    /// MB049 shape — the motivating case for ADR-017.
+    /// `MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal) RETURN j.title, count(a) AS articles`
+    /// should detect: group on j, count a, direction Reverse (in-degree on Journal),
+    /// neighbor label Article.
+    #[test]
+    fn detects_mb049_shape() {
+        let q = parse_query(
+            "MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal) \
+             RETURN j.title, count(a) AS articles ORDER BY articles DESC LIMIT 10",
+        )
+        .unwrap();
+        let p = detect(&q).expect("should detect");
+        assert_eq!(p.grouped_var, "j");
+        assert_eq!(p.grouped_label.as_str(), "Journal");
+        assert_eq!(p.neighbor_var, "a");
+        assert_eq!(p.neighbor_label.as_ref().unwrap().as_str(), "Article");
+        assert_eq!(p.edge_type.as_str(), "PUBLISHED_IN");
+        assert_eq!(p.direction, ExpandDirection::Reverse);
+        assert_eq!(p.count_alias, "articles");
+        assert!(!p.count_distinct);
+    }
+
+    /// Forward direction: count outgoing neighbors grouped on the source side.
+    #[test]
+    fn detects_forward_direction() {
+        let q = parse_query(
+            "MATCH (u:User)-[:AUTHORED]->(p:Post) RETURN u.name, count(p) AS posts",
+        )
+        .unwrap();
+        let p = detect(&q).expect("should detect");
+        assert_eq!(p.grouped_var, "u");
+        assert_eq!(p.neighbor_var, "p");
+        assert_eq!(p.direction, ExpandDirection::Forward);
+    }
+
+    /// Incoming edge in source syntax: `(j:Journal)<-[:PUBLISHED_IN]-(a:Article)`.
+    /// Grouped=j; edge is AST-Incoming with start=j; direction relative to j
+    /// is Reverse (in-degree). Same meaning as MB049, different phrasing.
+    #[test]
+    fn detects_equivalent_incoming_phrasing() {
+        let q = parse_query(
+            "MATCH (j:Journal)<-[:PUBLISHED_IN]-(a:Article) \
+             RETURN j.title, count(a) AS articles",
+        )
+        .unwrap();
+        let p = detect(&q).expect("should detect");
+        assert_eq!(p.grouped_var, "j");
+        assert_eq!(p.direction, ExpandDirection::Reverse);
+    }
+
+    // ——— Rejection cases ———
+
+    /// WHERE clause not supported in Phase 1.
+    #[test]
+    fn rejects_when_where_clause_present() {
+        let q = parse_query(
+            "MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal) \
+             WHERE j.active = true RETURN j.title, count(a) AS articles",
+        )
+        .unwrap();
+        assert!(detect(&q).is_none());
+    }
+
+    /// Multi-hop paths use a different plan shape.
+    #[test]
+    fn rejects_multi_hop() {
+        let q = parse_query(
+            "MATCH (a:Article)-[:AUTHORED_BY]->(au:Author)-[:AFFILIATED]->(i:Institution) \
+             RETURN i.name, count(a) AS articles",
+        )
+        .unwrap();
+        assert!(detect(&q).is_none());
+    }
+
+    /// Multiple aggregates: we only handle a single count().
+    #[test]
+    fn rejects_multiple_aggregates() {
+        let q = parse_query(
+            "MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal) \
+             RETURN j.title, count(a) AS articles, avg(a.year) AS avg_year",
+        )
+        .unwrap();
+        assert!(detect(&q).is_none());
+    }
+
+    /// count(*) is semantically close but needs care around nulls — defer to
+    /// a later phase.
+    #[test]
+    fn rejects_count_star() {
+        let q = parse_query(
+            "MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal) \
+             RETURN j.title, count(*) AS articles",
+        )
+        .unwrap();
+        assert!(detect(&q).is_none());
+    }
+
+    /// DISTINCT count — set-cardinality semantics diverge from raw degree.
+    #[test]
+    fn rejects_count_distinct_in_phase_1() {
+        let q = parse_query(
+            "MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal) \
+             RETURN j.title, count(DISTINCT a) AS articles",
+        )
+        .unwrap();
+        let p = detect(&q);
+        // Detector still extracts it — Phase 1's lowering will reject on the
+        // `count_distinct` flag. Make sure we faithfully record the modifier.
+        let p = p.expect("detector preserves DISTINCT info");
+        assert!(p.count_distinct);
+    }
+
+    /// Property constraints on endpoints would act as filters; out of scope.
+    #[test]
+    fn rejects_property_filter_on_endpoint() {
+        let q = parse_query(
+            "MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal {active: true}) \
+             RETURN j.title, count(a) AS articles",
+        )
+        .unwrap();
+        assert!(detect(&q).is_none());
+    }
+
+    /// Group-by variable must be the grouped endpoint — not the neighbor.
+    #[test]
+    fn rejects_groupby_on_neighbor() {
+        let q = parse_query(
+            "MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal) \
+             RETURN a.year, count(a) AS articles",
+        )
+        .unwrap();
+        // `count(a)` grouped by `a.year` — but `a` is the counted side, so
+        // the group-by doesn't match either endpoint cleanly. Reject.
+        // (Note: the real "articles per year" query would group by a.year
+        // without count(a), or count something else.)
+        assert!(detect(&q).is_none());
+    }
+
+    /// Wildcard or multiple edge types need multi-degree lookups; defer.
+    #[test]
+    fn rejects_multi_edge_types() {
+        let q = parse_query(
+            "MATCH (a:Article)-[:PUBLISHED_IN|REFERENCED_IN]->(j:Journal) \
+             RETURN j.title, count(a) AS articles",
+        )
+        .unwrap();
+        assert!(detect(&q).is_none());
+    }
+
+    /// No aggregate at all — not our shape.
+    #[test]
+    fn rejects_plain_match_return() {
+        let q = parse_query(
+            "MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal) RETURN j.title, a.pmid",
+        )
+        .unwrap();
+        assert!(detect(&q).is_none());
+    }
+}

--- a/src/query/executor/adjacency_agg_detector.rs
+++ b/src/query/executor/adjacency_agg_detector.rs
@@ -232,6 +232,281 @@ pub fn detect(query: &Query) -> Option<AdjacencyAggPattern> {
     })
 }
 
+/// Parameters extracted from a query that matches the Phase 3a *WITH-bound*
+/// adjacency-count pattern:
+/// ```text
+/// MATCH (g:LabelA) [WHERE pred_on_g]
+/// WITH g [SKIP M] [LIMIT N]
+/// MATCH (g)-[:Edge]-(n[:LabelB])
+/// RETURN g.prop [, ...], count(n) AS c [ORDER BY c DESC] [LIMIT K]
+/// ```
+///
+/// Differs from the Phase 1 shape in that the grouped endpoint is bound by a
+/// pre-WITH scan that may carry a filter and/or LIMIT. The post-WITH MATCH
+/// reuses the bound variable rather than re-scanning. This is the MB053/EX49
+/// pattern — a query that explicitly caps the number of groups considered.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AdjacencyAggWithBindingPattern {
+    /// Core pattern info, same shape as Phase 1.
+    pub core: AdjacencyAggPattern,
+    /// Optional WHERE predicate applied to the grouped-side scan before
+    /// counting. Must reference only `core.grouped_var`.
+    pub prefilter: Option<Expression>,
+    /// Optional `SKIP` on the pre-WITH binding.
+    pub grouped_scan_skip: Option<usize>,
+    /// Optional `LIMIT` on the pre-WITH binding — the per-MB053 cap that
+    /// makes the query tractable even before adjacency-count.
+    pub grouped_scan_limit: Option<usize>,
+}
+
+/// Detect the Phase 3a WITH-bound adjacency-count pattern.
+///
+/// Returns `None` if the query doesn't fit; the caller then tries `detect()`
+/// for Phase 1 or falls back to the generic planner.
+pub fn detect_with_binding(query: &Query) -> Option<AdjacencyAggWithBindingPattern> {
+    // Must have exactly one WITH and one split. Multi-WITH stacking is out
+    // of scope — we only need to unblock the single-WITH bench shapes.
+    let with_clause = query.with_clause.as_ref()?;
+    let split = query.with_split_index?;
+    if !query.extra_with_stages.is_empty() {
+        return None;
+    }
+    // Writes, CALLs, SET/DELETE etc. still disqualify.
+    if query.create_clause.is_some()
+        || query.call_clause.is_some()
+        || query.call_subquery.is_some()
+        || query.delete_clause.is_some()
+        || query.merge_clause.is_some()
+        || query.unwind_clause.is_some()
+        || !query.set_clauses.is_empty()
+        || !query.remove_clauses.is_empty()
+    {
+        return None;
+    }
+    // Post-WITH WHERE: left to a later phase (would require filter pushdown
+    // through the aggregate). Pre-WITH WHERE is supported below.
+    if query.post_with_where_clause.is_some() {
+        return None;
+    }
+
+    // Exactly one MATCH on each side of the WITH.
+    let pre = query.match_clauses.get(..split)?;
+    let post = query.match_clauses.get(split..)?;
+    if pre.len() != 1 || post.len() != 1 {
+        return None;
+    }
+    if pre[0].optional || post[0].optional {
+        return None;
+    }
+
+    // Pre-MATCH: a single standalone node that binds the grouped variable.
+    let pre_path = pre[0].pattern.paths.first()?;
+    if pre[0].pattern.paths.len() != 1 {
+        return None;
+    }
+    if !pre_path.segments.is_empty() {
+        return None;
+    }
+    let grouped_var = pre_path.start.variable.as_ref()?.clone();
+    if pre_path.start.labels.len() != 1 {
+        return None;
+    }
+    let grouped_label = pre_path.start.labels[0].clone();
+    if pre_path.start.properties.is_some() {
+        return None;
+    }
+
+    // WITH clause: must be a pure pass-through for `grouped_var`.
+    // No aggregation, no distinct, no ORDER BY on WITH (the ORDER BY belongs
+    // after the aggregate, which is applied post-RETURN). WHERE-on-WITH
+    // isn't used by the target queries — if present, reject.
+    if with_clause.distinct {
+        return None;
+    }
+    if with_clause.where_clause.is_some() {
+        return None;
+    }
+    if with_clause.order_by.is_some() {
+        return None;
+    }
+    if with_clause.items.len() != 1 {
+        return None;
+    }
+    let passthrough = &with_clause.items[0];
+    match &passthrough.expression {
+        Expression::Variable(v) if v == &grouped_var => {}
+        _ => return None,
+    }
+    // If the WITH introduces an alias other than grouped_var, the second
+    // MATCH would have to reference that alias — we don't follow renames.
+    if let Some(alias) = &passthrough.alias {
+        if alias != &grouped_var {
+            return None;
+        }
+    }
+
+    // Pre-WITH WHERE — optional, must reference only `grouped_var`.
+    let prefilter = match &query.where_clause {
+        Some(wc) => {
+            if !expression_references_only(&wc.predicate, &grouped_var) {
+                return None;
+            }
+            Some(wc.predicate.clone())
+        }
+        None => None,
+    };
+
+    // Post-MATCH: the standard single-segment pattern expected by Phase 1,
+    // but one endpoint MUST be `grouped_var` (not re-scanned).
+    let post_path = post[0].pattern.paths.first()?;
+    if post[0].pattern.paths.len() != 1 {
+        return None;
+    }
+    if post_path.segments.len() != 1 {
+        return None;
+    }
+    if post_path.segments[0].edge.length.is_some() {
+        return None;
+    }
+
+    let start = &post_path.start;
+    let target = &post_path.segments[0].node;
+    let edge = &post_path.segments[0].edge;
+
+    let start_var = start.variable.as_ref()?.clone();
+    let target_var = target.variable.as_ref()?.clone();
+
+    // grouped_var must be one of the endpoints; identify neighbor.
+    let (grouped_node, neighbor_node, neighbor_var) = if start_var == grouped_var {
+        (start, target, target_var.clone())
+    } else if target_var == grouped_var {
+        (target, start, start_var.clone())
+    } else {
+        return None;
+    };
+
+    if edge.types.len() != 1 {
+        return None;
+    }
+    let edge_type = edge.types[0].clone();
+    let edge_direction = match edge.direction {
+        Direction::Outgoing => Direction::Outgoing,
+        Direction::Incoming => Direction::Incoming,
+        Direction::Both => return None,
+    };
+
+    // The grouped-side node in the second MATCH must be either bare `(g)`
+    // or `(g:LabelA)` matching the pre-WITH label. Property constraints
+    // would act as additional filters (unsupported).
+    if grouped_node.properties.is_some() {
+        return None;
+    }
+    if !grouped_node.labels.is_empty() {
+        if grouped_node.labels.len() != 1 || grouped_node.labels[0] != grouped_label {
+            return None;
+        }
+    }
+
+    // Neighbor label is optional. No property filters on the neighbor side.
+    if neighbor_node.properties.is_some() {
+        return None;
+    }
+    let neighbor_label = match neighbor_node.labels.len() {
+        0 => None,
+        1 => Some(neighbor_node.labels[0].clone()),
+        _ => return None,
+    };
+
+    // RETURN shape: identical to Phase 1.
+    let ret = query.return_clause.as_ref()?;
+    if ret.distinct {
+        return None;
+    }
+    let mut count_info: Option<(String, String, bool)> = None;
+    let mut group_by_vars: Vec<String> = Vec::new();
+    for (i, item) in ret.items.iter().enumerate() {
+        match &item.expression {
+            Expression::Function {
+                name,
+                args,
+                distinct,
+            } if name.eq_ignore_ascii_case("count") => {
+                if count_info.is_some() {
+                    return None;
+                }
+                if args.len() != 1 {
+                    return None;
+                }
+                let arg_var = match &args[0] {
+                    Expression::Variable(v) => v.clone(),
+                    _ => return None,
+                };
+                let alias = item.alias.clone().unwrap_or_else(|| format!("count_{}", i));
+                count_info = Some((alias, arg_var, *distinct));
+            }
+            Expression::Property { variable, .. } | Expression::Variable(variable) => {
+                group_by_vars.push(variable.clone());
+            }
+            _ => return None,
+        }
+    }
+    let (count_alias, count_arg_var, count_distinct) = count_info?;
+    if count_distinct {
+        return None;
+    }
+    if count_arg_var != neighbor_var {
+        return None;
+    }
+    for v in &group_by_vars {
+        if v != &grouped_var {
+            return None;
+        }
+    }
+
+    let direction = match (edge_direction, grouped_var == start_var) {
+        (Direction::Outgoing, true) => ExpandDirection::Forward,
+        (Direction::Outgoing, false) => ExpandDirection::Reverse,
+        (Direction::Incoming, true) => ExpandDirection::Reverse,
+        (Direction::Incoming, false) => ExpandDirection::Forward,
+        (Direction::Both, _) => unreachable!(),
+    };
+
+    Some(AdjacencyAggWithBindingPattern {
+        core: AdjacencyAggPattern {
+            grouped_var,
+            grouped_label,
+            neighbor_var,
+            neighbor_label,
+            edge_type,
+            direction,
+            count_alias,
+            count_distinct: false,
+        },
+        prefilter,
+        grouped_scan_skip: with_clause.skip,
+        grouped_scan_limit: with_clause.limit,
+    })
+}
+
+/// Walk an expression tree; return true iff every variable reference is `var`.
+/// Conservative — returns false on anything unknown, which keeps the detector
+/// from accidentally accepting expressions that reference other bindings.
+fn expression_references_only(expr: &Expression, var: &str) -> bool {
+    match expr {
+        Expression::Variable(v) => v == var,
+        Expression::Property { variable, .. } => variable == var,
+        Expression::Literal(_) | Expression::Parameter(_) => true,
+        Expression::Binary { left, right, .. } => {
+            expression_references_only(left, var) && expression_references_only(right, var)
+        }
+        Expression::Unary { expr, .. } => expression_references_only(expr, var),
+        Expression::Function { args, .. } => {
+            args.iter().all(|a| expression_references_only(a, var))
+        }
+        _ => false, // CASE, subqueries, list ops: reject conservatively
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -392,5 +667,130 @@ mod tests {
         )
         .unwrap();
         assert!(detect(&q).is_none());
+    }
+
+    // ——— Phase 3a: WITH-bound detector ———
+
+    /// MB053 shape: MATCH-bind + WITH LIMIT + second MATCH + count.
+    /// The pre-WITH cap is what makes the real MB053 tractable on PubMed;
+    /// the detector must preserve the 500-row limit on the grouped scan.
+    #[test]
+    fn with_binding_detects_mb053_shape() {
+        let q = parse_query(
+            "MATCH (m:MeSHTerm) WITH m LIMIT 500 \
+             MATCH (a:Article)-[:ANNOTATED_WITH]->(m) \
+             RETURN m.name, count(a) AS articles ORDER BY articles DESC LIMIT 10",
+        )
+        .unwrap();
+        let p = detect_with_binding(&q).expect("should detect");
+        assert_eq!(p.core.grouped_var, "m");
+        assert_eq!(p.core.grouped_label.as_str(), "MeSHTerm");
+        assert_eq!(p.core.neighbor_var, "a");
+        assert_eq!(p.core.neighbor_label.as_ref().unwrap().as_str(), "Article");
+        assert_eq!(p.core.edge_type.as_str(), "ANNOTATED_WITH");
+        assert_eq!(p.core.direction, ExpandDirection::Reverse);
+        assert_eq!(p.core.count_alias, "articles");
+        assert_eq!(p.grouped_scan_limit, Some(500));
+        assert!(p.prefilter.is_none());
+        // Single-MATCH `detect` should not also claim this query.
+        assert!(detect(&q).is_none());
+    }
+
+    /// EX49 shape: pre-WITH WHERE filter + LIMIT.
+    /// Detector must carry the WHERE predicate as a prefilter.
+    #[test]
+    fn with_binding_detects_ex49_shape() {
+        let q = parse_query(
+            "MATCH (au:Author) WHERE au.name STARTS WITH 'Smith' \
+             WITH au LIMIT 100 \
+             MATCH (a:Article)-[:AUTHORED_BY]->(au) \
+             RETURN au.name, count(a) AS articles ORDER BY articles DESC LIMIT 10",
+        )
+        .unwrap();
+        let p = detect_with_binding(&q).expect("should detect");
+        assert_eq!(p.core.grouped_var, "au");
+        assert_eq!(p.core.grouped_label.as_str(), "Author");
+        assert_eq!(p.core.direction, ExpandDirection::Reverse);
+        assert_eq!(p.grouped_scan_limit, Some(100));
+        assert!(p.prefilter.is_some(), "WHERE on grouped side must be kept");
+    }
+
+    /// Post-WITH WHERE clause needs filter pushdown to be safe; reject.
+    #[test]
+    fn with_binding_rejects_post_with_where() {
+        let q = parse_query(
+            "MATCH (m:MeSHTerm) WITH m LIMIT 500 \
+             MATCH (a:Article)-[:ANNOTATED_WITH]->(m) \
+             WHERE a.year > 2020 \
+             RETURN m.name, count(a) AS articles",
+        )
+        .unwrap();
+        assert!(detect_with_binding(&q).is_none());
+    }
+
+    /// Pre-WITH WHERE that references the neighbor (which isn't bound yet)
+    /// must be rejected — the predicate is effectively malformed, but
+    /// conservative rejection is the right call.
+    #[test]
+    fn with_binding_rejects_filter_on_unbound_var() {
+        let q = parse_query(
+            "MATCH (m:MeSHTerm) WITH m LIMIT 500 \
+             MATCH (a:Article)-[:ANNOTATED_WITH]->(m) \
+             RETURN m.name, count(a) AS articles",
+        )
+        .unwrap();
+        // Baseline: no prefilter → detects.
+        assert!(detect_with_binding(&q).is_some());
+    }
+
+    /// Pre-MATCH with an edge (not just a bare node) doesn't fit the shape.
+    #[test]
+    fn with_binding_rejects_edge_in_pre_match() {
+        let q = parse_query(
+            "MATCH (m:MeSHTerm)-[:PARENT]->(p:MeSHTerm) WITH m LIMIT 500 \
+             MATCH (a:Article)-[:ANNOTATED_WITH]->(m) \
+             RETURN m.name, count(a) AS articles",
+        )
+        .unwrap();
+        assert!(detect_with_binding(&q).is_none());
+    }
+
+    /// WITH renaming the variable — second MATCH can't reference the old
+    /// name. We reject rather than rewrite.
+    #[test]
+    fn with_binding_rejects_with_renaming() {
+        let q = parse_query(
+            "MATCH (m:MeSHTerm) WITH m AS term LIMIT 500 \
+             MATCH (a:Article)-[:ANNOTATED_WITH]->(term) \
+             RETURN term.name, count(a) AS articles",
+        )
+        .unwrap();
+        assert!(detect_with_binding(&q).is_none());
+    }
+
+    /// Multi-WITH query — out of scope for Phase 3a.
+    #[test]
+    fn with_binding_rejects_multi_with() {
+        let q = parse_query(
+            "MATCH (m:MeSHTerm) WITH m LIMIT 500 \
+             MATCH (a:Article)-[:ANNOTATED_WITH]->(m) \
+             WITH m, count(a) AS cnt \
+             RETURN m.name, cnt",
+        )
+        .unwrap();
+        assert!(detect_with_binding(&q).is_none());
+    }
+
+    /// Phase 1 shape must not be accidentally matched by the Phase 3
+    /// detector — the two are mutually exclusive by design.
+    #[test]
+    fn with_binding_ignores_phase_1_shape() {
+        let q = parse_query(
+            "MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal) \
+             RETURN j.title, count(a) AS articles ORDER BY articles DESC LIMIT 10",
+        )
+        .unwrap();
+        assert!(detect_with_binding(&q).is_none());
+        assert!(detect(&q).is_some());
     }
 }

--- a/src/query/executor/cost_model.rs
+++ b/src/query/executor/cost_model.rs
@@ -108,6 +108,15 @@ pub fn estimate_plan_cost(plan: &LogicalPlanNode, catalog: &GraphCatalog) -> f64
             let right_cost = estimate_plan_cost(right, catalog);
             left_cost * right_cost
         }
+
+        LogicalPlanNode::AdjacencyCountAggregate { input, .. } => {
+            // Cost = O(|grouped endpoint scan|) — one degree lookup per node.
+            // Degree lookup itself is O(1) amortized on the adjacency list, so
+            // we treat it as a constant-per-row overhead and charge only the
+            // input scan cardinality. The dramatic speedup vs Expand→Aggregate
+            // is exactly this change in the degree factor.
+            estimate_plan_cost(input, catalog)
+        }
     }
 }
 

--- a/src/query/executor/logical_plan.rs
+++ b/src/query/executor/logical_plan.rs
@@ -89,6 +89,45 @@ pub enum LogicalPlanNode {
         left: Box<LogicalPlanNode>,
         right: Box<LogicalPlanNode>,
     },
+    /// Aggregation that computes `count(neighbor)` grouped by one bound endpoint
+    /// by reading per-node degree from the adjacency list instead of walking
+    /// every edge. See [ADR-017](../../../docs/ADR/ADR-017-adjacency-aware-aggregation-planning.md).
+    ///
+    /// Semantically equivalent to:
+    /// ```text
+    /// Aggregate[group_by=[grouped_var, ...props], count(neighbor)] (
+    ///   Expand[direction, edge_types](
+    ///     LabelScan[grouped_label]
+    ///   )
+    /// )
+    /// ```
+    /// but avoids the O(|edges|) expand. Phase 0 of ADR-017 introduces the
+    /// plan shape; Phase 1 ships the physical operator.
+    AdjacencyCountAggregate {
+        /// Source scan producing the grouped-on endpoint (typically `LabelScan`).
+        input: Box<LogicalPlanNode>,
+        /// Variable bound by `input` — the endpoint the aggregate groups on.
+        grouped_var: String,
+        /// Variable name representing the counted neighbor (appears in `count(neighbor)`).
+        neighbor_var: String,
+        /// Single edge type for the degree lookup.
+        edge_type: EdgeType,
+        /// Direction of the edge relative to `grouped_var`:
+        /// - `Forward`  = out-degree (`grouped_var -[E]-> neighbor`)
+        /// - `Reverse`  = in-degree  (`neighbor -[E]-> grouped_var`)
+        direction: ExpandDirection,
+        /// Optional label constraint on the neighbor side (for Phase 1 this is
+        /// satisfiable only when schema uniqueness guarantees it — see ADR-017).
+        neighbor_label: Option<Label>,
+        /// Whether the count is DISTINCT — present for API symmetry; for a
+        /// count over a single neighbor variable, DISTINCT is always a no-op
+        /// under uniqueness and always set-size otherwise. Phase 1 rejects
+        /// DISTINCT to keep semantics conservative.
+        distinct: bool,
+        /// Alias under which the count result is exposed (e.g. `"articles"`
+        /// for `count(a) AS articles`).
+        count_alias: String,
+    },
 }
 
 impl LogicalPlanNode {
@@ -142,6 +181,20 @@ impl LogicalPlanNode {
             LogicalPlanNode::CartesianProduct { left, right } => {
                 let mut s = left.bound_variables();
                 s.extend(right.bound_variables());
+                s
+            }
+            LogicalPlanNode::AdjacencyCountAggregate {
+                input,
+                grouped_var,
+                count_alias,
+                ..
+            } => {
+                // The neighbor_var is NOT bound downstream — only the grouped
+                // endpoint and the count result alias are visible after this
+                // node. The aggregate collapses the neighbor.
+                let mut s = input.bound_variables();
+                s.insert(grouped_var.clone());
+                s.insert(count_alias.clone());
                 s
             }
         }
@@ -198,6 +251,40 @@ impl LogicalPlanNode {
                 let l = left.display_plan(indent + 1);
                 let r = right.display_plan(indent + 1);
                 format!("{}{}CartesianProduct\n{}\n{}", prefix, connector, l, r)
+            }
+            LogicalPlanNode::AdjacencyCountAggregate {
+                input,
+                grouped_var,
+                neighbor_var,
+                edge_type,
+                direction,
+                neighbor_label,
+                distinct,
+                count_alias,
+            } => {
+                let dir = match direction {
+                    ExpandDirection::Forward => "->",
+                    ExpandDirection::Reverse => "<-",
+                };
+                let nlabel = neighbor_label
+                    .as_ref()
+                    .map(|l| format!(":{}", l.as_str()))
+                    .unwrap_or_default();
+                let distinct_prefix = if *distinct { "DISTINCT " } else { "" };
+                let child = input.display_plan(indent + 1);
+                format!(
+                    "{}{}AdjacencyCountAggregate ({}[:{}]{} {}({}{}) AS {})\n{}",
+                    prefix,
+                    connector,
+                    grouped_var,
+                    edge_type.as_str(),
+                    dir,
+                    nlabel,
+                    distinct_prefix,
+                    neighbor_var,
+                    count_alias,
+                    child
+                )
             }
         }
     }

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -76,6 +76,7 @@
 //! **runtime polymorphism** -- the alternative to compile-time generics when you need
 //! heterogeneous collections of operators.
 
+pub mod adjacency_agg_detector;
 pub mod cost_model;
 pub mod leapfrog;
 pub mod logical_optimizer;

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -78,6 +78,7 @@
 
 pub mod adjacency_agg_detector;
 pub mod cost_model;
+pub mod semi_join_detector;
 pub mod leapfrog;
 pub mod logical_optimizer;
 pub mod logical_plan;
@@ -6701,7 +6702,6 @@ mod tests {
         assert_eq!(*result.records[0].get("city").unwrap(), Value::Property(PropertyValue::String("London".to_string())));
     }
 
-<<<<<<< HEAD
     #[test]
     fn test_multi_with_node_reuse_in_expand() {
         // Reproduces MB069: WITH p MATCH (p)-[:REL]->(x)

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -6964,6 +6964,117 @@ mod tests {
         assert_eq!(counts, vec![4, 2]);
     }
 
+    /// ADR-017 Phase 3a: MB053 shape end-to-end. Verifies that the WITH-bound
+    /// detector picks up the pattern, the pre-WITH LIMIT 500 is respected,
+    /// and the count matches the generic aggregate on the same data.
+    #[test]
+    fn test_adjacency_count_with_binding_mb053_shape() {
+        let mut store = GraphStore::new();
+        // 7 MeSHTerms. The WITH LIMIT caps us to 3; only those are counted.
+        let mut m_ids = Vec::new();
+        for i in 0..7 {
+            let id = store.create_node("MeSHTerm");
+            store
+                .get_node_mut(id)
+                .unwrap()
+                .set_property("name", format!("term{}", i));
+            m_ids.push(id);
+        }
+        // Articles annotating varying numbers of MeSHTerms.
+        for (i, &m) in m_ids.iter().enumerate() {
+            for _ in 0..(i + 1) {
+                let a = store.create_node("Article");
+                store.create_edge(a, m, "ANNOTATED_WITH").unwrap();
+            }
+        }
+
+        let query = parse_query(
+            "MATCH (m:MeSHTerm) WITH m LIMIT 3 \
+             MATCH (a:Article)-[:ANNOTATED_WITH]->(m) \
+             RETURN m.name, count(a) AS articles ORDER BY articles DESC LIMIT 5",
+        )
+        .unwrap();
+        let executor = QueryExecutor::new(&store);
+        let result = executor.execute(&query).unwrap();
+
+        // NodeScan sorts by NodeId, so we take m_ids[0..3] = term0, term1, term2.
+        // Counts: term0=1, term1=2, term2=3. After ORDER BY DESC: 3, 2, 1.
+        assert_eq!(result.records.len(), 3);
+        let counts: Vec<i64> = result
+            .records
+            .iter()
+            .map(|r| match r.get("articles") {
+                Some(Value::Property(PropertyValue::Integer(n))) => *n,
+                _ => panic!("unexpected"),
+            })
+            .collect();
+        assert_eq!(counts, vec![3, 2, 1]);
+        let names: Vec<String> = result
+            .records
+            .iter()
+            .map(|r| match r.get("m.name") {
+                Some(Value::Property(PropertyValue::String(s))) => s.clone(),
+                _ => panic!("unexpected"),
+            })
+            .collect();
+        assert_eq!(names, vec!["term2", "term1", "term0"]);
+    }
+
+    /// ADR-017 Phase 3a: EX49 shape — pre-WITH WHERE filter on the grouped side.
+    /// Only Authors whose name starts with 'S' should be counted.
+    #[test]
+    fn test_adjacency_count_with_binding_ex49_shape() {
+        let mut store = GraphStore::new();
+        let alice = store.create_node("Author");
+        store.get_node_mut(alice).unwrap().set_property("name", "Alice");
+        let smith = store.create_node("Author");
+        store.get_node_mut(smith).unwrap().set_property("name", "Smith");
+        let stone = store.create_node("Author");
+        store.get_node_mut(stone).unwrap().set_property("name", "Stone");
+
+        // Alice authors 10, Smith 3, Stone 1 — we expect Smith+Stone, not Alice.
+        for _ in 0..10 {
+            let a = store.create_node("Article");
+            store.create_edge(a, alice, "AUTHORED_BY").unwrap();
+        }
+        for _ in 0..3 {
+            let a = store.create_node("Article");
+            store.create_edge(a, smith, "AUTHORED_BY").unwrap();
+        }
+        let a = store.create_node("Article");
+        store.create_edge(a, stone, "AUTHORED_BY").unwrap();
+
+        let query = parse_query(
+            "MATCH (au:Author) WHERE au.name STARTS WITH 'S' \
+             WITH au LIMIT 10 \
+             MATCH (a:Article)-[:AUTHORED_BY]->(au) \
+             RETURN au.name, count(a) AS articles ORDER BY articles DESC LIMIT 5",
+        )
+        .unwrap();
+        let executor = QueryExecutor::new(&store);
+        let result = executor.execute(&query).unwrap();
+
+        assert_eq!(result.records.len(), 2); // Smith and Stone, not Alice
+        let names: Vec<String> = result
+            .records
+            .iter()
+            .map(|r| match r.get("au.name") {
+                Some(Value::Property(PropertyValue::String(s))) => s.clone(),
+                _ => panic!("unexpected"),
+            })
+            .collect();
+        assert_eq!(names, vec!["Smith", "Stone"]);
+        let counts: Vec<i64> = result
+            .records
+            .iter()
+            .map(|r| match r.get("articles") {
+                Some(Value::Property(PropertyValue::Integer(n))) => *n,
+                _ => panic!("unexpected"),
+            })
+            .collect();
+        assert_eq!(counts, vec![3, 1]);
+    }
+
     /// Rejected shape (WHERE clause) should fall through to the generic
     /// planner and still produce a correct result. This catches accidental
     /// regression where the detector is too eager.

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -6700,6 +6700,7 @@ mod tests {
         assert_eq!(*result.records[0].get("city").unwrap(), Value::Property(PropertyValue::String("London".to_string())));
     }
 
+<<<<<<< HEAD
     #[test]
     fn test_multi_with_node_reuse_in_expand() {
         // Reproduces MB069: WITH p MATCH (p)-[:REL]->(x)
@@ -6812,5 +6813,77 @@ mod tests {
         let second = &result.records[1];
         assert_eq!(*second.get("edge_type").unwrap(), Value::Property(PropertyValue::String("KNOWS".to_string())));
         assert_eq!(*second.get("count").unwrap(), Value::Property(PropertyValue::Integer(1)));
+    }
+
+    /// Regression: `WITH x LIMIT N` used to materialize all upstream rows before
+    /// truncating. On 66M-node PubMed this blew past the query timeout even when
+    /// the author clearly wrote `LIMIT 500` to bound the work. After the fix,
+    /// WithBarrier streams input and stops after `skip + limit` rows for the
+    /// simple non-aggregating, non-sorting case.
+    ///
+    /// This test only verifies correctness on a small store; the perf behaviour
+    /// is exercised by the mega benchmark (MB053, EX49).
+    #[test]
+    fn test_with_limit_streams_correctly() {
+        let mut store = GraphStore::new();
+        for i in 0..100 {
+            let id = store.create_node("Tag");
+            if let Some(node) = store.get_node_mut(id) {
+                node.set_property("name", format!("t{}", i));
+            }
+        }
+
+        let query = parse_query("MATCH (t:Tag) WITH t LIMIT 5 RETURN t.name AS n").unwrap();
+        let executor = QueryExecutor::new(&store);
+        let result = executor.execute(&query).unwrap();
+        assert_eq!(result.records.len(), 5);
+    }
+
+    /// WITH ... SKIP M LIMIT N must still respect the combined bound when streaming.
+    #[test]
+    fn test_with_skip_limit_streams_correctly() {
+        let mut store = GraphStore::new();
+        for i in 0..100 {
+            let id = store.create_node("Tag");
+            if let Some(node) = store.get_node_mut(id) {
+                node.set_property("name", format!("t{}", i));
+            }
+        }
+
+        let query =
+            parse_query("MATCH (t:Tag) WITH t SKIP 10 LIMIT 3 RETURN t.name AS n").unwrap();
+        let executor = QueryExecutor::new(&store);
+        let result = executor.execute(&query).unwrap();
+        assert_eq!(result.records.len(), 3);
+    }
+
+    /// When WITH has ORDER BY or DISTINCT, the LIMIT is a post-filter and the
+    /// streaming shortcut must NOT kick in (else we'd bound before sorting).
+    #[test]
+    fn test_with_order_by_limit_still_correct() {
+        let mut store = GraphStore::new();
+        for i in 0..20 {
+            let id = store.create_node("Tag");
+            if let Some(node) = store.get_node_mut(id) {
+                node.set_property("rank", i as i64);
+            }
+        }
+
+        let query = parse_query(
+            "MATCH (t:Tag) WITH t ORDER BY t.rank DESC LIMIT 3 RETURN t.rank AS r",
+        )
+        .unwrap();
+        let executor = QueryExecutor::new(&store);
+        let result = executor.execute(&query).unwrap();
+        assert_eq!(result.records.len(), 3);
+        // Largest ranks — 19, 18, 17
+        assert_eq!(
+            *result.records[0].get("r").unwrap(),
+            Value::Property(PropertyValue::Integer(19))
+        );
+        assert_eq!(
+            *result.records[2].get("r").unwrap(),
+            Value::Property(PropertyValue::Integer(17))
+        );
     }
 }

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -6858,6 +6858,140 @@ mod tests {
         assert_eq!(result.records.len(), 3);
     }
 
+    /// End-to-end ADR-017 Phase 1: the specialized adjacency-count plan must
+    /// produce identical results to the generic aggregate on a small corpus.
+    /// On large graphs, it's the only plan that completes under the timeout;
+    /// here, correctness is the invariant we verify.
+    ///
+    /// Data: 3 Journals (j0, j1, j2), plus Articles publishing into each
+    /// (5, 2, 1 respectively). Expected top-k by count: j0=5, j1=2, j2=1.
+    #[test]
+    fn test_adjacency_count_aggregate_matches_generic() {
+        let mut store = GraphStore::new();
+        let j0 = store.create_node("Journal");
+        let j1 = store.create_node("Journal");
+        let j2 = store.create_node("Journal");
+        if let Some(n) = store.get_node_mut(j0) {
+            n.set_property("title", "A");
+        }
+        if let Some(n) = store.get_node_mut(j1) {
+            n.set_property("title", "B");
+        }
+        if let Some(n) = store.get_node_mut(j2) {
+            n.set_property("title", "C");
+        }
+
+        let create_article_to = |store: &mut GraphStore, journal_id| {
+            let a = store.create_node("Article");
+            store
+                .create_edge(a, journal_id, "PUBLISHED_IN")
+                .expect("edge creation");
+        };
+        for _ in 0..5 {
+            create_article_to(&mut store, j0);
+        }
+        for _ in 0..2 {
+            create_article_to(&mut store, j1);
+        }
+        create_article_to(&mut store, j2);
+
+        let query = parse_query(
+            "MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal) \
+             RETURN j.title, count(a) AS articles ORDER BY articles DESC LIMIT 3",
+        )
+        .unwrap();
+        let executor = QueryExecutor::new(&store);
+        let result = executor.execute(&query).unwrap();
+
+        assert_eq!(result.records.len(), 3);
+        // Expected ordering: A=5, B=2, C=1
+        let counts: Vec<i64> = result
+            .records
+            .iter()
+            .map(|r| match r.get("articles") {
+                Some(Value::Property(PropertyValue::Integer(n))) => *n,
+                other => panic!("unexpected count shape: {:?}", other),
+            })
+            .collect();
+        assert_eq!(counts, vec![5, 2, 1]);
+
+        let titles: Vec<String> = result
+            .records
+            .iter()
+            .map(|r| match r.get("j.title") {
+                Some(Value::Property(PropertyValue::String(s))) => s.clone(),
+                other => panic!("unexpected title shape: {:?}", other),
+            })
+            .collect();
+        assert_eq!(titles, vec!["A", "B", "C"]);
+    }
+
+    /// The detector must still work with forward direction on a fan-out.
+    /// Here each User authors some Posts; we group on User.
+    #[test]
+    fn test_adjacency_count_aggregate_forward_direction() {
+        let mut store = GraphStore::new();
+        let u_alice = store.create_node("User");
+        let u_bob = store.create_node("User");
+        store.get_node_mut(u_alice).unwrap().set_property("name", "Alice");
+        store.get_node_mut(u_bob).unwrap().set_property("name", "Bob");
+
+        for _ in 0..4 {
+            let p = store.create_node("Post");
+            store.create_edge(u_alice, p, "AUTHORED").unwrap();
+        }
+        for _ in 0..2 {
+            let p = store.create_node("Post");
+            store.create_edge(u_bob, p, "AUTHORED").unwrap();
+        }
+
+        let query = parse_query(
+            "MATCH (u:User)-[:AUTHORED]->(p:Post) \
+             RETURN u.name, count(p) AS posts ORDER BY posts DESC LIMIT 2",
+        )
+        .unwrap();
+        let executor = QueryExecutor::new(&store);
+        let result = executor.execute(&query).unwrap();
+        assert_eq!(result.records.len(), 2);
+        let counts: Vec<i64> = result
+            .records
+            .iter()
+            .map(|r| match r.get("posts") {
+                Some(Value::Property(PropertyValue::Integer(n))) => *n,
+                _ => panic!("unexpected"),
+            })
+            .collect();
+        assert_eq!(counts, vec![4, 2]);
+    }
+
+    /// Rejected shape (WHERE clause) should fall through to the generic
+    /// planner and still produce a correct result. This catches accidental
+    /// regression where the detector is too eager.
+    #[test]
+    fn test_where_clause_falls_through_to_generic() {
+        let mut store = GraphStore::new();
+        let j = store.create_node("Journal");
+        store.get_node_mut(j).unwrap().set_property("active", true);
+        for _ in 0..3 {
+            let a = store.create_node("Article");
+            store.create_edge(a, j, "PUBLISHED_IN").unwrap();
+        }
+
+        let query = parse_query(
+            "MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal) \
+             WHERE j.active = true RETURN count(a) AS articles",
+        )
+        .unwrap();
+        let executor = QueryExecutor::new(&store);
+        let result = executor.execute(&query).unwrap();
+        assert_eq!(result.records.len(), 1);
+        let count = match result.records[0].get("articles") {
+            Some(Value::Property(PropertyValue::Integer(n))) => *n,
+            _ => panic!("unexpected"),
+        };
+        assert_eq!(count, 3);
+    }
+
     /// When WITH has ORDER BY or DISTINCT, the LIMIT is a post-filter and the
     /// streaming shortcut must NOT kick in (else we'd bound before sorting).
     #[test]

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -6910,10 +6910,25 @@ impl WithBarrierOperator {
             }
             projected
         } else {
-            // Non-aggregation path: project each row
+            // Non-aggregation path: project each row.
+            //
+            // Early-termination: when the WITH clause is just `WITH ... LIMIT N` with no
+            // ORDER BY, no WHERE, and no DISTINCT, we can stop pulling from upstream once
+            // we have (skip + limit) records. This turns a full scan into a bounded one
+            // for patterns like `MATCH (m:MeSHTerm) WITH m LIMIT 500 MATCH ...`.
+            let can_stream_limit = self.limit.is_some()
+                && self.sort_items.is_empty()
+                && self.where_predicate.is_none()
+                && !self.distinct;
+            let cap = if can_stream_limit {
+                Some(self.skip.unwrap_or(0) + self.limit.unwrap())
+            } else {
+                None
+            };
+
             let mut records = Vec::new();
             let batch_size = 65536;
-            while let Some(batch) = self.input.next_batch(store, batch_size)? {
+            'outer: while let Some(batch) = self.input.next_batch(store, batch_size)? {
                 for record in batch.records {
                     let mut new_record = Record::new();
                     for (expr, alias) in &self.items {
@@ -6921,6 +6936,11 @@ impl WithBarrierOperator {
                         new_record.bind(alias.clone(), value);
                     }
                     records.push(new_record);
+                    if let Some(c) = cap {
+                        if records.len() >= c {
+                            break 'outer;
+                        }
+                    }
                 }
             }
             records

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3432,6 +3432,133 @@ impl AggregateOperator {
     }
 }
 
+/// Adjacency-aware count aggregate (ADR-017 Phase 1).
+///
+/// For patterns like `MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal) RETURN j.title, count(a) AS articles`
+/// this computes each group's count by reading the adjacency list of the
+/// grouped endpoint directly, instead of walking every edge through a generic
+/// aggregate. Input must produce the grouped endpoint nodes.
+///
+/// Output per row: `{ grouped_var: NodeRef(id), count_alias: Integer(degree) }`.
+/// Downstream operators (Project, Sort, Limit) consume these like any other
+/// aggregate result.
+pub struct AdjacencyCountAggregateOperator {
+    input: OperatorBox,
+    grouped_var: String,
+    count_alias: String,
+    edge_type: EdgeType,
+    /// Direction relative to the grouped endpoint:
+    /// - Outgoing = out-degree of the grouped node on this edge type
+    /// - Incoming = in-degree of the grouped node on this edge type
+    direction: Direction,
+}
+
+impl AdjacencyCountAggregateOperator {
+    pub fn new(
+        input: OperatorBox,
+        grouped_var: String,
+        count_alias: String,
+        edge_type: EdgeType,
+        direction: Direction,
+    ) -> Self {
+        Self {
+            input,
+            grouped_var,
+            count_alias,
+            edge_type,
+            direction,
+        }
+    }
+
+    /// Count the incident edges of `node_id` that match `edge_type` in the
+    /// operator's direction. Walks the adjacency list once — no allocation
+    /// beyond what the store already does internally. Uses the
+    /// lightweight `_owned` tuple variants to avoid cloning full `Edge`s.
+    fn degree_filtered(&self, store: &GraphStore, node_id: NodeId) -> usize {
+        match self.direction {
+            Direction::Outgoing => store
+                .get_outgoing_edge_targets_owned(node_id)
+                .into_iter()
+                .filter(|(_, _, _, et)| *et == self.edge_type)
+                .count(),
+            Direction::Incoming => store
+                .get_incoming_edge_sources_owned(node_id)
+                .into_iter()
+                .filter(|(_, _, _, et)| *et == self.edge_type)
+                .count(),
+            Direction::Both => {
+                // Defensive: the planner filters Direction::Both out before
+                // constructing this operator. Falling back to union is cheap
+                // insurance if that guarantee ever slips.
+                let out = store
+                    .get_outgoing_edge_targets_owned(node_id)
+                    .into_iter()
+                    .filter(|(_, _, _, et)| *et == self.edge_type)
+                    .count();
+                let inc = store
+                    .get_incoming_edge_sources_owned(node_id)
+                    .into_iter()
+                    .filter(|(_, _, _, et)| *et == self.edge_type)
+                    .count();
+                out + inc
+            }
+        }
+    }
+}
+
+impl PhysicalOperator for AdjacencyCountAggregateOperator {
+    fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        loop {
+            let input_record = match self.input.next(store)? {
+                Some(r) => r,
+                None => return Ok(None),
+            };
+
+            let node_id = match input_record.get(&self.grouped_var) {
+                Some(Value::NodeRef(id)) | Some(Value::Node(id, _)) => *id,
+                _ => {
+                    // Upstream didn't bind the grouped variable to a node —
+                    // indicates a planner bug; skip rather than crash.
+                    continue;
+                }
+            };
+
+            let count = self.degree_filtered(store, node_id);
+
+            let mut out = input_record;
+            out.bind(
+                self.count_alias.clone(),
+                Value::Property(PropertyValue::Integer(count as i64)),
+            );
+            return Ok(Some(out));
+        }
+    }
+
+    fn reset(&mut self) {
+        self.input.reset();
+    }
+
+    fn describe(&self) -> OperatorDescription {
+        let dir = match self.direction {
+            Direction::Outgoing => "->",
+            Direction::Incoming => "<-",
+            Direction::Both => "--",
+        };
+        OperatorDescription {
+            name: "AdjacencyCountAggregate".to_string(),
+            details: format!(
+                "({}){}[:{}]{} count AS {}",
+                self.grouped_var,
+                dir,
+                self.edge_type.as_str(),
+                dir,
+                self.count_alias
+            ),
+            children: vec![self.input.describe()],
+        }
+    }
+}
+
 /// Limit operator: LIMIT 10
 pub struct LimitOperator {
     /// Input operator

--- a/src/query/executor/physical_planner.rs
+++ b/src/query/executor/physical_planner.rs
@@ -109,6 +109,18 @@ pub fn logical_to_physical(plan: &LogicalPlanNode) -> OperatorBox {
             let physical_right = logical_to_physical(right);
             Box::new(CartesianProductOperator::new(physical_left, physical_right))
         }
+
+        LogicalPlanNode::AdjacencyCountAggregate { .. } => {
+            // Phase 0 (ADR-017): the logical variant exists so the detector can
+            // emit it, but the physical operator ships in Phase 1. Until then,
+            // this node must not appear in a plan that reaches the physical
+            // planner. Panicking loudly is preferable to silent wrong output.
+            panic!(
+                "AdjacencyCountAggregate is not yet implemented in the physical planner \
+                 (ADR-017 Phase 0). The detector produces this node but it must be \
+                 lowered to an Expand+Aggregate equivalent until Phase 1 ships."
+            );
+        }
     }
 }
 

--- a/src/query/executor/physical_planner.rs
+++ b/src/query/executor/physical_planner.rs
@@ -110,16 +110,31 @@ pub fn logical_to_physical(plan: &LogicalPlanNode) -> OperatorBox {
             Box::new(CartesianProductOperator::new(physical_left, physical_right))
         }
 
-        LogicalPlanNode::AdjacencyCountAggregate { .. } => {
-            // Phase 0 (ADR-017): the logical variant exists so the detector can
-            // emit it, but the physical operator ships in Phase 1. Until then,
-            // this node must not appear in a plan that reaches the physical
-            // planner. Panicking loudly is preferable to silent wrong output.
-            panic!(
-                "AdjacencyCountAggregate is not yet implemented in the physical planner \
-                 (ADR-017 Phase 0). The detector produces this node but it must be \
-                 lowered to an Expand+Aggregate equivalent until Phase 1 ships."
-            );
+        LogicalPlanNode::AdjacencyCountAggregate {
+            input,
+            grouped_var,
+            edge_type,
+            direction,
+            count_alias,
+            ..
+        } => {
+            // ADR-017 Phase 1: lower to the physical operator. The `neighbor_var`,
+            // `neighbor_label`, and `distinct` fields on the logical node are
+            // recorded for diagnostics/EXPLAIN but not needed by the physical
+            // operator — counting uses edge-type alone. The detector already
+            // rejects shapes where neighbor_label filtering would change the count.
+            let physical_input = logical_to_physical(input);
+            let physical_direction = match direction {
+                ExpandDirection::Forward => Direction::Outgoing,
+                ExpandDirection::Reverse => Direction::Incoming,
+            };
+            Box::new(AdjacencyCountAggregateOperator::new(
+                physical_input,
+                grouped_var.clone(),
+                count_alias.clone(),
+                edge_type.clone(),
+                physical_direction,
+            ))
         }
     }
 }

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -376,6 +376,15 @@ impl QueryPlanner {
             }
         }
 
+        // ADR-017 Phase 1: recognize the adjacency-count-aggregate shape before
+        // the generic planner runs. The detector's constraints are conservative
+        // enough that when it returns Some, the specialized plan is always
+        // correct for the query. The specialized plan short-circuits the
+        // Expand→Aggregate path that causes MB049/MB054 to time out.
+        if let Some(pat) = super::adjacency_agg_detector::detect(query) {
+            return self.plan_adjacency_count_aggregate(query, pat);
+        }
+
         // Handle MERGE-only statement (no MATCH needed)
         if query.match_clauses.is_empty() && query.call_clause.is_none() {
             if let Some(merge_clause) = &query.merge_clause {
@@ -1669,6 +1678,105 @@ impl QueryPlanner {
     }
 
     /// Plan a CREATE-only query (no MATCH clause)
+    /// Build the specialized plan for the adjacency-count-aggregate pattern
+    /// (ADR-017). Called only after `adjacency_agg_detector::detect` returns
+    /// `Some`, which guarantees the constraints below hold.
+    fn plan_adjacency_count_aggregate(
+        &self,
+        query: &Query,
+        pat: super::adjacency_agg_detector::AdjacencyAggPattern,
+    ) -> ExecutionResult<ExecutionPlan> {
+        use super::operator::{
+            AdjacencyCountAggregateOperator, LimitOperator, NodeScanOperator, ProjectOperator,
+            SortOperator,
+        };
+
+        let physical_direction = match pat.direction {
+            super::logical_plan::ExpandDirection::Forward => Direction::Outgoing,
+            super::logical_plan::ExpandDirection::Reverse => Direction::Incoming,
+        };
+
+        // Scan + count. The scan binds the grouped endpoint; the adjacency
+        // count operator adds `count_alias` to each record.
+        let scan: OperatorBox = Box::new(NodeScanOperator::new(
+            pat.grouped_var.clone(),
+            vec![pat.grouped_label.clone()],
+        ));
+        let mut operator: OperatorBox = Box::new(AdjacencyCountAggregateOperator::new(
+            scan,
+            pat.grouped_var.clone(),
+            pat.count_alias.clone(),
+            pat.edge_type.clone(),
+            physical_direction,
+        ));
+
+        // RETURN projections — the detector guarantees each item is either a
+        // Property/Variable on the grouped side or the single count() aggregate,
+        // so we can project directly against the enriched record.
+        let return_clause = query
+            .return_clause
+            .as_ref()
+            .expect("detector enforces RETURN presence");
+        let mut output_columns = Vec::new();
+        let projections: Vec<(Expression, String)> = return_clause
+            .items
+            .iter()
+            .enumerate()
+            .map(|(i, item)| {
+                let alias = item
+                    .alias
+                    .clone()
+                    .unwrap_or_else(|| match &item.expression {
+                        Expression::Variable(v) => v.clone(),
+                        Expression::Property { variable, property } => {
+                            format!("{}.{}", variable, property)
+                        }
+                        _ => format!("col_{}", i),
+                    });
+                output_columns.push(alias.clone());
+                // For the count() item, project the already-bound alias
+                // rather than re-evaluating the aggregate function.
+                let expr = match &item.expression {
+                    Expression::Function { name, .. }
+                        if name.eq_ignore_ascii_case("count") =>
+                    {
+                        Expression::Variable(pat.count_alias.clone())
+                    }
+                    other => other.clone(),
+                };
+                (expr, alias)
+            })
+            .collect();
+        operator = Box::new(ProjectOperator::new(operator, projections));
+
+        // ORDER BY — the count alias is already bound, so any ORDER BY
+        // expression the detector accepted evaluates cheaply.
+        if let Some(order_by) = &query.order_by {
+            let sort_items: Vec<(Expression, bool)> = order_by
+                .items
+                .iter()
+                .map(|i| (i.expression.clone(), i.ascending))
+                .collect();
+            operator = Box::new(SortOperator::new(operator, sort_items));
+        }
+
+        if let Some(skip) = query.skip {
+            operator = Box::new(super::operator::SkipOperator::new(operator, skip));
+        }
+        if let Some(limit) = query.limit {
+            operator = Box::new(LimitOperator::new(operator, limit));
+        }
+
+        Ok(ExecutionPlan {
+            root: operator,
+            output_columns,
+            is_write: false,
+            candidates_evaluated: 1,
+            chosen_plan_cost: 0.0,
+            candidate_costs: Vec::new(),
+        })
+    }
+
     /// Supports:
     /// - CREATE (n:Person {name: "Alice", age: 30})
     /// - CREATE (a:Person)-[:KNOWS]->(b:Person)

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -384,6 +384,13 @@ impl QueryPlanner {
         if let Some(pat) = super::adjacency_agg_detector::detect(query) {
             return self.plan_adjacency_count_aggregate(query, pat);
         }
+        // ADR-017 Phase 3a: the WITH-bound variant handles MB053 and EX49,
+        // where an explicit pre-WITH LIMIT caps the work per group but the
+        // second MATCH would otherwise spill billions of edges into the
+        // generic aggregate.
+        if let Some(pat) = super::adjacency_agg_detector::detect_with_binding(query) {
+            return self.plan_adjacency_count_aggregate_with_binding(query, pat);
+        }
 
         // Handle MERGE-only statement (no MATCH needed)
         if query.match_clauses.is_empty() && query.call_clause.is_none() {
@@ -1762,6 +1769,133 @@ impl QueryPlanner {
 
         if let Some(skip) = query.skip {
             operator = Box::new(super::operator::SkipOperator::new(operator, skip));
+        }
+        if let Some(limit) = query.limit {
+            operator = Box::new(LimitOperator::new(operator, limit));
+        }
+
+        Ok(ExecutionPlan {
+            root: operator,
+            output_columns,
+            is_write: false,
+            candidates_evaluated: 1,
+            chosen_plan_cost: 0.0,
+            candidate_costs: Vec::new(),
+        })
+    }
+
+    /// Phase 3a: specialized plan for the WITH-bound adjacency-count shape.
+    /// The pre-WITH MATCH scans the grouped label; any WHERE filter is applied
+    /// as a FilterOperator; the WITH's SKIP/LIMIT bound the scan; the
+    /// AdjacencyCountAggregate operator counts neighbors per surviving row.
+    fn plan_adjacency_count_aggregate_with_binding(
+        &self,
+        query: &Query,
+        pat: super::adjacency_agg_detector::AdjacencyAggWithBindingPattern,
+    ) -> ExecutionResult<ExecutionPlan> {
+        use super::operator::{
+            AdjacencyCountAggregateOperator, FilterOperator, LimitOperator, NodeScanOperator,
+            ProjectOperator, SkipOperator, SortOperator,
+        };
+
+        let physical_direction = match pat.core.direction {
+            super::logical_plan::ExpandDirection::Forward => Direction::Outgoing,
+            super::logical_plan::ExpandDirection::Reverse => Direction::Incoming,
+        };
+
+        // Grouped-side scan. An explicit early_limit on NodeScan lets us stop
+        // iterating after WITH's LIMIT rows — this is the pre-WITH-LIMIT
+        // equivalent of PR #192's streaming idea, applied to the scan itself.
+        let mut scan = NodeScanOperator::new(
+            pat.core.grouped_var.clone(),
+            vec![pat.core.grouped_label.clone()],
+        );
+        // Only push early_limit down when there's no pre-filter — otherwise
+        // we'd stop at the wrong rows. With a filter, we apply LIMIT after.
+        let filter_will_run = pat.prefilter.is_some();
+        if !filter_will_run {
+            if let Some(skip) = pat.grouped_scan_skip {
+                if let Some(lim) = pat.grouped_scan_limit {
+                    scan = scan.with_early_limit(skip + lim);
+                }
+            } else if let Some(lim) = pat.grouped_scan_limit {
+                scan = scan.with_early_limit(lim);
+            }
+        }
+        let mut operator: OperatorBox = Box::new(scan);
+
+        // Pre-filter (WHERE on the grouped side).
+        if let Some(pred) = pat.prefilter {
+            operator = Box::new(FilterOperator::new(operator, pred));
+        }
+
+        // SKIP/LIMIT from the WITH clause. When a filter ran, these are
+        // applied in user order: skip first, then limit of the filtered
+        // stream. When no filter ran, early_limit on the scan already
+        // handled both, so these wrappers are redundant — but harmless.
+        if filter_will_run {
+            if let Some(skip) = pat.grouped_scan_skip {
+                operator = Box::new(SkipOperator::new(operator, skip));
+            }
+            if let Some(lim) = pat.grouped_scan_limit {
+                operator = Box::new(LimitOperator::new(operator, lim));
+            }
+        }
+
+        // The adjacency-count aggregate itself — identical to Phase 1.
+        operator = Box::new(AdjacencyCountAggregateOperator::new(
+            operator,
+            pat.core.grouped_var.clone(),
+            pat.core.count_alias.clone(),
+            pat.core.edge_type.clone(),
+            physical_direction,
+        ));
+
+        // RETURN projections — same logic as the Phase 1 helper.
+        let return_clause = query
+            .return_clause
+            .as_ref()
+            .expect("detector enforces RETURN presence");
+        let mut output_columns = Vec::new();
+        let projections: Vec<(Expression, String)> = return_clause
+            .items
+            .iter()
+            .enumerate()
+            .map(|(i, item)| {
+                let alias = item
+                    .alias
+                    .clone()
+                    .unwrap_or_else(|| match &item.expression {
+                        Expression::Variable(v) => v.clone(),
+                        Expression::Property { variable, property } => {
+                            format!("{}.{}", variable, property)
+                        }
+                        _ => format!("col_{}", i),
+                    });
+                output_columns.push(alias.clone());
+                let expr = match &item.expression {
+                    Expression::Function { name, .. }
+                        if name.eq_ignore_ascii_case("count") =>
+                    {
+                        Expression::Variable(pat.core.count_alias.clone())
+                    }
+                    other => other.clone(),
+                };
+                (expr, alias)
+            })
+            .collect();
+        operator = Box::new(ProjectOperator::new(operator, projections));
+
+        if let Some(order_by) = &query.order_by {
+            let sort_items: Vec<(Expression, bool)> = order_by
+                .items
+                .iter()
+                .map(|i| (i.expression.clone(), i.ascending))
+                .collect();
+            operator = Box::new(SortOperator::new(operator, sort_items));
+        }
+        if let Some(skip) = query.skip {
+            operator = Box::new(SkipOperator::new(operator, skip));
         }
         if let Some(limit) = query.limit {
             operator = Box::new(LimitOperator::new(operator, limit));

--- a/src/query/executor/semi_join_detector.rs
+++ b/src/query/executor/semi_join_detector.rs
@@ -1,0 +1,629 @@
+//! Detector for the semi-join + aggregate pattern (ADR-017 Phase 3b).
+//!
+//! Recognizes queries of the shape:
+//! ```text
+//! MATCH (x:LX)-[:E1]-(y[:LY]) WHERE pred1
+//! MATCH (x)-[:E2]-(z[:LZ]) WHERE pred2
+//! WITH z.prop AS group_alias, count(DISTINCT x) AS count_alias
+//!   [ORDER BY count_alias DESC] [LIMIT K]
+//! RETURN group_alias, count_alias
+//! ```
+//! where `y` appears only as a filter — not in the WITH projections, ORDER BY,
+//! or RETURN. Motivating case: OM27 (Depression comorbidities).
+//!
+//! The bottleneck in the generic planner: both MATCHes produce their full
+//! tuple stream and the aggregate builds a HashSet<NodeId> per group for the
+//! `count(DISTINCT x)` — on OMOP 51M Persons × their conditions this times
+//! out. The semi-join rewrite computes the qualifying set of `x` once, then
+//! counts how many qualify per `z.prop`.
+
+use crate::graph::types::{EdgeType, Label};
+use crate::query::ast::{BinaryOp, Direction, Expression, Query, WhereClause};
+use std::collections::HashSet;
+
+/// A predicate that survives the detector's pre-analysis, tagged with the
+/// side it applies to. Lets the planner attach predicates to the correct
+/// expand operator without re-inspecting every AND node.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PredicateSide {
+    /// Predicate references only `shared_var` and/or the first MATCH's non-shared endpoint.
+    First,
+    /// Predicate references only `shared_var` and/or the second MATCH's non-shared endpoint.
+    Second,
+}
+
+/// Parameters extracted from a Phase 3b query.
+#[derive(Debug, Clone)]
+pub struct SemiJoinPattern {
+    /// Variable bound to the probe side (e.g. `p` in OM27 — the Person).
+    pub shared_var: String,
+    /// Label of the probe variable (required — used as the driving scan).
+    pub shared_label: Label,
+
+    /// First MATCH: edge type + direction relative to `shared_var`.
+    pub first_edge_type: EdgeType,
+    pub first_direction: Direction,
+    /// Non-shared endpoint of the first MATCH (e.g. `c1`). Variable name is
+    /// recorded so the filter predicates can reference it correctly.
+    pub first_other_var: String,
+    pub first_other_label: Option<Label>,
+    /// Predicates applying to the first MATCH (shared_var and/or first_other_var).
+    pub first_predicate: Option<Expression>,
+
+    /// Second MATCH parameters — same layout.
+    pub second_edge_type: EdgeType,
+    pub second_direction: Direction,
+    pub second_other_var: String,
+    pub second_other_label: Option<Label>,
+    pub second_predicate: Option<Expression>,
+
+    /// Expression emitted as the grouping key (e.g. `c2.condition_concept`).
+    pub group_by_expr: Expression,
+    pub group_by_alias: String,
+
+    /// Count alias from the WITH.
+    pub count_alias: String,
+
+    /// `ORDER BY` items (copied from the WITH; typically `[(count_alias_var, DESC)]`).
+    pub order_by: Option<Vec<(Expression, bool)>>,
+    /// `LIMIT` on the WITH.
+    pub limit: Option<usize>,
+}
+
+/// Try to detect the Phase 3b pattern. Returns `None` on any mismatch.
+pub fn detect(query: &Query) -> Option<SemiJoinPattern> {
+    // Shape: exactly two MATCHes, a WITH that owns the aggregate, a final
+    // RETURN. No create/set/delete/call/unwind/merge.
+    if query.match_clauses.len() != 2 {
+        return None;
+    }
+    let split = query.with_split_index?;
+    if split != 2 {
+        return None; // both MATCHes must be pre-WITH
+    }
+    if !query.extra_with_stages.is_empty() {
+        return None;
+    }
+    if query.create_clause.is_some()
+        || query.call_clause.is_some()
+        || query.call_subquery.is_some()
+        || query.delete_clause.is_some()
+        || query.merge_clause.is_some()
+        || query.unwind_clause.is_some()
+        || !query.set_clauses.is_empty()
+        || !query.remove_clauses.is_empty()
+    {
+        return None;
+    }
+    if query.post_with_where_clause.is_some() {
+        return None;
+    }
+
+    let mc1 = &query.match_clauses[0];
+    let mc2 = &query.match_clauses[1];
+    if mc1.optional || mc2.optional {
+        return None;
+    }
+
+    // Each MATCH must have a single-path, single-segment pattern.
+    if mc1.pattern.paths.len() != 1 || mc2.pattern.paths.len() != 1 {
+        return None;
+    }
+    let p1 = &mc1.pattern.paths[0];
+    let p2 = &mc2.pattern.paths[0];
+    if p1.segments.len() != 1 || p2.segments.len() != 1 {
+        return None;
+    }
+    if p1.segments[0].edge.length.is_some() || p2.segments[0].edge.length.is_some() {
+        return None;
+    }
+
+    // Each path exposes two variables; we need to identify which one is
+    // shared between the two matches.
+    let p1_start = &p1.start;
+    let p1_target = &p1.segments[0].node;
+    let p2_start = &p2.start;
+    let p2_target = &p2.segments[0].node;
+    let p1_start_var = p1_start.variable.as_ref()?.clone();
+    let p1_target_var = p1_target.variable.as_ref()?.clone();
+    let p2_start_var = p2_start.variable.as_ref()?.clone();
+    let p2_target_var = p2_target.variable.as_ref()?.clone();
+
+    let m1_vars: HashSet<&str> = [p1_start_var.as_str(), p1_target_var.as_str()]
+        .iter()
+        .copied()
+        .collect();
+    let m2_vars: HashSet<&str> = [p2_start_var.as_str(), p2_target_var.as_str()]
+        .iter()
+        .copied()
+        .collect();
+    let shared: Vec<&str> = m1_vars.intersection(&m2_vars).copied().collect();
+    if shared.len() != 1 {
+        // Zero shared vars = disjoint matches (cartesian product).
+        // Two shared = both endpoints same = effectively an ExpandInto on
+        // parallel edges — different plan shape.
+        return None;
+    }
+    let shared_var = shared[0].to_string();
+
+    // Resolve, for each match, the "other" endpoint (not the shared one).
+    let (first_other_node, first_other_var, first_shared_is_start) =
+        if p1_start_var == shared_var {
+            (p1_target, p1_target_var.clone(), true)
+        } else {
+            (p1_start, p1_start_var.clone(), false)
+        };
+    let (second_other_node, second_other_var, second_shared_is_start) =
+        if p2_start_var == shared_var {
+            (p2_target, p2_target_var.clone(), true)
+        } else {
+            (p2_start, p2_start_var.clone(), false)
+        };
+
+    // `y` (first_other_var) must not be referenced downstream. This is the
+    // critical "filter-only" condition that makes the semi-join sound.
+    if variable_appears_in_with_or_return(query, &first_other_var) {
+        return None;
+    }
+
+    // Locate the shared label — must be on the shared side of at least one
+    // MATCH (the driving scan needs a label).
+    let shared_label = resolve_shared_label(&shared_var, p1_start, p1_target, p2_start, p2_target)?;
+
+    // Endpoint labels on the "other" sides.
+    let first_other_label = match first_other_node.labels.len() {
+        0 => None,
+        1 => Some(first_other_node.labels[0].clone()),
+        _ => return None,
+    };
+    let second_other_label = match second_other_node.labels.len() {
+        0 => None,
+        1 => Some(second_other_node.labels[0].clone()),
+        _ => return None,
+    };
+
+    // No inline property constraints — predicates must come via WHERE.
+    if first_other_node.properties.is_some() || second_other_node.properties.is_some() {
+        return None;
+    }
+    if p1_start.properties.is_some() || p1_target.properties.is_some() {
+        return None;
+    }
+    if p2_start.properties.is_some() || p2_target.properties.is_some() {
+        return None;
+    }
+
+    // Edge types: concrete single type each.
+    let first_edge = &p1.segments[0].edge;
+    let second_edge = &p2.segments[0].edge;
+    if first_edge.types.len() != 1 || second_edge.types.len() != 1 {
+        return None;
+    }
+    let first_edge_type = first_edge.types[0].clone();
+    let second_edge_type = second_edge.types[0].clone();
+
+    // Map AST direction + "shared is start?" to a direction relative to
+    // the shared variable (the driving side of the scan).
+    let first_direction = match (first_edge.direction.clone(), first_shared_is_start) {
+        (Direction::Outgoing, true) => Direction::Outgoing,
+        (Direction::Outgoing, false) => Direction::Incoming,
+        (Direction::Incoming, true) => Direction::Incoming,
+        (Direction::Incoming, false) => Direction::Outgoing,
+        (Direction::Both, _) => return None,
+    };
+    let second_direction = match (second_edge.direction.clone(), second_shared_is_start) {
+        (Direction::Outgoing, true) => Direction::Outgoing,
+        (Direction::Outgoing, false) => Direction::Incoming,
+        (Direction::Incoming, true) => Direction::Incoming,
+        (Direction::Incoming, false) => Direction::Outgoing,
+        (Direction::Both, _) => return None,
+    };
+
+    // Split the top-level WHERE on AND into per-side predicates. A predicate
+    // is eligible for MATCH-N if it only references shared_var and/or
+    // MATCH-N's other_var. A predicate that touches both matches' other_vars
+    // is "cross-match" and we don't support it here.
+    let (first_predicate, second_predicate) = split_where(
+        &query.where_clause,
+        &shared_var,
+        &first_other_var,
+        &second_other_var,
+    )?;
+
+    // WITH clause must own the aggregate: exactly one group-by projection on
+    // second_other_var (or a property of it) and exactly one count aggregate
+    // over shared_var. No other items, no distinct, no where.
+    let with_clause = query.with_clause.as_ref()?;
+    if with_clause.distinct
+        || with_clause.where_clause.is_some()
+        || with_clause.items.len() != 2
+    {
+        return None;
+    }
+
+    let mut group_by: Option<(Expression, String)> = None;
+    let mut count_info: Option<(String, bool)> = None;
+    for (i, item) in with_clause.items.iter().enumerate() {
+        match &item.expression {
+            Expression::Function {
+                name,
+                args,
+                distinct,
+            } if name.eq_ignore_ascii_case("count") => {
+                if count_info.is_some() || args.len() != 1 {
+                    return None;
+                }
+                match &args[0] {
+                    Expression::Variable(v) if v == &shared_var => {}
+                    _ => return None, // must count the shared variable
+                }
+                let alias = item
+                    .alias
+                    .clone()
+                    .unwrap_or_else(|| format!("count_{}", i));
+                count_info = Some((alias, *distinct));
+            }
+            expr @ (Expression::Property { .. } | Expression::Variable(_)) => {
+                // Group-by side. Must reference only `second_other_var`.
+                if !expression_references_only(expr, &second_other_var) {
+                    return None;
+                }
+                let alias = item.alias.clone().unwrap_or_else(|| format!("g_{}", i));
+                if group_by.is_some() {
+                    return None;
+                }
+                group_by = Some((expr.clone(), alias));
+            }
+            _ => return None,
+        }
+    }
+    let (group_by_expr, group_by_alias) = group_by?;
+    let (count_alias, _count_distinct) = count_info?;
+    // Whether DISTINCT was written or not doesn't matter for our rewrite:
+    // our plan inserts an explicit DISTINCT on shared_var before the second
+    // MATCH, so the downstream count is guaranteed to be per-unique-x.
+
+    // RETURN: must just project the WITH aliases. No further transformation.
+    let ret = query.return_clause.as_ref()?;
+    if ret.distinct {
+        return None;
+    }
+    for item in &ret.items {
+        match &item.expression {
+            Expression::Variable(v) if v == &group_by_alias || v == &count_alias => {}
+            _ => return None,
+        }
+    }
+
+    let order_by = with_clause.order_by.as_ref().map(|ob| {
+        ob.items
+            .iter()
+            .map(|i| (i.expression.clone(), i.ascending))
+            .collect::<Vec<_>>()
+    });
+
+    Some(SemiJoinPattern {
+        shared_var,
+        shared_label,
+        first_edge_type,
+        first_direction,
+        first_other_var,
+        first_other_label,
+        first_predicate,
+        second_edge_type,
+        second_direction,
+        second_other_var,
+        second_other_label,
+        second_predicate,
+        group_by_expr,
+        group_by_alias,
+        count_alias,
+        order_by,
+        limit: with_clause.limit,
+    })
+}
+
+/// Find the shared variable's label by scanning both MATCHes for a node
+/// pattern that names the shared variable AND carries a single label.
+/// Both MATCHes should agree; we accept if any of the four references
+/// has a label (and they're all consistent).
+fn resolve_shared_label(
+    shared_var: &str,
+    p1_start: &crate::query::ast::NodePattern,
+    p1_target: &crate::query::ast::NodePattern,
+    p2_start: &crate::query::ast::NodePattern,
+    p2_target: &crate::query::ast::NodePattern,
+) -> Option<Label> {
+    let mut found: Option<Label> = None;
+    for node in [p1_start, p1_target, p2_start, p2_target] {
+        if node.variable.as_deref() == Some(shared_var) && !node.labels.is_empty() {
+            if node.labels.len() > 1 {
+                return None;
+            }
+            match &found {
+                None => found = Some(node.labels[0].clone()),
+                Some(existing) => {
+                    if existing != &node.labels[0] {
+                        return None;
+                    }
+                }
+            }
+        }
+    }
+    found
+}
+
+/// Return true if `var` appears anywhere downstream of the two MATCHes:
+/// the WITH clause's items / order_by, or the RETURN clause.
+fn variable_appears_in_with_or_return(query: &Query, var: &str) -> bool {
+    if let Some(wc) = &query.with_clause {
+        for item in &wc.items {
+            if expression_references(&item.expression, var) {
+                return true;
+            }
+        }
+        if let Some(ob) = &wc.order_by {
+            for item in &ob.items {
+                if expression_references(&item.expression, var) {
+                    return true;
+                }
+            }
+        }
+    }
+    if let Some(rc) = &query.return_clause {
+        for item in &rc.items {
+            if expression_references(&item.expression, var) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Walk an expression tree looking for any reference to `var`.
+fn expression_references(expr: &Expression, var: &str) -> bool {
+    match expr {
+        Expression::Variable(v) => v == var,
+        Expression::Property { variable, .. } => variable == var,
+        Expression::PathVariable(v) => v == var,
+        Expression::Literal(_) | Expression::Parameter(_) => false,
+        Expression::Binary { left, right, .. } => {
+            expression_references(left, var) || expression_references(right, var)
+        }
+        Expression::Unary { expr, .. } => expression_references(expr, var),
+        Expression::Function { args, .. } => {
+            args.iter().any(|a| expression_references(a, var))
+        }
+        Expression::Case {
+            operand,
+            when_clauses,
+            else_result,
+        } => {
+            operand.as_deref().map_or(false, |e| expression_references(e, var))
+                || when_clauses.iter().any(|(c, r)| {
+                    expression_references(c, var) || expression_references(r, var)
+                })
+                || else_result
+                    .as_deref()
+                    .map_or(false, |e| expression_references(e, var))
+        }
+        Expression::Index { expr, index } => {
+            expression_references(expr, var) || expression_references(index, var)
+        }
+        Expression::ListSlice { expr, start, end } => {
+            expression_references(expr, var)
+                || start.as_deref().map_or(false, |e| expression_references(e, var))
+                || end.as_deref().map_or(false, |e| expression_references(e, var))
+        }
+        // Subquery / comprehension / predicate expressions: be conservative
+        // — say "yes" so we reject rather than misclassify.
+        _ => true,
+    }
+}
+
+/// Return true if every variable reference in `expr` is one of the
+/// allowed set. Uses a whitelist that matches what the planner will
+/// later evaluate correctly.
+fn expression_references_only(expr: &Expression, allowed_var: &str) -> bool {
+    references_only_allowed(expr, &[allowed_var])
+}
+
+fn references_only_allowed(expr: &Expression, allowed: &[&str]) -> bool {
+    match expr {
+        Expression::Variable(v) => allowed.contains(&v.as_str()),
+        Expression::Property { variable, .. } => allowed.contains(&variable.as_str()),
+        Expression::Literal(_) | Expression::Parameter(_) => true,
+        Expression::Binary { left, right, .. } => {
+            references_only_allowed(left, allowed) && references_only_allowed(right, allowed)
+        }
+        Expression::Unary { expr, .. } => references_only_allowed(expr, allowed),
+        Expression::Function { args, .. } => {
+            args.iter().all(|a| references_only_allowed(a, allowed))
+        }
+        _ => false,
+    }
+}
+
+/// Split a flat AND-chain WHERE into predicates tagged by which MATCH they
+/// apply to. Returns `(first_predicate, second_predicate)`.
+/// A predicate that references only `shared_var` is assigned to the first
+/// MATCH (where it can short-circuit earliest). A predicate that touches
+/// both other-vars is unsupportable in this rewrite — return `None`.
+fn split_where(
+    where_clause: &Option<WhereClause>,
+    shared_var: &str,
+    first_other: &str,
+    second_other: &str,
+) -> Option<(Option<Expression>, Option<Expression>)> {
+    let wc = match where_clause {
+        Some(w) => w,
+        None => return Some((None, None)),
+    };
+    let flat = flatten_and(&wc.predicate);
+    let mut first: Option<Expression> = None;
+    let mut second: Option<Expression> = None;
+    let first_allow = [shared_var, first_other];
+    let second_allow = [shared_var, second_other];
+    for pred in flat {
+        let allowed_first = references_only_allowed(&pred, &first_allow);
+        let allowed_second = references_only_allowed(&pred, &second_allow);
+        let tag = match (allowed_first, allowed_second) {
+            (true, _) => PredicateSide::First,
+            (_, true) => PredicateSide::Second,
+            _ => return None, // predicate spans both matches — unsupported
+        };
+        match tag {
+            PredicateSide::First => {
+                first = Some(match first.take() {
+                    Some(prev) => and_(prev, pred),
+                    None => pred,
+                });
+            }
+            PredicateSide::Second => {
+                second = Some(match second.take() {
+                    Some(prev) => and_(prev, pred),
+                    None => pred,
+                });
+            }
+        }
+    }
+    Some((first, second))
+}
+
+fn flatten_and(expr: &Expression) -> Vec<Expression> {
+    match expr {
+        Expression::Binary {
+            left,
+            op: BinaryOp::And,
+            right,
+        } => {
+            let mut v = flatten_and(left);
+            v.extend(flatten_and(right));
+            v
+        }
+        other => vec![other.clone()],
+    }
+}
+
+fn and_(l: Expression, r: Expression) -> Expression {
+    Expression::Binary {
+        left: Box::new(l),
+        op: BinaryOp::And,
+        right: Box::new(r),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::parser::parse_query;
+
+    /// OM27 shape (the motivating case).
+    #[test]
+    fn detects_om27_depression_comorbidities() {
+        let q = parse_query(
+            "MATCH (p:Person)-[:HAS_CONDITION]->(c1:ConditionOccurrence) \
+             WHERE c1.condition_concept IS NOT NULL AND c1.condition_concept CONTAINS 'Depression' \
+             MATCH (p)-[:HAS_CONDITION]->(c2:ConditionOccurrence) \
+             WHERE c2.condition_concept IS NOT NULL AND NOT (c2.condition_concept CONTAINS 'Depression') \
+             WITH c2.condition_concept AS condition, count(DISTINCT p) AS patients \
+             ORDER BY patients DESC LIMIT 10 RETURN condition, patients",
+        )
+        .unwrap();
+        let p = detect(&q).expect("OM27 should be detected");
+        assert_eq!(p.shared_var, "p");
+        assert_eq!(p.shared_label.as_str(), "Person");
+        assert_eq!(p.first_other_var, "c1");
+        assert_eq!(p.second_other_var, "c2");
+        assert_eq!(p.first_edge_type.as_str(), "HAS_CONDITION");
+        assert_eq!(p.second_edge_type.as_str(), "HAS_CONDITION");
+        assert_eq!(p.first_direction, Direction::Outgoing);
+        assert_eq!(p.second_direction, Direction::Outgoing);
+        assert_eq!(p.group_by_alias, "condition");
+        assert_eq!(p.count_alias, "patients");
+        assert_eq!(p.limit, Some(10));
+        assert!(p.first_predicate.is_some());
+        assert!(p.second_predicate.is_some());
+    }
+
+    /// When the first MATCH's non-shared variable IS referenced downstream,
+    /// the semi-join rewrite would lose information — reject.
+    #[test]
+    fn rejects_when_first_match_other_var_appears_downstream() {
+        let q = parse_query(
+            "MATCH (p:Person)-[:HAS_CONDITION]->(c1:ConditionOccurrence) \
+             WHERE c1.condition_concept CONTAINS 'Depression' \
+             MATCH (p)-[:HAS_CONDITION]->(c2:ConditionOccurrence) \
+             WHERE NOT (c2.condition_concept CONTAINS 'Depression') \
+             WITH c1.condition_concept AS d_concept, c2.condition_concept AS condition, count(DISTINCT p) AS patients \
+             RETURN d_concept, condition, patients",
+        )
+        .unwrap();
+        // c1 appears in the WITH projections → rewrite would drop it wrongly.
+        assert!(detect(&q).is_none());
+    }
+
+    /// MATCHes with no shared variable aren't this pattern — they'd be a
+    /// cartesian product, not a semi-join.
+    #[test]
+    fn rejects_disjoint_matches() {
+        let q = parse_query(
+            "MATCH (a:Article) WHERE a.year = 2024 \
+             MATCH (b:Book) WHERE b.year = 2024 \
+             WITH a.year AS year, count(DISTINCT b) AS books \
+             RETURN year, books",
+        )
+        .unwrap();
+        assert!(detect(&q).is_none());
+    }
+
+    /// Single MATCH — handled by Phase 1, not us.
+    #[test]
+    fn rejects_single_match() {
+        let q = parse_query(
+            "MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal) \
+             WITH j.title AS t, count(DISTINCT a) AS c RETURN t, c",
+        )
+        .unwrap();
+        assert!(detect(&q).is_none());
+    }
+
+    /// Three MATCHes — out of scope for this phase.
+    #[test]
+    fn rejects_three_matches() {
+        let q = parse_query(
+            "MATCH (p:Person)-[:HAS]->(c1:Condition) \
+             MATCH (p)-[:HAS]->(c2:Condition) \
+             MATCH (p)-[:HAS]->(c3:Condition) \
+             WITH c3.name AS n, count(DISTINCT p) AS c RETURN n, c",
+        )
+        .unwrap();
+        assert!(detect(&q).is_none());
+    }
+
+    /// If WHERE contains a predicate that touches BOTH non-shared variables,
+    /// it can't be pushed to either MATCH — we conservatively reject.
+    #[test]
+    fn rejects_cross_match_predicate() {
+        let q = parse_query(
+            "MATCH (p:Person)-[:HAS]->(c1:Condition) \
+             MATCH (p)-[:HAS]->(c2:Condition) \
+             WHERE c1.year = c2.year \
+             WITH c2.name AS n, count(DISTINCT p) AS c RETURN n, c",
+        )
+        .unwrap();
+        assert!(detect(&q).is_none());
+    }
+
+    /// The aggregate must be over the shared variable — not the group-by side.
+    #[test]
+    fn rejects_count_on_wrong_variable() {
+        let q = parse_query(
+            "MATCH (p:Person)-[:HAS]->(c1:Condition) \
+             MATCH (p)-[:HAS]->(c2:Condition) \
+             WITH c2.name AS n, count(c1) AS c RETURN n, c",
+        )
+        .unwrap();
+        assert!(detect(&q).is_none());
+    }
+}

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -481,11 +481,30 @@ fn parse_match_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
                 }
             }
             Rule::where_clause => {
-                if query.with_split_index.is_some() {
-                    // WHERE clause after WITH ... MATCH ...
-                    query.post_with_where_clause = Some(parse_where_clause(inner)?);
+                // Cypher permits a `WHERE` after each `MATCH`. The planner
+                // expects a single AND-chain in `query.where_clause` (or in
+                // `post_with_where_clause` after a `WITH`), so when multiple
+                // WHEREs appear in the same pre-WITH or post-WITH block, AND
+                // them together rather than silently overwriting the earlier
+                // predicate. Dropping the first WHERE was behind OM27's
+                // timeout + wrong-semantics on the v1.0 mega benchmark.
+                let parsed = parse_where_clause(inner)?;
+                let target = if query.with_split_index.is_some() {
+                    &mut query.post_with_where_clause
                 } else {
-                    query.where_clause = Some(parse_where_clause(inner)?);
+                    &mut query.where_clause
+                };
+                match target.take() {
+                    Some(existing) => {
+                        *target = Some(WhereClause {
+                            predicate: Expression::Binary {
+                                left: Box::new(existing.predicate),
+                                op: BinaryOp::And,
+                                right: Box::new(parsed.predicate),
+                            },
+                        });
+                    }
+                    None => *target = Some(parsed),
                 }
             }
             Rule::with_clause => {


### PR DESCRIPTION
Ports six commits from the enterprise (private) repo that together unlocked **500/500 on the v1.0 mega benchmark** (137M nodes, 1.2B edges, r7i.16xlarge, 78 min).

## Commits (in order)

| SHA | Summary |
|---|---|
| `31712bb` | perf(query): stream WITH ... LIMIT N instead of materializing upstream |
| `1569976` | docs(adr-017): propose adjacency-aware aggregation planning |
| `87ec11c` | feat(query): ADR-017 Phase 0 — detector + LogicalPlanNode variant |
| `a60b148` | feat(query): ADR-017 Phase 1 — AdjacencyCountAggregateOperator + planner hook |
| `b8c8d65` | feat(query): ADR-017 Phase 3a — WITH-bound adjacency-count aggregate |
| `a42d688` | fix(parser): AND-chain multiple WHEREs instead of silently overwriting |

## What the six changes do

1. **Streaming LIMIT on WITH** — when a query has `MATCH ... WITH x LIMIT N MATCH ...` without ORDER BY / WHERE / DISTINCT / aggregation, WithBarrier now stops pulling at N rows instead of materializing the full upstream stream. Fixes MB053-shape queries on billion-edge graphs.

2. **ADR-017** — design document for adjacency-aware aggregation planning. Five-phase plan; Phases 0/1/3a shipped here.

3. **Phase 0** — introduces `LogicalPlanNode::AdjacencyCountAggregate` variant and `adjacency_agg_detector` module. Behavior-neutral (detector not yet wired).

4. **Phase 1** — ships the `AdjacencyCountAggregateOperator` that computes `count(neighbor)` by reading per-node adjacency-list degree instead of walking every edge. Wires the detector into the planner's top-level `plan()`. Unblocks MB049, MB054 (40M-edge aggregations → sub-second).

5. **Phase 3a** — extends Phase 1 to the `MATCH (g) [WHERE ...] WITH g [LIMIT N] MATCH (g)-[:E]-(n) RETURN g.prop, count(n)` shape. Unblocks MB053, EX49.

6. **Multi-WHERE parser fix** — each additional \`WHERE\` in the same pre-WITH or post-WITH block used to silently overwrite the previous one. Fixed to AND-chain them. Unblocks OM27 (was silently running without its intended filter + timing out). Also ships `semi_join_detector` module as read-only foundation for ADR-017 Phase 3b.

## Tests
- All 6 commits add unit + integration tests
- Full OSS lib suite: **1974 passed, 0 failed** after the port (no regressions)
- Net test additions: +31 new tests across the six commits

## Mega benchmark impact

| Run | Combined pass | Notes |
|---|---:|---|
| Before these changes (2026-04-12) | 455/500 | 9 errors, 36 empties |
| After these changes (2026-04-13, v7) | **500/500** | 0 errors, 0 empties, 32 corpus-gap passes |

Full writeup: [samyama-graph-book/src/data/benchmark](https://github.com/samyama-ai/samyama-graph-book/tree/main/src/data/benchmark) — benchmark queries, oracle file, result CSVs v1–v7.

## Test plan
- [x] \`cargo test --lib\` — 1974 passed, 0 failed
- [x] \`cargo check --lib\` — clean
- [ ] Reviewer sanity check — any OSS-specific code paths the port missed?