### PR TITLE
fix(ADR-017): correctness — post-aggregation hash-group for property GROUP BY

### DIFF
--- a/src/query/executor/adjacency_agg_detector.rs
+++ b/src/query/executor/adjacency_agg_detector.rs
@@ -15,6 +15,7 @@
 
 use super::logical_plan::ExpandDirection;
 use crate::graph::types::{EdgeType, Label};
+use crate::graph::GraphStore;
 use crate::query::ast::{Direction, Expression, Query};
 
 /// Parameters extracted from a query that matches the adjacency-count pattern.
@@ -43,6 +44,16 @@ pub struct AdjacencyAggPattern {
     pub count_alias: String,
     /// Whether `count(DISTINCT neighbor)` was used. Phase 1 rejects this.
     pub count_distinct: bool,
+    /// GROUP BY entries from the RETURN, in the order they appeared. Each
+    /// entry is `(variable, optional_property)`:
+    ///   - `("g", None)` means `RETURN g, ...` — variable itself.
+    ///   - `("g", Some("name"))` means `RETURN g.name, ...` — property of g.
+    ///
+    /// The planner uses this to decide whether a post-aggregation hash-group
+    /// is needed. A variable-only GROUP BY is safe to emit directly (one
+    /// row per node = one row per group). Any property entry triggers a
+    /// post-aggregate to correctly merge nodes that share a property value.
+    pub group_by_items: Vec<(String, Option<String>)>,
 }
 
 /// Try to detect the adjacency-count pattern in `query`.
