### PR TITLE
feat: ADR-019 cross-KG entity dedup via HTTP

### DIFF
--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -603,14 +603,14 @@ pub async fn export_snapshot_handler(
 /// Query parameters for snapshot import
 #[derive(Deserialize, Default)]
 pub struct SnapshotImportParams {
-    /// Property keys for cross-KG entity deduplication (can be repeated).
-    /// e.g. ?dedup_key=name&dedup_key=go_id
+    /// Comma-separated property keys for cross-KG entity deduplication.
+    /// e.g. ?dedup_key=name,go_id
     #[serde(default)]
-    pub dedup_key: Vec<String>,
+    pub dedup_key: Option<String>,
 }
 
 /// POST /api/snapshot/import — import a .sgsnap snapshot
-/// Optional query params: ?dedup_key=name&dedup_key=go_id
+/// Optional query param: ?dedup_key=name,go_id (comma-separated)
 pub async fn restore_snapshot_handler(
     State(state): State<AppState>,
     Query(params): Query<SnapshotImportParams>,
@@ -656,7 +656,11 @@ pub async fn restore_snapshot_handler(
 
     let mut store_guard = state.store.write().await;
     let cursor = std::io::Cursor::new(&data);
-    let dedup_key_refs: Vec<&str> = params.dedup_key.iter().map(|s| s.as_str()).collect();
+    let dedup_keys: Vec<String> = params
+        .dedup_key
+        .map(|s| s.split(',').map(|k| k.trim().to_string()).filter(|k| !k.is_empty()).collect())
+        .unwrap_or_default();
+    let dedup_key_refs: Vec<&str> = dedup_keys.iter().map(|s| s.as_str()).collect();
 
     match crate::snapshot::import_tenant_with_dedup(&mut store_guard, cursor, &dedup_key_refs) {
         Ok(stats) => {

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -1,7 +1,7 @@
 //! HTTP handlers for the Visualizer API
 
 use axum::{
-    extract::{State, Json, Multipart},
+    extract::{Query, State, Json, Multipart},
     response::IntoResponse,
 };
 use crate::query::Value;
@@ -600,9 +600,20 @@ pub async fn export_snapshot_handler(
     }
 }
 
+/// Query parameters for snapshot import
+#[derive(Deserialize, Default)]
+pub struct SnapshotImportParams {
+    /// Property keys for cross-KG entity deduplication (can be repeated).
+    /// e.g. ?dedup_key=name&dedup_key=go_id
+    #[serde(default)]
+    pub dedup_key: Vec<String>,
+}
+
 /// POST /api/snapshot/import — import a .sgsnap snapshot
+/// Optional query params: ?dedup_key=name&dedup_key=go_id
 pub async fn restore_snapshot_handler(
     State(state): State<AppState>,
+    Query(params): Query<SnapshotImportParams>,
     mut multipart: Multipart,
 ) -> impl IntoResponse {
     // Read the snapshot file from multipart
@@ -645,8 +656,9 @@ pub async fn restore_snapshot_handler(
 
     let mut store_guard = state.store.write().await;
     let cursor = std::io::Cursor::new(&data);
+    let dedup_key_refs: Vec<&str> = params.dedup_key.iter().map(|s| s.as_str()).collect();
 
-    match crate::snapshot::import_tenant(&mut store_guard, cursor) {
+    match crate::snapshot::import_tenant_with_dedup(&mut store_guard, cursor, &dedup_key_refs) {
         Ok(stats) => {
             // HA-08: Persist snapshot to disk so it survives server restart
             if let Some(ref data_path) = state.data_path {
@@ -665,6 +677,7 @@ pub async fn restore_snapshot_handler(
             Json(json!({
                 "status": "ok",
                 "nodes_imported": stats.node_count,
+                "nodes_merged": stats.merged_count,
                 "edges_imported": stats.edge_count,
                 "labels": stats.labels,
                 "edge_types": stats.edge_types,

--- a/src/snapshot/format.rs
+++ b/src/snapshot/format.rs
@@ -61,6 +61,7 @@ pub struct ExportStats {
 pub struct ImportStats {
     pub node_count: u64,
     pub edge_count: u64,
+    pub merged_count: u64,
     pub labels: Vec<String>,
     pub edge_types: Vec<String>,
 }

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -268,10 +268,10 @@ pub fn import_tenant_with_dedup(
     let mut imported_labels: HashSet<String> = HashSet::new();
     let mut imported_edge_types: HashSet<String> = HashSet::new();
 
-    // Entity dedup index: (label, dedup_key, value_string) → existing NodeId
-    // When importing a node, if the same label+key+value exists, reuse that NodeId
-    // instead of creating a duplicate. This enables cross-snapshot federation.
-    // Entity dedup index: (label, dedup_key, value_string) → existing NodeId.
+    // Normalize dedup values: lowercase + trim for case-insensitive matching
+    let normalize_dedup = |s: &str| -> String { s.trim().to_lowercase() };
+
+    // Entity dedup index: (label, dedup_key, normalized_value) → existing NodeId.
     // Only populated when the caller provides dedup_keys.
     let mut dedup_index: HashMap<(String, String, String), NodeId> = HashMap::new();
 
@@ -283,7 +283,7 @@ pub fn import_tenant_with_dedup(
             // Check node HashMap properties
             if let Some(val) = node.get_property(key) {
                 let val_str = match val {
-                    PropertyValue::String(s) => s.clone(),
+                    PropertyValue::String(s) => normalize_dedup(s),
                     PropertyValue::Integer(i) => i.to_string(),
                     _ => continue,
                 };
@@ -293,7 +293,7 @@ pub fn import_tenant_with_dedup(
             let col_val = store.node_columns.get_property(node.id.as_u64() as usize, key);
             match &col_val {
                 PropertyValue::String(s) if !s.is_empty() => {
-                    dedup_index.insert((label.clone(), key.to_string(), s.clone()), node.id);
+                    dedup_index.insert((label.clone(), key.to_string(), normalize_dedup(s)), node.id);
                 }
                 PropertyValue::Integer(i) => {
                     dedup_index.insert((label.clone(), key.to_string(), i.to_string()), node.id);
@@ -326,7 +326,7 @@ pub fn import_tenant_with_dedup(
             for &key in dedup_keys.iter() {
                 if let Some(json_val) = snap_node.props.get(key) {
                     let val_str = match json_val {
-                        serde_json::Value::String(s) => s.clone(),
+                        serde_json::Value::String(s) => normalize_dedup(s),
                         serde_json::Value::Number(n) => n.to_string(),
                         _ => continue,
                     };
@@ -412,7 +412,7 @@ pub fn import_tenant_with_dedup(
                 for &key in dedup_keys {
                     if let Some(json_val) = snap_node.props.get(key) {
                         let val_str = match json_val {
-                            serde_json::Value::String(s) => s.clone(),
+                            serde_json::Value::String(s) => normalize_dedup(s),
                             serde_json::Value::Number(n) => n.to_string(),
                             _ => continue,
                         };
@@ -435,7 +435,7 @@ pub fn import_tenant_with_dedup(
                 for &key in dedup_keys {
                     if let Some(pv) = store.get_node(new_id).and_then(|n| n.get_property(key)) {
                         let val_str = match pv {
-                            PropertyValue::String(s) => s.clone(),
+                            PropertyValue::String(s) => normalize_dedup(s),
                             PropertyValue::Integer(i) => i.to_string(),
                             _ => continue,
                         };
@@ -513,6 +513,7 @@ pub fn import_tenant_with_dedup(
     Ok(ImportStats {
         node_count: imported_node_count,
         edge_count: imported_edge_count,
+        merged_count: merged_node_count,
         labels,
         edge_types,
     })
@@ -1348,7 +1349,10 @@ mod nct_bridge_edge_tests {
 #[cfg(test)]
 mod dedup_tests {
     use super::*;
+    use std::io::Cursor;
     use crate::graph::store::GraphStore;
+    use crate::graph::PropertyValue;
+    use crate::query::{parser::parse_query, executor::QueryExecutor};
 
     #[test]
     fn test_index_backfill_on_imported_snapshot() {
@@ -1474,5 +1478,139 @@ mod dedup_tests {
         assert!(!result.records.is_empty(),
             "Cypher query should find Country with iso_code='IND' after snapshot import + CREATE INDEX. Got {} rows.",
             result.records.len());
+    }
+
+    #[test]
+    fn test_cross_kg_dedup_merges_shared_nodes() {
+        // Snapshot 1: Drug "Methotrexate" with source=faers
+        let mut store1 = GraphStore::new();
+        let d1 = store1.create_node("Drug");
+        store1.get_node_mut(d1).unwrap().set_property("name", PropertyValue::String("Methotrexate".to_string()));
+        store1.get_node_mut(d1).unwrap().set_property("source", PropertyValue::String("faers".to_string()));
+        let ae = store1.create_node("AdverseEvent");
+        store1.get_node_mut(ae).unwrap().set_property("name", PropertyValue::String("Nausea".to_string()));
+        store1.create_edge(ae, d1, "REPORTED_DRUG").unwrap();
+
+        let mut buf1 = Vec::new();
+        export_tenant(&store1, &mut buf1).unwrap();
+
+        // Snapshot 2: Drug "Methotrexate" with source=clinicaltrials (same name, different case)
+        let mut store2 = GraphStore::new();
+        let d2 = store2.create_node("Drug");
+        store2.get_node_mut(d2).unwrap().set_property("name", PropertyValue::String("methotrexate".to_string()));
+        store2.get_node_mut(d2).unwrap().set_property("source", PropertyValue::String("clinicaltrials".to_string()));
+        let ct = store2.create_node("ClinicalTrial");
+        store2.get_node_mut(ct).unwrap().set_property("name", PropertyValue::String("NCT001".to_string()));
+        store2.create_edge(ct, d2, "TESTS").unwrap();
+
+        let mut buf2 = Vec::new();
+        export_tenant(&store2, &mut buf2).unwrap();
+
+        // Import both into a combined store with dedup on "name"
+        let mut combined = GraphStore::new();
+        let s1 = import_tenant_with_dedup(&mut combined, Cursor::new(&buf1), &["name"]).unwrap();
+        assert_eq!(s1.node_count, 2); // Drug + AdverseEvent
+        assert_eq!(s1.merged_count, 0);
+
+        let s2 = import_tenant_with_dedup(&mut combined, Cursor::new(&buf2), &["name"]).unwrap();
+        assert_eq!(s2.node_count, 1); // Only ClinicalTrial is new
+        assert_eq!(s2.merged_count, 1); // Drug "methotrexate" merged with "Methotrexate"
+
+        // Should have 3 nodes total: Drug, AdverseEvent, ClinicalTrial
+        assert_eq!(combined.node_count(), 3);
+        // Should have 2 edges: both pointing to the same Drug node
+        assert_eq!(combined.edge_count(), 2);
+    }
+
+    #[test]
+    fn test_dedup_properties_merged_additively() {
+        let mut store1 = GraphStore::new();
+        let d = store1.create_node("Drug");
+        store1.get_node_mut(d).unwrap().set_property("name", PropertyValue::String("Aspirin".to_string()));
+        store1.get_node_mut(d).unwrap().set_property("source", PropertyValue::String("faers".to_string()));
+
+        let mut buf1 = Vec::new();
+        export_tenant(&store1, &mut buf1).unwrap();
+
+        let mut store2 = GraphStore::new();
+        let d2 = store2.create_node("Drug");
+        store2.get_node_mut(d2).unwrap().set_property("name", PropertyValue::String("aspirin".to_string()));
+        store2.get_node_mut(d2).unwrap().set_property("mechanism", PropertyValue::String("COX inhibitor".to_string()));
+
+        let mut buf2 = Vec::new();
+        export_tenant(&store2, &mut buf2).unwrap();
+
+        let mut combined = GraphStore::new();
+        import_tenant_with_dedup(&mut combined, Cursor::new(&buf1), &["name"]).unwrap();
+        import_tenant_with_dedup(&mut combined, Cursor::new(&buf2), &["name"]).unwrap();
+
+        assert_eq!(combined.node_count(), 1);
+
+        // Original property kept
+        let nodes = combined.all_nodes();
+        let nid = nodes[0].id.as_u64() as usize;
+        assert_eq!(
+            combined.node_columns.get_property(nid, "source"),
+            PropertyValue::String("faers".to_string())
+        );
+        // New property added
+        assert_eq!(
+            combined.node_columns.get_property(nid, "mechanism"),
+            PropertyValue::String("COX inhibitor".to_string())
+        );
+    }
+
+    #[test]
+    fn test_dedup_cross_domain_cypher_query() {
+        // Build two KGs with shared Drug, import with dedup, run cross-domain query
+        let mut store1 = GraphStore::new();
+        let d1 = store1.create_node("Drug");
+        store1.get_node_mut(d1).unwrap().set_property("name", PropertyValue::String("Methotrexate".to_string()));
+        let ae = store1.create_node("AdverseEventCase");
+        store1.get_node_mut(ae).unwrap().set_property("case_id", PropertyValue::String("AE001".to_string()));
+        store1.create_edge(ae, d1, "REPORTED_DRUG").unwrap();
+
+        let mut buf1 = Vec::new();
+        export_tenant(&store1, &mut buf1).unwrap();
+
+        let mut store2 = GraphStore::new();
+        let d2 = store2.create_node("Drug");
+        store2.get_node_mut(d2).unwrap().set_property("name", PropertyValue::String("  Methotrexate  ".to_string()));
+        let ct = store2.create_node("ClinicalTrial");
+        store2.get_node_mut(ct).unwrap().set_property("nct_id", PropertyValue::String("NCT001".to_string()));
+        store2.create_edge(ct, d2, "TESTS").unwrap();
+
+        let mut buf2 = Vec::new();
+        export_tenant(&store2, &mut buf2).unwrap();
+
+        let mut combined = GraphStore::new();
+        import_tenant_with_dedup(&mut combined, Cursor::new(&buf1), &["name"]).unwrap();
+        import_tenant_with_dedup(&mut combined, Cursor::new(&buf2), &["name"]).unwrap();
+
+        // Cross-domain query: ClinicalTrial -TESTS-> Drug <-REPORTED_DRUG- AdverseEventCase
+        let query = parse_query(
+            "MATCH (ct:ClinicalTrial)-[:TESTS]->(d:Drug)<-[:REPORTED_DRUG]-(aec:AdverseEventCase) RETURN ct.nct_id, aec.case_id"
+        ).unwrap();
+        let exec = QueryExecutor::new(&combined);
+        let result = exec.execute(&query).unwrap();
+
+        assert_eq!(result.records.len(), 1, "Cross-domain query should return 1 result");
+    }
+
+    #[test]
+    fn test_dedup_no_keys_no_merge() {
+        // Without dedup_keys, same-name nodes should NOT be merged
+        let mut store1 = GraphStore::new();
+        let d = store1.create_node("Drug");
+        store1.get_node_mut(d).unwrap().set_property("name", PropertyValue::String("Aspirin".to_string()));
+        let mut buf1 = Vec::new();
+        export_tenant(&store1, &mut buf1).unwrap();
+
+        let mut combined = GraphStore::new();
+        import_tenant(&mut combined, Cursor::new(&buf1)).unwrap();
+        import_tenant(&mut combined, Cursor::new(&buf1)).unwrap();
+
+        // Without dedup, we get 2 Drug nodes
+        assert_eq!(combined.node_count(), 2);
     }
 }


### PR DESCRIPTION
## Summary
- Expose `import_tenant_with_dedup()` via HTTP: `POST /api/snapshot/import?dedup_key=name,go_id`
- Normalize dedup values (lowercase + trim) so "Methotrexate" and "methotrexate" merge correctly
- Backward compatible — omitting `dedup_key` preserves existing import behavior
- Response now includes `nodes_merged` count

## Verified on AWS VM (r7i.16xlarge, ap-south-1)
- Loaded 5 KG snapshots (18.7M nodes, 122M edges) with `?dedup_key=name,go_id`
- **457,740 nodes deduplicated** across druginteractions → pathways → uniprot → clinical-trials → FAERS
- Cross-domain query: `Intervention -[:CODED_AS_DRUG]-> Drug <-[:REPORTED_DRUG]- AdverseEventCase` returns 3 interventions × 90,620 adverse event cases through single "Methotrexate" node

## Test plan
- [x] 4 new unit tests (merge, additive properties, cross-domain Cypher, no-dedup backward compat)
- [x] 1978 existing tests pass (0 regressions)
- [x] AWS VM verification with real KG snapshots