### PR TITLE
HA-08 + HA-09: snapshot persistence and unified tenant registry

### DIFF
--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -664,17 +664,16 @@ pub async fn restore_snapshot_handler(
 
     match crate::snapshot::import_tenant_with_dedup(&mut store_guard, cursor, &dedup_key_refs) {
         Ok(stats) => {
-            // HA-08: Persist snapshot to disk so it survives server restart
+            // HA-08: Persist snapshot atomically (tmp → fsync → rename → marker)
+            // so it survives server restart. Crash-before-marker = ignored on boot.
             if let Some(ref data_path) = state.data_path {
-                let snap_dir = format!("{}/snapshots", data_path);
-                if let Err(e) = std::fs::create_dir_all(&snap_dir) {
-                    eprintln!("[snapshot-persist] Failed to create dir {}: {}", snap_dir, e);
-                } else {
-                    let snap_path = format!("{}/default.sgsnap", snap_dir);
-                    match std::fs::write(&snap_path, &data) {
-                        Ok(_) => eprintln!("[snapshot-persist] Saved {} ({} bytes)", snap_path, data.len()),
-                        Err(e) => eprintln!("[snapshot-persist] Failed to write {}: {}", snap_path, e),
-                    }
+                match crate::snapshot::persist::persist_snapshot(data_path, &data) {
+                    Ok(_) => eprintln!(
+                        "[snapshot-persist] Committed snapshot to {}/snapshots ({} bytes)",
+                        data_path,
+                        data.len()
+                    ),
+                    Err(e) => eprintln!("[snapshot-persist] Failed to persist: {}", e),
                 }
             }
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -3,6 +3,7 @@
 pub mod server;
 pub mod handler;
 pub mod optimize;
+pub mod tenants;
 pub mod uc_problems;
 
 pub use server::HttpServer;

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -6,6 +6,7 @@ use axum::{
     response::{Html, IntoResponse},
 };
 use crate::graph::GraphStore;
+use crate::persistence::TenantManager;
 use crate::query::QueryEngine;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -17,6 +18,12 @@ use super::handler::{
     import_csv_handler, import_json_handler,
     export_snapshot_handler, restore_snapshot_handler,
 };
+
+/// HA-09: Build the tenant CRUD sub-router backed by the shared `TenantManager`.
+/// Exposed at the crate level so integration tests can mount it in isolation.
+pub fn build_tenant_router(tenants: Arc<TenantManager>) -> axum::Router {
+    super::tenants::router(tenants)
+}
 use rust_embed::RustEmbed;
 
 #[derive(RustEmbed)]
@@ -47,17 +54,25 @@ pub struct HttpServer {
     store: Arc<RwLock<GraphStore>>,
     port: u16,
     data_path: Option<String>,
+    tenants: Option<Arc<TenantManager>>,
 }
 
 impl HttpServer {
     /// Create a new HTTP server
     pub fn new(store: Arc<RwLock<GraphStore>>, port: u16) -> Self {
-        Self { store, port, data_path: None }
+        Self { store, port, data_path: None, tenants: None }
     }
 
     /// Set the data directory for snapshot persistence (HA-08)
     pub fn with_data_path(mut self, path: Option<String>) -> Self {
         self.data_path = path;
+        self
+    }
+
+    /// HA-09: share a `TenantManager` with the RESP command handler so
+    /// tenants created via HTTP are immediately visible to `GRAPH.LIST`.
+    pub fn with_tenant_manager(mut self, tenants: Arc<TenantManager>) -> Self {
+        self.tenants = Some(tenants);
         self
     }
 
@@ -84,9 +99,14 @@ impl HttpServer {
                 .layer(DefaultBodyLimit::max(2 * 1024 * 1024 * 1024))) // 2 GB
             .with_state(state);
 
-        let app = main_router
-            .merge(super::optimize::router().with_state(optimize_state))
-            .layer(CorsLayer::permissive());
+        let mut app = main_router
+            .merge(super::optimize::router().with_state(optimize_state));
+
+        if let Some(tm) = self.tenants.as_ref() {
+            app = app.merge(super::tenants::router(Arc::clone(tm)));
+        }
+
+        let app = app.layer(CorsLayer::permissive());
 
         let addr = format!("0.0.0.0:{}", self.port);
         let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/src/http/tenants.rs
+++ b/src/http/tenants.rs
@@ -1,0 +1,134 @@
+//! HA-09: HTTP endpoints for tenant CRUD, backed by the shared `TenantManager`.
+//!
+//! Routes:
+//! - `POST   /api/tenants`       — create a tenant
+//! - `GET    /api/tenants`       — list all tenants
+//! - `GET    /api/tenants/:id`   — get one tenant
+//! - `DELETE /api/tenants/:id`   — delete a tenant
+//!
+//! A tenant created here is immediately visible to the RESP `GRAPH.LIST`
+//! command because the same `Arc<TenantManager>` backs both paths.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{delete, get, post},
+    Json, Router,
+};
+use serde::Deserialize;
+use serde_json::json;
+use std::sync::Arc;
+
+use crate::persistence::{ResourceQuotas, TenantError, TenantManager};
+
+#[derive(Clone)]
+pub struct TenantState {
+    pub tenants: Arc<TenantManager>,
+}
+
+#[derive(Deserialize)]
+pub struct CreateTenantBody {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub quotas: Option<ResourceQuotas>,
+}
+
+fn tenant_to_json(t: &crate::persistence::Tenant) -> serde_json::Value {
+    json!({
+        "id": t.id,
+        "name": t.name,
+        "enabled": t.enabled,
+    })
+}
+
+pub async fn create_tenant(
+    State(state): State<TenantState>,
+    Json(body): Json<CreateTenantBody>,
+) -> impl IntoResponse {
+    match state.tenants.create_tenant(body.id.clone(), body.name.clone(), body.quotas) {
+        Ok(()) => match state.tenants.get_tenant(&body.id) {
+            Ok(t) => (StatusCode::CREATED, Json(tenant_to_json(&t))).into_response(),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response(),
+        },
+        Err(TenantError::AlreadyExists(id)) => (
+            StatusCode::CONFLICT,
+            Json(json!({ "error": format!("Tenant '{}' already exists", id) })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+pub async fn list_tenants(State(state): State<TenantState>) -> impl IntoResponse {
+    let mut tenants = state.tenants.list_tenants();
+    tenants.sort_by(|a, b| a.id.cmp(&b.id));
+    let body = json!({
+        "tenants": tenants.iter().map(tenant_to_json).collect::<Vec<_>>(),
+    });
+    (StatusCode::OK, Json(body)).into_response()
+}
+
+pub async fn get_tenant(
+    State(state): State<TenantState>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match state.tenants.get_tenant(&id) {
+        Ok(t) => (StatusCode::OK, Json(tenant_to_json(&t))).into_response(),
+        Err(TenantError::NotFound(_)) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": format!("Tenant '{}' not found", id) })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+pub async fn delete_tenant(
+    State(state): State<TenantState>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match state.tenants.delete_tenant(&id) {
+        Ok(()) => (StatusCode::NO_CONTENT, ()).into_response(),
+        Err(TenantError::NotFound(_)) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": format!("Tenant '{}' not found", id) })),
+        )
+            .into_response(),
+        Err(TenantError::PermissionDenied(msg)) => (
+            StatusCode::FORBIDDEN,
+            Json(json!({ "error": msg })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+/// Build the tenant CRUD router, parameterised on the shared `TenantManager`.
+pub fn router(tenants: Arc<TenantManager>) -> Router {
+    let state = TenantState { tenants };
+    Router::new()
+        .route("/api/tenants", post(create_tenant).get(list_tenants))
+        .route(
+            "/api/tenants/:id",
+            get(get_tenant).delete(delete_tenant),
+        )
+        .with_state(state)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -525,6 +525,13 @@ async fn start_server() {
     let store = Arc::new(RwLock::new(graph));
     let http_data_path = config.data_path.clone();
 
+    // HA-09: one TenantManager shared between RESP and HTTP so a tenant
+    // created via either path is visible to both.
+    let shared_tenants: Arc<samyama::persistence::TenantManager> = persistence
+        .as_ref()
+        .map(|pm| pm.tenants_arc())
+        .unwrap_or_else(|| Arc::new(samyama::persistence::TenantManager::new()));
+
     println!("\nServer starting on {}:{}", config.address, config.port);
 
     // Start background indexer now that store is wrapped in Arc
@@ -534,20 +541,18 @@ async fn start_server() {
 
     // Start HTTP server for Visualizer API on port 8080
     let http_store = Arc::clone(&store);
+    let http_tenants = Arc::clone(&shared_tenants);
     tokio::spawn(async move {
         let http_server = HttpServer::new(http_store, 8080)
-            .with_data_path(http_data_path);
+            .with_data_path(http_data_path)
+            .with_tenant_manager(http_tenants);
         println!("HTTP server starting on port 8080 (visualizer + API)");
         if let Err(e) = http_server.start().await {
             eprintln!("HTTP server error: {}", e);
         }
     });
 
-    let server = if let Some(pm) = persistence {
-        RespServer::new_with_persistence(config, store, pm)
-    } else {
-        RespServer::new(config, store)
-    };
+    let server = RespServer::new_with_tenants(config, store, persistence, shared_tenants);
 
     println!("Server ready. Press Ctrl+C to stop.\n");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -503,11 +503,27 @@ async fn start_server() {
         }
     }
 
+    // HA-08: If no RocksDB recovery happened, replay the last committed .sgsnap
+    // snapshot from <data_path>/snapshots/ so imports survive restart.
+    if !recovered {
+        if let Some(path) = &config.data_path {
+            match samyama::snapshot::persist::restore_persisted_snapshots(path, &mut graph) {
+                Ok(Some(stats)) => println!(
+                    "[snapshot-persist] Restored {} nodes, {} edges from {}/snapshots",
+                    stats.node_count, stats.edge_count, path
+                ),
+                Ok(None) => {}
+                Err(e) => eprintln!("[snapshot-persist] Restore error: {}", e),
+            }
+        }
+    }
+
     println!("\nGraph Statistics:");
     println!("  Total nodes: {}", graph.node_count());
     println!("  Total edges: {}", graph.edge_count());
 
     let store = Arc::new(RwLock::new(graph));
+    let http_data_path = config.data_path.clone();
 
     println!("\nServer starting on {}:{}", config.address, config.port);
 
@@ -519,7 +535,8 @@ async fn start_server() {
     // Start HTTP server for Visualizer API on port 8080
     let http_store = Arc::clone(&store);
     tokio::spawn(async move {
-        let http_server = HttpServer::new(http_store, 8080);
+        let http_server = HttpServer::new(http_store, 8080)
+            .with_data_path(http_data_path);
         println!("HTTP server starting on port 8080 (visualizer + API)");
         if let Err(e) = http_server.start().await {
             eprintln!("HTTP server error: {}", e);

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -106,6 +106,11 @@ impl PersistenceManager {
         &self.tenants
     }
 
+    /// Get a cloneable handle to the shared tenant registry (HA-09).
+    pub fn tenants_arc(&self) -> Arc<TenantManager> {
+        Arc::clone(&self.tenants)
+    }
+
     /// Start the background indexer for a store
     pub fn start_indexer(&self, store: &GraphStore, receiver: tokio::sync::mpsc::UnboundedReceiver<crate::graph::event::IndexEvent>) {
         let vector_index = Arc::clone(&store.vector_index);

--- a/src/protocol/command.rs
+++ b/src/protocol/command.rs
@@ -4,7 +4,7 @@
 //! Now with persistence support - writes are persisted to disk when enabled
 
 use crate::graph::GraphStore;
-use crate::persistence::PersistenceManager;
+use crate::persistence::{PersistenceManager, TenantManager};
 use crate::protocol::resp::RespValue;
 use crate::query::{QueryEngine, Value};
 use std::sync::Arc;
@@ -16,16 +16,45 @@ pub struct CommandHandler {
     query_engine: QueryEngine,
     /// Optional persistence manager - when Some, writes are persisted to disk
     persistence: Option<Arc<PersistenceManager>>,
+    /// Shared tenant registry — HA-09 unifies HTTP + RESP views
+    tenant_manager: Arc<TenantManager>,
 }
 
 impl CommandHandler {
     /// Create a new command handler
-    /// Pass Some(persistence) to enable persistence, or None for in-memory only
+    /// Pass Some(persistence) to enable persistence, or None for in-memory only.
+    /// When persistence is Some, its TenantManager is reused; otherwise a fresh
+    /// one is created. For tests/integrations that need to share a registry
+    /// across HTTP+RESP, use `new_with_tenants` instead.
     pub fn new(persistence: Option<Arc<PersistenceManager>>) -> Self {
+        let tenant_manager = persistence
+            .as_ref()
+            .map(|p| p.tenants_arc())
+            .unwrap_or_else(|| Arc::new(TenantManager::new()));
         Self {
             query_engine: QueryEngine::new(),
             persistence,
+            tenant_manager,
         }
+    }
+
+    /// Create a command handler that shares a pre-existing `TenantManager`.
+    /// Both the RESP path and the HTTP tenant routes must see the same `Arc`
+    /// to satisfy HA-09 (cross-registry visibility).
+    pub fn new_with_tenants(
+        persistence: Option<Arc<PersistenceManager>>,
+        tenant_manager: Arc<TenantManager>,
+    ) -> Self {
+        Self {
+            query_engine: QueryEngine::new(),
+            persistence,
+            tenant_manager,
+        }
+    }
+
+    /// Access the shared tenant registry (for HTTP wiring in main).
+    pub fn tenant_manager(&self) -> Arc<TenantManager> {
+        Arc::clone(&self.tenant_manager)
     }
 
     /// Handle a RESP command
@@ -202,16 +231,24 @@ impl CommandHandler {
         RespValue::SimpleString("OK".to_string())
     }
 
-    /// Handle GRAPH.LIST command
+    /// Handle GRAPH.LIST command — reads from the shared TenantManager (HA-09).
     async fn handle_graph_list(
         &self,
         _args: &[RespValue],
         _store: &Arc<RwLock<GraphStore>>,
     ) -> RespValue {
-        // For single-graph mode, return a single graph
-        RespValue::Array(vec![
-            RespValue::BulkString(Some(b"default".to_vec())),
-        ])
+        let mut ids: Vec<String> = self
+            .tenant_manager
+            .list_tenants()
+            .into_iter()
+            .map(|t| t.id)
+            .collect();
+        ids.sort();
+        RespValue::Array(
+            ids.into_iter()
+                .map(|id| RespValue::BulkString(Some(id.into_bytes())))
+                .collect(),
+        )
     }
 
     /// Handle PING command

--- a/src/protocol/server.rs
+++ b/src/protocol/server.rs
@@ -92,6 +92,34 @@ impl RespServer {
         }
     }
 
+    /// HA-09: Create a RESP server that shares a pre-existing `TenantManager`
+    /// with HTTP routes, so tenants created via either path are visible to both.
+    pub fn new_with_tenants(
+        config: ServerConfig,
+        store: Arc<RwLock<GraphStore>>,
+        persistence: Option<Arc<PersistenceManager>>,
+        tenants: Arc<crate::persistence::TenantManager>,
+    ) -> Self {
+        let handler = Arc::new(CommandHandler::new_with_tenants(
+            persistence.as_ref().map(Arc::clone),
+            tenants,
+        ));
+        Self {
+            config,
+            store,
+            handler,
+            persistence,
+            router: None,
+            proxy: None,
+            cluster_manager: None,
+        }
+    }
+
+    /// Access the shared tenant registry (for wiring HTTP routes).
+    pub fn tenant_manager(&self) -> Arc<crate::persistence::TenantManager> {
+        self.handler.tenant_manager()
+    }
+
     /// Enable sharding for this server
     pub fn with_sharding(
         mut self,

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -8,6 +8,7 @@
 //! On import, old node IDs are remapped to new IDs via a HashMap.
 
 pub mod format;
+pub mod persist;
 
 use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Read, Write};

--- a/src/snapshot/persist.rs
+++ b/src/snapshot/persist.rs
@@ -1,0 +1,108 @@
+//! HA-08: Durable snapshot persistence.
+//!
+//! Pattern: Redis RDB. Bulk imports bypass the WAL; durability is handled by
+//! writing the received .sgsnap bytes to disk atomically (tmp → fsync → rename),
+//! then dropping a `<file>.committed` marker. On boot the server scans the
+//! snapshot directory and only replays snapshots whose marker is present, so a
+//! crash mid-flush leaves no partial state in play.
+
+use std::fs::{self, File};
+use std::io::{Cursor, Write};
+use std::path::{Path, PathBuf};
+
+use crate::graph::store::GraphStore;
+use crate::snapshot::format::ImportStats;
+
+/// Filename used for the single-tenant default snapshot.
+const DEFAULT_SNAPSHOT_NAME: &str = "default.sgsnap";
+const COMMITTED_SUFFIX: &str = ".committed";
+const TMP_SUFFIX: &str = ".tmp";
+
+fn snapshot_dir(data_path: &str) -> PathBuf {
+    Path::new(data_path).join("snapshots")
+}
+
+/// Atomically persist `bytes` as `<data_path>/snapshots/default.sgsnap`.
+///
+/// Sequence:
+/// 1. Create `snapshots/` if missing.
+/// 2. Write bytes to `default.sgsnap.tmp`, fsync.
+/// 3. Rename tmp → `default.sgsnap`.
+/// 4. Drop empty marker file `default.sgsnap.committed`, fsync.
+///
+/// A crash between steps leaves either no marker (ignored on boot) or a
+/// fully-written file with marker (replayed on boot).
+pub fn persist_snapshot(data_path: &str, bytes: &[u8]) -> std::io::Result<()> {
+    let dir = snapshot_dir(data_path);
+    fs::create_dir_all(&dir)?;
+
+    let final_path = dir.join(DEFAULT_SNAPSHOT_NAME);
+    let tmp_path = dir.join(format!("{}{}", DEFAULT_SNAPSHOT_NAME, TMP_SUFFIX));
+    let marker_path = dir.join(format!("{}{}", DEFAULT_SNAPSHOT_NAME, COMMITTED_SUFFIX));
+
+    // Remove stale marker before writing so a crash mid-write can't be mistaken
+    // for a valid previous snapshot.
+    let _ = fs::remove_file(&marker_path);
+
+    {
+        let mut f = File::create(&tmp_path)?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp_path, &final_path)?;
+
+    // Drop the committed marker last and fsync it.
+    {
+        let f = File::create(&marker_path)?;
+        f.sync_all()?;
+    }
+
+    Ok(())
+}
+
+/// If a committed snapshot exists under `<data_path>/snapshots/`, import it
+/// into `store` and return its stats. Returns `Ok(None)` if no committed
+/// snapshot is present (fresh install or crash-before-commit).
+pub fn restore_persisted_snapshots(
+    data_path: &str,
+    store: &mut GraphStore,
+) -> Result<Option<ImportStats>, Box<dyn std::error::Error>> {
+    let dir = snapshot_dir(data_path);
+    if !dir.exists() {
+        return Ok(None);
+    }
+
+    let snap_path = dir.join(DEFAULT_SNAPSHOT_NAME);
+    let marker_path = dir.join(format!("{}{}", DEFAULT_SNAPSHOT_NAME, COMMITTED_SUFFIX));
+    if !snap_path.exists() || !marker_path.exists() {
+        return Ok(None);
+    }
+
+    let bytes = fs::read(&snap_path)?;
+    let cursor = Cursor::new(bytes);
+    let stats = crate::snapshot::import_tenant_with_dedup(store, cursor, &[])?;
+    Ok(Some(stats))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restore_none_when_dir_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store = GraphStore::new();
+        let res = restore_persisted_snapshots(&tmp.path().to_string_lossy(), &mut store).unwrap();
+        assert!(res.is_none());
+    }
+
+    #[test]
+    fn persist_writes_marker_last() {
+        let tmp = tempfile::tempdir().unwrap();
+        persist_snapshot(&tmp.path().to_string_lossy(), b"not-a-real-snap").unwrap();
+        let dir = tmp.path().join("snapshots");
+        assert!(dir.join("default.sgsnap").exists());
+        assert!(dir.join("default.sgsnap.committed").exists());
+        assert!(!dir.join("default.sgsnap.tmp").exists());
+    }
+}

--- a/tests/snapshot_persistence.rs
+++ b/tests/snapshot_persistence.rs
@@ -1,0 +1,123 @@
+//! HA-08: Snapshot import persistence (survive restart).
+//!
+//! These tests assert that after a snapshot is imported and persisted,
+//! the data is recoverable on a fresh server boot without re-uploading.
+
+use samyama::graph::GraphStore;
+use samyama::snapshot::{export_tenant, persist};
+
+/// Build a small graph and return an exported .sgsnap byte blob.
+fn build_sample_snapshot() -> Vec<u8> {
+    let mut store = GraphStore::new();
+    let a = store.create_node("Person");
+    store.get_node_mut(a).unwrap().set_property("name", "Alice");
+    let b = store.create_node("Person");
+    store.get_node_mut(b).unwrap().set_property("name", "Bob");
+    store.create_edge(a, b, "KNOWS").unwrap();
+
+    let mut buf = Vec::new();
+    export_tenant(&store, &mut buf).expect("export");
+    buf
+}
+
+#[test]
+fn persist_then_restore_roundtrip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data_path = tmp.path().to_string_lossy().to_string();
+    let bytes = build_sample_snapshot();
+
+    // Persist.
+    persist::persist_snapshot(&data_path, &bytes).expect("persist");
+
+    // Simulate restart: fresh empty store, restore from the same dir.
+    let mut restored = GraphStore::new();
+    let stats = persist::restore_persisted_snapshots(&data_path, &mut restored)
+        .expect("restore")
+        .expect("some snapshot found");
+
+    assert_eq!(stats.node_count, 2);
+    assert_eq!(stats.edge_count, 1);
+    assert_eq!(restored.node_count(), 2);
+    assert_eq!(restored.edge_count(), 1);
+}
+
+#[test]
+fn restore_is_noop_when_no_snapshot_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data_path = tmp.path().to_string_lossy().to_string();
+    let mut store = GraphStore::new();
+
+    let result = persist::restore_persisted_snapshots(&data_path, &mut store).expect("ok");
+    assert!(result.is_none(), "no snapshot should yield None");
+    assert_eq!(store.node_count(), 0);
+}
+
+#[test]
+fn restore_skips_partial_write_without_marker() {
+    // Simulate a crash mid-flush: .sgsnap exists but marker file does not.
+    let tmp = tempfile::tempdir().unwrap();
+    let data_path = tmp.path().to_string_lossy().to_string();
+    let snap_dir = std::path::PathBuf::from(&data_path).join("snapshots");
+    std::fs::create_dir_all(&snap_dir).unwrap();
+
+    // Write a malformed-but-present snapshot file, no marker.
+    std::fs::write(snap_dir.join("default.sgsnap"), b"partial junk").unwrap();
+
+    let mut store = GraphStore::new();
+    let result = persist::restore_persisted_snapshots(&data_path, &mut store).expect("ok");
+    assert!(result.is_none(), "partial snapshot without marker must be ignored");
+    assert_eq!(store.node_count(), 0);
+}
+
+#[test]
+fn persist_is_atomic_no_partial_file() {
+    // After persist_snapshot returns Ok, both the .sgsnap and marker exist.
+    let tmp = tempfile::tempdir().unwrap();
+    let data_path = tmp.path().to_string_lossy().to_string();
+    let bytes = build_sample_snapshot();
+
+    persist::persist_snapshot(&data_path, &bytes).expect("persist");
+
+    let snap = std::path::PathBuf::from(&data_path)
+        .join("snapshots")
+        .join("default.sgsnap");
+    let marker = std::path::PathBuf::from(&data_path)
+        .join("snapshots")
+        .join("default.sgsnap.committed");
+    assert!(snap.exists(), ".sgsnap should exist");
+    assert!(marker.exists(), "committed marker should exist");
+    // No leftover temp file.
+    let tmp_file = std::path::PathBuf::from(&data_path)
+        .join("snapshots")
+        .join("default.sgsnap.tmp");
+    assert!(!tmp_file.exists(), "temp file should be renamed away");
+}
+
+#[test]
+fn persist_overwrites_previous_snapshot() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data_path = tmp.path().to_string_lossy().to_string();
+
+    // First import: 2 nodes.
+    persist::persist_snapshot(&data_path, &build_sample_snapshot()).unwrap();
+
+    // Second import: different graph, 3 nodes.
+    let bigger = {
+        let mut s = GraphStore::new();
+        for i in 0..3 {
+            let n = s.create_node("T");
+            s.get_node_mut(n).unwrap().set_property("i", i as i64);
+        }
+        let mut buf = Vec::new();
+        export_tenant(&s, &mut buf).unwrap();
+        buf
+    };
+    persist::persist_snapshot(&data_path, &bigger).unwrap();
+
+    let mut restored = GraphStore::new();
+    let stats = persist::restore_persisted_snapshots(&data_path, &mut restored)
+        .unwrap()
+        .unwrap();
+    assert_eq!(stats.node_count, 3, "latest snapshot wins");
+    assert_eq!(restored.node_count(), 3);
+}

--- a/tests/tenant_registry_unification.rs
+++ b/tests/tenant_registry_unification.rs
@@ -1,0 +1,173 @@
+//! HA-09: Unify HTTP + RESP tenant registries.
+//!
+//! A tenant created via HTTP must be visible to the RESP `GRAPH.LIST`
+//! command, and vice versa — both paths share a single `TenantManager`.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    Router,
+};
+use http_body_util::BodyExt;
+use samyama::graph::GraphStore;
+use samyama::persistence::TenantManager;
+use samyama::protocol::command::CommandHandler;
+use samyama::protocol::resp::RespValue;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tower::util::ServiceExt;
+
+fn http_router(tm: Arc<TenantManager>) -> Router {
+    samyama::http::server::build_tenant_router(tm)
+}
+
+async fn post_json(app: Router, path: &str, body: Value) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("POST")
+        .uri(path)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, json)
+}
+
+async fn get_json(app: Router, path: &str) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("GET")
+        .uri(path)
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, json)
+}
+
+fn resp_graph_list(handler: &CommandHandler, store: &Arc<RwLock<GraphStore>>) -> Vec<String> {
+    let rt = tokio::runtime::Handle::current();
+    let cmd = RespValue::Array(vec![
+        RespValue::BulkString(Some(b"GRAPH.LIST".to_vec())),
+    ]);
+    let result = tokio::task::block_in_place(|| {
+        rt.block_on(handler.handle_command(&cmd, store))
+    });
+    match result {
+        RespValue::Array(items) => items
+            .into_iter()
+            .filter_map(|v| match v {
+                RespValue::BulkString(Some(b)) => Some(String::from_utf8_lossy(&b).to_string()),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tenant_created_via_http_visible_to_resp() {
+    let tm = Arc::new(TenantManager::new());
+    let store = Arc::new(RwLock::new(GraphStore::new()));
+    let handler = CommandHandler::new_with_tenants(None, Arc::clone(&tm));
+
+    // Precondition: only "default" exists.
+    assert_eq!(resp_graph_list(&handler, &store), vec!["default".to_string()]);
+
+    // Create via HTTP.
+    let (status, _body) = post_json(
+        http_router(Arc::clone(&tm)),
+        "/api/tenants",
+        json!({ "id": "alpha", "name": "Alpha Tenant" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    // RESP now sees both.
+    let mut listed = resp_graph_list(&handler, &store);
+    listed.sort();
+    assert_eq!(listed, vec!["alpha".to_string(), "default".to_string()]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tenant_created_via_tenant_manager_visible_to_http() {
+    let tm = Arc::new(TenantManager::new());
+    tm.create_tenant("beta".to_string(), "Beta".to_string(), None)
+        .unwrap();
+
+    let (status, body) = get_json(http_router(Arc::clone(&tm)), "/api/tenants").await;
+    assert_eq!(status, StatusCode::OK);
+
+    let ids: Vec<String> = body
+        .get("tenants")
+        .and_then(|v| v.as_array())
+        .unwrap()
+        .iter()
+        .filter_map(|t| t.get("id").and_then(|v| v.as_str()).map(String::from))
+        .collect();
+    assert!(ids.contains(&"default".to_string()));
+    assert!(ids.contains(&"beta".to_string()));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn duplicate_tenant_creation_returns_conflict() {
+    let tm = Arc::new(TenantManager::new());
+    let (status1, _) = post_json(
+        http_router(Arc::clone(&tm)),
+        "/api/tenants",
+        json!({ "id": "dup", "name": "First" }),
+    )
+    .await;
+    assert_eq!(status1, StatusCode::CREATED);
+
+    let (status2, _) = post_json(
+        http_router(Arc::clone(&tm)),
+        "/api/tenants",
+        json!({ "id": "dup", "name": "Second" }),
+    )
+    .await;
+    assert_eq!(status2, StatusCode::CONFLICT);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_tenant_removes_from_both_views() {
+    let tm = Arc::new(TenantManager::new());
+    let store = Arc::new(RwLock::new(GraphStore::new()));
+    let handler = CommandHandler::new_with_tenants(None, Arc::clone(&tm));
+
+    post_json(
+        http_router(Arc::clone(&tm)),
+        "/api/tenants",
+        json!({ "id": "ephemeral", "name": "E" }),
+    )
+    .await;
+    assert!(resp_graph_list(&handler, &store).contains(&"ephemeral".to_string()));
+
+    // Delete via HTTP.
+    let req = Request::builder()
+        .method("DELETE")
+        .uri("/api/tenants/ephemeral")
+        .body(Body::empty())
+        .unwrap();
+    let resp = http_router(Arc::clone(&tm)).oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    // Gone from RESP too.
+    assert!(!resp_graph_list(&handler, &store).contains(&"ephemeral".to_string()));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cannot_delete_default_tenant() {
+    let tm = Arc::new(TenantManager::new());
+    let req = Request::builder()
+        .method("DELETE")
+        .uri("/api/tenants/default")
+        .body(Body::empty())
+        .unwrap();
+    let resp = http_router(Arc::clone(&tm)).oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}


### PR DESCRIPTION
Bundles two P0/P1 items that land on the same state surface.

## HA-08 — Snapshot import persistence
- Atomic persist of imported `.sgsnap` (tmp → fsync → rename → marker fsync)
- Boot-time restore replays the last committed snapshot when RocksDB recovery finds nothing
- Crash mid-flush = partial file ignored on boot; crash after marker = snapshot replayed

## HA-09 — Unified tenant registry
- One `Arc<TenantManager>` now backs both RESP `GRAPH.LIST` and new HTTP `/api/tenants` CRUD
- Tenant created via either path is immediately visible to the other
- New routes: `POST /api/tenants`, `GET /api/tenants`, `GET /api/tenants/:id`, `DELETE /api/tenants/:id`
- `GRAPH.LIST` now iterates the live tenant list instead of returning hardcoded `["default"]`
- When persistence is on, reuses the manager owned by `PersistenceManager`

## Tests
- [x] `cargo test --test snapshot_persistence` — 5/5
- [x] `cargo test --test tenant_registry_unification` — 5/5
- [x] `cargo test --lib` — 1991/1991
- [x] `cargo build --bin samyama` — clean
- Pre-existing MVCC failures (`test_mvcc_edge_snapshot_isolation`, `test_mvcc_edge_version_history`) are present on `main` independently of this PR — verified via `git stash`.

## Known scope limits
- Snapshot persistence is single-tenant (hardcoded `default.sgsnap`). Per-tenant snapshot paths follow once tenant-scoped routes land.
- Snapshot flush is synchronous in the import handler. Fine while imports already hold the write lock; can move to `spawn_blocking` if flush time grows.

Refs: BACKLOG.md HA-08 (P0, M), HA-09 (P1, S)