### PR TITLE
feat(http): expose UC2 (drug-combination dosing) on /optimize/solve

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -3,6 +3,7 @@
 pub mod server;
 pub mod handler;
 pub mod optimize;
+pub mod uc_problems;
 
 pub use server::HttpServer;
 

--- a/src/http/optimize.rs
+++ b/src/http/optimize.rs
@@ -262,6 +262,7 @@ fn benchmark_catalog() -> Vec<BenchmarkInfo> {
         BenchmarkInfo { id: "zdt2",       name: "ZDT2",       dim: 30, lower: 0.0,      upper: 1.0,     num_objectives: 2, ty: "multi",  optimum: None },
         BenchmarkInfo { id: "zdt3",       name: "ZDT3",       dim: 30, lower: 0.0,      upper: 1.0,     num_objectives: 2, ty: "multi",  optimum: None },
         BenchmarkInfo { id: "dtlz1",      name: "DTLZ1",      dim: 7,  lower: 0.0,      upper: 1.0,     num_objectives: 3, ty: "multi",  optimum: None },
+        BenchmarkInfo { id: "uc2_dosing", name: "UC2 — Drug-combination dosing", dim: 6, lower: 0.0, upper: 1.0, num_objectives: 3, ty: "usecase", optimum: None },
     ]
 }
 
