### PR TITLE
feat(agent): plan executor with USED_TOOL telemetry writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,6 +2693,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "sparesults",
  "spargebra",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tracing-subscriber = "0.3"
 rocksdb = { version = "0.22", default-features = false, features = ["lz4", "zstd"] }
 bincode = "1.3"
 chrono = "0.4"
+sha2 = "0.10"
 
 # High Availability (Phase 4)
 openraft = { version = "0.9", features = ["serde"] }

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -1,0 +1,265 @@
+//! Plan executor — runs a `ToolPlan` against registered `Tool`s, writing
+//! one `(:Question)-[:USED_TOOL]->(:Tool)` edge per call with timing and
+//! cost telemetry. The same Question node is reused across runs sharing
+//! the same prompt (qid = sha256(prompt) prefix).
+
+use crate::agent::planner::{PlanRunResult, ToolCall, ToolCallRecord, ToolPlan};
+use crate::agent::{AgentError, AgentResult, Tool};
+use crate::graph::{GraphStore, Label, NodeId, PropertyValue};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::RwLock;
+
+/// Owns the registered tools + a graph handle for telemetry writes.
+pub struct PlanExecutor {
+    tools: HashMap<String, Arc<dyn Tool>>,
+    store: Arc<RwLock<GraphStore>>,
+}
+
+impl PlanExecutor {
+    pub fn new(
+        tools: HashMap<String, Arc<dyn Tool>>,
+        store: Arc<RwLock<GraphStore>>,
+    ) -> Self {
+        Self { tools, store }
+    }
+
+    /// Stable identifier for a question — sha256 prefix, hex-encoded.
+    pub fn question_id(prompt: &str) -> String {
+        let digest = Sha256::digest(prompt.as_bytes());
+        hex_prefix(&digest, 16)
+    }
+
+    /// Execute a plan. Each parallel group runs concurrently; groups
+    /// run sequentially. After execution, telemetry edges are written
+    /// in plan order under a single write lock.
+    pub async fn execute(
+        &self,
+        prompt: &str,
+        plan: &ToolPlan,
+    ) -> AgentResult<PlanRunResult> {
+        let qid = Self::question_id(prompt);
+        let groups = plan.parallel_groups();
+        let mut records: Vec<Option<ToolCallRecord>> = vec![None; plan.calls.len()];
+
+        let t0 = Instant::now();
+        for group in &groups {
+            // Run group concurrently. Each future returns (idx, ToolCallRecord).
+            let mut futures = Vec::with_capacity(group.len());
+            for &idx in group {
+                let call = plan.calls[idx].clone();
+                let tool = self.tools.get(&call.tool).cloned();
+                futures.push(async move {
+                    let rec = run_one(idx, call, tool).await;
+                    (idx, rec)
+                });
+            }
+            let results = futures::future::join_all(futures).await;
+            for (idx, rec) in results {
+                records[idx] = Some(rec);
+            }
+        }
+        let total_latency_ms = t0.elapsed().as_millis() as u64;
+
+        let records: Vec<ToolCallRecord> = records
+            .into_iter()
+            .map(|r| r.expect("every slot populated by join_all"))
+            .collect();
+        let total_token_cost: u64 = records.iter().map(|r| r.token_cost).sum();
+
+        // Write telemetry. Holds a single write lock for atomicity within a run.
+        write_telemetry(&self.store, &qid, prompt, &records).await?;
+
+        Ok(PlanRunResult {
+            question_id: qid,
+            records,
+            total_latency_ms,
+            total_token_cost,
+        })
+    }
+}
+
+async fn run_one(
+    _idx: usize,
+    call: ToolCall,
+    tool: Option<Arc<dyn Tool>>,
+) -> ToolCallRecord {
+    let started = Instant::now();
+    let args = call.args.clone();
+    let (result, error, hit_rate) = match tool {
+        None => (
+            None,
+            Some(format!("tool '{}' not registered", call.tool)),
+            0.0,
+        ),
+        Some(t) => match t.execute(args.clone()).await {
+            Ok(v) => {
+                let h = score_hit_rate(&v);
+                (Some(v), None, h)
+            }
+            Err(e) => (None, Some(e.to_string()), 0.0),
+        },
+    };
+    let latency_ms = started.elapsed().as_millis() as u64;
+    let token_cost = estimate_tokens(&args, result.as_ref());
+    ToolCallRecord {
+        tool: call.tool,
+        args,
+        latency_ms,
+        token_cost,
+        hit_rate,
+        result,
+        error,
+    }
+}
+
+/// Heuristic 0..1 score: 1.0 for non-empty Ok, 0.5 for empty Ok, 0.0 for
+/// errors. Refine when AGE has a downstream answer-synthesizer that can
+/// signal whether the tool's output was actually used.
+fn score_hit_rate(v: &serde_json::Value) -> f64 {
+    use serde_json::Value;
+    match v {
+        Value::Null => 0.0,
+        Value::Bool(_) | Value::Number(_) => 1.0,
+        Value::String(s) => if s.is_empty() { 0.5 } else { 1.0 },
+        Value::Array(a) => if a.is_empty() { 0.5 } else { 1.0 },
+        Value::Object(o) => {
+            // Common shape: {"records": [...], ...} — empty records = miss.
+            if let Some(Value::Array(records)) = o.get("records") {
+                return if records.is_empty() { 0.5 } else { 1.0 };
+            }
+            if o.is_empty() { 0.5 } else { 1.0 }
+        }
+    }
+}
+
+/// Coarse byte→token estimate (4 bytes/token is industry rule of thumb
+/// for English text; close enough for telemetry).
+fn estimate_tokens(args: &serde_json::Value, result: Option<&serde_json::Value>) -> u64 {
+    let mut bytes = serde_json::to_vec(args).map(|v| v.len()).unwrap_or(0);
+    if let Some(r) = result {
+        bytes += serde_json::to_vec(r).map(|v| v.len()).unwrap_or(0);
+    }
+    ((bytes as f64) / 4.0).ceil() as u64
+}
+
+async fn write_telemetry(
+    store: &RwLock<GraphStore>,
+    qid: &str,
+    prompt: &str,
+    records: &[ToolCallRecord],
+) -> AgentResult<()> {
+    let mut guard = store.write().await;
+
+    // Find-or-create Question node by qid.
+    let q_node = find_node_by_property(&guard, "Question", "qid", qid)
+        .unwrap_or_else(|| {
+            let nid = guard.create_node("Question");
+            if let Some(node) = guard.get_node_mut(nid) {
+                node.set_property("qid", qid);
+                node.set_property("text", prompt);
+            }
+            nid
+        });
+
+    // Find-or-create one Tool node per distinct tool referenced.
+    let mut tool_nodes: HashMap<String, NodeId> = HashMap::new();
+    for rec in records {
+        if tool_nodes.contains_key(&rec.tool) { continue; }
+        let nid = find_node_by_property(&guard, "Tool", "tid", &rec.tool)
+            .unwrap_or_else(|| {
+                let nid = guard.create_node("Tool");
+                if let Some(node) = guard.get_node_mut(nid) {
+                    node.set_property("tid", rec.tool.as_str());
+                }
+                nid
+            });
+        tool_nodes.insert(rec.tool.clone(), nid);
+    }
+
+    // Append one USED_TOOL edge per call, in plan order.
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    for (slot, rec) in records.iter().enumerate() {
+        let tnode = tool_nodes[&rec.tool];
+        let eid = guard
+            .create_edge(q_node, tnode, "USED_TOOL")
+            .map_err(|e| AgentError::ExecutionError(format!("create_edge: {e}")))?;
+        guard.set_edge_property(eid, "latency_ms", rec.latency_ms as i64)
+            .map_err(|e| AgentError::ExecutionError(format!("set_edge_property: {e}")))?;
+        guard.set_edge_property(eid, "token_cost", rec.token_cost as i64)
+            .map_err(|e| AgentError::ExecutionError(format!("set_edge_property: {e}")))?;
+        guard.set_edge_property(eid, "hit_rate", rec.hit_rate)
+            .map_err(|e| AgentError::ExecutionError(format!("set_edge_property: {e}")))?;
+        guard.set_edge_property(eid, "slot", slot as i64)
+            .map_err(|e| AgentError::ExecutionError(format!("set_edge_property: {e}")))?;
+        guard.set_edge_property(eid, "ts_ms", now_ms)
+            .map_err(|e| AgentError::ExecutionError(format!("set_edge_property: {e}")))?;
+        if let Some(err) = &rec.error {
+            guard.set_edge_property(eid, "error", err.as_str())
+                .map_err(|e| AgentError::ExecutionError(format!("set_edge_property: {e}")))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn find_node_by_property(
+    store: &GraphStore,
+    label: &str,
+    key: &str,
+    value: &str,
+) -> Option<NodeId> {
+    let lbl = Label::new(label);
+    for node in store.get_nodes_by_label(&lbl) {
+        if let Some(PropertyValue::String(s)) = node.get_property(key) {
+            if s == value { return Some(node.id); }
+        }
+    }
+    None
+}
+
+fn hex_prefix(bytes: &[u8], n_chars: usize) -> String {
+    let mut s = String::with_capacity(n_chars);
+    for b in bytes {
+        if s.len() >= n_chars { break; }
+        s.push_str(&format!("{:02x}", b));
+    }
+    s.truncate(n_chars);
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn question_id_is_stable() {
+        let a = PlanExecutor::question_id("hello");
+        let b = PlanExecutor::question_id("hello");
+        assert_eq!(a, b);
+        assert_ne!(a, PlanExecutor::question_id("world"));
+        assert_eq!(a.len(), 16);
+    }
+
+    #[test]
+    fn hit_rate_heuristic_distinguishes_outcomes() {
+        assert_eq!(score_hit_rate(&json!(null)), 0.0);
+        assert_eq!(score_hit_rate(&json!([])), 0.5);
+        assert_eq!(score_hit_rate(&json!([1, 2, 3])), 1.0);
+        assert_eq!(score_hit_rate(&json!({"records": []})), 0.5);
+        assert_eq!(score_hit_rate(&json!({"records": [["x"]]})), 1.0);
+    }
+
+    #[test]
+    fn token_estimate_is_proportional_to_payload() {
+        let small = estimate_tokens(&json!({"q": "x"}), Some(&json!("y")));
+        let large = estimate_tokens(
+            &json!({"q": "x".repeat(400)}),
+            Some(&json!("y".repeat(400))),
+        );
+        assert!(large > small * 10, "expected large>>small, got {small} vs {large}");
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -2,15 +2,22 @@
 //!
 //! Implements agents that can use tools to enrich the graph.
 
+pub mod executor;
+pub mod planner;
 pub mod tools;
 
-use crate::persistence::tenant::{AgentConfig, NLQConfig};
+use crate::graph::GraphStore;
 use crate::nlq::client::NLQClient;
+use crate::persistence::tenant::{AgentConfig, NLQConfig};
+use async_trait::async_trait;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
-use async_trait::async_trait;
+use tokio::sync::RwLock;
+
+pub use executor::PlanExecutor;
+pub use planner::{PlanRunResult, ToolCall, ToolCallRecord, ToolPlan};
 
 #[derive(Error, Debug)]
 pub enum AgentError {
@@ -39,6 +46,10 @@ pub trait Tool: Send + Sync {
 pub struct AgentRuntime {
     config: AgentConfig,
     tools: HashMap<String, Arc<dyn Tool>>,
+    /// Optional graph store for telemetry writes from plan execution.
+    /// When set, `execute_plan` / `plan_and_execute` record each tool
+    /// call as a `(:Question)-[:USED_TOOL]->(:Tool)` edge.
+    store: Option<Arc<RwLock<GraphStore>>>,
 }
 
 impl AgentRuntime {
@@ -46,7 +57,14 @@ impl AgentRuntime {
         Self {
             config,
             tools: HashMap::new(),
+            store: None,
         }
+    }
+
+    /// Attach a graph store handle so plan execution emits telemetry edges.
+    pub fn with_store(mut self, store: Arc<RwLock<GraphStore>>) -> Self {
+        self.store = Some(store);
+        self
     }
 
     pub fn register_tool(&mut self, tool: Arc<dyn Tool>) {
@@ -68,11 +86,69 @@ impl AgentRuntime {
     /// Process a trigger (e.g., "Enrich Company node X")
     pub async fn process_trigger(&self, prompt: &str, _context: &str) -> AgentResult<String> {
         let nlq_config = Self::to_nlq_config(&self.config);
-        let client = NLQClient::new(&nlq_config)
-            .map_err(|e| AgentError::ConfigError(e.to_string()))?;
-        let response = client.generate_cypher(prompt).await
+        let client =
+            NLQClient::new(&nlq_config).map_err(|e| AgentError::ConfigError(e.to_string()))?;
+        let response = client
+            .generate_cypher(prompt)
+            .await
             .map_err(|e| AgentError::LLMError(e.to_string()))?;
         Ok(response)
+    }
+
+    /// Execute a pre-built plan against the registered tools, writing
+    /// telemetry edges to the attached store.
+    pub async fn execute_plan(
+        &self,
+        prompt: &str,
+        plan: &ToolPlan,
+    ) -> AgentResult<PlanRunResult> {
+        let store = self.store.as_ref().ok_or_else(|| {
+            AgentError::ConfigError(
+                "AgentRuntime has no store; call with_store() before execute_plan".into(),
+            )
+        })?;
+        let exec = PlanExecutor::new(self.tools.clone(), store.clone());
+        exec.execute(prompt, plan).await
+    }
+
+    /// Ask the configured LLM to emit a plan given the available tools
+    /// and then execute it, recording telemetry.
+    pub async fn plan_and_execute(
+        &self,
+        prompt: &str,
+        context: &str,
+    ) -> AgentResult<PlanRunResult> {
+        let nlq_config = Self::to_nlq_config(&self.config);
+        let client =
+            NLQClient::new(&nlq_config).map_err(|e| AgentError::ConfigError(e.to_string()))?;
+
+        let tool_catalog: Vec<Value> = self
+            .tools
+            .values()
+            .map(|t| {
+                serde_json::json!({
+                    "name": t.name(),
+                    "description": t.description(),
+                    "parameters": t.parameters(),
+                })
+            })
+            .collect();
+        let planner_prompt = format!(
+            "You are a tool-call planner. Given the user prompt and a catalogue of tools, \
+output ONLY a JSON plan matching `{{\"calls\": [{{\"tool\": string, \"args\": object, \"parallel_with_prev\": bool}}]}}`. \
+Do not repeat a tool in a plan. Choose parallel_with_prev=true only when the call does not depend on the previous one.\n\n\
+Tools: {}\n\nContext: {}\n\nPrompt: {}",
+            serde_json::to_string(&tool_catalog).unwrap_or_default(),
+            context,
+            prompt,
+        );
+
+        let raw = client
+            .generate_cypher(&planner_prompt)
+            .await
+            .map_err(|e| AgentError::LLMError(e.to_string()))?;
+        let plan = ToolPlan::from_llm_json(&raw)?;
+        self.execute_plan(prompt, &plan).await
     }
 }
 
@@ -106,7 +182,6 @@ mod tests {
         let config = mock_agent_config();
         let mut runtime = AgentRuntime::new(config);
 
-        // Create and register WebSearchTool
         let tool = Arc::new(tools::WebSearchTool::new("test-key".to_string()));
         runtime.register_tool(tool);
         assert_eq!(runtime.tools.len(), 1);
@@ -129,6 +204,6 @@ mod tests {
         let result = runtime.process_trigger("Find all persons", "context").await;
         assert!(result.is_ok());
         let cypher = result.unwrap();
-        assert!(cypher.contains("MATCH")); // Mock returns "MATCH (n) RETURN n LIMIT 10"
+        assert!(cypher.contains("MATCH"));
     }
 }

--- a/src/agent/planner.rs
+++ b/src/agent/planner.rs
@@ -1,0 +1,144 @@
+//! Tool-call planning data structures and LLM-output parsing.
+//!
+//! A plan is a flat sequence of tool calls; consecutive calls flagged
+//! `parallel_with_prev = true` form a parallel group. The executor
+//! (see `super::executor`) realises this with `tokio::join_all` per group.
+
+use crate::agent::AgentError;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// One step in a plan.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ToolCall {
+    pub tool: String,
+    #[serde(default)]
+    pub args: Value,
+    /// If true, this call runs concurrently with the previous call (and
+    /// any earlier consecutive `parallel_with_prev` calls in the same
+    /// group). The first call in a plan ignores this flag.
+    #[serde(default)]
+    pub parallel_with_prev: bool,
+}
+
+/// A complete plan — a flat ordered list of tool calls.
+#[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq)]
+pub struct ToolPlan {
+    pub calls: Vec<ToolCall>,
+}
+
+impl ToolPlan {
+    /// Parse an LLM-emitted plan. Accepts either:
+    ///  - bare JSON `{"calls": [...]}` or `[...]`
+    ///  - JSON wrapped in ```json ... ``` markdown fences (LLM noise)
+    pub fn from_llm_json(s: &str) -> Result<Self, AgentError> {
+        let cleaned = strip_fences(s);
+        // Try object form first, then array form.
+        if let Ok(plan) = serde_json::from_str::<ToolPlan>(&cleaned) {
+            return Ok(plan);
+        }
+        if let Ok(calls) = serde_json::from_str::<Vec<ToolCall>>(&cleaned) {
+            return Ok(ToolPlan { calls });
+        }
+        Err(AgentError::ExecutionError(format!(
+            "could not parse plan as ToolPlan or [ToolCall]; first 200 chars: {:?}",
+            &cleaned.chars().take(200).collect::<String>()
+        )))
+    }
+
+    /// Group consecutive `parallel_with_prev` calls together. Returned as
+    /// `Vec<Vec<index>>` of original positions.
+    pub fn parallel_groups(&self) -> Vec<Vec<usize>> {
+        let mut groups: Vec<Vec<usize>> = Vec::new();
+        for (i, call) in self.calls.iter().enumerate() {
+            if i == 0 || !call.parallel_with_prev {
+                groups.push(vec![i]);
+            } else {
+                groups.last_mut().unwrap().push(i);
+            }
+        }
+        groups
+    }
+}
+
+/// Telemetry record for a single tool call (one per plan slot, in plan order).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ToolCallRecord {
+    pub tool: String,
+    pub args: Value,
+    pub latency_ms: u64,
+    pub token_cost: u64,
+    pub hit_rate: f64,
+    pub result: Option<Value>,
+    pub error: Option<String>,
+}
+
+/// Result of executing a plan end-to-end.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PlanRunResult {
+    pub question_id: String,
+    pub records: Vec<ToolCallRecord>,
+    /// Total wall-clock latency including parallel overlap.
+    pub total_latency_ms: u64,
+    /// Sum of per-call token cost estimates.
+    pub total_token_cost: u64,
+}
+
+fn strip_fences(s: &str) -> String {
+    let trimmed = s.trim();
+    if let Some(rest) = trimmed.strip_prefix("```json") {
+        return rest.trim_start().trim_end_matches("```").trim().to_string();
+    }
+    if let Some(rest) = trimmed.strip_prefix("```") {
+        return rest.trim_start().trim_end_matches("```").trim().to_string();
+    }
+    trimmed.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_object_form() {
+        let s = r#"{"calls": [{"tool": "cypher", "args": {"q": "MATCH (n) RETURN n"}}]}"#;
+        let p = ToolPlan::from_llm_json(s).unwrap();
+        assert_eq!(p.calls.len(), 1);
+        assert_eq!(p.calls[0].tool, "cypher");
+    }
+
+    #[test]
+    fn parses_array_form() {
+        let s = r#"[{"tool": "a"}, {"tool": "b", "parallel_with_prev": true}]"#;
+        let p = ToolPlan::from_llm_json(s).unwrap();
+        assert_eq!(p.calls.len(), 2);
+        assert!(p.calls[1].parallel_with_prev);
+    }
+
+    #[test]
+    fn strips_markdown_fences() {
+        let s = "```json\n[{\"tool\": \"x\"}]\n```";
+        let p = ToolPlan::from_llm_json(s).unwrap();
+        assert_eq!(p.calls[0].tool, "x");
+    }
+
+    #[test]
+    fn parallel_groups_partitions_correctly() {
+        let plan = ToolPlan {
+            calls: vec![
+                ToolCall { tool: "a".into(), args: json!(null), parallel_with_prev: false },
+                ToolCall { tool: "b".into(), args: json!(null), parallel_with_prev: true },
+                ToolCall { tool: "c".into(), args: json!(null), parallel_with_prev: true },
+                ToolCall { tool: "d".into(), args: json!(null), parallel_with_prev: false },
+            ],
+        };
+        let groups = plan.parallel_groups();
+        assert_eq!(groups, vec![vec![0, 1, 2], vec![3]]);
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(ToolPlan::from_llm_json("not json").is_err());
+    }
+}

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -1,7 +1,103 @@
-use crate::agent::{Tool, AgentResult, AgentError};
+use crate::agent::{AgentError, AgentResult, Tool};
+use crate::graph::GraphStore;
+use crate::query::QueryEngine;
 use async_trait::async_trait;
-use serde_json::{Value, json};
 use reqwest::Client;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Cypher read-only query tool. Executes the `query` arg against the
+/// provided graph store and returns `{records: [[...]], headers: [...]}`.
+/// Unlike WebSearchTool below this is not a stub — it wires straight
+/// to the same QueryEngine the RESP/HTTP layers use.
+pub struct CypherTool {
+    engine: Arc<QueryEngine>,
+    store: Arc<RwLock<GraphStore>>,
+    tenant: String,
+}
+
+impl CypherTool {
+    pub fn new(engine: Arc<QueryEngine>, store: Arc<RwLock<GraphStore>>) -> Self {
+        Self { engine, store, tenant: "default".to_string() }
+    }
+
+    pub fn with_tenant(mut self, tenant: impl Into<String>) -> Self {
+        self.tenant = tenant.into();
+        self
+    }
+}
+
+#[async_trait]
+impl Tool for CypherTool {
+    fn name(&self) -> &str { "cypher" }
+    fn description(&self) -> &str {
+        "Run a read-only Cypher query against the graph and return matching records."
+    }
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string", "description": "Cypher MATCH/RETURN text" }
+            },
+            "required": ["query"]
+        })
+    }
+    async fn execute(&self, args: Value) -> AgentResult<Value> {
+        let query = args.get("query").and_then(|v| v.as_str()).ok_or_else(|| {
+            AgentError::ToolError("missing 'query' parameter".into())
+        })?;
+        let store = self.store.read().await;
+        let batch = self
+            .engine
+            .execute(query, &*store)
+            .map_err(|e| AgentError::ToolError(format!("cypher: {e}")))?;
+        let records: Vec<Vec<Value>> = batch
+            .records
+            .iter()
+            .map(|r| {
+                batch
+                    .columns
+                    .iter()
+                    .map(|col| r.get(col).map(value_to_json).unwrap_or(Value::Null))
+                    .collect()
+            })
+            .collect();
+        Ok(json!({ "headers": batch.columns, "records": records }))
+    }
+}
+
+fn value_to_json(v: &crate::query::executor::record::Value) -> Value {
+    use crate::query::executor::record::Value as V;
+    match v {
+        V::Null => Value::Null,
+        V::Property(p) => prop_to_json(p),
+        V::Node(id, _) | V::NodeRef(id) => json!({ "node_id": id.as_u64() }),
+        V::Edge(id, _) | V::EdgeRef(id, _, _, _) => json!({ "edge_id": id.as_u64() }),
+        V::Path { nodes, edges } => json!({
+            "nodes": nodes.iter().map(|n| n.as_u64()).collect::<Vec<_>>(),
+            "edges": edges.iter().map(|e| e.as_u64()).collect::<Vec<_>>(),
+        }),
+    }
+}
+
+fn prop_to_json(p: &crate::graph::PropertyValue) -> Value {
+    use crate::graph::PropertyValue as P;
+    match p {
+        P::String(s) => json!(s),
+        P::Integer(i) => json!(i),
+        P::Float(f) => json!(f),
+        P::Boolean(b) => json!(b),
+        P::DateTime(ts) => json!(ts),
+        P::Null => Value::Null,
+        P::Array(a) => Value::Array(a.iter().map(prop_to_json).collect()),
+        P::Map(m) => Value::Object(m.iter().map(|(k, v)| (k.clone(), prop_to_json(v))).collect()),
+        P::Vector(v) => json!(v),
+        P::Duration { months, days, seconds, nanos } => {
+            json!({"months": months, "days": days, "seconds": seconds, "nanos": nanos})
+        }
+    }
+}
 
 pub struct WebSearchTool {
     api_key: String, // Google Custom Search API Key (or SerpApi)

--- a/tests/age_plan_executor_test.rs
+++ b/tests/age_plan_executor_test.rs
@@ -1,0 +1,191 @@
+//! AGE plan-executor contract tests.
+//!
+//! Wiring UC5 into the agent runtime: register a real CypherTool, run a
+//! ToolPlan with sequential and parallel calls, verify that
+//! (:Question)-[:USED_TOOL]->(:Tool) telemetry edges land in the store
+//! with latency_ms, token_cost, hit_rate, slot, ts_ms.
+
+use samyama::agent::tools::CypherTool;
+use samyama::agent::{AgentRuntime, ToolCall, ToolPlan};
+use samyama::graph::{GraphStore, Label};
+use samyama::persistence::tenant::{AgentConfig, LLMProvider};
+use samyama::query::QueryEngine;
+use serde_json::json;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+fn mock_agent_config() -> AgentConfig {
+    AgentConfig {
+        enabled: true,
+        provider: LLMProvider::Mock,
+        model: "mock".into(),
+        api_key: None,
+        api_base_url: None,
+        system_prompt: None,
+        tools: vec![],
+        policies: std::collections::HashMap::new(),
+    }
+}
+
+async fn new_runtime_with_fixture() -> (Arc<RwLock<GraphStore>>, AgentRuntime) {
+    let store = Arc::new(RwLock::new(GraphStore::new()));
+    {
+        let mut g = store.write().await;
+        for name in ["Alice", "Bob", "Charlie"] {
+            let nid = g.create_node("Person");
+            if let Some(n) = g.get_node_mut(nid) {
+                n.set_property("name", name);
+            }
+        }
+    }
+    let engine = Arc::new(QueryEngine::new());
+    let mut rt = AgentRuntime::new(mock_agent_config()).with_store(store.clone());
+    rt.register_tool(Arc::new(CypherTool::new(engine, store.clone())));
+    (store, rt)
+}
+
+#[tokio::test]
+async fn executes_sequential_plan_and_writes_telemetry() {
+    let (store, rt) = new_runtime_with_fixture().await;
+    let prompt = "count people";
+    let plan = ToolPlan {
+        calls: vec![
+            ToolCall {
+                tool: "cypher".into(),
+                args: json!({"query": "MATCH (n:Person) RETURN count(n) AS c"}),
+                parallel_with_prev: false,
+            },
+            ToolCall {
+                tool: "cypher".into(),
+                args: json!({"query": "MATCH (n:Person) RETURN n.name AS name"}),
+                parallel_with_prev: false,
+            },
+        ],
+    };
+
+    let result = rt.execute_plan(prompt, &plan).await.expect("execute");
+
+    assert_eq!(result.records.len(), 2);
+    for rec in &result.records {
+        assert_eq!(rec.tool, "cypher");
+        assert!(rec.error.is_none(), "unexpected error: {:?}", rec.error);
+        assert_eq!(rec.hit_rate, 1.0, "non-empty cypher result should score 1.0");
+        assert!(rec.token_cost > 0);
+    }
+
+    // Telemetry edges are in the graph: 1 Question, 1 Tool, 2 USED_TOOL edges
+    // sharing the same Question (same prompt).
+    let g = store.read().await;
+    let questions = g.get_nodes_by_label(&Label::new("Question"));
+    let tools = g.get_nodes_by_label(&Label::new("Tool"));
+    assert_eq!(questions.len(), 1, "expected 1 Question node");
+    assert_eq!(tools.len(), 1, "expected 1 Tool node (cypher)");
+
+    let edges = g.get_edges_by_type(&samyama::graph::EdgeType::new("USED_TOOL"));
+    assert_eq!(edges.len(), 2, "expected 2 USED_TOOL edges");
+    for e in &edges {
+        assert!(e.get_property("latency_ms").is_some());
+        assert!(e.get_property("token_cost").is_some());
+        assert!(e.get_property("hit_rate").is_some());
+        assert!(e.get_property("slot").is_some());
+        assert!(e.get_property("ts_ms").is_some());
+    }
+}
+
+#[tokio::test]
+async fn parallel_group_shares_wall_time() {
+    let (_store, rt) = new_runtime_with_fixture().await;
+    let plan = ToolPlan {
+        calls: vec![
+            ToolCall {
+                tool: "cypher".into(),
+                args: json!({"query": "MATCH (n:Person) RETURN count(n)"}),
+                parallel_with_prev: false,
+            },
+            ToolCall {
+                tool: "cypher".into(),
+                args: json!({"query": "MATCH (n:Person) RETURN count(n)"}),
+                parallel_with_prev: true,
+            },
+            ToolCall {
+                tool: "cypher".into(),
+                args: json!({"query": "MATCH (n:Person) RETURN count(n)"}),
+                parallel_with_prev: true,
+            },
+        ],
+    };
+    let r = rt.execute_plan("parallel probe", &plan).await.unwrap();
+    let sum: u64 = r.records.iter().map(|x| x.latency_ms).sum();
+    // Parallel total wall should be < sum of individual latencies
+    // for a 3-way parallel group. We accept equality on very fast runs
+    // (everything rounds to 0 ms) — the important property is <=.
+    assert!(
+        r.total_latency_ms <= sum,
+        "parallel wall {} should be <= serial sum {}",
+        r.total_latency_ms,
+        sum
+    );
+}
+
+#[tokio::test]
+async fn same_prompt_reuses_question_node() {
+    let (store, rt) = new_runtime_with_fixture().await;
+    let plan = ToolPlan {
+        calls: vec![ToolCall {
+            tool: "cypher".into(),
+            args: json!({"query": "MATCH (n:Person) RETURN count(n)"}),
+            parallel_with_prev: false,
+        }],
+    };
+    rt.execute_plan("identical", &plan).await.unwrap();
+    rt.execute_plan("identical", &plan).await.unwrap();
+    rt.execute_plan("different", &plan).await.unwrap();
+
+    let g = store.read().await;
+    let questions = g.get_nodes_by_label(&Label::new("Question"));
+    assert_eq!(
+        questions.len(),
+        2,
+        "expected 2 distinct Question nodes (identical dedups, different is new)"
+    );
+    let edges = g.get_edges_by_type(&samyama::graph::EdgeType::new("USED_TOOL"));
+    assert_eq!(edges.len(), 3);
+}
+
+#[tokio::test]
+async fn unknown_tool_records_error_without_panicking() {
+    let (store, rt) = new_runtime_with_fixture().await;
+    let plan = ToolPlan {
+        calls: vec![ToolCall {
+            tool: "not_registered".into(),
+            args: json!({}),
+            parallel_with_prev: false,
+        }],
+    };
+    let r = rt.execute_plan("bad tool", &plan).await.unwrap();
+    assert_eq!(r.records.len(), 1);
+    assert!(r.records[0].error.is_some());
+    assert_eq!(r.records[0].hit_rate, 0.0);
+
+    let g = store.read().await;
+    let edges = g.get_edges_by_type(&samyama::graph::EdgeType::new("USED_TOOL"));
+    assert_eq!(edges.len(), 1);
+    assert!(edges[0].get_property("error").is_some());
+}
+
+#[tokio::test]
+async fn runtime_without_store_refuses_execute_plan() {
+    let engine = Arc::new(QueryEngine::new());
+    let store = Arc::new(RwLock::new(GraphStore::new()));
+    let mut rt = AgentRuntime::new(mock_agent_config());
+    rt.register_tool(Arc::new(CypherTool::new(engine, store)));
+    let plan = ToolPlan {
+        calls: vec![ToolCall {
+            tool: "cypher".into(),
+            args: json!({"query": "MATCH (n) RETURN n"}),
+            parallel_with_prev: false,
+        }],
+    };
+    let err = rt.execute_plan("no store", &plan).await.unwrap_err();
+    assert!(format!("{err}").contains("no store"));
+}


### PR DESCRIPTION
OSS port of samyama-graph-enterprise PR #206 (already merged there).

Wires the plan/execute loop UC5's wiki design assumed but that wasn't implemented. Two new modules (\`agent::planner\`, \`agent::executor\`), plus a real \`CypherTool\` that wires straight to the same \`QueryEngine\` the RESP/HTTP layers use.

## Edge schema
\`(:Question {qid, text})-[:USED_TOOL {latency_ms, token_cost, hit_rate, slot, ts_ms, error?}]->(:Tool {tid})\`

Question nodes deduplicated by \`qid = sha256(prompt)[:16]\`.

## Tests
- sequential plan writes two edges sharing one Question + one Tool
- 3-way parallel group wall-clock <= serial sum
- identical prompts dedup to the same Question node
- unknown tool records an error edge, doesn't panic
- runtime without store refuses \`execute_plan\`

5/5 new tests pass; 22/22 pre-existing agent tests still pass.

## Known limitations / deferred
- \`process_trigger\` unchanged; HTTP enrich path doesn't use the new plan loop yet.
- Hit-rate is a heuristic. A real signal (was the tool's output used in the final answer?) needs an answer-synthesizer step.
- Token cost is bytes/4. For LLM-backed tools we'd pull tokens from the provider response.

## Test plan
- [x] \`cargo test --test age_plan_executor_test\` — 5/5 pass
- [x] \`cargo test --lib agent\` — 22/22 pass