### PR TITLE
fix(mvcc): edge version log records post-mutation state

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -1091,6 +1091,12 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
     }
 
     /// Set a property on an edge, updating both columnar and row storage.
+    ///
+    /// MVCC contract: the version log records POST-mutation state keyed at
+    /// `current_version`. `get_edge_at_version(eid, V)` finds the entry with
+    /// the largest `version <= V`, which then represents the state as of that
+    /// version. Writes at the same `current_version` coalesce onto the last
+    /// entry instead of creating a new one (intra-transaction updates).
     pub fn set_edge_property(
         &mut self,
         edge_id: EdgeId,
@@ -1101,23 +1107,30 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         let val = value.into();
         let idx = edge_id.as_u64() as usize;
 
-        // MVCC: Snapshot current properties before modification
-        let current_props = self.edge_properties.get(&edge_id).cloned()
-            .or_else(|| self.get_edge(edge_id).map(|e| e.properties.clone()))
-            .unwrap_or_default();
-        let version_log = self.edge_version_log.entry(edge_id).or_insert_with(Vec::new);
-        if version_log.is_empty() || version_log.last().unwrap().version != self.current_version {
-            version_log.push(EdgeVersionEntry {
-                version: self.current_version,
-                properties: current_props,
-            });
-        }
-
-        // Update columnar storage
+        // Apply the mutation to the live stores first so the snapshot below
+        // captures the new state.
         self.edge_columns.set_property(idx, &key_str, val.clone());
-
-        // Update DS-07c sparse property map (single source of truth)
         self.set_edge_property_sparse(edge_id, key_str, val);
+
+        // Record the POST-mutation properties in the version log.
+        let post_props = self
+            .edge_properties
+            .get(&edge_id)
+            .cloned()
+            .unwrap_or_default();
+        let current_version = self.current_version;
+        let version_log = self.edge_version_log.entry(edge_id).or_insert_with(Vec::new);
+        match version_log.last_mut() {
+            Some(last) if last.version == current_version => {
+                last.properties = post_props;
+            }
+            _ => {
+                version_log.push(EdgeVersionEntry {
+                    version: current_version,
+                    properties: post_props,
+                });
+            }
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
Fixes two long-standing failures on `main`:
- `test_mvcc_edge_version_history`
- `test_mvcc_edge_snapshot_isolation`

## Root cause
\`set_edge_property\` was snapshotting the **pre-mutation** properties into the edge version log before applying the write. But \`get_edge_at_version(eid, V)\` looks for the entry with the largest \`version <= V\` and expects its properties to represent state **as of V**. Result: historical reads returned the previous version's values (or empty), not the values written at V.

Other parts of the code already use the post-mutation convention — `test_snapshot_isolation_edge_read` and `test_gc_edge_version_log` both construct entries as \`{version: V, properties: state-as-of-V}\`. The node MVCC path (COW node vector) matches too. This patch aligns the edge writer with that convention.

## Fix
1. Apply the mutation first (update `edge_columns` + sparse `edge_properties`).
2. Record post-mutation properties in the version log, keyed at `current_version`.
3. Multiple writes at the same `current_version` coalesce onto the last entry instead of pushing duplicates.

## Test plan
- [x] \`cargo test --test mvcc_test\` — 4/4 (previously 2/4)
- [x] \`cargo test --lib\` — 1991/1991
- [x] \`cargo test --tests\` — full integration suite passes, no regressions

Independent of PR #190 (HA-08 + HA-09) so it can merge on its own timeline.