### PR TITLE
fix(executor): emit single record with all bindings from CREATE pattern (#196)

### DIFF
--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -6198,6 +6198,29 @@ mod tests {
     }
 
     #[test]
+    fn test_create_edge_return_both_pattern_variables() {
+        // Regression for #196: CREATE (a)-[:KNOWS]->(b) RETURN a.name, b.name
+        // used to error with "Variable not found: b". Both pattern variables
+        // must be in scope after the CREATE clause.
+        let mut store = GraphStore::new();
+        let query = parse_query(
+            r#"CREATE (a:Person {name: "Alice"})-[:KNOWS]->(b:Person {name: "Bob"}) RETURN a.name, b.name"#,
+        ).unwrap();
+        let mut executor = MutQueryExecutor::new(&mut store, "default".to_string());
+        let result = executor.execute(&query).expect("CREATE-RETURN with second variable should succeed");
+        assert_eq!(result.columns, vec!["a.name", "b.name"]);
+        assert_eq!(result.records.len(), 1);
+        assert_eq!(
+            *result.records[0].get("a.name").unwrap(),
+            Value::Property(PropertyValue::String("Alice".to_string()))
+        );
+        assert_eq!(
+            *result.records[0].get("b.name").unwrap(),
+            Value::Property(PropertyValue::String("Bob".to_string()))
+        );
+    }
+
+    #[test]
     fn test_create_return_multiple_properties() {
         let mut store = GraphStore::new();
         let query = parse_query(r#"CREATE (n:Person {name: "Carol", age: 30}) RETURN n.name, n.age"#).unwrap();

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -5304,19 +5304,23 @@ impl PhysicalOperator for CreateNodesAndEdgesOperator {
             self.phase = 2;
         }
 
-        // Phase 2: Return results one by one
-        if self.result_index >= self.results.len() {
+        // Phase 2: Emit a single record with ALL pattern bindings.
+        //
+        // openCypher semantics: `CREATE (a)-[r:R]->(b) RETURN a.name, b.name`
+        // produces ONE row where a, r, and b are all in scope. Emitting one
+        // record per created entity used to leave RETURN unable to resolve
+        // the second variable (regression #196).
+        if self.result_index > 0 {
             return Ok(None);
         }
-
-        let (var, value) = &self.results[self.result_index];
-        self.result_index += 1;
+        self.result_index = 1;
 
         let mut record = Record::new();
-        if let Some(v) = var {
-            record.bind(v.clone(), value.clone());
+        for (var, value) in &self.results {
+            if let Some(v) = var {
+                record.bind(v.clone(), value.clone());
+            }
         }
-
         Ok(Some(record))
     }
 


### PR DESCRIPTION
## Summary

`CREATE (a)-[:KNOWS]->(b) RETURN a.name, b.name` used to error with `Variable not found: b`. Cause: \`CreateNodesAndEdgesOperator\` emitted one record per created entity, so the projection only saw \`a\` bound on the first row. Fix: coalesce all pattern bindings into a single emitted record per the openCypher semantics.

Closes #196.

## Test plan
- [x] Added \`test_create_edge_return_both_pattern_variables\` (regression test)
- [x] All 41 CREATE-related tests pass
- [x] Workspace test 2,202/2,203 — the 1 fail is \`parallel_group_shares_wall_time\` which is a pre-existing clock-granularity flake on main (verified by running 3x on main without this patch: FAIL/FAIL/OK)