### PR TITLE
fix(optimize): stream final Pareto front for multi-objective runs

### DIFF
--- a/crates/samyama-optimization/src/algorithms/nsga2.rs
+++ b/crates/samyama-optimization/src/algorithms/nsga2.rs
@@ -249,8 +249,13 @@ impl NSGA2Solver {
         for i in 0..vars.len() {
             if rng.gen::<f64>() < self.mutation_rate {
                 let range = upper[i] - lower[i];
-                vars[i] = (vars[i] + (rng.gen::<f64>() - 0.5) * range * 0.1).clamp(lower[i], upper[i]);
+                vars[i] = vars[i] + (rng.gen::<f64>() - 0.5) * range * 0.1;
             }
+            // Always clamp to bounds — BLX-alpha crossover routinely produces
+            // children outside [lower, upper], and unmutated genes were
+            // previously left unclamped, causing problems like ZDT1 to evaluate
+            // sqrt(negative) → NaN.
+            vars[i] = vars[i].clamp(lower[i], upper[i]);
         }
     }
 }

--- a/src/http/optimize.rs
+++ b/src/http/optimize.rs
@@ -364,8 +364,8 @@ struct CancelHandle {
 
 #[derive(Debug, Clone)]
 enum SseEvent {
-    Iteration { iter: usize, best_fitness: f64 },
-    Done { final_fitness: f64, iterations: usize },
+    Iteration { iter: usize, best_fitness: f64, pareto_front: Option<Vec<Vec<f64>>> },
+    Done { final_fitness: f64, iterations: usize, final_pareto: Option<Vec<Vec<f64>>> },
     Error { message: String },
 }
 
@@ -463,14 +463,20 @@ async fn start_solve(
         });
 
         match compute.await {
-            Ok(Ok(SolverOutcome { history, final_fitness })) => {
+            Ok(Ok(SolverOutcome { history, final_fitness, final_pareto })) => {
+                let iterations = history.len();
+                let last_iter = iterations.saturating_sub(1);
                 for (iter, best) in history.iter().enumerate() {
                     if cancelled_flag.load(std::sync::atomic::Ordering::Relaxed) {
                         let _ = event_tx.send(SseEvent::Error { message: "cancelled".into() }).await;
                         return;
                     }
+                    // Stamp the final Pareto front onto the LAST iteration event
+                    // so the samyama-insight hook (which reads pareto_front from
+                    // iteration events, not from done) renders the chart.
+                    let pareto_for_event = if iter == last_iter { final_pareto.clone() } else { None };
                     if event_tx
-                        .send(SseEvent::Iteration { iter, best_fitness: *best })
+                        .send(SseEvent::Iteration { iter, best_fitness: *best, pareto_front: pareto_for_event })
                         .await
                         .is_err()
                     {
@@ -478,7 +484,7 @@ async fn start_solve(
                     }
                 }
                 let _ = event_tx
-                    .send(SseEvent::Done { final_fitness, iterations: history.len() })
+                    .send(SseEvent::Done { final_fitness, iterations, final_pareto })
                     .await;
             }
             Ok(Err(e)) => {
@@ -496,6 +502,9 @@ async fn start_solve(
 struct SolverOutcome {
     history: Vec<f64>,
     final_fitness: f64,
+    /// Final Pareto front, one entry per non-dominated individual, each a vector
+    /// of objective values. None for single-objective runs.
+    final_pareto: Option<Vec<Vec<f64>>>,
 }
 
 fn run_solver(
@@ -507,12 +516,7 @@ fn run_solver(
     cfg: SolverConfig,
 ) -> Result<SolverOutcome, String> {
     if multi_objective {
-        // MO problems: track first-objective best across iterations.
-        let run = |hist: Vec<f64>, final_first: f64| SolverOutcome {
-            final_fitness: final_first,
-            history: hist,
-        };
-        let (hist, final_f) = match bench_id {
+        let (hist, final_f, pareto) = match bench_id {
             "zdt1" | "zdt2" | "zdt3" => {
                 let v = bench_id.chars().last().unwrap().to_digit(10).unwrap() as u8;
                 let problem = ZDT { variant: v, dim: 30 };
@@ -527,7 +531,14 @@ fn run_solver(
                 let final_first = r.pareto_front.iter()
                     .map(|ind| ind.fitness[0])
                     .fold(f64::INFINITY, f64::min);
-                (r.history, final_first)
+                // Drop individuals with non-finite objective values — serde_json
+                // serializes NaN/Inf as null, which breaks downstream consumers
+                // (e.g. the samyama-insight Pareto chart).
+                let pareto: Vec<Vec<f64>> = r.pareto_front.iter()
+                    .filter(|ind| ind.fitness.iter().all(|v| v.is_finite()))
+                    .map(|ind| ind.fitness.clone())
+                    .collect();
+                (r.history, final_first, pareto)
             }
             "dtlz1" => {
                 let problem = DTLZ1 { dim: 7, m: 3 };
@@ -542,11 +553,18 @@ fn run_solver(
                 let final_first = r.pareto_front.iter()
                     .map(|ind| ind.fitness[0])
                     .fold(f64::INFINITY, f64::min);
-                (r.history, final_first)
+                // Drop individuals with non-finite objective values — serde_json
+                // serializes NaN/Inf as null, which breaks downstream consumers
+                // (e.g. the samyama-insight Pareto chart).
+                let pareto: Vec<Vec<f64>> = r.pareto_front.iter()
+                    .filter(|ind| ind.fitness.iter().all(|v| v.is_finite()))
+                    .map(|ind| ind.fitness.clone())
+                    .collect();
+                (r.history, final_first, pareto)
             }
             other => return Err(format!("benchmark {} is not multi-objective", other)),
         };
-        Ok(run(hist, final_f))
+        Ok(SolverOutcome { history: hist, final_fitness: final_f, final_pareto: Some(pareto) })
     } else {
         let bench = benchmark_catalog().into_iter().find(|b| b.id == bench_id)
             .ok_or_else(|| format!("unknown benchmark: {bench_id}"))?;
@@ -577,6 +595,7 @@ fn run_solver(
         Ok(SolverOutcome {
             final_fitness: result.best_fitness,
             history: result.history,
+            final_pareto: None,
         })
     }
 }
@@ -600,16 +619,21 @@ async fn stream_solve(
 
     let stream = ReceiverStream::new(rx).map(|evt| {
         let ev = match evt {
-            SseEvent::Iteration { iter, best_fitness } => Event::default()
+            SseEvent::Iteration { iter, best_fitness, pareto_front } => Event::default()
                 .event("iteration")
-                .json_data(serde_json::json!({ "iter": iter, "best_fitness": best_fitness }))
+                .json_data(serde_json::json!({
+                    "iter": iter,
+                    "best_fitness": best_fitness,
+                    "pareto_front": pareto_front,
+                }))
                 .unwrap(),
-            SseEvent::Done { final_fitness, iterations } => Event::default()
+            SseEvent::Done { final_fitness, iterations, final_pareto } => Event::default()
                 .event("done")
                 .json_data(serde_json::json!({
                     "final_fitness": final_fitness,
                     "iterations": iterations,
                     "total_time_ms": 0,
+                    "final_pareto": final_pareto,
                 }))
                 .unwrap(),
             SseEvent::Error { message } => Event::default()

--- a/tests/optimize_http_test.rs
+++ b/tests/optimize_http_test.rs
@@ -189,3 +189,148 @@ async fn cancel_endpoint_returns_ok_even_for_unknown_job() {
     let v = body_to_json(res.into_body()).await;
     assert_eq!(v["cancelled"], false);
 }
+
+#[tokio::test]
+async fn nsga2_zdt1_done_event_emits_final_pareto() {
+    // Regression: SGE was emitting only {iter, best_fitness} for multi-objective
+    // runs, leaving the samyama-insight Pareto chart empty. The done event for
+    // an MO solve must include `final_pareto`: a non-empty list of [obj1, obj2]
+    // points so the UI can render the front.
+    let app = router();
+
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/optimize/solve")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "algorithm": "nsga2",
+                        "benchmark": "zdt1",
+                        "population_size": 30,
+                        "iterations": 100
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let job_id = body_to_json(res.into_body()).await["job_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let stream_res = tokio::time::timeout(Duration::from_secs(30), async {
+        app.oneshot(
+            Request::builder()
+                .uri(format!("/optimize/solve/{}/stream", job_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+    })
+    .await
+    .expect("stream request timed out");
+    assert_eq!(stream_res.status(), StatusCode::OK);
+
+    let bytes = stream_res.into_body().collect().await.unwrap().to_bytes();
+    let text = String::from_utf8_lossy(&bytes);
+
+    let done_line = text
+        .lines()
+        .skip_while(|l| !l.starts_with("event: done"))
+        .nth(1)
+        .expect("done data line");
+    let done: Value = serde_json::from_str(done_line.trim_start_matches("data: ")).unwrap();
+
+    let pareto = done["final_pareto"]
+        .as_array()
+        .expect("done event must include final_pareto array for multi-objective runs");
+    assert!(!pareto.is_empty(), "final_pareto must contain points");
+    let first = pareto[0].as_array().expect("each pareto point is an array");
+    assert_eq!(
+        first.len(),
+        2,
+        "ZDT1 has 2 objectives, point should be [obj1, obj2]"
+    );
+    // Use as_f64() — serde_json stores whole-number f64 values as integers and
+    // is_f64() returns false for those. as_f64() coerces correctly.
+    assert!(
+        first[0].as_f64().is_some() && first[1].as_f64().is_some(),
+        "expected numeric obj values, got {first:?}"
+    );
+}
+
+#[tokio::test]
+async fn nsga2_zdt1_last_iteration_event_carries_pareto_front() {
+    // The samyama-insight hook subscribes to iteration events and reads the
+    // optional `pareto_front` field. To keep the UI working without a separate
+    // event, SGE stamps the final Pareto front onto the last iteration event.
+    let app = router();
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/optimize/solve")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({"algorithm":"nsga2","benchmark":"zdt1","population_size":30,"iterations":50})
+                        .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let job_id = body_to_json(res.into_body()).await["job_id"].as_str().unwrap().to_string();
+
+    let stream_res = tokio::time::timeout(Duration::from_secs(20), async {
+        app.oneshot(
+            Request::builder()
+                .uri(format!("/optimize/solve/{}/stream", job_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+    })
+    .await
+    .unwrap();
+    let bytes = stream_res.into_body().collect().await.unwrap().to_bytes();
+    let text = String::from_utf8_lossy(&bytes);
+
+    // Collect all iteration data lines.
+    let iter_payloads: Vec<Value> = text
+        .lines()
+        .scan(false, |is_iter, line| {
+            if line.starts_with("event: iteration") { *is_iter = true; return Some(None); }
+            if line.starts_with("event:") { *is_iter = false; return Some(None); }
+            if *is_iter && line.starts_with("data: ") {
+                let v: Value = serde_json::from_str(line.trim_start_matches("data: ")).unwrap();
+                return Some(Some(v));
+            }
+            Some(None)
+        })
+        .flatten()
+        .collect();
+
+    assert!(iter_payloads.len() >= 10, "expected many iteration payloads");
+    // All non-final iterations should have null pareto_front.
+    for p in iter_payloads.iter().take(iter_payloads.len() - 1) {
+        assert!(p["pareto_front"].is_null(),
+            "non-final iteration should not carry pareto_front, got {p}");
+    }
+    // The last iteration should carry the populated pareto_front.
+    let last = iter_payloads.last().unwrap();
+    let front = last["pareto_front"]
+        .as_array()
+        .expect("last iteration must carry pareto_front for multi-objective runs");
+    assert!(!front.is_empty());
+    let pt = front[0].as_array().unwrap();
+    assert_eq!(pt.len(), 2);
+}


### PR DESCRIPTION
## Summary
- Emit the final Pareto front on the SSE stream for `/optimize/solve` (fixes empty Pareto chart in samyama-insight).
- Stamp it onto the last `iteration` event (the UI hook reads from iteration events) and include a durable copy on the `done` event as `final_pareto`.
- Filter non-finite objective values before serialization so NaN/Inf don't leak out as JSON null.
- Fix a bound-violation in `NSGA2Solver::mutate`: BLX-α crossover produces children outside `[lower, upper]`, and `mutate()` only clamped when mutation triggered. Un-mutated genes stayed unclamped, making ZDT1 evaluate `sqrt(negative) → NaN` across most of the population. `mutate()` now always clamps.

## Test plan
- [x] `cargo test --test optimize_http_test` — 6/6 green, incl. two new tests:
  - `nsga2_zdt1_done_event_emits_final_pareto`
  - `nsga2_zdt1_last_iteration_event_carries_pareto_front`
- [x] `cargo test -p samyama-optimization` — 36/36 green (no regression)
- [x] End-to-end: samyama-insight `demos/34-optimization-live.spec.ts` renders the ZDT1 Pareto front against this SGE build