### PR TITLE
perf+fix(adr-017): in-operator GROUP BY for adjacency-count aggregate

### DIFF
--- a/src/query/executor/adjacency_agg_detector.rs
+++ b/src/query/executor/adjacency_agg_detector.rs
@@ -485,6 +485,24 @@ pub fn detect_with_binding(query: &Query) -> Option<AdjacencyAggWithBindingPatte
             _ => return None,
         }
     }
+    // Re-walk the RETURN items to also capture each GROUP BY entry as
+    // (variable, optional_property). Phase 3a previously discarded the
+    // property name; the in-operator group-by (P8.5) needs it to build
+    // per-group counts during the per-node walk.
+    let mut group_by_items: Vec<(String, Option<String>)> = Vec::new();
+    for item in &ret.items {
+        match &item.expression {
+            Expression::Function { name, .. } if name.eq_ignore_ascii_case("count") => continue,
+            Expression::Variable(variable) => {
+                group_by_items.push((variable.clone(), None));
+            }
+            Expression::Property { variable, property } => {
+                group_by_items.push((variable.clone(), Some(property.clone())));
+            }
+            _ => {}
+        }
+    }
+
     let (count_alias, count_arg_var, count_distinct) = count_info?;
     if count_distinct {
         return None;
@@ -516,7 +534,7 @@ pub fn detect_with_binding(query: &Query) -> Option<AdjacencyAggWithBindingPatte
             direction,
             count_alias,
             count_distinct: false,
-            group_by_items: Vec::new(), // Phase 3a doesn't expose group_by; planner uses default per-node emission
+            group_by_items,
         },
         prefilter,
         grouped_scan_skip: with_clause.skip,

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3616,6 +3616,29 @@ pub struct AdjacencyCountAggregateOperator {
     /// - Outgoing = out-degree of the grouped node on this edge type
     /// - Incoming = in-degree of the grouped node on this edge type
     direction: Direction,
+    /// Optional property names to group on, in user-RETURN order.
+    /// When empty, emit one record per input node (per-node mode — fast,
+    /// correct only when downstream cannot collapse rows).
+    /// When non-empty, accumulate per-group counts in an internal HashMap
+    /// and emit one record per distinct property-value combination —
+    /// avoids the planner-side post-aggregate hash-group entirely.
+    group_by_props: Vec<String>,
+    /// Lazy-built grouped output, populated on first `next()` when
+    /// `group_by_props` is non-empty.
+    grouped_iter: Option<std::vec::IntoIter<GroupedRow>>,
+}
+
+/// One pre-aggregated row for the in-operator group-by mode.
+struct GroupedRow {
+    /// Property values in the order of `group_by_props` (used by the
+    /// downstream Project to look up `g.prop` directly).
+    prop_values: Vec<PropertyValue>,
+    /// Sum of per-node degrees across all nodes in this group.
+    count: i64,
+    /// One representative node from this group. Used by Project so that
+    /// expressions like `g` (the variable itself) still bind to a real
+    /// NodeRef. All nodes in the group share the same `prop_values`.
+    sample_node: NodeId,
 }
 
 impl AdjacencyCountAggregateOperator {
@@ -3632,7 +3655,67 @@ impl AdjacencyCountAggregateOperator {
             count_alias,
             edge_type,
             direction,
+            group_by_props: Vec::new(),
+            grouped_iter: None,
         }
+    }
+
+    /// Enable the in-operator group-by path. When non-empty, the operator
+    /// accumulates per-group counts in a HashMap keyed on the listed
+    /// property values of the grouped node, then emits one record per
+    /// group rather than per node. This is the correctness-preserving
+    /// fast path that replaces the planner-side post-aggregate.
+    pub fn with_group_by_props(mut self, props: Vec<String>) -> Self {
+        self.group_by_props = props;
+        self
+    }
+
+    fn build_grouped_iter(&mut self, store: &GraphStore) -> ExecutionResult<()> {
+        // Accumulate per-(prop_values) counts. FxHashMap for the same
+        // reason it's used in AggregateOperator — SipHash overhead matters
+        // when the input is millions of nodes.
+        let mut groups: rustc_hash::FxHashMap<Vec<PropertyValue>, (NodeId, i64)> =
+            rustc_hash::FxHashMap::default();
+
+        loop {
+            let input_record = match self.input.next(store)? {
+                Some(r) => r,
+                None => break,
+            };
+
+            let node_id = match input_record.get(&self.grouped_var) {
+                Some(Value::NodeRef(id)) | Some(Value::Node(id, _)) => *id,
+                _ => continue,
+            };
+
+            // Resolve each group-by property of this node. NULL is a valid
+            // group key (all NULL values collapse together — matches Cypher).
+            // Use the canonical Value::resolve_property accessor — it checks
+            // the columnar store first (where snapshot-imported properties
+            // live; node.properties is empty post-import per the columnar
+            // storage design), then falls back to the in-memory node map.
+            let value_for_lookup = Value::NodeRef(node_id);
+            let key: Vec<PropertyValue> = self
+                .group_by_props
+                .iter()
+                .map(|p| value_for_lookup.resolve_property(p, store))
+                .collect();
+
+            let degree = self.degree_filtered(store, node_id) as i64;
+            let entry = groups.entry(key).or_insert((node_id, 0));
+            entry.1 += degree;
+        }
+
+        let rows: Vec<GroupedRow> = groups
+            .into_iter()
+            .map(|(prop_values, (sample_node, count))| GroupedRow {
+                prop_values,
+                count,
+                sample_node,
+            })
+            .collect();
+        self.grouped_iter = Some(rows.into_iter());
+        Ok(())
     }
 
     /// Count the incident edges of `node_id` that match `edge_type` in the
