### PR TITLE
port(bench): unified_benchmark runner + 2 missing KG loaders

### DIFF
--- a/examples/health_determinants_common/mod.rs
+++ b/examples/health_determinants_common/mod.rs
@@ -1,0 +1,524 @@
+//! Health Determinants KG data loading utilities.
+//!
+//! Loads World Bank WDI, WHO Air Quality, FAO AQUASTAT, UNDP HDI data
+//! into GraphStore via direct API calls.
+//!
+//! Data format: Pre-downloaded JSON + CSV files
+
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use samyama_sdk::{GraphStore, NodeId, PropertyValue};
+use serde::Deserialize;
+
+pub type Error = Box<dyn std::error::Error>;
+
+// ============================================================================
+// DATA STRUCTURES — World Bank
+// ============================================================================
+
+#[derive(Deserialize)]
+pub struct WBCountry {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub region: WBRegionRef,
+    #[serde(rename = "incomeLevel", default)]
+    pub income_level: WBRegionRef,
+}
+
+#[derive(Deserialize, Default)]
+pub struct WBRegionRef {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub value: String,
+}
+
+#[derive(Deserialize)]
+pub struct WBRegion {
+    pub code: String,
+    pub name: String,
+}
+
+#[derive(Deserialize)]
+pub struct WDIRecord {
+    pub country: WDICountryRef,
+    #[serde(default)]
+    pub countryiso3code: String,
+    pub indicator: WDIIndicatorRef,
+    pub date: Option<String>,
+    pub value: Option<f64>,
+}
+
+#[derive(Deserialize)]
+pub struct WDICountryRef {
+    pub id: String,
+}
+
+#[derive(Deserialize)]
+pub struct WDIIndicatorRef {
+    pub id: String,
+    pub value: String,
+}
+
+// CSV record for air quality, AQUASTAT, HDI
+#[derive(Debug)]
+pub struct CsvRecord {
+    pub country_code: String,
+    pub fields: HashMap<String, String>,
+}
+
+// ============================================================================
+// LOAD RESULT
+// ============================================================================
+
+pub struct LoadResult {
+    pub country_nodes: usize,
+    pub region_nodes: usize,
+    pub socioeconomic_nodes: usize,
+    pub environmental_nodes: usize,
+    pub nutrition_nodes: usize,
+    pub demographic_nodes: usize,
+    pub water_nodes: usize,
+    pub total_nodes: usize,
+    pub total_edges: usize,
+}
+
+// ============================================================================
+// FORMATTING
+// ============================================================================
+
+pub fn format_num(n: usize) -> String {
+    let s = n.to_string();
+    let mut result = String::new();
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
+}
+
+pub fn format_duration(d: Duration) -> String {
+    let secs = d.as_secs_f64();
+    if secs < 1.0 {
+        format!("{:.0}ms", secs * 1000.0)
+    } else if secs < 60.0 {
+        format!("{:.1}s", secs)
+    } else {
+        let mins = (secs / 60.0).floor() as u64;
+        let rem = secs - (mins as f64 * 60.0);
+        format!("{}m {:.1}s", mins, rem)
+    }
+}
+
+fn clean_str(s: &str) -> String {
+    s.replace('"', "").replace('\n', " ").replace('\r', "")
+}
+
+// ============================================================================
+// CATEGORY CONFIG
+// ============================================================================
+
+struct CategoryConfig {
+    label: &'static str,
+    edge_type: &'static str,
+    id_prefix: &'static str,
+    filename: &'static str,
+}
+
+const CATEGORIES: &[CategoryConfig] = &[
+    CategoryConfig {
+        label: "SocioeconomicIndicator",
+        edge_type: "HAS_INDICATOR",
+        id_prefix: "SE",
+        filename: "socioeconomic.json",
+    },
+    CategoryConfig {
+        label: "EnvironmentalFactor",
+        edge_type: "ENVIRONMENT_OF",
+        id_prefix: "EF",
+        filename: "environmental.json",
+    },
+    CategoryConfig {
+        label: "NutritionIndicator",
+        edge_type: "NUTRITION_STATUS",
+        id_prefix: "NI",
+        filename: "nutrition.json",
+    },
+    CategoryConfig {
+        label: "DemographicProfile",
+        edge_type: "DEMOGRAPHIC_OF",
+        id_prefix: "DP",
+        filename: "demographic.json",
+    },
+    CategoryConfig {
+        label: "WaterResource",
+        edge_type: "WATER_RESOURCE_OF",
+        id_prefix: "WR",
+        filename: "water.json",
+    },
+];
+
+// ============================================================================
+// CSV PARSER
+// ============================================================================
+
+fn parse_csv_records(path: &Path) -> Result<Vec<CsvRecord>, Error> {
+    let file = fs::File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut lines = reader.lines();
+
+    let header_line = match lines.next() {
+        Some(Ok(l)) => l,
+        _ => return Ok(vec![]),
+    };
+    let headers: Vec<&str> = header_line.split(',').collect();
+
+    let mut records = Vec::new();
+    for line in lines {
+        let line = line?;
+        let fields: Vec<&str> = line.split(',').collect();
+        if fields.len() < headers.len() {
+            continue;
+        }
+        let mut map = HashMap::new();
+        for (i, h) in headers.iter().enumerate() {
+            map.insert(h.to_string(), fields[i].to_string());
+        }
+        let cc = map.get("country_code").cloned().unwrap_or_default();
+        if !cc.is_empty() {
+            records.push(CsvRecord {
+                country_code: cc,
+                fields: map,
+            });
+        }
+    }
+    Ok(records)
+}
+
+// ============================================================================
+// MAIN LOADER
+// ============================================================================
+
+pub fn load_dataset(graph: &mut GraphStore, data_dir: &Path) -> Result<LoadResult, Error> {
+    let wb_dir = data_dir.join("worldbank");
+    let mut country_map: HashMap<String, NodeId> = HashMap::new();
+    let mut region_map: HashMap<String, NodeId> = HashMap::new();
+
+    let mut country_nodes = 0;
+    let mut region_nodes = 0;
+    let mut cat_nodes = [0usize; 5]; // SE, EF, NI, DP, WR
+    let mut total_edges = 0;
+
+    // ── Countries ──
+    let countries_path = wb_dir.join("countries.json");
+    if countries_path.exists() {
+        let data = fs::read_to_string(&countries_path)?;
+        let countries: Vec<WBCountry> = serde_json::from_str(&data)?;
+        for c in &countries {
+            if c.id.is_empty() || c.name.is_empty() {
+                continue;
+            }
+            let id = graph.create_node("Country");
+            if let Some(n) = graph.get_node_mut(id) {
+                n.set_property("iso_code", PropertyValue::String(c.id.clone()));
+                n.set_property("name", PropertyValue::String(clean_str(&c.name)));
+                if !c.income_level.value.is_empty() {
+                    n.set_property(
+                        "income_level",
+                        PropertyValue::String(c.income_level.value.clone()),
+                    );
+                }
+                if !c.region.value.is_empty() {
+                    n.set_property("region_wb", PropertyValue::String(c.region.value.clone()));
+                }
+            }
+            country_map.insert(c.id.clone(), id);
+            country_nodes += 1;
+        }
+        eprintln!("    Countries: {}", format_num(country_nodes));
+    }
+
+    // ── Regions ──
+    let regions_path = wb_dir.join("regions.json");
+    if regions_path.exists() {
+        let data = fs::read_to_string(&regions_path)?;
+        let regions: Vec<WBRegion> = serde_json::from_str(&data)?;
+        for r in &regions {
+            if r.code.is_empty() || r.name.is_empty() {
+                continue;
+            }
+            let id = graph.create_node("Region");
+            if let Some(n) = graph.get_node_mut(id) {
+                n.set_property("code", PropertyValue::String(r.code.clone()));
+                n.set_property("name", PropertyValue::String(clean_str(&r.name)));
+            }
+            region_map.insert(r.code.clone(), id);
+            region_nodes += 1;
+        }
+        eprintln!("    Regions: {}", format_num(region_nodes));
+    }
+
+    // ── Country → Region edges ──
+    if countries_path.exists() {
+        let data = fs::read_to_string(&countries_path)?;
+        let countries: Vec<WBCountry> = serde_json::from_str(&data)?;
+        let mut cr_edges = 0;
+        for c in &countries {
+            if let (Some(&country_id), Some(&region_id)) =
+                (country_map.get(&c.id), region_map.get(&c.region.id))
+            {
+                let _ = graph.create_edge(country_id, region_id, "IN_REGION");
+                cr_edges += 1;
+            }
+        }
+        total_edges += cr_edges;
+        eprintln!("    IN_REGION edges: {}", format_num(cr_edges));
+    }
+
+    // ── WDI Indicator Categories ──
+    for (ci, cat) in CATEGORIES.iter().enumerate() {
+        let cat_path = wb_dir.join(cat.filename);
+        if !cat_path.exists() {
+            eprintln!("    {}: (no data file)", cat.label);
+            continue;
+        }
+        let data = fs::read_to_string(&cat_path)?;
+        let records: Vec<WDIRecord> = serde_json::from_str(&data)?;
+        let mut nodes = 0;
+        let mut edges = 0;
+
+        let t0 = Instant::now();
+        for rec in &records {
+            let cc = if rec.countryiso3code.is_empty() {
+                &rec.country.id
+            } else {
+                &rec.countryiso3code
+            };
+            let country_id = match country_map.get(cc.as_str()) {
+                Some(&id) => id,
+                None => continue,
+            };
+            let date = match &rec.date {
+                Some(d) if !d.is_empty() => d.as_str(),
+                _ => continue,
+            };
+            let value = match rec.value {
+                Some(v) => v,
+                None => continue,
+            };
+
+            let nid_str = format!("{}-{}-{}-{}", cat.id_prefix, cc, rec.indicator.id, date);
+            let node_id = graph.create_node(cat.label);
+            if let Some(n) = graph.get_node_mut(node_id) {
+                n.set_property("id", PropertyValue::String(nid_str));
+                n.set_property(
+                    "indicator_code",
+                    PropertyValue::String(rec.indicator.id.clone()),
+                );
+                n.set_property(
+                    "indicator_name",
+                    PropertyValue::String(clean_str(&rec.indicator.value)),
+                );
+                if let Ok(y) = date.parse::<i64>() {
+                    n.set_property("year", PropertyValue::Integer(y));
+                }
+                n.set_property("value", PropertyValue::Float(value));
+            }
+            nodes += 1;
+
+            let _ = graph.create_edge(country_id, node_id, cat.edge_type);
+            edges += 1;
+
+            if nodes % 50_000 == 0 {
+                eprintln!(
+                    "      ... {} nodes ({:.0}/sec)",
+                    format_num(nodes),
+                    nodes as f64 / t0.elapsed().as_secs_f64()
+                );
+            }
+        }
+        cat_nodes[ci] = nodes;
+        total_edges += edges;
+        eprintln!(
+            "    {}: {} nodes, {} edges",
+            cat.label,
+            format_num(nodes),
+            format_num(edges)
+        );
+    }
+
+    // ── WHO Air Quality (CSV) ──
+    let aq_path = data_dir.join("who_airquality").join("air_quality.csv");
+    let mut aq_nodes = 0;
+    if aq_path.exists() {
+        let records = parse_csv_records(&aq_path)?;
+        for rec in &records {
+            let country_id = match country_map.get(&rec.country_code) {
+                Some(&id) => id,
+                None => continue,
+            };
+            let city = rec.fields.get("city").map(|s| s.as_str()).unwrap_or("");
+            let year = rec.fields.get("year").map(|s| s.as_str()).unwrap_or("");
+            let pm25 = rec.fields.get("pm25").and_then(|s| s.parse::<f64>().ok());
+
+            if year.is_empty() {
+                continue;
+            }
+
+            let nid_str = format!("EF-{}-AQ-{}-{}", rec.country_code, city, year);
+            let node_id = graph.create_node("EnvironmentalFactor");
+            if let Some(n) = graph.get_node_mut(node_id) {
+                n.set_property("id", PropertyValue::String(nid_str));
+                n.set_property(
+                    "indicator_code",
+                    PropertyValue::String("AIR_QUALITY".to_string()),
+                );
+                n.set_property(
+                    "indicator_name",
+                    PropertyValue::String("Ambient air quality".to_string()),
+                );
+                n.set_property("category", PropertyValue::String("air_quality".to_string()));
+                n.set_property("city", PropertyValue::String(clean_str(city)));
+                if let Ok(y) = year.parse::<i64>() {
+                    n.set_property("year", PropertyValue::Integer(y));
+                }
+                if let Some(v) = pm25 {
+                    n.set_property("value", PropertyValue::Float(v));
+                }
+                let pm10 = rec.fields.get("pm10").and_then(|s| s.parse::<f64>().ok());
+                if let Some(v) = pm10 {
+                    n.set_property("pm10", PropertyValue::Float(v));
+                }
+            }
+            let _ = graph.create_edge(country_id, node_id, "ENVIRONMENT_OF");
+            aq_nodes += 1;
+            total_edges += 1;
+        }
+        cat_nodes[1] += aq_nodes;
+        eprintln!("    Air quality: {} nodes", format_num(aq_nodes));
+    }
+
+    // ── FAO AQUASTAT (CSV) ──
+    let fao_path = data_dir.join("fao").join("aquastat.csv");
+    let mut fao_nodes = 0;
+    if fao_path.exists() {
+        let records = parse_csv_records(&fao_path)?;
+        for rec in &records {
+            let country_id = match country_map.get(&rec.country_code) {
+                Some(&id) => id,
+                None => continue,
+            };
+            let indicator_code = rec
+                .fields
+                .get("indicator_code")
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let indicator_name = rec
+                .fields
+                .get("indicator_name")
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let year = rec.fields.get("year").map(|s| s.as_str()).unwrap_or("");
+            let value = rec.fields.get("value").and_then(|s| s.parse::<f64>().ok());
+
+            if indicator_code.is_empty() || year.is_empty() || value.is_none() {
+                continue;
+            }
+
+            let nid_str = format!("WR-{}-{}-{}", rec.country_code, indicator_code, year);
+            let node_id = graph.create_node("WaterResource");
+            if let Some(n) = graph.get_node_mut(node_id) {
+                n.set_property("id", PropertyValue::String(nid_str));
+                n.set_property(
+                    "indicator_code",
+                    PropertyValue::String(indicator_code.to_string()),
+                );
+                n.set_property(
+                    "indicator_name",
+                    PropertyValue::String(clean_str(indicator_name)),
+                );
+                n.set_property("category", PropertyValue::String("water".to_string()));
+                if let Ok(y) = year.parse::<i64>() {
+                    n.set_property("year", PropertyValue::Integer(y));
+                }
+                if let Some(v) = value {
+                    n.set_property("value", PropertyValue::Float(v));
+                }
+            }
+            let _ = graph.create_edge(country_id, node_id, "WATER_RESOURCE_OF");
+            fao_nodes += 1;
+            total_edges += 1;
+        }
+        cat_nodes[4] += fao_nodes;
+        eprintln!("    AQUASTAT: {} nodes", format_num(fao_nodes));
+    }
+
+    // ── UNDP HDI (CSV) ──
+    let hdi_path = data_dir.join("undp").join("hdi.csv");
+    let mut hdi_nodes = 0;
+    if hdi_path.exists() {
+        let records = parse_csv_records(&hdi_path)?;
+        for rec in &records {
+            let country_id = match country_map.get(&rec.country_code) {
+                Some(&id) => id,
+                None => continue,
+            };
+            let year = rec.fields.get("year").map(|s| s.as_str()).unwrap_or("");
+            let hdi = rec.fields.get("hdi").and_then(|s| s.parse::<f64>().ok());
+            let rank = rec.fields.get("rank").and_then(|s| s.parse::<i64>().ok());
+
+            if year.is_empty() || hdi.is_none() {
+                continue;
+            }
+
+            let nid_str = format!("SE-{}-HDI-{}", rec.country_code, year);
+            let node_id = graph.create_node("SocioeconomicIndicator");
+            if let Some(n) = graph.get_node_mut(node_id) {
+                n.set_property("id", PropertyValue::String(nid_str));
+                n.set_property("indicator_code", PropertyValue::String("HDI".to_string()));
+                n.set_property(
+                    "indicator_name",
+                    PropertyValue::String("Human Development Index".to_string()),
+                );
+                n.set_property("category", PropertyValue::String("development".to_string()));
+                if let Ok(y) = year.parse::<i64>() {
+                    n.set_property("year", PropertyValue::Integer(y));
+                }
+                if let Some(v) = hdi {
+                    n.set_property("value", PropertyValue::Float(v));
+                }
+                if let Some(r) = rank {
+                    n.set_property("rank", PropertyValue::Integer(r));
+                }
+            }
+            let _ = graph.create_edge(country_id, node_id, "HAS_INDICATOR");
+            hdi_nodes += 1;
+            total_edges += 1;
+        }
+        cat_nodes[0] += hdi_nodes;
+        eprintln!("    HDI: {} nodes", format_num(hdi_nodes));
+    }
+
+    let total_nodes = country_nodes + region_nodes + cat_nodes.iter().sum::<usize>();
+
+    Ok(LoadResult {
+        country_nodes,
+        region_nodes,
+        socioeconomic_nodes: cat_nodes[0],
+        environmental_nodes: cat_nodes[1],
+        nutrition_nodes: cat_nodes[2],
+        demographic_nodes: cat_nodes[3],
+        water_nodes: cat_nodes[4],
+        total_nodes,
+        total_edges,
+    })
+}