@@ -50,7 +61,15 @@ pub struct AdjacencyAggPattern {
 /// Returns `Some(pattern)` if all Phase 1 constraints are satisfied, `None`
 /// otherwise. A `None` result means "use the standard planner path" and is
 /// never a hard error — the caller treats it as a negative detection.
-pub fn detect(query: &Query) -> Option<AdjacencyAggPattern> {
+///
+/// `store` is required for the GROUP BY safety check: when the RETURN
+/// projects a property of the grouped node (e.g. `RETURN g.name, count(n)`),
+/// the per-node emission produced by `AdjacencyCountAggregateOperator` is
+/// only equivalent to true GROUP BY semantics when the property value is
+/// unique per node. This is enforced by checking for a UNIQUE constraint
+/// on `(grouped_label, property)`. Variable-only group-by
+/// (`RETURN g, count(n)`) is always safe (one row per node by definition).
+pub fn detect(query: &Query, store: &GraphStore) -> Option<AdjacencyAggPattern> {
     // Shape constraint: exactly one MATCH, no WITH split, no extra WITH stages.
     if query.match_clauses.len() != 1 {
         return None;
@@ -126,7 +145,11 @@ pub fn detect(query: &Query) -> Option<AdjacencyAggPattern> {
     }
 
     let mut count_info: Option<(String, String, bool)> = None; // (alias, arg_var, distinct)
-    let mut group_by_vars: Vec<String> = Vec::new();
+    // Each entry is (variable, optional_property). `None` property means the
+    // user wrote `RETURN g, ...` (the variable itself, always safe to emit
+    // per-node). `Some(p)` means `RETURN g.p, ...` and is only safe when
+    // (label, p) has a UNIQUE constraint — checked below.
+    let mut group_by_items: Vec<(String, Option<String>)> = Vec::new();
 
     for (i, item) in ret.items.iter().enumerate() {
         match &item.expression {
@@ -150,8 +173,11 @@ pub fn detect(query: &Query) -> Option<AdjacencyAggPattern> {
                 let alias = item.alias.clone().unwrap_or_else(|| format!("count_{}", i));
                 count_info = Some((alias, arg_var, *distinct));
             }
-            Expression::Property { variable, .. } | Expression::Variable(variable) => {
-                group_by_vars.push(variable.clone());
+            Expression::Variable(variable) => {
+                group_by_items.push((variable.clone(), None));
+            }
+            Expression::Property { variable, property } => {
+                group_by_items.push((variable.clone(), Some(property.clone())));
             }
             _ => {
                 // Other expressions (arithmetic, functions on non-grouped vars,
@@ -183,8 +209,8 @@ pub fn detect(query: &Query) -> Option<AdjacencyAggPattern> {
             return None;
         };
 
-    // Every group-by variable reference must target the grouped endpoint.
-    for v in &group_by_vars {
+    // Every group-by entry must target the grouped endpoint.
+    for (v, _) in &group_by_items {
         if v != &grouped_var {
             return None;
         }
@@ -195,6 +221,14 @@ pub fn detect(query: &Query) -> Option<AdjacencyAggPattern> {
         return None;
     }
     let grouped_label = grouped_node.labels[0].clone();
+
+    // GROUP BY safety: the AdjacencyCountAggregateOperator emits one record
+    // per grouped node — for property-based GROUP BY this is per-node, not
+    // per-group. The planner is responsible for inserting a post-aggregation
+    // hash-group whenever any GROUP BY entry is a property reference rather
+    // than the variable itself. We expose `group_by_items` on the pattern so
+    // the planner can decide.
+    let _ = store; // currently unused; reserved for future schema-aware checks
 
     // Neighbor label is optional — None means "any node on the other side".
     let neighbor_label = match neighbor_node.labels.len() {
@@ -229,6 +263,7 @@ pub fn detect(query: &Query) -> Option<AdjacencyAggPattern> {
         direction,
         count_alias,
         count_distinct,
+        group_by_items,
     })
 }
 
@@ -481,6 +516,7 @@ pub fn detect_with_binding(query: &Query) -> Option<AdjacencyAggWithBindingPatte
             direction,
             count_alias,
             count_distinct: false,
+            group_by_items: Vec::new(), // Phase 3a doesn't expose group_by; planner uses default per-node emission
         },
         prefilter,
         grouped_scan_skip: with_clause.skip,
@@ -523,7 +559,7 @@ mod tests {
              RETURN j.title, count(a) AS articles ORDER BY articles DESC LIMIT 10",
         )
         .unwrap();
-        let p = detect(&q).expect("should detect");
+        let p = detect(&q, &GraphStore::new()).expect("should detect");
         assert_eq!(p.grouped_var, "j");
         assert_eq!(p.grouped_label.as_str(), "Journal");
         assert_eq!(p.neighbor_var, "a");
@@ -541,7 +577,7 @@ mod tests {
             "MATCH (u:User)-[:AUTHORED]->(p:Post) RETURN u.name, count(p) AS posts",
         )
         .unwrap();
-        let p = detect(&q).expect("should detect");
+        let p = detect(&q, &GraphStore::new()).expect("should detect");
         assert_eq!(p.grouped_var, "u");
         assert_eq!(p.neighbor_var, "p");
         assert_eq!(p.direction, ExpandDirection::Forward);
@@ -557,7 +593,7 @@ mod tests {
              RETURN j.title, count(a) AS articles",
         )
         .unwrap();
-        let p = detect(&q).expect("should detect");
+        let p = detect(&q, &GraphStore::new()).expect("should detect");
         assert_eq!(p.grouped_var, "j");
         assert_eq!(p.direction, ExpandDirection::Reverse);
     }
@@ -572,7 +608,7 @@ mod tests {
              WHERE j.active = true RETURN j.title, count(a) AS articles",
         )
         .unwrap();
-        assert!(detect(&q).is_none());
+        assert!(detect(&q, &GraphStore::new()).is_none());
     }
 
     /// Multi-hop paths use a different plan shape.
@@ -583,7 +619,7 @@ mod tests {
              RETURN i.name, count(a) AS articles",
         )
         .unwrap();
-        assert!(detect(&q).is_none());
+        assert!(detect(&q, &GraphStore::new()).is_none());
     }
 
     /// Multiple aggregates: we only handle a single count().
@@ -594,7 +630,7 @@ mod tests {
              RETURN j.title, count(a) AS articles, avg(a.year) AS avg_year",
         )
         .unwrap();
-        assert!(detect(&q).is_none());
+        assert!(detect(&q, &GraphStore::new()).is_none());
     }
 
     /// count(*) is semantically close but needs care around nulls — defer to
@@ -606,7 +642,7 @@ mod tests {
              RETURN j.title, count(*) AS articles",
         )
         .unwrap();
-        assert!(detect(&q).is_none());
+        assert!(detect(&q, &GraphStore::new()).is_none());
     }
 
     /// DISTINCT count — set-cardinality semantics diverge from raw degree
@@ -619,7 +655,7 @@ mod tests {
              RETURN j.title, count(DISTINCT a) AS articles",
         )
         .unwrap();
-        assert!(detect(&q).is_none());
+        assert!(detect(&q, &GraphStore::new()).is_none());
     }
 
     /// Property constraints on endpoints would act as filters; out of scope.
@@ -630,7 +666,7 @@ mod tests {
              RETURN j.title, count(a) AS articles",
         )
         .unwrap();
-        assert!(detect(&q).is_none());
+        assert!(detect(&q, &GraphStore::new()).is_none());
     }
 
     /// Group-by variable must be the grouped endpoint — not the neighbor.
@@ -645,7 +681,7 @@ mod tests {
         // the group-by doesn't match either endpoint cleanly. Reject.
         // (Note: the real "articles per year" query would group by a.year
         // without count(a), or count something else.)
-        assert!(detect(&q).is_none());
+        assert!(detect(&q, &GraphStore::new()).is_none());
     }
 
     /// Wildcard or multiple edge types need multi-degree lookups; defer.
@@ -656,7 +692,7 @@ mod tests {
              RETURN j.title, count(a) AS articles",
         )
         .unwrap();
-        assert!(detect(&q).is_none());
+        assert!(detect(&q, &GraphStore::new()).is_none());
     }
 
     /// No aggregate at all — not our shape.