@@ -3673,6 +3756,31 @@ impl AdjacencyCountAggregateOperator {
 
 impl PhysicalOperator for AdjacencyCountAggregateOperator {
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        // Grouped path: accumulate per-(prop_values) counts on first call,
+        // then emit one record per group. Correctness-preserving fast path
+        // for `RETURN n.prop, count(...)` patterns where multiple nodes may
+        // share the same property value (NULL collapse, non-unique attrs).
+        if !self.group_by_props.is_empty() {
+            if self.grouped_iter.is_none() {
+                self.build_grouped_iter(store)?;
+            }
+            let row = match self.grouped_iter.as_mut().and_then(|it| it.next()) {
+                Some(r) => r,
+                None => return Ok(None),
+            };
+            // Bind the sample node — downstream Project will resolve
+            // properties from it. All nodes in the group share the same
+            // values for `group_by_props`, so any group member is correct.
+            let _ = row.prop_values;
+            let mut out = Record::new();
+            out.bind(self.grouped_var.clone(), Value::NodeRef(row.sample_node));
+            out.bind(
+                self.count_alias.clone(),
+                Value::Property(PropertyValue::Integer(row.count)),
+            );
+            return Ok(Some(out));
+        }
+
         loop {
             let input_record = match self.input.next(store)? {
                 Some(r) => r,
@@ -3701,6 +3809,7 @@ impl PhysicalOperator for AdjacencyCountAggregateOperator {
 
     fn reset(&mut self) {
         self.input.reset();
+        self.grouped_iter = None;
     }
 
     fn describe(&self) -> OperatorDescription {

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1722,13 +1722,35 @@ impl QueryPlanner {
             pat.grouped_var.clone(),
             vec![pat.grouped_label.clone()],
         ));
-        let mut operator: OperatorBox = Box::new(AdjacencyCountAggregateOperator::new(
+        // Push GROUP BY into the operator: it accumulates per-(prop_values)
+        // counts in an internal HashMap during the per-node walk, emitting
+        // one row per group rather than per node. Replaces the earlier
+        // post-aggregate hash-group (which on PubMed-scale workloads cost
+        // ~76 minutes across the 500-query mega-bench, per ADR-017 bug doc).
+        // Variable-only GROUP BY leaves `group_by_props` empty — per-node =
+        // per-group for that case, no hashing needed.
+        let group_by_props: Vec<String> = pat
+            .group_by_items
+            .iter()
+            .filter_map(|(var, prop)| {
+                if var == &pat.grouped_var {
+                    prop.clone()
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let mut adj_op = AdjacencyCountAggregateOperator::new(
             scan,
             pat.grouped_var.clone(),
             pat.count_alias.clone(),
             pat.edge_type.clone(),
             physical_direction,
-        ));
+        );
+        if !group_by_props.is_empty() {
+            adj_op = adj_op.with_group_by_props(group_by_props);
+        }
+        let mut operator: OperatorBox = Box::new(adj_op);
 
         // RETURN projections — the detector guarantees each item is either a
         // Property/Variable on the grouped side or the single count() aggregate,
@@ -1769,54 +1791,8 @@ impl QueryPlanner {
             .collect();
         operator = Box::new(ProjectOperator::new(operator, projections));
 
-        // GROUP BY safety: the AdjacencyCountAggregateOperator emits one
-        // record per grouped node — for property-based GROUP BY this is
-        // per-node, not per-group. When the user wrote `RETURN g.prop, count(n)`
-        // and multiple grouped nodes share the same prop value, the per-node
-        // emission would give multiple rows where there should be one.
-        // Insert a hash-aggregate that SUMs the per-node counts grouped by
-        // the user's projected non-count keys. For variable-only GROUP BY
-        // (`RETURN g, count(n)`), per-node = per-group already, so skip this
-        // step to avoid the extra HashMap pass.
-        let needs_post_group = pat
-            .group_by_items
-            .iter()
-            .any(|(_, prop)| prop.is_some());
-        if needs_post_group {
-            use super::operator::{AggregateFunction, AggregateOperator, AggregateType};
-            // GROUP BY the projected aliases of the non-count items (in
-            // RETURN order). Aggregate is SUM(count_alias) → count_alias
-            // (re-using the same name so downstream ORDER BY / LIMIT keeps
-            // working without further renaming).
-            let mut group_by: Vec<(Expression, String)> = Vec::new();
-            for item in &return_clause.items {
-                let is_count = matches!(
-                    &item.expression,
-                    Expression::Function { name, .. } if name.eq_ignore_ascii_case("count")
-                );
-                if is_count {
-                    continue;
-                }
-                let alias = item
-                    .alias
-                    .clone()
-                    .unwrap_or_else(|| match &item.expression {
-                        Expression::Variable(v) => v.clone(),
-                        Expression::Property { variable, property } => {
-                            format!("{}.{}", variable, property)
-                        }
-                        _ => String::new(),
-                    });
-                group_by.push((Expression::Variable(alias.clone()), alias));
-            }
-            let aggregates = vec![AggregateFunction {
-                func: AggregateType::Sum,
-                expr: Expression::Variable(pat.count_alias.clone()),
-                alias: pat.count_alias.clone(),
-                distinct: false,
-            }];
-            operator = Box::new(AggregateOperator::new(operator, group_by, aggregates));
-        }
+        // (GROUP BY is now handled inside AdjacencyCountAggregateOperator
+        // via `with_group_by_props` above — no post-aggregate step needed.)
 
         // ORDER BY — the count alias is already bound, so any ORDER BY
         // expression the detector accepted evaluates cheaply.
@@ -1904,14 +1880,35 @@ impl QueryPlanner {
             }
         }
 
-        // The adjacency-count aggregate itself — identical to Phase 1.
-        operator = Box::new(AdjacencyCountAggregateOperator::new(
+        // Adjacency-count aggregate. Like Phase 1 (P8.5), push any
+        // property-based GROUP BY into the operator so it accumulates
+        // per-group counts in an internal HashMap during the per-node walk
+        // — avoids a post-step that would re-traverse the bound rows on
+        // PubMed-scale inputs (root cause of MB053/MB111/MB113 35s–407s
+        // under the post-aggregate plan).
+        let group_by_props: Vec<String> = pat
+            .core
+            .group_by_items
+            .iter()
+            .filter_map(|(var, prop)| {
+                if var == &pat.core.grouped_var {
+                    prop.clone()
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let mut adj_op = AdjacencyCountAggregateOperator::new(
             operator,
             pat.core.grouped_var.clone(),
             pat.core.count_alias.clone(),
             pat.core.edge_type.clone(),
             physical_direction,
-        ));
+        );
+        if !group_by_props.is_empty() {
+            adj_op = adj_op.with_group_by_props(group_by_props);
+        }
+        operator = Box::new(adj_op);
 
         // RETURN projections — same logic as the Phase 1 helper.
         let return_clause = query


### PR DESCRIPTION
## Summary
Three-part change to fix the latent ADR-017 correctness bug while avoiding the post-aggregate hash-group's perf cost on snapshot-scale data. SGE has the equivalent commits as PRs #230, #231, #232.

- **P8.5** — Phase 1: push GROUP BY into AdjacencyCountAggregateOperator via group_by_props + grouped_iter (FxHashMap accumulator). Removes the planner post-step.
- **P8.6** — Phase 3a (WITH-binding): detect_with_binding now propagates group_by_items with property names; planner mirrors Phase 1.
- **Columnar-lookup fix**: switched build_grouped_iter from \`node.properties.get(k)\` to \`Value::NodeRef(id).resolve_property(k, store)\` — snapshot-imported properties live in node_columns, the in-memory map is empty post-import.

## Test plan
- [x] cargo test --lib — 2004/2004
- [x] SGE 500-query mega-bench v10: MB053 FAIL→PASS, 96min vs v8's 126min