--- a/examples/health_systems_common/mod.rs
+++ b/examples/health_systems_common/mod.rs
@@ -1,0 +1,438 @@
+//! Health Systems KG data loading utilities.
+//!
+//! Loads WHO SPAR, NHWA, GAVI, Global Fund, IHME data
+//! into GraphStore via direct API calls.
+
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::time::Duration;
+
+use samyama_sdk::{GraphStore, NodeId, PropertyValue};
+use serde::Deserialize;
+
+pub type Error = Box<dyn std::error::Error>;
+
+// ============================================================================
+// DATA STRUCTURES
+// ============================================================================
+
+#[derive(Deserialize)]
+pub struct HSCountry {
+    pub iso_code: String,
+    pub name: String,
+    #[serde(default)]
+    pub who_region: String,
+    #[serde(default)]
+    pub income_level: String,
+}
+
+#[derive(Debug)]
+pub struct CsvRecord {
+    pub country_code: String,
+    pub fields: HashMap<String, String>,
+}
+
+// ============================================================================
+// LOAD RESULT
+// ============================================================================
+
+pub struct LoadResult {
+    pub country_nodes: usize,
+    pub emergency_response_nodes: usize,
+    pub health_workforce_nodes: usize,
+    pub supply_chain_nodes: usize,
+    pub funding_flow_nodes: usize,
+    pub total_nodes: usize,
+    pub total_edges: usize,
+}
+
+// ============================================================================
+// FORMATTING
+// ============================================================================
+
+pub fn format_num(n: usize) -> String {
+    let s = n.to_string();
+    let mut result = String::new();
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
+}
+
+pub fn format_duration(d: Duration) -> String {
+    let secs = d.as_secs_f64();
+    if secs < 1.0 {
+        format!("{:.0}ms", secs * 1000.0)
+    } else if secs < 60.0 {
+        format!("{:.1}s", secs)
+    } else {
+        let mins = (secs / 60.0).floor() as u64;
+        format!("{}m {:.1}s", mins, secs - (mins as f64 * 60.0))
+    }
+}
+
+fn clean_str(s: &str) -> String {
+    s.replace('"', "").replace('\n', " ").replace('\r', "")
+}
+
+fn parse_csv_records(path: &Path) -> Result<Vec<CsvRecord>, Error> {
+    let file = fs::File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut lines = reader.lines();
+    let header_line = match lines.next() {
+        Some(Ok(l)) => l,
+        _ => return Ok(vec![]),
+    };
+    let headers: Vec<&str> = header_line.split(',').collect();
+    let mut records = Vec::new();
+    for line in lines {
+        let line = line?;
+        let fields: Vec<&str> = line.split(',').collect();
+        if fields.len() < headers.len() {
+            continue;
+        }
+        let mut map = HashMap::new();
+        for (i, h) in headers.iter().enumerate() {
+            map.insert(h.to_string(), fields[i].to_string());
+        }
+        let cc = map.get("country_code").cloned().unwrap_or_default();
+        if !cc.is_empty() {
+            records.push(CsvRecord {
+                country_code: cc,
+                fields: map,
+            });
+        }
+    }
+    Ok(records)
+}
+
+// ============================================================================
+// MAIN LOADER
+// ============================================================================
+
+pub fn load_dataset(graph: &mut GraphStore, data_dir: &Path) -> Result<LoadResult, Error> {
+    let mut country_map: HashMap<String, NodeId> = HashMap::new();
+
+    let mut country_nodes = 0;
+    let mut er_nodes = 0;
+    let mut hw_nodes = 0;
+    let mut sc_nodes = 0;
+    let mut ff_nodes = 0;
+    let mut total_edges = 0;
+
+    // ── Countries (from SPAR directory) ──
+    let countries_path = data_dir.join("who_spar").join("countries.json");
+    if countries_path.exists() {
+        let data = fs::read_to_string(&countries_path)?;
+        let countries: Vec<HSCountry> = serde_json::from_str(&data)?;
+        for c in &countries {
+            if c.iso_code.is_empty() || c.name.is_empty() {
+                continue;
+            }
+            let id = graph.create_node("Country");
+            if let Some(n) = graph.get_node_mut(id) {
+                n.set_property("iso_code", PropertyValue::String(c.iso_code.clone()));
+                n.set_property("name", PropertyValue::String(clean_str(&c.name)));
+                if !c.who_region.is_empty() {
+                    n.set_property("who_region", PropertyValue::String(c.who_region.clone()));
+                }
+                if !c.income_level.is_empty() {
+                    n.set_property(
+                        "income_level",
+                        PropertyValue::String(c.income_level.clone()),
+                    );
+                }
+            }
+            country_map.insert(c.iso_code.clone(), id);
+            country_nodes += 1;
+        }
+        eprintln!("    Countries: {}", format_num(country_nodes));
+    }
+
+    // ── SPAR (Emergency Response) ──
+    let spar_path = data_dir.join("who_spar").join("spar.csv");
+    if spar_path.exists() {
+        let records = parse_csv_records(&spar_path)?;
+        for rec in &records {
+            let country_id = match country_map.get(&rec.country_code) {
+                Some(&id) => id,
+                None => continue,
+            };
+            let cap_code = rec
+                .fields
+                .get("capacity_code")
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let cap_name = rec
+                .fields
+                .get("capacity_name")
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let year = rec.fields.get("year").map(|s| s.as_str()).unwrap_or("");
+            let score = rec.fields.get("score").and_then(|s| s.parse::<f64>().ok());
+            if cap_code.is_empty() || year.is_empty() {
+                continue;
+            }
+
+            let nid = format!("ER-{}-{}-{}", rec.country_code, cap_code, year);
+            let node_id = graph.create_node("EmergencyResponse");
+            if let Some(n) = graph.get_node_mut(node_id) {
+                n.set_property("id", PropertyValue::String(nid));
+                n.set_property("capacity_code", PropertyValue::String(cap_code.to_string()));
+                n.set_property("capacity_name", PropertyValue::String(clean_str(cap_name)));
+                if let Ok(y) = year.parse::<i64>() {
+                    n.set_property("year", PropertyValue::Integer(y));
+                }
+                if let Some(s) = score {
+                    n.set_property("score", PropertyValue::Integer(s as i64));
+                }
+                n.set_property(
+                    "country_code",
+                    PropertyValue::String(rec.country_code.clone()),
+                );
+            }
+            let _ = graph.create_edge(node_id, country_id, "CAPACITY_FOR");
+            er_nodes += 1;
+            total_edges += 1;
+        }
+        eprintln!("    Emergency Response (SPAR): {}", format_num(er_nodes));
+    }
+
+    // ── NHWA (Health Workforce) ──
+    let nhwa_path = data_dir.join("who_nhwa").join("nhwa.csv");
+    if nhwa_path.exists() {
+        let records = parse_csv_records(&nhwa_path)?;
+        for rec in &records {
+            let country_id = match country_map.get(&rec.country_code) {
+                Some(&id) => id,
+                None => continue,
+            };
+            let prof = rec
+                .fields
+                .get("profession")
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let year = rec.fields.get("year").map(|s| s.as_str()).unwrap_or("");
+            if prof.is_empty() || year.is_empty() {
+                continue;
+            }
+
+            let nid = format!("HW-{}-{}-{}", rec.country_code, prof, year);
+            let node_id = graph.create_node("HealthWorkforce");
+            if let Some(n) = graph.get_node_mut(node_id) {
+                n.set_property("id", PropertyValue::String(nid));
+                n.set_property("profession", PropertyValue::String(prof.to_string()));
+                if let Ok(y) = year.parse::<i64>() {
+                    n.set_property("year", PropertyValue::Integer(y));
+                }
+                let count = rec.fields.get("count").and_then(|s| s.parse::<f64>().ok());
+                if let Some(c) = count {
+                    n.set_property("count", PropertyValue::Integer(c as i64));
+                }
+                let density = rec
+                    .fields
+                    .get("density_per_10k")
+                    .and_then(|s| s.parse::<f64>().ok());
+                if let Some(d) = density {
+                    n.set_property("density_per_10k", PropertyValue::Float(d));
+                }
+                n.set_property(
+                    "country_code",
+                    PropertyValue::String(rec.country_code.clone()),
+                );
+            }
+            let _ = graph.create_edge(node_id, country_id, "SERVES");
+            hw_nodes += 1;
+            total_edges += 1;
+        }
+        eprintln!("    Health Workforce (NHWA): {}", format_num(hw_nodes));
+    }
+
+    // ── GAVI (Supply Chain) ──
+    let gavi_path = data_dir.join("gavi").join("supply.csv");
+    if gavi_path.exists() {
+        let records = parse_csv_records(&gavi_path)?;
+        for rec in &records {
+            let country_id = match country_map.get(&rec.country_code) {
+                Some(&id) => id,
+                None => continue,
+            };
+            let vaccine = rec
+                .fields
+                .get("vaccine_name")
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let year = rec.fields.get("year").map(|s| s.as_str()).unwrap_or("");
+            if vaccine.is_empty() || year.is_empty() {
+                continue;
+            }
+
+            let nid = format!(
+                "SC-{}-{}-{}",
+                rec.country_code,
+                vaccine.replace(' ', "_"),
+                year
+            );
+            let node_id = graph.create_node("SupplyChain");
+            if let Some(n) = graph.get_node_mut(node_id) {
+                n.set_property("id", PropertyValue::String(nid));
+                n.set_property("vaccine_name", PropertyValue::String(vaccine.to_string()));
+                if let Ok(y) = year.parse::<i64>() {
+                    n.set_property("year", PropertyValue::Integer(y));
+                }
+                for (field, key) in [
+                    ("doses_shipped", "doses_shipped"),
+                    ("doses_used", "doses_used"),
+                    ("wastage_pct", "wastage_pct"),
+                ] {
+                    if let Some(v) = rec.fields.get(field).and_then(|s| s.parse::<f64>().ok()) {
+                        n.set_property(key, PropertyValue::Float(v));
+                    }
+                }
+                n.set_property(
+                    "country_code",
+                    PropertyValue::String(rec.country_code.clone()),
+                );
+            }
+            let _ = graph.create_edge(node_id, country_id, "SUPPLIES");
+            sc_nodes += 1;
+            total_edges += 1;
+        }
+        eprintln!("    Supply Chain (GAVI): {}", format_num(sc_nodes));
+    }
+
+    // ── Global Fund (Funding Flows) ──
+    let gf_path = data_dir.join("globalfund").join("disbursements.csv");
+    if gf_path.exists() {
+        let records = parse_csv_records(&gf_path)?;
+        for rec in &records {
+            let country_id = match country_map.get(&rec.country_code) {
+                Some(&id) => id,
+                None => continue,
+            };
+            let component = rec
+                .fields
+                .get("disease_component")
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let year = rec.fields.get("year").map(|s| s.as_str()).unwrap_or("");
+            if component.is_empty() || year.is_empty() {
+                continue;
+            }
+
+            let nid = format!(
+                "FF-{}-GF-{}-{}",
+                rec.country_code,
+                component.replace(' ', "_").replace('/', "_"),
+                year
+            );
+            let node_id = graph.create_node("FundingFlow");
+            if let Some(n) = graph.get_node_mut(node_id) {
+                n.set_property("id", PropertyValue::String(nid));
+                n.set_property(
+                    "donor",
+                    PropertyValue::String(
+                        rec.fields
+                            .get("donor")
+                            .cloned()
+                            .unwrap_or_else(|| "Global Fund".to_string()),
+                    ),
+                );
+                n.set_property(
+                    "disease_component",
+                    PropertyValue::String(component.to_string()),
+                );
+                if let Ok(y) = year.parse::<i64>() {
+                    n.set_property("year", PropertyValue::Integer(y));
+                }
+                if let Some(v) = rec
+                    .fields
+                    .get("amount_usd")
+                    .and_then(|s| s.parse::<f64>().ok())
+                {
+                    n.set_property("amount_usd", PropertyValue::Float(v));
+                }
+                n.set_property(
+                    "country_code",
+                    PropertyValue::String(rec.country_code.clone()),
+                );
+            }
+            let _ = graph.create_edge(node_id, country_id, "FUNDED_BY");
+            ff_nodes += 1;
+            total_edges += 1;
+        }
+        eprintln!("    Global Fund: {}", format_num(ff_nodes));
+    }
+
+    // ── IHME (Health Expenditure) ──
+    let ihme_path = data_dir.join("ihme").join("expenditure.csv");
+    if ihme_path.exists() {
+        let records = parse_csv_records(&ihme_path)?;
+        for rec in &records {
+            let country_id = match country_map.get(&rec.country_code) {
+                Some(&id) => id,
+                None => continue,
+            };
+            let indicator = rec
+                .fields
+                .get("indicator")
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let indicator_name = rec
+                .fields
+                .get("indicator_name")
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let year = rec.fields.get("year").map(|s| s.as_str()).unwrap_or("");
+            let value = rec.fields.get("value").and_then(|s| s.parse::<f64>().ok());
+            if indicator.is_empty() || year.is_empty() || value.is_none() {
+                continue;
+            }
+
+            let nid = format!("FF-{}-IHME-{}-{}", rec.country_code, indicator, year);
+            let node_id = graph.create_node("FundingFlow");
+            if let Some(n) = graph.get_node_mut(node_id) {
+                n.set_property("id", PropertyValue::String(nid));
+                n.set_property("donor", PropertyValue::String("IHME".to_string()));
+                n.set_property("indicator", PropertyValue::String(indicator.to_string()));
+                n.set_property(
+                    "indicator_name",
+                    PropertyValue::String(clean_str(indicator_name)),
+                );
+                if let Ok(y) = year.parse::<i64>() {
+                    n.set_property("year", PropertyValue::Integer(y));
+                }
+                if let Some(v) = value {
+                    n.set_property("value", PropertyValue::Float(v));
+                }
+                n.set_property(
+                    "country_code",
+                    PropertyValue::String(rec.country_code.clone()),
+                );
+            }
+            let _ = graph.create_edge(node_id, country_id, "FUNDED_BY");
+            ff_nodes += 1;
+            total_edges += 1;
+        }
+        eprintln!("    IHME: {} total funding nodes", format_num(ff_nodes));
+    }
+
+    let total_nodes = country_nodes + er_nodes + hw_nodes + sc_nodes + ff_nodes;
+
+    Ok(LoadResult {
+        country_nodes,
+        emergency_response_nodes: er_nodes,
+        health_workforce_nodes: hw_nodes,
+        supply_chain_nodes: sc_nodes,
+        funding_flow_nodes: ff_nodes,
+        total_nodes,
+        total_edges,
+    })
+}

