### PR TITLE
perf(ADR-017): allow WHERE on grouped endpoint in adjacency-count path

### DIFF
--- a/examples/explain_aggs.rs
+++ b/examples/explain_aggs.rs
@@ -1,0 +1,32 @@
+use samyama::graph::GraphStore;
+use samyama::query::QueryEngine;
+use samyama::snapshot::import_tenant;
+use std::fs::File;
+use std::io::BufReader;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut store = GraphStore::new();
+    for s in ["pathways", "druginteractions"] {
+        let path = format!("../{}-kg/data/{}.sgsnap", s, s);
+        if let Ok(f) = File::open(&path) {
+            let _ = import_tenant(&mut store, BufReader::new(f));
+        }
+    }
+    eprintln!("Loaded {} nodes / {} edges", store.node_count(), store.edge_count());
+
+    let engine = QueryEngine::new();
+    let queries = [
+        ("CT09-shape (Phase 1?)", "MATCH (a:Drug)-[:HAS_SIDE_EFFECT]->(b:SideEffect) RETURN b.name, count(a) AS n ORDER BY n DESC LIMIT 5"),
+        ("CT08-shape (DISTINCT)", "MATCH (a:Drug)-[:HAS_SIDE_EFFECT]->(b:SideEffect) RETURN b.name, count(DISTINCT a) AS n ORDER BY n DESC LIMIT 5"),
+    ];
+    for (name, q) in queries {
+        eprintln!("\n=== {} ===", name);
+        eprintln!("Q: {}", q);
+        if let Ok(r) = engine.execute(&format!("EXPLAIN {}", q), &store) {
+            for rec in r.records.iter().take(3) {
+                eprintln!("  {:?}", rec);
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/query/executor/adjacency_agg_detector.rs
+++ b/src/query/executor/adjacency_agg_detector.rs
@@ -43,6 +43,16 @@ pub struct AdjacencyAggPattern {
     pub count_alias: String,
     /// Whether `count(DISTINCT neighbor)` was used. Phase 1 rejects this.
     pub count_distinct: bool,
+    /// Optional WHERE predicate that filters the **grouped** endpoint only.
+    /// When `Some`, the planner builds an indexed scan if any clause matches
+    /// `grouped_var.prop = literal` against an existing index, then wraps a
+    /// FilterOperator with the remaining predicates. When `None`, the
+    /// existing Phase 1 path runs unchanged.
+    ///
+    /// Predicates that reference the neighbor or any other variable are
+    /// rejected by the detector — those would change which edges are
+    /// counted, breaking the per-node degree shortcut.
+    pub where_on_grouped: Option<Expression>,
 }
 
 /// Try to detect the adjacency-count pattern in `query`.
@@ -61,8 +71,10 @@ pub fn detect(query: &Query) -> Option<AdjacencyAggPattern> {
     if query.with_clause.is_some() {
         return None;
     }
-    // No WHERE in Phase 1 — predicate interaction needs careful design.
-    if query.where_clause.is_some() || query.post_with_where_clause.is_some() {
+    // post_with_where_clause is still rejected — that would filter aggregated
+    // groups, requiring HAVING-style handling we don't do yet. The pre-MATCH
+    // WHERE is allowed below if it references only the grouped endpoint.
+    if query.post_with_where_clause.is_some() {
         return None;
     }
     // Writes, CALLs, SET/DELETE etc. disqualify.
@@ -220,6 +232,19 @@ pub fn detect(query: &Query) -> Option<AdjacencyAggPattern> {
         (Direction::Both, _) => unreachable!(), // filtered above
     };
 
+    // Phase 3: WHERE on grouped endpoint. The predicate must reference only
+    // `grouped_var` — anything touching the neighbor would change which edges
+    // are counted, breaking the per-node degree shortcut.
+    let where_on_grouped = match query.where_clause.as_ref() {
+        None => None,
+        Some(wc) => {
+            if !expression_only_references(&wc.predicate, &grouped_var) {
+                return None;
+            }
+            Some(wc.predicate.clone())
+        }
+    };
+
     Some(AdjacencyAggPattern {
         grouped_var,
         grouped_label,
@@ -229,7 +254,49 @@ pub fn detect(query: &Query) -> Option<AdjacencyAggPattern> {
         direction,
         count_alias,
         count_distinct,
+        where_on_grouped,
     })
+}
+
+/// Returns true iff `expr` references no Variable other than `var` and
+/// `expr` does not contain aggregate function calls. Used by Phase 3 to
+/// verify a WHERE predicate filters only the grouped endpoint.
+fn expression_only_references(expr: &Expression, var: &str) -> bool {
+    use Expression::*;
+    match expr {
+        Variable(v) => v == var,
+        Property { variable, .. } => variable == var,
+        Literal(_) | Parameter(_) => true,
+        Binary { left, right, .. } => {
+            expression_only_references(left, var) && expression_only_references(right, var)
+        }
+        Unary { expr, .. } => expression_only_references(expr, var),
+        Function { name, args, .. } => {
+            // Reject aggregate functions in a WHERE predicate (would change
+            // the operator's semantic; HAVING is not what we're handling).
+            let lname = name.to_ascii_lowercase();
+            if matches!(lname.as_str(), "count" | "sum" | "avg" | "min" | "max" | "collect") {
+                return false;
+            }
+            args.iter().all(|a| expression_only_references(a, var))
+        }
+        Case { operand, when_clauses, else_result } => {
+            operand
+                .as_ref()
+                .map(|o| expression_only_references(o, var))
+                .unwrap_or(true)
+                && when_clauses
+                    .iter()
+                    .all(|(c, v)| expression_only_references(c, var) && expression_only_references(v, var))
+                && else_result
+                    .as_ref()
+                    .map(|d| expression_only_references(d, var))
+                    .unwrap_or(true)
+        }
+        // Anything else (lists, maps, path expressions, exists subqueries,
+        // pattern comprehensions...) is conservatively rejected.
+        _ => false,
+    }
 }
 
 /// Parameters extracted from a query that matches the Phase 3a *WITH-bound*
@@ -481,6 +548,7 @@ pub fn detect_with_binding(query: &Query) -> Option<AdjacencyAggWithBindingPatte
             direction,
             count_alias,
             count_distinct: false,
+            where_on_grouped: None, // Phase 3a uses core.prefilter instead
         },
         prefilter,
         grouped_scan_skip: with_clause.skip,
@@ -511,6 +579,35 @@ fn expression_references_only(expr: &Expression, var: &str) -> bool {
 mod tests {
     use super::*;
     use crate::query::parser::parse_query;
+
+    /// Phase 3: WHERE filtering on the grouped endpoint should be detected
+    /// and the predicate captured for the planner to apply.
+    #[test]
+    fn detects_with_where_on_grouped() {
+        let q = parse_query(
+            "MATCH (t:ClinicalTrial)-[:CONDUCTED_AT]->(s:Site) \
+             WHERE s.country = 'United States' \
+             RETURN s.name, count(t) AS trials ORDER BY trials DESC LIMIT 10",
+        )
+        .unwrap();
+        let p = detect(&q).expect("should detect WHERE-on-grouped");
+        assert_eq!(p.grouped_var, "s");
+        assert!(p.where_on_grouped.is_some(), "WHERE should be captured");
+    }
+
+    /// WHERE that touches the neighbor (counted) side must be rejected —
+    /// it would change which edges count, breaking the per-node degree
+    /// shortcut.
+    #[test]
+    fn rejects_where_on_neighbor() {
+        let q = parse_query(
+            "MATCH (t:ClinicalTrial)-[:CONDUCTED_AT]->(s:Site) \
+             WHERE t.phase = '3' \
+             RETURN s.name, count(t) AS trials",
+        )
+        .unwrap();
+        assert!(detect(&q).is_none(), "neighbor-side WHERE must be rejected");
+    }
 
     /// MB049 shape — the motivating case for ADR-017.
     /// `MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal) RETURN j.title, count(a) AS articles`
@@ -565,14 +662,19 @@ mod tests {
     // ——— Rejection cases ———
 
     /// WHERE clause not supported in Phase 1.
+    /// Phase 3 lifted the unconditional WHERE rejection: a WHERE that
+    /// touches only the grouped endpoint is now accepted (the planner
+    /// applies it as a pre-filter on the scan). This test now confirms
+    /// the WHERE is detected and captured.
     #[test]
-    fn rejects_when_where_clause_present() {
+    fn accepts_where_on_grouped() {
         let q = parse_query(
             "MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal) \
              WHERE j.active = true RETURN j.title, count(a) AS articles",
         )
         .unwrap();
-        assert!(detect(&q).is_none());
+        let p = detect(&q).expect("WHERE-on-grouped should now be detected");
+        assert!(p.where_on_grouped.is_some());
     }
 
     /// Multi-hop paths use a different plan shape.

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -382,7 +382,7 @@ impl QueryPlanner {
         // correct for the query. The specialized plan short-circuits the
         // Expand→Aggregate path that causes MB049/MB054 to time out.
         if let Some(pat) = super::adjacency_agg_detector::detect(query) {
-            return self.plan_adjacency_count_aggregate(query, pat);
+            return self.plan_adjacency_count_aggregate(query, pat, store);
         }
         // ADR-017 Phase 3a: the WITH-bound variant handles MB053 and EX49,
         // where an explicit pre-WITH LIMIT caps the work per group but the
@@ -1705,10 +1705,11 @@ impl QueryPlanner {
         &self,
         query: &Query,
         pat: super::adjacency_agg_detector::AdjacencyAggPattern,
+        store: &GraphStore,
     ) -> ExecutionResult<ExecutionPlan> {
         use super::operator::{
-            AdjacencyCountAggregateOperator, LimitOperator, NodeScanOperator, ProjectOperator,
-            SortOperator,
+            AdjacencyCountAggregateOperator, FilterOperator, IndexScanOperator, LimitOperator,
+            NodeScanOperator, ProjectOperator, SortOperator,
         };
 
         let physical_direction = match pat.direction {
@@ -1716,12 +1717,60 @@ impl QueryPlanner {
             super::logical_plan::ExpandDirection::Reverse => Direction::Incoming,
         };
 
-        // Scan + count. The scan binds the grouped endpoint; the adjacency
-        // count operator adds `count_alias` to each record.
-        let scan: OperatorBox = Box::new(NodeScanOperator::new(
-            pat.grouped_var.clone(),
-            vec![pat.grouped_label.clone()],
-        ));
+        // Build the grouped-side scan. Three cases:
+        //   1. No WHERE → NodeScan(grouped_label).
+        //   2. WHERE has an indexed equality clause on grouped_label →
+        //      IndexScan + (optional) Filter for remaining clauses.
+        //   3. WHERE present but not index-eligible → NodeScan + Filter.
+        let scan: OperatorBox = if let Some(pred) = &pat.where_on_grouped {
+            // Decompose AND-chain so we can route one clause to the index
+            // and keep the rest as a residual filter. The common case is a
+            // single equality on an indexed property (one IndexScan, no
+            // residuals); compound predicates fall back to NodeScan + Filter
+            // for the parts that can't index.
+            let clauses = flatten_and_predicates(pred);
+            let mut index_op: Option<OperatorBox> = None;
+            let mut residuals: Vec<Expression> = Vec::new();
+            for c in clauses {
+                if index_op.is_none() {
+                    if let Some(op) = build_index_scan_for_clause(
+                        &c,
+                        &pat.grouped_var,
+                        &pat.grouped_label,
+                        store,
+                    ) {
+                        index_op = Some(op);
+                        continue;
+                    }
+                }
+                residuals.push(c);
+            }
+            let base: OperatorBox = index_op.unwrap_or_else(|| {
+                Box::new(NodeScanOperator::new(
+                    pat.grouped_var.clone(),
+                    vec![pat.grouped_label.clone()],
+                ))
+            });
+            if residuals.is_empty() {
+                base
+            } else {
+                // Combine residuals back into a single AND-chain.
+                let combined = residuals
+                    .into_iter()
+                    .reduce(|a, b| Expression::Binary {
+                        left: Box::new(a),
+                        op: BinaryOp::And,
+                        right: Box::new(b),
+                    })
+                    .expect("non-empty checked above");
+                Box::new(FilterOperator::new(base, combined))
+            }
+        } else {
+            Box::new(NodeScanOperator::new(
+                pat.grouped_var.clone(),
+                vec![pat.grouped_label.clone()],
+            ))
+        };
         let mut operator: OperatorBox = Box::new(AdjacencyCountAggregateOperator::new(
             scan,
             pat.grouped_var.clone(),
@@ -2034,6 +2083,50 @@ fn flatten_and_predicates(expr: &Expression) -> Vec<Expression> {
         }
         _ => vec![expr.clone()],
     }
+}
+
+/// If `clause` is an indexable equality/range on `var.prop` against a literal
+/// and the store has an index on `(label, prop)`, return an `IndexScanOperator`
+/// for it. Otherwise return `None`. Mirrors the logic in `plan_match` so the
+/// adjacency-aware path picks up the same indexes as the generic plan.
+fn build_index_scan_for_clause(
+    clause: &Expression,
+    var: &str,
+    label: &Label,
+    store: &GraphStore,
+) -> Option<OperatorBox> {
+    use super::operator::IndexScanOperator;
+    let (left, op, right) = match clause {
+        Expression::Binary { left, op, right } => (left.as_ref(), op.clone(), right.as_ref()),
+        _ => return None,
+    };
+    let (variable, property) = match left {
+        Expression::Property { variable, property } => (variable, property),
+        _ => return None,
+    };
+    if variable != var {
+        return None;
+    }
+    let val = match right {
+        Expression::Literal(v) => v.clone(),
+        _ => return None,
+    };
+    if !store.property_index.has_index(label, property) {
+        return None;
+    }
+    if !matches!(
+        op,
+        BinaryOp::Eq | BinaryOp::Gt | BinaryOp::Ge | BinaryOp::Lt | BinaryOp::Le
+    ) {
+        return None;
+    }
+    Some(Box::new(IndexScanOperator::new(
+        var.to_string(),
+        label.clone(),
+        property.clone(),
+        op,
+        val,
+    )))
 }
 
 impl QueryPlanner {


### PR DESCRIPTION
Extends Phase 1 of ADR-017 to handle WHERE predicates that filter only the grouped endpoint. Routes index-eligible clauses to IndexScan, keeps residuals as Filter. Full suite 2004/2004.