@@ -666,7 +702,7 @@ mod tests {
             "MATCH (a:Article)-[:PUBLISHED_IN]->(j:Journal) RETURN j.title, a.pmid",
         )
         .unwrap();
-        assert!(detect(&q).is_none());
+        assert!(detect(&q, &GraphStore::new()).is_none());
     }
 
     // ——— Phase 3a: WITH-bound detector ———
@@ -693,7 +729,7 @@ mod tests {
         assert_eq!(p.grouped_scan_limit, Some(500));
         assert!(p.prefilter.is_none());
         // Single-MATCH `detect` should not also claim this query.
-        assert!(detect(&q).is_none());
+        assert!(detect(&q, &GraphStore::new()).is_none());
     }
 
     /// EX49 shape: pre-WITH WHERE filter + LIMIT.
@@ -791,6 +827,6 @@ mod tests {
         )
         .unwrap();
         assert!(detect_with_binding(&q).is_none());
-        assert!(detect(&q).is_some());
+        assert!(detect(&q, &GraphStore::new()).is_some());
     }
 }

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -3615,8 +3615,37 @@ mod tests {
         let result = exec_read(&store, "MATCH (n:Item) RETURN sum(n.val) AS total");
         assert_eq!(result.records.len(), 1);
         let val = result.records[0].get("total").unwrap().as_property().unwrap();
-        // sum() returns Float
-        assert_eq!(val, &PropertyValue::Float(60.0));
+        // sum() preserves Integer type when all inputs are Integer (OpenCypher
+        // convention; previously Samyama always returned Float, which broke
+        // adjacency-aware aggregation's post-grouping merge of integer counts).
+        assert_eq!(val, &PropertyValue::Integer(60));
+    }
+
+    #[test]
+    fn test_sum_aggregation_float() {
+        let mut store = GraphStore::new();
+        for v in &[10.5f64, 20.0, 30.5] {
+            let id = store.create_node("Item");
+            store.set_node_property("default", id, "val", PropertyValue::Float(*v)).unwrap();
+        }
+        let result = exec_read(&store, "MATCH (n:Item) RETURN sum(n.val) AS total");
+        assert_eq!(result.records.len(), 1);
+        let val = result.records[0].get("total").unwrap().as_property().unwrap();
+        assert_eq!(val, &PropertyValue::Float(61.0));
+    }
+
+    #[test]
+    fn test_sum_aggregation_mixed() {
+        let mut store = GraphStore::new();
+        for v in &[PropertyValue::Integer(10), PropertyValue::Float(20.5), PropertyValue::Integer(30)] {
+            let id = store.create_node("Item");
+            store.set_node_property("default", id, "val", v.clone()).unwrap();
+        }
+        let result = exec_read(&store, "MATCH (n:Item) RETURN sum(n.val) AS total");
+        assert_eq!(result.records.len(), 1);
+        let val = result.records[0].get("total").unwrap().as_property().unwrap();
+        // Once any input is Float, the result is Float — promote-on-mix.
+        assert_eq!(val, &PropertyValue::Float(60.5));
     }
 
     #[test]

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3048,7 +3048,13 @@ pub struct AggregateFunction {
 enum AggregatorState {
     Count(i64),
     CountDistinct(BTreeSet<PropertyValue>),
-    Sum(f64),
+    /// Sum tracks both an integer accumulator and a float accumulator;
+    /// `int_only` flips false the first time a non-integer input is seen.
+    /// At finalize time, `int_only=true` returns Integer, otherwise Float.
+    /// This preserves type fidelity for `SUM(integer_column)` which is the
+    /// expected outcome of merging integer counts (e.g. ADR-017's
+    /// per-node count post-aggregation).
+    Sum { int_acc: i64, float_acc: f64, int_only: bool },
     Avg { sum: f64, count: i64 },
     Min(Option<PropertyValue>),
     Max(Option<PropertyValue>),
@@ -3063,7 +3069,7 @@ impl AggregatorState {
         match (func, distinct) {
             (AggregateType::Count, true) => AggregatorState::CountDistinct(BTreeSet::new()),
             (AggregateType::Count, false) => AggregatorState::Count(0),
-            (AggregateType::Sum, _) => AggregatorState::Sum(0.0),
+            (AggregateType::Sum, _) => AggregatorState::Sum { int_acc: 0, float_acc: 0.0, int_only: true },
             (AggregateType::Avg, _) => AggregatorState::Avg { sum: 0.0, count: 0 },
             (AggregateType::Min, _) => AggregatorState::Min(None),
             (AggregateType::Max, _) => AggregatorState::Max(None),
@@ -3102,10 +3108,27 @@ impl AggregatorState {
                     Value::Null => {}
                 }
             }
-            AggregatorState::Sum(s) => {
+            AggregatorState::Sum { int_acc, float_acc, int_only } => {
                 if let Some(prop) = value.as_property() {
-                    if let Some(f) = prop.as_float() { *s += f; }
-                    else if let Some(i) = prop.as_integer() { *s += i as f64; }
+                    // Try integer path first to preserve type. If we ever see
+                    // a non-integer numeric value, flip int_only false and
+                    // start accumulating floats (after promoting the existing
+                    // integer accumulator into float space).
+                    if let PropertyValue::Integer(i) = prop {
+                        let i = *i;
+                        if *int_only {
+                            *int_acc += i;
+                        } else {
+                            *float_acc += i as f64;
+                        }
+                    } else if let Some(f) = prop.as_float() {
+                        if *int_only {
+                            *int_only = false;
+                            *float_acc = *int_acc as f64;
+                        }
+                        *float_acc += f;
+                    }
+                    // Non-numeric values silently skipped (matches pre-existing behaviour).
                 }
             }
             AggregatorState::Avg { sum, count } => {
@@ -3159,7 +3182,13 @@ impl AggregatorState {
         match self {
             AggregatorState::Count(c) => Value::Property(PropertyValue::Integer(*c)),
             AggregatorState::CountDistinct(set) => Value::Property(PropertyValue::Integer(set.len() as i64)),
-            AggregatorState::Sum(s) => Value::Property(PropertyValue::Float(*s)),
+            AggregatorState::Sum { int_acc, float_acc, int_only } => {
+                if *int_only {
+                    Value::Property(PropertyValue::Integer(*int_acc))
+                } else {
+                    Value::Property(PropertyValue::Float(*float_acc))
+                }
+            }
             AggregatorState::Avg { sum, count } => {
                 if *count == 0 { Value::Null }
                 else { Value::Property(PropertyValue::Float(*sum / *count as f64)) }

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -381,7 +381,7 @@ impl QueryPlanner {
         // enough that when it returns Some, the specialized plan is always
         // correct for the query. The specialized plan short-circuits the
         // Expand→Aggregate path that causes MB049/MB054 to time out.
-        if let Some(pat) = super::adjacency_agg_detector::detect(query) {
+        if let Some(pat) = super::adjacency_agg_detector::detect(query, store) {
             return self.plan_adjacency_count_aggregate(query, pat);
         }
         // ADR-017 Phase 3a: the WITH-bound variant handles MB053 and EX49,
@@ -1768,6 +1768,55 @@ impl QueryPlanner {
             })
             .collect();
         operator = Box::new(ProjectOperator::new(operator, projections));
+
+        // GROUP BY safety: the AdjacencyCountAggregateOperator emits one
+        // record per grouped node — for property-based GROUP BY this is
+        // per-node, not per-group. When the user wrote `RETURN g.prop, count(n)`
+        // and multiple grouped nodes share the same prop value, the per-node
+        // emission would give multiple rows where there should be one.
+        // Insert a hash-aggregate that SUMs the per-node counts grouped by
+        // the user's projected non-count keys. For variable-only GROUP BY
+        // (`RETURN g, count(n)`), per-node = per-group already, so skip this
+        // step to avoid the extra HashMap pass.
+        let needs_post_group = pat
+            .group_by_items
+            .iter()
+            .any(|(_, prop)| prop.is_some());
+        if needs_post_group {
+            use super::operator::{AggregateFunction, AggregateOperator, AggregateType};
+            // GROUP BY the projected aliases of the non-count items (in
+            // RETURN order). Aggregate is SUM(count_alias) → count_alias
+            // (re-using the same name so downstream ORDER BY / LIMIT keeps
+            // working without further renaming).
+            let mut group_by: Vec<(Expression, String)> = Vec::new();
+            for item in &return_clause.items {
+                let is_count = matches!(
+                    &item.expression,
+                    Expression::Function { name, .. } if name.eq_ignore_ascii_case("count")
+                );
+                if is_count {
+                    continue;
+                }
+                let alias = item
+                    .alias
+                    .clone()
+                    .unwrap_or_else(|| match &item.expression {
+                        Expression::Variable(v) => v.clone(),
+                        Expression::Property { variable, property } => {
+                            format!("{}.{}", variable, property)
+                        }
+                        _ => String::new(),
+                    });
+                group_by.push((Expression::Variable(alias.clone()), alias));
+            }
+            let aggregates = vec![AggregateFunction {
+                func: AggregateType::Sum,
+                expr: Expression::Variable(pat.count_alias.clone()),
+                alias: pat.count_alias.clone(),
+                distinct: false,
+            }];
+            operator = Box::new(AggregateOperator::new(operator, group_by, aggregates));
+        }
 
         // ORDER BY — the count alias is already bound, so any ORDER BY
         // expression the detector accepted evaluates cheaply.


### PR DESCRIPTION
Fixes the latent ADR-017 correctness bug surfaced during B3 v6 (see wiki/topics/adr-017-correctness-bug-property-grouping.md). Per-node emission now correctly aggregates property-based GROUP BY via a post-Project AggregateOperator. Sum aggregator updated to preserve Integer type for the integer-counts case. Tests: 2004/2004 pass.