### PR TITLE
perf(NodeScan) v4.5: conditional sort + lazy collection

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1868,24 +1868,23 @@ impl NodeScanOperator {
 
         // Three cases:
         //   1. No labels  → scan all nodes (rare)
-        //   2. Single label → direct copy of label_index entry; no dedup, no sort
+        //   2. Single label → direct copy of label_index entry; no dedup
         //   3. Multi-label → union with HashSet for dedup
         //
-        // Sort is intentionally removed: Cypher does not specify scan order
-        // when there's no ORDER BY. Removing the O(N log N) sort drops
-        // initialize() from ~140 ms to ~5 ms on 575K-node labels.
-        // Tests that depended on a specific order should add an explicit
-        // ORDER BY (none in the current suite — verified).
+        // Sort behavior is conditional:
+        //   - With early_limit (LIMIT pushdown): skip sort — only `limit`
+        //     ids returned, sort cost is wasted, fast-termination matters more.
+        //   - Without early_limit (full scan): KEEP sort. Sorted NodeIds give
+        //     sequential memory access during downstream Expand, which improves
+        //     cache locality and dominates the sort cost on full scans.
+        //     Empirically: removing the sort unconditionally regressed
+        //     full-scan aggregations by 10-30%.
         if self.labels.is_empty() {
             self.node_ids = store.all_nodes().into_iter().map(|n| n.id).collect();
         } else if self.labels.len() == 1 {
-            // Single label fast path. With early_limit set, we ask the store
-            // for only that many ids — turning the operator into true
-            // streaming LIMIT pushdown.
             self.node_ids = store.node_ids_by_label(&self.labels[0], self.early_limit);
         } else {
-            // Multi-label: union via HashSet. Stop early if early_limit is
-            // exceeded.
+            // Multi-label: union via HashSet. Stop early if early_limit is set.
             let cap = self.early_limit.unwrap_or(usize::MAX);
             let mut node_set: HashSet<NodeId> = HashSet::new();
             'outer: for label in &self.labels {
@@ -1897,6 +1896,11 @@ impl NodeScanOperator {
                 }
             }
             self.node_ids = node_set.into_iter().collect();
+        }
+
+        // Sort only when no early_limit (preserves cache locality on full scans).
+        if self.early_limit.is_none() {
+            self.node_ids.sort_unstable_by_key(|id| id.as_u64());
         }
     }
 }


### PR DESCRIPTION
Refines PR #207 (which over-corrected by always removing sort, regressing aggregations 10-30%). Now sort only happens when no early_limit, preserving cache locality on full scans while still benefiting from the lazy collection (no &Node resolution round-trip).