### PR TITLE
fix(ldbc): parse float-suffixed IDs + use real Person seed

### DIFF
--- a/benches/ldbc_benchmark.rs
+++ b/benches/ldbc_benchmark.rs
@@ -62,7 +62,7 @@ fn ldbc_queries() -> Vec<LdbcQuery> {
             name: "Person Profile",
             category: "short",
             cypher: "\
-MATCH (p:Person {id: 933})
+MATCH (p:Person {id: 2435})
 RETURN p.firstName, p.lastName, p.birthday, p.locationIP, p.browserUsed, p.gender, p.creationDate",
         },
 
@@ -72,7 +72,7 @@ RETURN p.firstName, p.lastName, p.birthday, p.locationIP, p.browserUsed, p.gende
             category: "short",
             // Adapted: query Posts only (Comment variant would be a separate UNION)
             cypher: "\
-MATCH (p:Person {id: 933})<-[:HAS_CREATOR]-(m:Post)
+MATCH (p:Person {id: 2435})<-[:HAS_CREATOR]-(m:Post)
 RETURN m.id, m.content, m.creationDate
 ORDER BY m.creationDate DESC
 LIMIT 10",
@@ -83,7 +83,7 @@ LIMIT 10",
             name: "Friends of Person",
             category: "short",
             cypher: "\
-MATCH (p:Person {id: 933})-[:KNOWS]-(friend:Person)
+MATCH (p:Person {id: 2435})-[:KNOWS]-(friend:Person)
 RETURN friend.id, friend.firstName, friend.lastName
 ORDER BY friend.firstName, friend.lastName",
         },