--- a/examples/unified_benchmark.rs
+++ b/examples/unified_benchmark.rs
@@ -1,0 +1,559 @@
+//! Unified Benchmark (200+ queries)
+//!
+//! Loads up to 9 KGs into one graph using the optimal method for each:
+//! - PubMed, Clinical Trials, Pathways, FAERS, UniProt: snapshot import
+//! - Drug Interactions, Surveillance, Health Determinants, Health Systems: direct Rust loaders
+//!
+//! Usage:
+//!   cargo run --release --example unified_benchmark -- \
+//!     --pubmed-snap ~/samyama/pubmed-v2.sgsnap \
+//!     --ct-snap ~/samyama/clinical-trials.sgsnap \
+//!     --pw-snap ~/samyama/pathways.sgsnap \
+//!     --faers-snap ~/samyama/faers-full.sgsnap \
+//!     --uniprot-snap ~/samyama/uniprot.sgsnap \
+//!     --di-data ~/kg-data/druginteractions \
+//!     --surv-data ~/kg-data/surveillance \
+//!     --hd-data ~/kg-data/health-determinants \
+//!     --hs-data ~/kg-data/health-systems \
+//!     --queries ~/samyama
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::time::Instant;
+
+use samyama_sdk::{EmbeddedClient, SamyamaClient};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct Oracle {
+    #[serde(default)]
+    status: OracleStatus,
+    #[serde(default)]
+    rows: Option<usize>,
+    #[serde(default)]
+    min: Option<usize>,
+    #[serde(default)]
+    max: Option<usize>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "snake_case")]
+enum OracleStatus {
+    #[default]
+    NonEmpty,
+    DataDependent,
+    Aggregation,
+    Exact,
+    Range,
+}
+
+#[derive(Debug, Deserialize)]
+struct OracleFile {
+    #[serde(default)]
+    queries: HashMap<String, Oracle>,
+}
+
+fn load_oracle(path: &std::path::Path) -> HashMap<String, Oracle> {
+    match fs::read_to_string(path) {
+        Ok(s) => match serde_yaml::from_str::<OracleFile>(&s) {
+            Ok(f) => {
+                eprintln!("Loaded oracle with {} entries from {:?}", f.queries.len(), path);
+                f.queries
+            }
+            Err(e) => {
+                eprintln!("Warning: failed to parse oracle {:?}: {}", path, e);
+                HashMap::new()
+            }
+        },
+        Err(_) => HashMap::new(),
+    }
+}
+
+/// Classify a result given rows returned and the oracle.
+/// Returns (status_str, counts_as_pass).
+fn classify(rows: usize, oracle: Option<&Oracle>) -> (&'static str, bool) {
+    match oracle.map(|o| o.status).unwrap_or(OracleStatus::NonEmpty) {
+        OracleStatus::NonEmpty => {
+            if rows > 0 { ("pass", true) } else { ("empty", false) }
+        }
+        OracleStatus::DataDependent => {
+            if rows > 0 { ("pass", true) } else { ("pass_data_gap", true) }
+        }
+        OracleStatus::Aggregation => ("pass", true), // any result (including 0 row) is fine
+        OracleStatus::Exact => {
+            let want = oracle.and_then(|o| o.rows).unwrap_or(0);
+            if rows == want { ("pass", true) } else { ("fail_count", false) }
+        }
+        OracleStatus::Range => {
+            let lo = oracle.and_then(|o| o.min).unwrap_or(1);
+            let hi = oracle.and_then(|o| o.max).unwrap_or(usize::MAX);
+            if rows >= lo && rows <= hi { ("pass", true) } else { ("fail_count", false) }
+        }
+    }
+}
+
+mod druginteractions_common;
+mod health_determinants_common;
+mod health_systems_common;
+mod surveillance_common;
+
+type Error = Box<dyn std::error::Error>;
+
+fn parse_csv_queries(path: &std::path::Path) -> Vec<(String, String, String, String)> {
+    let file = match fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return vec![],
+    };
+    let reader = BufReader::new(file);
+    let mut queries = Vec::new();
+    let mut num_columns = 0;
+
+    for (i, line) in reader.lines().enumerate() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        if i == 0 {
+            num_columns = line.split(',').count();
+            continue;
+        }
+        let cypher = if let Some(pos) = line.rfind(",\"") {
+            let raw = &line[pos + 1..];
+            raw.trim_matches('"').to_string()
+        } else {
+            let skip = if num_columns >= 6 { 5 } else { 4 };
+            let parts: Vec<&str> = line.splitn(skip + 1, ',').collect();
+            if parts.len() > skip {
+                parts[skip].to_string()
+            } else {
+                continue;
+            }
+        };
+        let parts: Vec<&str> = line.splitn(4, ',').collect();
+        if parts.len() < 4 {
+            continue;
+        }
+        let id = parts[0].to_string();
+        let name = parts[1].to_string();
+        let category = parts[2].to_string();
+        if cypher.contains("MATCH") || cypher.contains("RETURN") {
+            queries.push((id, name, category, cypher));
+        }
+    }
+    queries
+}
+
+fn get_arg(args: &[String], flag: &str) -> Option<PathBuf> {
+    args.iter()
+        .position(|a| a == flag)
+        .map(|p| PathBuf::from(&args[p + 1]))
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let args: Vec<String> = std::env::args().collect();
+
+    let pubmed_snap = get_arg(&args, "--pubmed-snap");
+    let ct_snap = get_arg(&args, "--ct-snap");
+    let pw_snap = get_arg(&args, "--pw-snap");
+    let faers_snap = get_arg(&args, "--faers-snap");
+    let uniprot_snap = get_arg(&args, "--uniprot-snap");
+    let omop_snap = get_arg(&args, "--omop-snap");
+    let di_snap = get_arg(&args, "--di-snap");
+    let surv_snap = get_arg(&args, "--surv-snap");
+    let hd_snap = get_arg(&args, "--hd-snap");
+    let hs_snap = get_arg(&args, "--hs-snap");
+    let di_data = get_arg(&args, "--di-data");
+    let surv_data = get_arg(&args, "--surv-data");
+    let hd_data = get_arg(&args, "--hd-data");
+    let hs_data = get_arg(&args, "--hs-data");
+    let study_refs = get_arg(&args, "--study-refs");
+    let queries_dir = get_arg(&args, "--queries").unwrap_or_else(|| PathBuf::from("."));
+    let oracle_path = get_arg(&args, "--oracle")
+        .unwrap_or_else(|| queries_dir.join("expected_rows.yaml"));
+    let oracle = load_oracle(&oracle_path);
+
+    let client = EmbeddedClient::new();
+    let total_start = Instant::now();
+
+    // ── Phase 1: Import large snapshots ──
+    for (name, path) in &[
+        ("PubMed", &pubmed_snap),
+        ("Clinical Trials", &ct_snap),
+        ("Pathways", &pw_snap),
+        ("FAERS", &faers_snap),
+        ("UniProt", &uniprot_snap),
+        ("OMOP", &omop_snap),
+        ("Drug Interactions", &di_snap),
+        ("Surveillance", &surv_snap),
+        ("Health Determinants", &hd_snap),
+        ("Health Systems", &hs_snap),
+    ] {
+        if let Some(ref p) = path {
+            eprint!("Importing {} snapshot... ", name);
+            let t0 = Instant::now();
+            let stats = client.import_snapshot("default", p).await?;
+            eprintln!(
+                "{} nodes, {} edges in {:.1}s",
+                stats.node_count,
+                stats.edge_count,
+                t0.elapsed().as_secs_f64()
+            );
+        }
+    }
+
+    // ── Phase 2: Run direct loaders (HashMap properties, correct IDs) ──
+    {
+        let mut graph = client.store_write().await;
+
+        if let Some(ref dir) = di_data {
+            eprint!("Loading Drug Interactions (direct)... ");
+            let t0 = Instant::now();
+            let all_phases: Vec<String> = vec![
+                "drugbank_dgidb".into(),
+                "sider".into(),
+                "chembl_ttd".into(),
+                "openfda".into(),
+            ];
+            let r = druginteractions_common::load_dataset(&mut graph, dir, &all_phases)?;
+            eprintln!(
+                "{} nodes, {} edges in {:.1}s",
+                r.total_nodes,
+                r.total_edges,
+                t0.elapsed().as_secs_f64()
+            );
+        }
+
+        if let Some(ref dir) = surv_data {
+            eprint!("Loading Surveillance (direct)... ");
+            let t0 = Instant::now();
+            let r = surveillance_common::load_dataset(&mut graph, dir)?;
+            eprintln!(
+                "{} nodes, {} edges in {:.1}s",
+                r.total_nodes,
+                r.total_edges,
+                t0.elapsed().as_secs_f64()
+            );
+        }
+
+        if let Some(ref dir) = hd_data {
+            eprint!("Loading Health Determinants (direct)... ");
+            let t0 = Instant::now();
+            let r = health_determinants_common::load_dataset(&mut graph, dir)?;
+            eprintln!(
+                "{} nodes, {} edges in {:.1}s",
+                r.total_nodes,
+                r.total_edges,
+                t0.elapsed().as_secs_f64()
+            );
+        }
+
+        if let Some(ref dir) = hs_data {
+            eprint!("Loading Health Systems (direct)... ");
+            let t0 = Instant::now();
+            let r = health_systems_common::load_dataset(&mut graph, dir)?;
+            eprintln!(
+                "{} nodes, {} edges in {:.1}s",
+                r.total_nodes,
+                r.total_edges,
+                t0.elapsed().as_secs_f64()
+            );
+        }
+    }
+
+    let import_elapsed = total_start.elapsed();
+    eprintln!("\nAll data loaded in {:.1}s", import_elapsed.as_secs_f64());
+
+    // ── Phase 2b: Set nct_id on Articles from study_references.txt ──
+    // Then build REFERENCED_IN edges.
+    {
+        let mut graph = client.store_write().await;
+
+        // Step 1: Read study_references.txt and set nct_id on matching Article nodes
+        if let Some(ref refs_path) = study_refs {
+            eprintln!("Setting nct_id on Articles from study_references.txt...");
+            let refs_start = Instant::now();
+
+            // Build pmid → Article NodeId lookup
+            let articles = graph.get_nodes_by_label(&"Article".into());
+            let mut pmid_to_article: std::collections::HashMap<String, samyama_sdk::NodeId> =
+                std::collections::HashMap::new();
+            for a in &articles {
+                let col_val = graph
+                    .node_columns
+                    .get_property(a.id.as_u64() as usize, "pmid");
+                if let samyama_sdk::PropertyValue::String(pmid) = col_val {
+                    if !pmid.is_empty() {
+                        pmid_to_article.insert(pmid, a.id);
+                    }
+                }
+            }
+            eprintln!("  {} Articles with pmid indexed", pmid_to_article.len());
+
+            // Read study_references.txt (pipe-delimited: id|nct_id|pmid|reference_type|citation)
+            let mut nct_set = 0u64;
+            if let Ok(file) = std::fs::File::open(refs_path) {
+                let reader = std::io::BufReader::with_capacity(4 * 1024 * 1024, file);
+                for line in reader.lines() {
+                    let line = match line {
+                        Ok(l) => l,
+                        Err(_) => continue,
+                    };
+                    let fields: Vec<&str> = line.split('|').collect();
+                    if fields.len() < 3 {
+                        continue;
+                    }
+                    let nct_id = fields[1].trim();
+                    let pmid = fields[2].trim();
+                    if pmid.is_empty() || nct_id.is_empty() {
+                        continue;
+                    }
+                    if let Some(&article_id) = pmid_to_article.get(pmid) {
+                        graph.set_column_property(
+                            article_id,
+                            "nct_id",
+                            samyama_sdk::PropertyValue::String(nct_id.to_string()),
+                        );
+                        nct_set += 1;
+                    }
+                }
+            }
+            eprintln!(
+                "  {} articles tagged with nct_id in {:.1}s",
+                nct_set,
+                refs_start.elapsed().as_secs_f64()
+            );
+        }
+
+        // Step 2: Build REFERENCED_IN edges
+        eprintln!("Building NCT bridge (Article → ClinicalTrial)...");
+        let bridge_start = Instant::now();
+
+        // Build nct_id → ClinicalTrial NodeId lookup from existing CT nodes
+        let ct_nodes = graph.get_nodes_by_label(&"ClinicalTrial".into());
+        let mut nct_to_ct: std::collections::HashMap<String, samyama_sdk::NodeId> =
+            std::collections::HashMap::new();
+        for ct in &ct_nodes {
+            // Check HashMap property
+            if let Some(samyama_sdk::PropertyValue::String(nct)) = ct.get_property("nct_id") {
+                nct_to_ct.insert(nct.clone(), ct.id);
+            }
+            // Check ColumnStore
+            let col_val = graph
+                .node_columns
+                .get_property(ct.id.as_u64() as usize, "nct_id");
+            if let samyama_sdk::PropertyValue::String(nct) = col_val {
+                if !nct.is_empty() {
+                    nct_to_ct.insert(nct, ct.id);
+                }
+            }
+        }
+        eprintln!("  {} ClinicalTrial nodes with nct_id", nct_to_ct.len());
+
+        // Scan articles with nct_id and create edges
+        let article_nodes = graph.get_nodes_by_label(&"Article".into());
+        let mut bridge_count = 0;
+        let mut article_ids_with_nct: Vec<(samyama_sdk::NodeId, String)> = Vec::new();
+
+        for article in &article_nodes {
+            let col_val = graph
+                .node_columns
+                .get_property(article.id.as_u64() as usize, "nct_id");
+            if let samyama_sdk::PropertyValue::String(nct) = col_val {
+                if !nct.is_empty() {
+                    article_ids_with_nct.push((article.id, nct));
+                }
+            }
+        }
+
+        for (article_id, nct) in &article_ids_with_nct {
+            if let Some(&ct_id) = nct_to_ct.get(nct) {
+                let _ = graph.create_edge(*article_id, ct_id, "REFERENCED_IN");
+                bridge_count += 1;
+            }
+        }
+        eprintln!(
+            "  {} REFERENCED_IN edges created in {:.1}s",
+            bridge_count,
+            bridge_start.elapsed().as_secs_f64()
+        );
+    }
+
+    // ── Phase 3: Create indexes ──
+    eprintln!("Creating indexes...");
+    let idx_start = Instant::now();
+    let indexes = &[
+        "CREATE INDEX ON :Article(pmid)",
+        "CREATE INDEX ON :Author(name)",
+        "CREATE INDEX ON :MeSHTerm(name)",
+        "CREATE INDEX ON :Chemical(name)",
+        "CREATE INDEX ON :Journal(title)",
+        "CREATE INDEX ON :Grant(agency)",
+        "CREATE INDEX ON :ClinicalTrial(nct_id)",
+        "CREATE INDEX ON :Condition(name)",
+        "CREATE INDEX ON :Intervention(name)",
+        "CREATE INDEX ON :Sponsor(name)",
+        "CREATE INDEX ON :Protein(name)",
+        "CREATE INDEX ON :Protein(gene_name)",
+        "CREATE INDEX ON :Pathway(name)",
+        "CREATE INDEX ON :GOTerm(name)",
+        "CREATE INDEX ON :Drug(name)",
+        "CREATE INDEX ON :Drug(drugbank_id)",
+        "CREATE INDEX ON :Gene(gene_name)",
+        "CREATE INDEX ON :SideEffect(name)",
+        "CREATE INDEX ON :Country(iso_code)",
+        "CREATE INDEX ON :Country(name)",
+        "CREATE INDEX ON :Region(code)",
+        "CREATE INDEX ON :Region(who_code)",
+        "CREATE INDEX ON :Disease(indicator_code)",
+        "CREATE INDEX ON :Disease(name)",
+        "CREATE INDEX ON :SocioeconomicIndicator(id)",
+        "CREATE INDEX ON :EnvironmentalFactor(id)",
+        "CREATE INDEX ON :NutritionIndicator(id)",
+        "CREATE INDEX ON :DemographicProfile(id)",
+        "CREATE INDEX ON :WaterResource(id)",
+        "CREATE INDEX ON :EmergencyResponse(id)",
+        "CREATE INDEX ON :HealthWorkforce(id)",
+        "CREATE INDEX ON :VaccineCoverage(id)",
+        // FAERS
+        "CREATE INDEX ON :AdverseEventCase(case_id)",
+        "CREATE INDEX ON :Reaction(preferred_term)",
+        // UniProt
+        "CREATE INDEX ON :Protein(uniprot_id)",
+        "CREATE INDEX ON :Protein(gene_name)",
+        "CREATE INDEX ON :Organism(name)",
+        "CREATE INDEX ON :GOTerm(go_id)",
+        // OMOP
+        "CREATE INDEX ON :Person(person_id)",
+        "CREATE INDEX ON :Visit(encounter_id)",
+        "CREATE INDEX ON :ConditionOccurrence(snomed_code)",
+        "CREATE INDEX ON :DrugExposure(rxnorm_code)",
+        "CREATE INDEX ON :Measurement(loinc_code)",
+    ];
+    let mut idx_ok = 0;
+    for idx in indexes {
+        if client.query("default", idx).await.is_ok() {
+            idx_ok += 1;
+        }
+    }
+    eprintln!(
+        "  {} indexes created in {:.1}s\n",
+        idx_ok,
+        idx_start.elapsed().as_secs_f64()
+    );
+
+    // ── Phase 4: Load and run queries ──
+    let mut all_queries = Vec::new();
+    for filename in &[
+        "pubmed-queries.csv",
+        "clinical-trials-queries.csv",
+        "pathways-queries.csv",
+        "drug-interactions-queries.csv",
+        "cross-kg-queries.csv",
+        "health-determinants-queries.csv",
+        "health-systems-queries.csv",
+        "public-health-cross-kg-queries.csv",
+        "expanded-queries.csv",
+        "uniprot-queries.csv",
+        "faers-queries.csv",
+        "omop-queries.csv",
+        "mega-benchmark-queries.csv",
+    ] {
+        let path = queries_dir.join(filename);
+        let queries = parse_csv_queries(&path);
+        if !queries.is_empty() {
+            eprintln!("Loaded {} queries from {}", queries.len(), filename);
+        }
+        all_queries.extend(queries);
+    }
+
+    eprintln!("\nRunning {} queries...\n", all_queries.len());
+    println!("id,name,category,time_ms,rows,status,sample_result");
+
+    let mut pass = 0;
+    let mut pass_data_gap = 0;
+    let mut empty = 0;
+    let mut fail_count = 0;
+    let mut errors = 0;
+
+    for (id, name, category, cypher) in &all_queries {
+        let t0 = Instant::now();
+        let result = client.query("default", cypher).await;
+        let ms = t0.elapsed().as_secs_f64() * 1000.0;
+
+        match result {
+            Ok(r) => {
+                let rows = r.records.len();
+                let (status, counted_pass) = classify(rows, oracle.get(id));
+                let sample = r
+                    .records
+                    .first()
+                    .map(|row| {
+                        let vals: Vec<String> = row.iter().map(|v| format!("{}", v)).collect();
+                        format!("[{}]", vals.join("; "))
+                    })
+                    .unwrap_or_else(|| "[]".to_string());
+                let sample_esc = sample.replace('"', "\"\"");
+                println!(
+                    "{},{},{},{:.1},{},{},\"{}\"",
+                    id, name, category, ms, rows, status, sample_esc
+                );
+                let tag = match status {
+                    "pass" => "PASS",
+                    "pass_data_gap" => "PASS*",
+                    "fail_count" => "FAIL#",
+                    _ => "EMPTY",
+                };
+                eprintln!(
+                    "  {} {}: {} rows in {:.1}ms [{}]",
+                    tag, id, rows, ms, name
+                );
+                match status {
+                    "pass" => pass += 1,
+                    "pass_data_gap" => pass_data_gap += 1,
+                    "fail_count" => fail_count += 1,
+                    _ => empty += 1,
+                }
+                let _ = counted_pass; // accounted for above
+            }
+            Err(e) => {
+                let msg = format!("{}", e)
+                    .replace('"', "'")
+                    .chars()
+                    .take(200)
+                    .collect::<String>();
+                println!("{},{},{},{:.1},0,error,\"{}\"", id, name, category, ms, msg);
+                eprintln!(
+                    "  ERROR {}: {} [{:.1}ms]",
+                    id,
+                    &msg[..msg.len().min(80)],
+                    ms
+                );
+                errors += 1;
+            }
+        }
+    }
+
+    eprintln!("\n========================================");
+    let total_pass = pass + pass_data_gap;
+    eprintln!(
+        "Results: {}/{} pass ({} full + {} data_gap), {} empty, {} fail_count, {} error",
+        total_pass,
+        all_queries.len(),
+        pass,
+        pass_data_gap,
+        empty,
+        fail_count,
+        errors
+    );
+    eprintln!("Total time: {:.1}s", total_start.elapsed().as_secs_f64());
+    eprintln!("========================================");
+
+    Ok(())
+}