@@ -534,6 +535,25 @@ fn run_solver(
                 // Drop individuals with non-finite objective values — serde_json
                 // serializes NaN/Inf as null, which breaks downstream consumers
                 // (e.g. the samyama-insight Pareto chart).
+                let pareto: Vec<Vec<f64>> = r.pareto_front.iter()
+                    .filter(|ind| ind.fitness.iter().all(|v| v.is_finite()))
+                    .map(|ind| ind.fitness.clone())
+                    .collect();
+                (r.history, final_first, pareto)
+            }
+            "uc2_dosing" => {
+                let problem = super::uc_problems::UC2DosingProblem::new();
+                let r = match algo_id {
+                    "mo_bmr"    => MOBMWRSolver::new(cfg, MOBMWRVariant::MOBMR).solve(&problem),
+                    "mo_bwr"    => MOBMWRSolver::new(cfg, MOBMWRVariant::MOBWR).solve(&problem),
+                    "mo_bmwr"   => MOBMWRSolver::new(cfg, MOBMWRVariant::MOBMWR).solve(&problem),
+                    "mo_rao_de" => MORaoDESolver::new(cfg).solve(&problem),
+                    "nsga2"     => NSGA2Solver::new(cfg).solve(&problem),
+                    _           => return Err(format!("algorithm {} not multi-objective", algo_id)),
+                };
+                let final_first = r.pareto_front.iter()
+                    .map(|ind| ind.fitness[0])
+                    .fold(f64::INFINITY, f64::min);
                 let pareto: Vec<Vec<f64>> = r.pareto_front.iter()
                     .filter(|ind| ind.fitness.iter().all(|v| v.is_finite()))
                     .map(|ind| ind.fitness.clone())

--- a/src/http/uc_problems.rs
+++ b/src/http/uc_problems.rs
@@ -1,0 +1,211 @@
+//! Use-case Cypher-driven multi-objective problems, exposed through
+//! `/optimize/solve` so they render on the same Pareto chart as the
+//! synthetic ZDT/DTLZ1 benchmarks.
+//!
+//! Each UC owns its embedded GraphStore + QueryEngine; the fitness fn
+//! queries its own graph (no shared state, no async locks). Runs inside
+//! the existing spawn_blocking so QueryEngine's sync API is natural.
+
+use crate::graph::GraphStore;
+use crate::query::QueryEngine;
+use ndarray::Array1;
+use samyama_optimization::common::MultiObjectiveProblem;
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+/// UC2 — Drug-combination dosing. Mirrors `examples/uc2_combo_dosing.rs`:
+/// 6 drugs, 7 genes, 4 pathways, 1 disease, 7 INTERACTS_WITH edges
+/// including a contraindicated pair (D3+D4, severity 1.0). Fitness runs
+/// two Cypher queries per candidate and composes a 3-vector of
+/// (-efficacy, risk, total_dose), with a 1e6 penalty added to every
+/// objective when the contraindicated pair is simultaneously active.
+pub struct UC2DosingProblem {
+    engine: QueryEngine,
+    store: RwLock<GraphStore>,
+    drug_dids: Vec<&'static str>,
+}
+
+const UC2_DISEASE: &str = "type2_diabetes";
+const UC2_DRUGS: &[(&str, &str, f64)] = &[
+    ("D0", "metformin", 2000.0),
+    ("D1", "sitagliptin", 100.0),
+    ("D2", "empagliflozin", 25.0),
+    ("D3", "simvastatin", 40.0),
+    ("D4", "clarithromycin", 1000.0),
+    ("D5", "warfarin", 10.0),
+];
+const UC2_TARGETS: &[(&str, &str)] = &[
+    ("D0", "AMPK"), ("D0", "GLUT4"), ("D1", "DPP4"), ("D2", "SGLT2"),
+    ("D3", "HMGCR"), ("D4", "50S"), ("D5", "VKOR"),
+];
+const UC2_PART_OF: &[(&str, &str)] = &[
+    ("AMPK", "glucose_homeostasis"), ("GLUT4", "glucose_homeostasis"),
+    ("DPP4", "glucose_homeostasis"), ("SGLT2", "glucose_homeostasis"),
+    ("HMGCR", "lipid_metabolism"), ("50S", "antibiotic"), ("VKOR", "coagulation"),
+];
+const UC2_IMPLICATED: &[(&str, &str)] = &[("glucose_homeostasis", UC2_DISEASE)];
+const UC2_INTERACTIONS: &[(&str, &str, f64)] = &[
+    ("D0", "D1", 0.1), ("D0", "D2", 0.1), ("D1", "D2", 0.1),
+    ("D0", "D3", 0.3), ("D3", "D5", 0.7),
+    ("D3", "D4", 1.0), // contraindicated
+    ("D4", "D5", 0.3),
+];
+
+impl UC2DosingProblem {
+    pub fn new() -> Self {
+        let mut store = GraphStore::new();
+        let mut drug_id = HashMap::<&str, crate::graph::NodeId>::new();
+        for (did, name, max_dose) in UC2_DRUGS {
+            let nid = store.create_node("Drug");
+            if let Some(n) = store.get_node_mut(nid) {
+                n.set_property("did", *did);
+                n.set_property("name", *name);
+                n.set_property("max_dose_mg", *max_dose);
+            }
+            drug_id.insert(*did, nid);
+        }
+        let mut genes: Vec<&str> = UC2_TARGETS.iter().map(|(_, g)| *g).collect();
+        genes.sort(); genes.dedup();
+        let mut gene_id = HashMap::<&str, crate::graph::NodeId>::new();
+        for g in &genes {
+            let nid = store.create_node("Gene");
+            if let Some(n) = store.get_node_mut(nid) { n.set_property("gid", *g); }
+            gene_id.insert(*g, nid);
+        }
+        let mut pathways: Vec<&str> = UC2_PART_OF.iter().map(|(_, p)| *p).collect();
+        pathways.sort(); pathways.dedup();
+        let mut pathway_id = HashMap::<&str, crate::graph::NodeId>::new();
+        for p in &pathways {
+            let nid = store.create_node("Pathway");
+            if let Some(n) = store.get_node_mut(nid) { n.set_property("pid", *p); }
+            pathway_id.insert(*p, nid);
+        }
+        let dz = store.create_node("Disease");
+        if let Some(n) = store.get_node_mut(dz) { n.set_property("did", UC2_DISEASE); }
+
+        for (d, g) in UC2_TARGETS {
+            store.create_edge(drug_id[d], gene_id[g], "TARGETS").unwrap();
+        }
+        for (g, p) in UC2_PART_OF {
+            store.create_edge(gene_id[g], pathway_id[p], "PART_OF").unwrap();
+        }
+        for (p, _) in UC2_IMPLICATED {
+            store.create_edge(pathway_id[p], dz, "IMPLICATED_IN").unwrap();
+        }
+        for (a, b, sev) in UC2_INTERACTIONS {
+            let eid = store.create_edge(drug_id[a], drug_id[b], "INTERACTS_WITH").unwrap();
+            store.set_edge_property(eid, "severity_score", *sev).unwrap();
+        }
+
+        Self {
+            engine: QueryEngine::new(),
+            store: RwLock::new(store),
+            drug_dids: UC2_DRUGS.iter().map(|(d, ..)| *d).collect(),
+        }
+    }
+
+    fn run(&self, q: &str) -> crate::query::RecordBatch {
+        let s = self.store.read().unwrap();
+        self.engine.execute(q, &*s).unwrap_or_else(|e| panic!("uc2 cypher: {e}\n{q}"))
+    }
+}
+
+impl Default for UC2DosingProblem {
+    fn default() -> Self { Self::new() }
+}
+
+impl MultiObjectiveProblem for UC2DosingProblem {
+    fn dim(&self) -> usize { self.drug_dids.len() }
+    fn num_objectives(&self) -> usize { 3 }
+    fn bounds(&self) -> (Array1<f64>, Array1<f64>) {
+        (Array1::zeros(self.dim()), Array1::ones(self.dim()))
+    }
+    fn objectives(&self, x: &Array1<f64>) -> Vec<f64> {
+        use crate::graph::PropertyValue as P;
+        use crate::query::executor::record::Value as V;
+
+        let active_idx: Vec<usize> = (0..self.drug_dids.len()).filter(|&i| x[i] >= 0.05).collect();
+        if active_idx.is_empty() { return vec![0.0, 0.0, 0.0]; }
+        let id_list = active_idx.iter().map(|&i| format!("\"{}\"", self.drug_dids[i]))
+            .collect::<Vec<_>>().join(", ");
+
+        let q1 = format!(
+            "MATCH (d:Drug)-[:TARGETS]->(:Gene)-[:PART_OF]->(p:Pathway)-[:IMPLICATED_IN]->(dz:Disease) \
+             WHERE d.did IN [{id_list}] AND dz.did = \"{UC2_DISEASE}\" \
+             RETURN d.did AS did, count(DISTINCT p) AS coverage"
+        );
+        let r1 = self.run(&q1);
+        let mut coverage = HashMap::<String, f64>::new();
+        for rec in &r1.records {
+            let did = match rec.get("did") { Some(V::Property(P::String(s))) => s.clone(), _ => continue };
+            let cov = match rec.get("coverage") { Some(V::Property(P::Integer(i))) => *i as f64, _ => 0.0 };
+            coverage.insert(did, cov);
+        }
+
+        let q2 = format!(
+            "MATCH (a:Drug)-[r:INTERACTS_WITH]->(b:Drug) \
+             WHERE a.did IN [{id_list}] AND b.did IN [{id_list}] \
+             RETURN a.did AS a, b.did AS b, r.severity_score AS sev"
+        );
+        let r2 = self.run(&q2);
+
+        let efficacy: f64 = active_idx.iter().map(|&i| {
+            let cov = coverage.get(self.drug_dids[i]).copied().unwrap_or(0.0);
+            x[i] * cov
+        }).sum();
+
+        let did_to_idx: HashMap<&str, usize> = self.drug_dids.iter().enumerate()
+            .map(|(i, &d)| (d, i)).collect();
+        let mut risk = 0.0_f64;
+        let mut bad = false;
+        for rec in &r2.records {
+            let a = match rec.get("a") { Some(V::Property(P::String(s))) => s.as_str(), _ => continue };
+            let b = match rec.get("b") { Some(V::Property(P::String(s))) => s.as_str(), _ => continue };
+            let sev = match rec.get("sev") {
+                Some(V::Property(P::Float(f))) => *f,
+                Some(V::Property(P::Integer(i))) => *i as f64,
+                _ => 0.0,
+            };
+            if let (Some(&ia), Some(&ib)) = (did_to_idx.get(a), did_to_idx.get(b)) {
+                risk += sev * x[ia] * x[ib];
+                if sev >= 0.999 && x[ia] >= 0.05 && x[ib] >= 0.05 { bad = true; }
+            }
+        }
+        let total_dose: f64 = (0..self.drug_dids.len()).map(|i| x[i]).sum();
+        let penalty = if bad { 1e6 } else { 0.0 };
+        vec![-efficacy + penalty, risk + penalty, total_dose + penalty]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uc2_built_graph_has_expected_shape() {
+        let p = UC2DosingProblem::new();
+        // smoke-check via cypher: 6 drugs, 7 interactions.
+        let g = p.store.read().unwrap();
+        let drugs = g.get_nodes_by_label(&crate::graph::Label::new("Drug"));
+        assert_eq!(drugs.len(), 6);
+        let ints = g.get_edges_by_type(&crate::graph::EdgeType::new("INTERACTS_WITH"));
+        assert_eq!(ints.len(), 7);
+    }
+
+    #[test]
+    fn uc2_empty_plan_returns_zero_vector() {
+        let p = UC2DosingProblem::new();
+        let x = Array1::zeros(6);
+        assert_eq!(p.objectives(&x), vec![0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn uc2_contraindicated_pair_gets_penalty() {
+        let p = UC2DosingProblem::new();
+        // D3 + D4 both active at 0.5, others zero — penalty must apply.
+        let x = Array1::from(vec![0.0, 0.0, 0.0, 0.5, 0.5, 0.0]);
+        let obj = p.objectives(&x);
+        // Every objective carries the 1e6 penalty.
+        for v in &obj { assert!(*v >= 1e5, "expected penalty in {:?}", obj); }
+    }
+}

--- a/tests/optimize_http_test.rs
+++ b/tests/optimize_http_test.rs
@@ -334,3 +334,95 @@ async fn nsga2_zdt1_last_iteration_event_carries_pareto_front() {
     let pt = front[0].as_array().unwrap();
     assert_eq!(pt.len(), 2);
 }
+
+#[tokio::test]
+async fn benchmarks_endpoint_exposes_uc2_dosing() {
+    let app = router();
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/optimize/benchmarks")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let v = body_to_json(res.into_body()).await;
+    let arr = v.as_array().unwrap();
+    let uc2 = arr.iter().find(|b| b["id"] == "uc2_dosing")
+        .expect("uc2_dosing must be listed in /optimize/benchmarks");
+    assert_eq!(uc2["num_objectives"], 3);
+    assert_eq!(uc2["type"], "usecase");
+    assert_eq!(uc2["dim"], 6);
+}
+
+#[tokio::test]
+async fn nsga2_uc2_dosing_produces_three_objective_pareto() {
+    // End-to-end: /optimize/solve with uc2_dosing + nsga2 must build the
+    // embedded graph, run the Cypher-driven fitness, and emit a 3-objective
+    // Pareto front on the done event. Same SSE shape as ZDT/DTLZ1 so the
+    // Spec-34 Pareto chart renders it without UI changes.
+    let app = router();
+
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/optimize/solve")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "algorithm": "nsga2",
+                        "benchmark": "uc2_dosing",
+                        "population_size": 30,
+                        "iterations": 30
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let job_id = body_to_json(res.into_body()).await["job_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let stream_res = tokio::time::timeout(Duration::from_secs(30), async {
+        app.oneshot(
+            Request::builder()
+                .uri(format!("/optimize/solve/{}/stream", job_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+    })
+    .await
+    .expect("stream request timed out");
+    assert_eq!(stream_res.status(), StatusCode::OK);
+
+    let bytes = stream_res.into_body().collect().await.unwrap().to_bytes();
+    let text = String::from_utf8_lossy(&bytes);
+    let done_line = text
+        .lines()
+        .skip_while(|l| !l.starts_with("event: done"))
+        .nth(1)
+        .expect("done event line");
+    let done: Value = serde_json::from_str(done_line.trim_start_matches("data: ")).unwrap();
+    let pareto = done["final_pareto"].as_array().expect("final_pareto array");
+    assert!(!pareto.is_empty());
+    let pt0 = pareto[0].as_array().unwrap();
+    assert_eq!(pt0.len(), 3, "uc2_dosing has 3 objectives");
+    // No plan on the front may carry the 1e6 contraindicated-pair penalty.
+    for pt in pareto.iter() {
+        let arr = pt.as_array().unwrap();
+        for v in arr {
+            let f = v.as_f64().unwrap();
+            assert!(f < 1e5, "Pareto point {pt} carries a penalty");
+        }
+    }
+}


### PR DESCRIPTION
Surfaces the first SGE+optimization use-case on the same \`/optimize/*\` API that the Spec-34 Pareto chart already consumes — **no UI changes required**, the existing samyama-insight chart renders the 3-objective front out of the box.

## What's new
- \`UC2DosingProblem\` in \`src/http/uc_problems.rs\`: owns its embedded GraphStore + QueryEngine, mirrors \`examples/uc2_combo_dosing.rs\`'s 6-drug / 7-interaction fixture
- \`uc2_dosing\` entry in \`/optimize/benchmarks\` (type: \`usecase\`, 3 objectives, 6-dim)
- Wired into \`run_solver\`'s multi-objective branch — works with NSGA-II / MO-Rao+DE / MO-BMR / MO-BWR / MO-BMWR

## Tests
- 3 unit tests on \`UC2DosingProblem\` (graph shape, empty plan, penalty)
- \`/optimize/benchmarks\` lists \`uc2_dosing\`
- \`/optimize/solve\` end-to-end with NSGA-II returns a 3-objective Pareto where every plan is below the 1e6 penalty threshold

8/8 \`optimize_http_test\` tests pass (6 pre-existing + 2 new).

## How to use from the UI
After merging, \`uc2_dosing\` shows up in the existing benchmark dropdown alongside ZDT/DTLZ1. Pick \`nsga2\` algorithm, hit Run — the Pareto chart renders the 3-objective drug-combination front. No frontend work needed.

## Followups
- UC5 (agent routing) is the same pattern; deferred to a separate small PR
- Lovable prompt to add a "Use cases" section header in the benchmark dropdown so they're visually grouped (optional polish)