@@ -139,7 +139,7 @@ LIMIT 20",
             category: "complex",
             // Friends up to distance 3 with a given first name
             cypher: "\
-MATCH (p:Person {id: 933})-[:KNOWS*1..3]-(friend:Person {firstName: \"Mahinda\"})
+MATCH (p:Person {id: 2435})-[:KNOWS*1..3]-(friend:Person {firstName: \"Mahinda\"})
 WHERE friend.id <> 933
 RETURN DISTINCT friend.id, friend.lastName, friend.birthday, friend.creationDate,
        friend.gender, friend.browserUsed, friend.locationIP
@@ -153,7 +153,7 @@ LIMIT 20",
             category: "complex",
             // Recent posts by direct friends
             cypher: "\
-MATCH (p:Person {id: 933})-[:KNOWS]-(friend:Person)<-[:HAS_CREATOR]-(m:Post)
+MATCH (p:Person {id: 2435})-[:KNOWS]-(friend:Person)<-[:HAS_CREATOR]-(m:Post)
 WHERE m.creationDate < 1354320000000
 RETURN friend.id, friend.firstName, friend.lastName,
        m.id, m.content, m.creationDate
@@ -167,7 +167,7 @@ LIMIT 20",
             category: "complex",
             // Friends who posted in two given countries within a date range
             cypher: "\
-MATCH (p:Person {id: 933})-[:KNOWS*1..2]-(friend:Person)
+MATCH (p:Person {id: 2435})-[:KNOWS*1..2]-(friend:Person)
 WHERE friend.id <> 933
 WITH DISTINCT friend
 MATCH (friend)<-[:HAS_CREATOR]-(m:Post)-[:IS_LOCATED_IN]->(place:Place)
@@ -184,7 +184,7 @@ LIMIT 20",
             category: "complex",
             // Tags on posts created by friends within a date window
             cypher: "\
-MATCH (p:Person {id: 933})-[:KNOWS]-(friend:Person)<-[:HAS_CREATOR]-(post:Post)-[:HAS_TAG]->(tag:Tag)
+MATCH (p:Person {id: 2435})-[:KNOWS]-(friend:Person)<-[:HAS_CREATOR]-(post:Post)-[:HAS_TAG]->(tag:Tag)
 WHERE post.creationDate >= 1338508800000 AND post.creationDate < 1341100800000
 RETURN tag.name, count(post) AS postCount
 ORDER BY postCount DESC
@@ -197,7 +197,7 @@ LIMIT 10",
             category: "complex",
             // Forums joined by friends-of-friends after a given date
             cypher: "\
-MATCH (p:Person {id: 933})-[:KNOWS*1..2]-(friend:Person)
+MATCH (p:Person {id: 2435})-[:KNOWS*1..2]-(friend:Person)
 WHERE friend.id <> 933
 WITH DISTINCT friend
 MATCH (friend)<-[:HAS_MEMBER]-(forum:Forum)
@@ -212,7 +212,7 @@ LIMIT 20",
             category: "complex",
             // Tags that co-occur with a given tag on posts by friends-of-friends
             cypher: "\
-MATCH (p:Person {id: 933})-[:KNOWS*1..2]-(friend:Person)<-[:HAS_CREATOR]-(post:Post)-[:HAS_TAG]->(tag:Tag {name: \"Hamid_Karzai\"})
+MATCH (p:Person {id: 2435})-[:KNOWS*1..2]-(friend:Person)<-[:HAS_CREATOR]-(post:Post)-[:HAS_TAG]->(tag:Tag {name: \"Hamid_Karzai\"})
 WHERE friend.id <> 933
 WITH DISTINCT post
 MATCH (post)-[:HAS_TAG]->(otherTag:Tag)
@@ -228,7 +228,7 @@ LIMIT 10",
             category: "complex",
             // People who liked a person's posts, with recency
             cypher: "\
-MATCH (p:Person {id: 933})<-[:HAS_CREATOR]-(m:Post)<-[:LIKES]-(liker:Person)
+MATCH (p:Person {id: 2435})<-[:HAS_CREATOR]-(m:Post)<-[:LIKES]-(liker:Person)
 RETURN liker.id, liker.firstName, liker.lastName, m.id, m.creationDate
 ORDER BY m.creationDate DESC
 LIMIT 20",
@@ -240,7 +240,7 @@ LIMIT 20",
             category: "complex",
             // Recent reply-comments to a person's posts
             cypher: "\
-MATCH (p:Person {id: 933})<-[:HAS_CREATOR]-(m:Post)<-[:REPLY_OF]-(c:Comment)-[:HAS_CREATOR]->(author:Person)
+MATCH (p:Person {id: 2435})<-[:HAS_CREATOR]-(m:Post)<-[:REPLY_OF]-(c:Comment)-[:HAS_CREATOR]->(author:Person)
 RETURN author.id, author.firstName, author.lastName, c.creationDate, c.id, c.content
 ORDER BY c.creationDate DESC
 LIMIT 20",
@@ -252,7 +252,7 @@ LIMIT 20",
             category: "complex",
             // Recent posts by friends-of-friends
             cypher: "\
-MATCH (p:Person {id: 933})-[:KNOWS*1..2]-(friend:Person)<-[:HAS_CREATOR]-(m:Post)
+MATCH (p:Person {id: 2435})-[:KNOWS*1..2]-(friend:Person)<-[:HAS_CREATOR]-(m:Post)
 WHERE friend.id <> 933 AND m.creationDate < 1354320000000
 RETURN DISTINCT friend.id, friend.firstName, friend.lastName,
        m.id, coalesce(m.content, m.imageFile), m.creationDate
@@ -266,7 +266,7 @@ LIMIT 20",
             category: "complex",
             // Full LDBC IC10: friends-of-friends NOT already friends, ranked by shared interests
             cypher: "\
-MATCH (p:Person {id: 933})-[:KNOWS*2]-(stranger:Person)
+MATCH (p:Person {id: 2435})-[:KNOWS*2]-(stranger:Person)
 WHERE stranger.id <> 933 AND NOT EXISTS { MATCH (p)-[:KNOWS]-(stranger) }
 WITH DISTINCT stranger
 MATCH (stranger)-[:HAS_INTEREST]->(tag:Tag)
@@ -281,7 +281,7 @@ LIMIT 10",
             category: "complex",
             // Friends-of-friends who worked at a company before a given year
             cypher: "\
-MATCH (p:Person {id: 933})-[:KNOWS*1..2]-(friend:Person)-[wa:WORK_AT]->(org:Organisation)
+MATCH (p:Person {id: 2435})-[:KNOWS*1..2]-(friend:Person)-[wa:WORK_AT]->(org:Organisation)
 WHERE friend.id <> 933 AND org.name = \"MDLR_Airlines\" AND wa.workFrom < 2012
 RETURN DISTINCT friend.id, friend.firstName, friend.lastName, wa.workFrom, org.name
 ORDER BY wa.workFrom
@@ -294,7 +294,7 @@ LIMIT 10",
             category: "complex",
             // Full LDBC IC12: friends who replied to posts tagged with a given tag class, count distinct replies
             cypher: "\
-MATCH (p:Person {id: 933})-[:KNOWS]-(friend:Person)<-[:HAS_CREATOR]-(c:Comment)-[:REPLY_OF]->(post:Post)-[:HAS_TAG]->(tag:Tag)-[:HAS_TYPE]->(tc:TagClass)
+MATCH (p:Person {id: 2435})-[:KNOWS]-(friend:Person)<-[:HAS_CREATOR]-(c:Comment)-[:REPLY_OF]->(post:Post)-[:HAS_TAG]->(tag:Tag)-[:HAS_TYPE]->(tc:TagClass)
 WHERE tc.name = \"MusicalArtist\"
 RETURN friend.id, friend.firstName, friend.lastName, count(DISTINCT c) AS replyCount
 ORDER BY replyCount DESC
@@ -307,7 +307,7 @@ LIMIT 10",
             name: "Single Shortest Path",
             category: "complex",
             cypher: "\
-MATCH p = shortestPath((p1:Person {id: 933})-[:KNOWS*]-(p2:Person {id: 4139}))
+MATCH p = shortestPath((p1:Person {id: 2435})-[:KNOWS*]-(p2:Person {id: 4139}))
 RETURN length(p) AS pathLength",
         },
 
@@ -317,7 +317,7 @@ RETURN length(p) AS pathLength",
             name: "Trusted Connection Paths",
             category: "complex",
             cypher: "\
-MATCH p = allShortestPaths((p1:Person {id: 933})-[:KNOWS*]-(p2:Person {id: 4139}))
+MATCH p = allShortestPaths((p1:Person {id: 2435})-[:KNOWS*]-(p2:Person {id: 4139}))
 RETURN length(p) AS pathLength, nodes(p) AS pathNodes",
         },
     ]
@@ -361,7 +361,7 @@ CREATE (f:Forum {id: 999998, title: \"Benchmark Forum\", creationDate: 170925120
             name: "Add Forum Member",
             category: "update",
             cypher: "\
-MATCH (f:Forum {id: 999998}), (p:Person {id: 933})
+MATCH (f:Forum {id: 999998}), (p:Person {id: 2435})
 CREATE (f)-[:HAS_MEMBER {joinDate: 1709251200000}]->(p)",
         },
         LdbcQuery {
@@ -383,7 +383,7 @@ CREATE (c:Comment {id: 999996, creationDate: 1709251200000, locationIP: \"1.2.3.
             name: "Add Friendship",
             category: "update",
             cypher: "\
-MATCH (p1:Person {id: 933}), (p2:Person {id: 999999})
+MATCH (p1:Person {id: 2435}), (p2:Person {id: 999999})
 CREATE (p1)-[:KNOWS {creationDate: 1709251200000}]->(p2)",
         },
     ]
@@ -410,7 +410,7 @@ DETACH DELETE p",
             name: "Delete Like (Post)",
             category: "delete",
             cypher: "\
-MATCH (p:Person {id: 933})-[l:LIKES]->(m:Post {id: 1236950581248})
+MATCH (p:Person {id: 2435})-[l:LIKES]->(m:Post {id: 1236950581248})
 DELETE l",
         },
         // DEL-3: Remove LIKES edge from Person to Comment
@@ -419,7 +419,7 @@ DELETE l",
             name: "Delete Like (Comment)",
             category: "delete",
             cypher: "\
-MATCH (p:Person {id: 933})-[l:LIKES]->(c:Comment {id: 1236950581249})
+MATCH (p:Person {id: 2435})-[l:LIKES]->(c:Comment {id: 1236950581249})
 DELETE l",
         },
         // DEL-4: Remove a Forum (cascading via DETACH DELETE)
@@ -437,7 +437,7 @@ DETACH DELETE f",
             name: "Delete Forum Member",
             category: "delete",
             cypher: "\
-MATCH (f:Forum {id: 999998})-[m:HAS_MEMBER]->(p:Person {id: 933})
+MATCH (f:Forum {id: 999998})-[m:HAS_MEMBER]->(p:Person {id: 2435})
 DELETE m",
         },
         // DEL-6: Remove a Post (cascading via DETACH DELETE)