### PR DESCRIPTION
Makes the 500/500 mega benchmark result fully reproducible from OSS. After #170 shipped the engine fixes but left the runner in the private enterprise repo, a reader couldn't run the 500-query sweep end-to-end. This ports the missing pieces.

## What's ported
- `examples/unified_benchmark.rs` — the driver that loads 10 KGs, executes all queries, classifies results against a YAML oracle via `--oracle` (separates engine capability from corpus coverage).
- `examples/health_determinants_common/` — loader for World Bank WDI, WHO AQ, FAO AQUASTAT, UNDP HDI.
- `examples/health_systems_common/` — loader for WHO GHED, IHR SPAR, vaccination coverage.

## Enterprise edge preserved
Nothing enterprise-only was touched. Runner uses only `samyama_sdk::{EmbeddedClient, SamyamaClient}` and `serde_yaml` — both already in OSS `Cargo.toml`. No license checks, no paid features, no credentials, no internal hostnames.

## Verification
- `cargo check --example unified_benchmark` — clean
- `cargo test --lib` — 1974 passed, 0 failed

## Usage (documented in the file header)
```
cargo run --release --example unified_benchmark -- \
  --pubmed-snap ~/samyama/pubmed-v2.sgsnap \
  --queries ~/samyama-graph-book/src/data/benchmark \
  --oracle ~/samyama-graph-book/src/data/benchmark/expected_rows.yaml
```
(All `--*-snap` flags are optional; runner handles whatever subset of KGs you provide.)