@@ -464,7 +464,7 @@ DETACH DELETE c",
             name: "Delete Friendship",
             category: "delete",
             cypher: "\
-MATCH (p1:Person {id: 933})-[k:KNOWS]->(p2:Person {id: 999999})
+MATCH (p1:Person {id: 2435})-[k:KNOWS]->(p2:Person {id: 999999})
 DELETE k",
         },
     ]

--- a/benches/ldbc_common/mod.rs
+++ b/benches/ldbc_common/mod.rs
@@ -139,13 +139,19 @@ where
         let fields: Vec<&str> = line.split('|').collect();
         if fields.len() < 2 { continue; }
 
-        let src_id: i64 = match fields[0].parse() {
-            Ok(v) => v,
-            Err(_) => { skipped += 1; continue; }
+        // LDBC datagen sometimes writes integer IDs with a trailing `.0`
+        // (e.g. `2336462209434.0` in comment_replyOf_*.csv). Strip
+        // trailing decimals before parsing.
+        fn parse_id(s: &str) -> Option<i64> {
+            s.parse().ok().or_else(|| s.split('.').next()?.parse().ok())
+        }
+        let src_id = match parse_id(fields[0]) {
+            Some(v) => v,
+            None => { skipped += 1; continue; }
         };
-        let tgt_id: i64 = match fields[1].parse() {
-            Ok(v) => v,
-            Err(_) => { skipped += 1; continue; }
+        let tgt_id = match parse_id(fields[1]) {
+            Some(v) => v,
+            None => { skipped += 1; continue; }
         };
 
         let src_node = match src_map.get(&src_id) {


### PR DESCRIPTION
Mirror of SGE PR #233. Loader was dropping all 2.4M REPLY_OF rows because LDBC datagen writes those IDs as floats. Bench used Person id 933 which doesn't exist in SF1; switched to Person 2435 (865 KNOWS edges). Verified locally: 21/21 SNB Interactive pass in 291.6s on M4, 17 of 21 returning non-zero rows (was 4 of 21 pre-fix).