### PR TITLE
Add HGNC + Ensembl gene identity loader

### DIFF
--- a/examples/hgnc_ensembl_common/mod.rs
+++ b/examples/hgnc_ensembl_common/mod.rs
@@ -24,6 +24,8 @@ pub type Error = Box<dyn std::error::Error>;
 pub struct LoadResult {
     pub gene_nodes: usize,
     pub same_as_edges: usize,
+    pub transcript_nodes: usize,
+    pub has_transcript_edges: usize,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -35,6 +37,23 @@ pub struct HgncRow {
     pub locus_type: String,
     pub chromosome: String,
     pub uniprot_ids: Vec<String>,
+    pub ensembl_gene_id: String,
+}
+
+/// A single mRNA-typed feature line from an Ensembl GFF3 file. We only model
+/// the transcript layer needed to bridge HGNC genes to downstream variant /
+/// evidence loaders; exons and CDS are out of scope for the canonical
+/// identity layer.
+#[derive(Debug, PartialEq, Eq)]
+pub struct GffMrnaRow {
+    pub transcript_id: String,
+    pub parent_gene_id: String,
+    pub biotype: String,
+    pub is_canonical: bool,
+    pub chromosome: String,
+    pub start: i64,
+    pub end: i64,
+    pub strand: String,
 }
 
 pub fn format_num(n: usize) -> String {
@@ -115,6 +134,58 @@ pub fn parse_row(headers: &HashMap<&str, usize>, fields: &[&str]) -> Option<Hgnc
         locus_type: get("locus_type").to_string(),
         chromosome: parse_chromosome(get("location")),
         uniprot_ids,
+        ensembl_gene_id: get("ensembl_gene_id").to_string(),
+    })
+}
+
+/// Parse a GFF3 attributes column ("key=value;key=value") into a map.
+/// Trailing semicolons and surrounding whitespace are tolerated.
+pub fn parse_gff3_attributes(s: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    for part in s.trim().split(';') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        if let Some(eq) = part.find('=') {
+            out.insert(part[..eq].to_string(), part[eq + 1..].to_string());
+        }
+    }
+    out
+}
+
+/// Parse a single GFF3 line. Returns Some(row) only for `mRNA` features with
+/// a parsable Parent gene ID; returns None for comments, non-mRNA features,
+/// or malformed lines.
+pub fn parse_gff3_mrna_line(line: &str) -> Option<GffMrnaRow> {
+    if line.is_empty() || line.starts_with('#') {
+        return None;
+    }
+    let cols: Vec<&str> = line.split('\t').collect();
+    if cols.len() < 9 || cols[2] != "mRNA" {
+        return None;
+    }
+    let attrs = parse_gff3_attributes(cols[8]);
+    let raw_id = attrs.get("ID")?.clone();
+    let raw_parent = attrs.get("Parent")?.clone();
+    // Strip Ensembl "transcript:" / "gene:" prefixes if present.
+    let transcript_id = raw_id.trim_start_matches("transcript:").to_string();
+    let parent_gene_id = raw_parent.trim_start_matches("gene:").to_string();
+    let is_canonical = attrs
+        .get("tag")
+        .map(|t| t.split(',').any(|x| x.trim() == "Ensembl_canonical"))
+        .unwrap_or(false);
+    let start = cols[3].parse::<i64>().ok()?;
+    let end = cols[4].parse::<i64>().ok()?;
+    Some(GffMrnaRow {
+        transcript_id,
+        parent_gene_id,
+        biotype: attrs.get("biotype").cloned().unwrap_or_default(),
+        is_canonical,
+        chromosome: cols[0].to_string(),
+        start,
+        end,
+        strand: cols[6].to_string(),
     })
 }
 
@@ -128,6 +199,18 @@ fn set_str(g: &mut GraphStore, id: NodeId, k: &str, v: &str) {
         if let Some(n) = g.get_node_mut(id) {
             n.set_property(k, PropertyValue::String(v.to_string()));
         }
+    }
+}
+
+fn set_int(g: &mut GraphStore, id: NodeId, k: &str, v: i64) {
+    if let Some(n) = g.get_node_mut(id) {
+        n.set_property(k, PropertyValue::Integer(v));
+    }
+}
+
+fn set_bool(g: &mut GraphStore, id: NodeId, k: &str, v: bool) {
+    if let Some(n) = g.get_node_mut(id) {
+        n.set_property(k, PropertyValue::Boolean(v));
     }
 }
 
@@ -148,6 +231,7 @@ pub fn upsert_gene(
     set_str(graph, id, "locus_group", &row.locus_group);
     set_str(graph, id, "locus_type", &row.locus_type);
     set_str(graph, id, "chromosome", &row.chromosome);
+    set_str(graph, id, "ensembl_gene_id", &row.ensembl_gene_id);
     hgnc_to_node.insert(row.hgnc_id.clone(), id);
     (id, true)
 }
@@ -209,16 +293,101 @@ pub fn load_hgnc_tsv(
     Ok(result)
 }
 
+/// Stream an Ensembl GFF3 file, creating :Transcript nodes for every `mRNA`
+/// feature whose Parent gene resolves through the supplied
+/// `ensembl_gene_to_node` map (built by the HGNC pass). Each transcript is
+/// linked to its parent :Gene with a HAS_TRANSCRIPT edge carrying
+/// `is_canonical` and `biotype` properties.
+///
+/// The file may be plain text or gzip-compressed; the caller passes a path
+/// to either. Decompression is handled via `flate2`.
+pub fn load_ensembl_gff3(
+    graph: &mut GraphStore,
+    path: &Path,
+    ensembl_gene_to_node: &HashMap<String, NodeId>,
+    max_rows: usize,
+) -> Result<(usize, usize), Error> {
+    use std::io::Read;
+    let file = File::open(path)?;
+    let reader: Box<dyn BufRead> = if path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e == "gz")
+        .unwrap_or(false)
+    {
+        let gz = flate2::read::GzDecoder::new(file);
+        Box::new(BufReader::with_capacity(4 * 1024 * 1024, gz))
+    } else {
+        Box::new(BufReader::with_capacity(4 * 1024 * 1024, file))
+    };
+    // Silence unused-import lint for Read in non-gz paths.
+    let _ = std::marker::PhantomData::<Box<dyn Read>>;
+
+    let mut transcript_to_node: HashMap<String, NodeId> = HashMap::with_capacity(250_000);
+    let mut transcripts = 0usize;
+    let mut edges = 0usize;
+    let mut count = 0usize;
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let row = match parse_gff3_mrna_line(&line) {
+            Some(r) => r,
+            None => continue,
+        };
+        let parent_node = match ensembl_gene_to_node.get(&row.parent_gene_id) {
+            Some(id) => *id,
+            None => continue, // gene not in our HGNC index — skip
+        };
+        if transcript_to_node.contains_key(&row.transcript_id) {
+            continue;
+        }
+        let tid = graph.create_node("Transcript");
+        set_str(graph, tid, "ensembl_transcript_id", &row.transcript_id);
+        set_str(graph, tid, "biotype", &row.biotype);
+        set_str(graph, tid, "chromosome", &row.chromosome);
+        set_str(graph, tid, "strand", &row.strand);
+        set_int(graph, tid, "start", row.start);
+        set_int(graph, tid, "end", row.end);
+        set_bool(graph, tid, "is_canonical", row.is_canonical);
+        transcript_to_node.insert(row.transcript_id.clone(), tid);
+        transcripts += 1;
+        if graph.create_edge(parent_node, tid, "HAS_TRANSCRIPT").is_ok() {
+            edges += 1;
+        }
+        count += 1;
+        if max_rows > 0 && count >= max_rows {
+            break;
+        }
+        if count % 50_000 == 0 {
+            eprint!("\r  Ensembl mRNA rows: {}", format_num(count));
+        }
+    }
+    eprintln!("\r  Ensembl mRNA rows: {} (done)", format_num(count));
+    Ok((transcripts, edges))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use samyama_sdk::GraphStore;
 
-    const FIXTURE: &str = "hgnc_id\tsymbol\tname\tlocus_group\tlocus_type\tlocation\tuniprot_ids\n\
-        HGNC:1100\tBRCA1\tBRCA1 DNA repair associated\tprotein-coding gene\tgene with protein product\t17q21.31\tP38398\n\
-        HGNC:1101\tBRCA2\tBRCA2 DNA repair associated\tprotein-coding gene\tgene with protein product\t13q13.1\tP51587\n\
-        HGNC:11998\tTP53\ttumor protein p53\tprotein-coding gene\tgene with protein product\t17p13.1\tP04637|Q53GA5\n\
-        HGNC:9999\t\tno-symbol-row\tprotein-coding gene\tgene with protein product\t1q21\tQ12345\n";
+    const FIXTURE: &str = "hgnc_id\tsymbol\tname\tlocus_group\tlocus_type\tlocation\tuniprot_ids\tensembl_gene_id\n\
+        HGNC:1100\tBRCA1\tBRCA1 DNA repair associated\tprotein-coding gene\tgene with protein product\t17q21.31\tP38398\tENSG00000012048\n\
+        HGNC:1101\tBRCA2\tBRCA2 DNA repair associated\tprotein-coding gene\tgene with protein product\t13q13.1\tP51587\tENSG00000139618\n\
+        HGNC:11998\tTP53\ttumor protein p53\tprotein-coding gene\tgene with protein product\t17p13.1\tP04637|Q53GA5\tENSG00000141510\n\
+        HGNC:9999\t\tno-symbol-row\tprotein-coding gene\tgene with protein product\t1q21\tQ12345\tENSG00000999999\n";
+
+    const GFF_FIXTURE: &str = "##gff-version 3\n\
+        # comment line\n\
+        17\tensembl_havana\tgene\t43044295\t43125483\t.\t-\t.\tID=gene:ENSG00000012048;Name=BRCA1;biotype=protein_coding\n\
+        17\tensembl_havana\tmRNA\t43044295\t43125483\t.\t-\t.\tID=transcript:ENST00000357654;Parent=gene:ENSG00000012048;biotype=protein_coding;tag=Ensembl_canonical\n\
+        17\tensembl_havana\tmRNA\t43045802\t43125483\t.\t-\t.\tID=transcript:ENST00000471181;Parent=gene:ENSG00000012048;biotype=protein_coding\n\
+        17\tensembl_havana\texon\t43044295\t43045802\t.\t-\t.\tParent=transcript:ENST00000357654\n\
+        13\tensembl_havana\tmRNA\t32315086\t32400266\t.\t+\t.\tID=transcript:ENST00000380152;Parent=gene:ENSG00000139618;biotype=protein_coding;tag=Ensembl_canonical\n\
+        99\tensembl_havana\tmRNA\t1\t100\t.\t+\t.\tID=transcript:ENST00000999999;Parent=gene:ENSG_NOT_IN_HGNC;biotype=protein_coding\n";
 
     #[test]
     fn parses_chromosome_from_location() {
@@ -279,6 +448,7 @@ mod tests {
             locus_type: "gene with protein product".into(),
             chromosome: "17".into(),
             uniprot_ids: vec!["P38398".into()],
+            ensembl_gene_id: "ENSG00000012048".into(),
         };
         let (id1, new1) = upsert_gene(&mut g, &row, &mut map);
         let (id2, new2) = upsert_gene(&mut g, &row, &mut map);
@@ -308,6 +478,62 @@ mod tests {
         assert_eq!(result.gene_nodes, 3);
         // Only BRCA1's UniProt accession is in the bridge map.
         assert_eq!(result.same_as_edges, 1);
+    }
+
+    #[test]
+    fn parses_gff3_attributes_into_map() {
+        let m = parse_gff3_attributes("ID=transcript:ENST00000357654;Parent=gene:ENSG00000012048;biotype=protein_coding;tag=Ensembl_canonical");
+        assert_eq!(m.get("ID").map(String::as_str), Some("transcript:ENST00000357654"));
+        assert_eq!(m.get("Parent").map(String::as_str), Some("gene:ENSG00000012048"));
+        assert_eq!(m.get("biotype").map(String::as_str), Some("protein_coding"));
+        assert_eq!(m.get("tag").map(String::as_str), Some("Ensembl_canonical"));
+    }
+
+    #[test]
+    fn parses_mrna_line_strips_prefixes_and_detects_canonical() {
+        let line = "17\tensembl_havana\tmRNA\t43044295\t43125483\t.\t-\t.\tID=transcript:ENST00000357654;Parent=gene:ENSG00000012048;biotype=protein_coding;tag=Ensembl_canonical";
+        let row = parse_gff3_mrna_line(line).expect("mRNA row");
+        assert_eq!(row.transcript_id, "ENST00000357654");
+        assert_eq!(row.parent_gene_id, "ENSG00000012048");
+        assert_eq!(row.biotype, "protein_coding");
+        assert!(row.is_canonical);
+        assert_eq!(row.chromosome, "17");
+        assert_eq!(row.start, 43044295);
+        assert_eq!(row.end, 43125483);
+        assert_eq!(row.strand, "-");
+    }
+
+    #[test]
+    fn skips_non_mrna_and_comment_lines() {
+        assert!(parse_gff3_mrna_line("##gff-version 3").is_none());
+        assert!(parse_gff3_mrna_line("# comment").is_none());
+        assert!(parse_gff3_mrna_line("").is_none());
+        let gene_line = "17\tensembl\tgene\t1\t100\t.\t+\t.\tID=gene:ENSG00000012048";
+        assert!(parse_gff3_mrna_line(gene_line).is_none());
+        let exon_line = "17\tensembl\texon\t1\t100\t.\t+\t.\tParent=transcript:ENST00000357654";
+        assert!(parse_gff3_mrna_line(exon_line).is_none());
+    }
+
+    #[test]
+    fn load_ensembl_creates_transcripts_and_skips_unmapped_genes() {
+        let dir = tempdir();
+        let gff_path = dir.join("Homo_sapiens.GRCh38.gff3");
+        std::fs::write(&gff_path, GFF_FIXTURE).unwrap();
+
+        let mut g = GraphStore::new();
+        // Pre-create two :Gene nodes mirroring HGNC pass for BRCA1 and BRCA2.
+        let brca1 = g.create_node("Gene");
+        g.get_node_mut(brca1).unwrap().set_property("symbol", PropertyValue::String("BRCA1".into()));
+        let brca2 = g.create_node("Gene");
+        g.get_node_mut(brca2).unwrap().set_property("symbol", PropertyValue::String("BRCA2".into()));
+        let mut ensembl_map = HashMap::new();
+        ensembl_map.insert("ENSG00000012048".to_string(), brca1);
+        ensembl_map.insert("ENSG00000139618".to_string(), brca2);
+
+        let (transcripts, edges) = load_ensembl_gff3(&mut g, &gff_path, &ensembl_map, 0).unwrap();
+        // BRCA1 has 2 mRNAs, BRCA2 has 1, ENSG_NOT_IN_HGNC is skipped.
+        assert_eq!(transcripts, 3);
+        assert_eq!(edges, 3);
     }
 
     fn tempdir() -> std::path::PathBuf {

--- a/examples/hgnc_ensembl_common/mod.rs
+++ b/examples/hgnc_ensembl_common/mod.rs
@@ -1,0 +1,324 @@
+//! HGNC + Ensembl — canonical Gene/Transcript identity layer.
+//!
+//! HGNC slice first; Ensembl GFF transcript layer follows in a second pass.
+//!
+//! Schema:
+//!   :Gene    (hgnc_id PK, symbol, name, locus_group, locus_type, chromosome)
+//!   :SAME_AS (Gene -> existing :Protein, props: source="HGNC")
+//!
+//! HGNC source: hgnc_complete_set.txt (TSV, header row, ~45K rows).
+//! Columns we care about: hgnc_id, symbol, name, locus_group, locus_type,
+//! location, uniprot_ids (pipe-delimited within the field).
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::time::Duration;
+
+use samyama_sdk::{GraphStore, NodeId, PropertyValue};
+
+pub type Error = Box<dyn std::error::Error>;
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct LoadResult {
+    pub gene_nodes: usize,
+    pub same_as_edges: usize,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct HgncRow {
+    pub hgnc_id: String,
+    pub symbol: String,
+    pub name: String,
+    pub locus_group: String,
+    pub locus_type: String,
+    pub chromosome: String,
+    pub uniprot_ids: Vec<String>,
+}
+
+pub fn format_num(n: usize) -> String {
+    let s = n.to_string();
+    let mut r = String::new();
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            r.push(',');
+        }
+        r.push(c);
+    }
+    r.chars().rev().collect()
+}
+
+pub fn format_duration(d: Duration) -> String {
+    let s = d.as_secs_f64();
+    if s < 60.0 {
+        format!("{:.1}s", s)
+    } else if s < 3600.0 {
+        format!("{}m {:.1}s", s as u64 / 60, s % 60.0)
+    } else {
+        format!("{}h {}m", s as u64 / 3600, (s as u64 % 3600) / 60)
+    }
+}
+
+/// Parse the HGNC `location` field down to a chromosome name.
+/// Examples: "11q13.1" -> "11", "Xp22.33" -> "X", "mitochondria" -> "MT".
+pub fn parse_chromosome(location: &str) -> String {
+    let trimmed = location.trim();
+    if trimmed.is_empty() || trimmed == "reserved" || trimmed == "unplaced" {
+        return String::new();
+    }
+    if trimmed.eq_ignore_ascii_case("mitochondria") {
+        return "MT".to_string();
+    }
+    let mut out = String::new();
+    for c in trimmed.chars() {
+        if c == 'p' || c == 'q' || c == ' ' || c == '.' || c.is_ascii_digit() && !out.is_empty() && out.ends_with(|x: char| x == 'p' || x == 'q') {
+            break;
+        }
+        out.push(c);
+    }
+    // Strip trailing band digits (e.g. "11q13" -> we already broke at 'q', but
+    // also handle pure-digit chromosomes that fell through).
+    out.trim_end_matches(|c: char| c == 'p' || c == 'q').to_string()
+}
+
+/// Parse a single HGNC TSV header + data row pair into a typed row.
+/// Returns None if required fields are missing/empty.
+pub fn parse_row(headers: &HashMap<&str, usize>, fields: &[&str]) -> Option<HgncRow> {
+    let get = |key: &str| -> &str {
+        headers
+            .get(key)
+            .and_then(|i| fields.get(*i))
+            .copied()
+            .unwrap_or("")
+    };
+    let hgnc_id = get("hgnc_id").to_string();
+    let symbol = get("symbol").to_string();
+    if hgnc_id.is_empty() || symbol.is_empty() {
+        return None;
+    }
+    let uniprot_field = get("uniprot_ids");
+    let uniprot_ids = if uniprot_field.is_empty() {
+        Vec::new()
+    } else {
+        uniprot_field
+            .split('|')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    };
+    Some(HgncRow {
+        hgnc_id,
+        symbol,
+        name: get("name").to_string(),
+        locus_group: get("locus_group").to_string(),
+        locus_type: get("locus_type").to_string(),
+        chromosome: parse_chromosome(get("location")),
+        uniprot_ids,
+    })
+}
+
+/// Build a header-name -> column-index map from the first line of an HGNC TSV.
+pub fn parse_header(line: &str) -> HashMap<&str, usize> {
+    line.split('\t').enumerate().map(|(i, c)| (c, i)).collect()
+}
+
+fn set_str(g: &mut GraphStore, id: NodeId, k: &str, v: &str) {
+    if !v.is_empty() {
+        if let Some(n) = g.get_node_mut(id) {
+            n.set_property(k, PropertyValue::String(v.to_string()));
+        }
+    }
+}
+
+/// Insert a single HGNC row as a :Gene node, deduped on HGNC ID.
+/// Returns the NodeId (newly created or pre-existing) and whether it was new.
+pub fn upsert_gene(
+    graph: &mut GraphStore,
+    row: &HgncRow,
+    hgnc_to_node: &mut HashMap<String, NodeId>,
+) -> (NodeId, bool) {
+    if let Some(&id) = hgnc_to_node.get(&row.hgnc_id) {
+        return (id, false);
+    }
+    let id = graph.create_node("Gene");
+    set_str(graph, id, "hgnc_id", &row.hgnc_id);
+    set_str(graph, id, "symbol", &row.symbol);
+    set_str(graph, id, "name", &row.name);
+    set_str(graph, id, "locus_group", &row.locus_group);
+    set_str(graph, id, "locus_type", &row.locus_type);
+    set_str(graph, id, "chromosome", &row.chromosome);
+    hgnc_to_node.insert(row.hgnc_id.clone(), id);
+    (id, true)
+}
+
+/// Stream an HGNC TSV file into the graph. `uniprot_to_node` is an optional
+/// pre-populated map (UniProt accession -> :Protein NodeId) from the existing
+/// v1.0 KG; when present, :SAME_AS edges are created.
+pub fn load_hgnc_tsv(
+    graph: &mut GraphStore,
+    path: &Path,
+    uniprot_to_node: Option<&HashMap<String, NodeId>>,
+    max_rows: usize,
+) -> Result<LoadResult, Error> {
+    let file = File::open(path)?;
+    let reader = BufReader::with_capacity(4 * 1024 * 1024, file);
+    let mut hgnc_to_node: HashMap<String, NodeId> = HashMap::with_capacity(50_000);
+    let mut result = LoadResult::default();
+
+    let mut lines = reader.lines();
+    let header_line = match lines.next() {
+        Some(Ok(l)) => l,
+        _ => return Err("HGNC TSV: missing header".into()),
+    };
+    let headers = parse_header(&header_line);
+
+    let mut count = 0usize;
+    for line in lines {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let fields: Vec<&str> = line.split('\t').collect();
+        let row = match parse_row(&headers, &fields) {
+            Some(r) => r,
+            None => continue,
+        };
+        let (gene_id, is_new) = upsert_gene(graph, &row, &mut hgnc_to_node);
+        if is_new {
+            result.gene_nodes += 1;
+        }
+        if let Some(map) = uniprot_to_node {
+            for acc in &row.uniprot_ids {
+                if let Some(&pid) = map.get(acc) {
+                    if graph.create_edge(gene_id, pid, "SAME_AS").is_ok() {
+                        result.same_as_edges += 1;
+                    }
+                }
+            }
+        }
+        count += 1;
+        if max_rows > 0 && count >= max_rows {
+            break;
+        }
+        if count % 10_000 == 0 {
+            eprint!("\r  HGNC rows: {}", format_num(count));
+        }
+    }
+    eprintln!("\r  HGNC rows: {} (done)", format_num(count));
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use samyama_sdk::GraphStore;
+
+    const FIXTURE: &str = "hgnc_id\tsymbol\tname\tlocus_group\tlocus_type\tlocation\tuniprot_ids\n\
+        HGNC:1100\tBRCA1\tBRCA1 DNA repair associated\tprotein-coding gene\tgene with protein product\t17q21.31\tP38398\n\
+        HGNC:1101\tBRCA2\tBRCA2 DNA repair associated\tprotein-coding gene\tgene with protein product\t13q13.1\tP51587\n\
+        HGNC:11998\tTP53\ttumor protein p53\tprotein-coding gene\tgene with protein product\t17p13.1\tP04637|Q53GA5\n\
+        HGNC:9999\t\tno-symbol-row\tprotein-coding gene\tgene with protein product\t1q21\tQ12345\n";
+
+    #[test]
+    fn parses_chromosome_from_location() {
+        assert_eq!(parse_chromosome("17q21.31"), "17");
+        assert_eq!(parse_chromosome("Xp22.33"), "X");
+        assert_eq!(parse_chromosome("13q13.1"), "13");
+        assert_eq!(parse_chromosome("mitochondria"), "MT");
+        assert_eq!(parse_chromosome("reserved"), "");
+        assert_eq!(parse_chromosome(""), "");
+    }
+
+    #[test]
+    fn parses_header_into_index_map() {
+        let h = parse_header("hgnc_id\tsymbol\tname");
+        assert_eq!(h.get("hgnc_id"), Some(&0));
+        assert_eq!(h.get("symbol"), Some(&1));
+        assert_eq!(h.get("name"), Some(&2));
+    }
+
+    #[test]
+    fn parses_well_formed_row() {
+        let lines: Vec<&str> = FIXTURE.lines().collect();
+        let headers = parse_header(lines[0]);
+        let fields: Vec<&str> = lines[1].split('\t').collect();
+        let row = parse_row(&headers, &fields).expect("BRCA1 row");
+        assert_eq!(row.hgnc_id, "HGNC:1100");
+        assert_eq!(row.symbol, "BRCA1");
+        assert_eq!(row.chromosome, "17");
+        assert_eq!(row.uniprot_ids, vec!["P38398"]);
+    }
+
+    #[test]
+    fn parses_pipe_delimited_uniprot_ids() {
+        let lines: Vec<&str> = FIXTURE.lines().collect();
+        let headers = parse_header(lines[0]);
+        let fields: Vec<&str> = lines[3].split('\t').collect();
+        let row = parse_row(&headers, &fields).expect("TP53 row");
+        assert_eq!(row.uniprot_ids, vec!["P04637", "Q53GA5"]);
+    }
+
+    #[test]
+    fn skips_rows_with_empty_required_fields() {
+        let lines: Vec<&str> = FIXTURE.lines().collect();
+        let headers = parse_header(lines[0]);
+        let fields: Vec<&str> = lines[4].split('\t').collect();
+        assert!(parse_row(&headers, &fields).is_none(), "row missing symbol must be rejected");
+    }
+
+    #[test]
+    fn upsert_dedupes_on_hgnc_id() {
+        let mut g = GraphStore::new();
+        let mut map = HashMap::new();
+        let row = HgncRow {
+            hgnc_id: "HGNC:1100".into(),
+            symbol: "BRCA1".into(),
+            name: "BRCA1 DNA repair associated".into(),
+            locus_group: "protein-coding gene".into(),
+            locus_type: "gene with protein product".into(),
+            chromosome: "17".into(),
+            uniprot_ids: vec!["P38398".into()],
+        };
+        let (id1, new1) = upsert_gene(&mut g, &row, &mut map);
+        let (id2, new2) = upsert_gene(&mut g, &row, &mut map);
+        assert!(new1);
+        assert!(!new2);
+        assert_eq!(id1, id2);
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn load_creates_gene_nodes_and_same_as_edges() {
+        let dir = tempdir();
+        let path = dir.join("hgnc_complete_set.txt");
+        std::fs::write(&path, FIXTURE).unwrap();
+
+        let mut g = GraphStore::new();
+        // Pre-populate one Protein so SAME_AS edge fires for BRCA1.
+        let prot_id = g.create_node("Protein");
+        g.get_node_mut(prot_id)
+            .unwrap()
+            .set_property("accession", PropertyValue::String("P38398".into()));
+        let mut uniprot_map = HashMap::new();
+        uniprot_map.insert("P38398".to_string(), prot_id);
+
+        let result = load_hgnc_tsv(&mut g, &path, Some(&uniprot_map), 0).unwrap();
+        // Three valid gene rows (BRCA1, BRCA2, TP53); the no-symbol row is skipped.
+        assert_eq!(result.gene_nodes, 3);
+        // Only BRCA1's UniProt accession is in the bridge map.
+        assert_eq!(result.same_as_edges, 1);
+    }
+
+    fn tempdir() -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!("hgnc_test_{}_{}", std::process::id(), rand_suffix()));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+    fn rand_suffix() -> String {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().subsec_nanos();
+        format!("{}", nanos)
+    }
+}

--- a/examples/hgnc_ensembl_loader.rs
+++ b/examples/hgnc_ensembl_loader.rs
@@ -1,0 +1,123 @@
+//! HGNC + Ensembl Loader
+//!
+//! Loads the canonical Gene identity layer from HGNC's `hgnc_complete_set.txt`
+//! and bridges to existing :Protein nodes (UniProt) via :SAME_AS edges.
+//! Ensembl GFF3 transcript layer is added in a follow-up pass.
+//!
+//! Usage:
+//!   cargo run --release --example hgnc_ensembl_loader -- \
+//!     --hgnc data/hgnc/hgnc_complete_set.txt
+//!   cargo run --release --example hgnc_ensembl_loader -- \
+//!     --hgnc data/hgnc/hgnc_complete_set.txt --snapshot hgnc.sgsnap
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use samyama_sdk::{EmbeddedClient, NodeId, PropertyValue, Label};
+
+mod hgnc_ensembl_common;
+use hgnc_ensembl_common::{format_duration, format_num, load_hgnc_tsv};
+
+type Error = Box<dyn std::error::Error>;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        eprintln!("Usage: cargo run --release --example hgnc_ensembl_loader [OPTIONS]");
+        eprintln!("  --hgnc PATH       HGNC TSV (hgnc_complete_set.txt) [required]");
+        eprintln!("  --snapshot PATH   Export snapshot after loading");
+        eprintln!("  --max-rows N      Limit input rows (0=all, default 0)");
+        std::process::exit(0);
+    }
+
+    let hgnc_path = args
+        .iter()
+        .position(|a| a == "--hgnc")
+        .and_then(|i| args.get(i + 1))
+        .map(PathBuf::from)
+        .ok_or("--hgnc PATH is required")?;
+
+    let snapshot_path = args
+        .iter()
+        .position(|a| a == "--snapshot")
+        .map(|pos| PathBuf::from(args.get(pos + 1).expect("--snapshot requires PATH")));
+
+    let max_rows: usize = args
+        .iter()
+        .position(|a| a == "--max-rows")
+        .and_then(|i| args.get(i + 1))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+
+    eprintln!("HGNC + Ensembl Loader (Phase 1b)");
+    eprintln!("  HGNC: {}", hgnc_path.display());
+    if max_rows > 0 {
+        eprintln!("  Max rows: {}", format_num(max_rows));
+    }
+    eprintln!();
+
+    let client = EmbeddedClient::new();
+    let total_start = Instant::now();
+
+    let result = {
+        let mut graph = client.store_write().await;
+        // Build UniProt accession -> :Protein NodeId map by walking the existing
+        // store. Empty on a fresh DB, populated when chained after the UniProt
+        // loader's snapshot has been imported.
+        let uniprot_map = build_uniprot_index(&graph);
+        eprintln!(
+            "  UniProt :Protein bridge: {} accessions",
+            format_num(uniprot_map.len())
+        );
+        load_hgnc_tsv(
+            &mut graph,
+            &hgnc_path,
+            if uniprot_map.is_empty() {
+                None
+            } else {
+                Some(&uniprot_map)
+            },
+            max_rows,
+        )?
+    };
+
+    let total_elapsed = total_start.elapsed();
+    eprintln!();
+    eprintln!("========================================");
+    eprintln!("HGNC load complete.");
+    eprintln!("  Gene nodes:    {}", format_num(result.gene_nodes));
+    eprintln!("  SAME_AS edges: {}", format_num(result.same_as_edges));
+    eprintln!("  Time:          {}", format_duration(total_elapsed));
+    eprintln!("========================================");
+
+    if let Some(ref snap_path) = snapshot_path {
+        eprintln!("\nExporting snapshot to {}...", snap_path.display());
+        let t = Instant::now();
+        let s = client.export_snapshot("default", snap_path).await?;
+        let sz = std::fs::metadata(snap_path).map(|m| m.len()).unwrap_or(0);
+        eprintln!(
+            "Snapshot: {} nodes, {} edges ({:.1} MB) in {}",
+            format_num(s.node_count as usize),
+            format_num(s.edge_count as usize),
+            sz as f64 / (1024.0 * 1024.0),
+            format_duration(t.elapsed()),
+        );
+    }
+    Ok(())
+}
+
+/// Walk all :Protein nodes in the store and index them by `accession` property.
+/// Used to build the bridge map for HGNC :SAME_AS edges.
+fn build_uniprot_index(graph: &samyama_sdk::GraphStore) -> HashMap<String, NodeId> {
+    let mut out = HashMap::new();
+    let label: Label = "Protein".into();
+    for node in graph.get_nodes_by_label(&label) {
+        if let Some(PropertyValue::String(acc)) = node.get_property("accession") {
+            out.insert(acc.clone(), node.id);
+        }
+    }
+    out
+}

--- a/examples/hgnc_ensembl_loader.rs
+++ b/examples/hgnc_ensembl_loader.rs
@@ -17,7 +17,7 @@ use std::time::Instant;
 use samyama_sdk::{EmbeddedClient, NodeId, PropertyValue, Label};
 
 mod hgnc_ensembl_common;
-use hgnc_ensembl_common::{format_duration, format_num, load_hgnc_tsv};
+use hgnc_ensembl_common::{format_duration, format_num, load_ensembl_gff3, load_hgnc_tsv};
 
 type Error = Box<dyn std::error::Error>;
 
@@ -28,8 +28,9 @@ async fn main() -> Result<(), Error> {
     if args.iter().any(|a| a == "--help" || a == "-h") {
         eprintln!("Usage: cargo run --release --example hgnc_ensembl_loader [OPTIONS]");
         eprintln!("  --hgnc PATH       HGNC TSV (hgnc_complete_set.txt) [required]");
+        eprintln!("  --gff3 PATH       Ensembl GRCh38 GFF3 (.gff3 or .gff3.gz)");
         eprintln!("  --snapshot PATH   Export snapshot after loading");
-        eprintln!("  --max-rows N      Limit input rows (0=all, default 0)");
+        eprintln!("  --max-rows N      Limit input rows per source (0=all, default 0)");
         std::process::exit(0);
     }
 
@@ -39,6 +40,12 @@ async fn main() -> Result<(), Error> {
         .and_then(|i| args.get(i + 1))
         .map(PathBuf::from)
         .ok_or("--hgnc PATH is required")?;
+
+    let gff3_path = args
+        .iter()
+        .position(|a| a == "--gff3")
+        .and_then(|i| args.get(i + 1))
+        .map(PathBuf::from);
 
     let snapshot_path = args
         .iter()
@@ -52,8 +59,11 @@ async fn main() -> Result<(), Error> {
         .and_then(|s| s.parse().ok())
         .unwrap_or(0);
 
-    eprintln!("HGNC + Ensembl Loader (Phase 1b)");
+    eprintln!("HGNC + Ensembl Loader");
     eprintln!("  HGNC: {}", hgnc_path.display());
+    if let Some(ref p) = gff3_path {
+        eprintln!("  GFF3: {}", p.display());
+    }
     if max_rows > 0 {
         eprintln!("  Max rows: {}", format_num(max_rows));
     }
@@ -62,7 +72,7 @@ async fn main() -> Result<(), Error> {
     let client = EmbeddedClient::new();
     let total_start = Instant::now();
 
-    let result = {
+    let mut result = {
         let mut graph = client.store_write().await;
         // Build UniProt accession -> :Protein NodeId map by walking the existing
         // store. Empty on a fresh DB, populated when chained after the UniProt
@@ -84,13 +94,28 @@ async fn main() -> Result<(), Error> {
         )?
     };
 
+    if let Some(ref gff_path) = gff3_path {
+        let mut graph = client.store_write().await;
+        let ensembl_map = build_ensembl_gene_index(&graph);
+        eprintln!(
+            "  Ensembl gene bridge:    {} ENSG IDs",
+            format_num(ensembl_map.len())
+        );
+        let (transcripts, edges) =
+            load_ensembl_gff3(&mut graph, gff_path, &ensembl_map, max_rows)?;
+        result.transcript_nodes = transcripts;
+        result.has_transcript_edges = edges;
+    }
+
     let total_elapsed = total_start.elapsed();
     eprintln!();
     eprintln!("========================================");
     eprintln!("HGNC load complete.");
-    eprintln!("  Gene nodes:    {}", format_num(result.gene_nodes));
-    eprintln!("  SAME_AS edges: {}", format_num(result.same_as_edges));
-    eprintln!("  Time:          {}", format_duration(total_elapsed));
+    eprintln!("  Gene nodes:           {}", format_num(result.gene_nodes));
+    eprintln!("  SAME_AS edges:        {}", format_num(result.same_as_edges));
+    eprintln!("  Transcript nodes:     {}", format_num(result.transcript_nodes));
+    eprintln!("  HAS_TRANSCRIPT edges: {}", format_num(result.has_transcript_edges));
+    eprintln!("  Time:                 {}", format_duration(total_elapsed));
     eprintln!("========================================");
 
     if let Some(ref snap_path) = snapshot_path {
@@ -117,6 +142,21 @@ fn build_uniprot_index(graph: &samyama_sdk::GraphStore) -> HashMap<String, NodeI
     for node in graph.get_nodes_by_label(&label) {
         if let Some(PropertyValue::String(acc)) = node.get_property("accession") {
             out.insert(acc.clone(), node.id);
+        }
+    }
+    out
+}
+
+/// Walk all :Gene nodes (just loaded from HGNC) and index by Ensembl gene ID
+/// so the GFF3 pass can resolve `Parent=gene:ENSG...` to a NodeId.
+fn build_ensembl_gene_index(graph: &samyama_sdk::GraphStore) -> HashMap<String, NodeId> {
+    let mut out = HashMap::new();
+    let label: Label = "Gene".into();
+    for node in graph.get_nodes_by_label(&label) {
+        if let Some(PropertyValue::String(eid)) = node.get_property("ensembl_gene_id") {
+            if !eid.is_empty() {
+                out.insert(eid.clone(), node.id);
+            }
         }
     }
     out


### PR DESCRIPTION
## Summary
- Adds `examples/hgnc_ensembl_loader.rs` + `hgnc_ensembl_common` module that streams HGNC `hgnc_complete_set.txt` into deduped `:Gene` nodes and bridges them to existing `:Protein` nodes via `:SAME_AS` edges when a UniProt accession map is present.
- Extends with an Ensembl GRCh38 GFF3 streaming pass (plain or gzipped) creating `:Transcript` nodes and `HAS_TRANSCRIPT` edges back to `:Gene`, joining via the `ensembl_gene_id` column from HGNC.
- Establishes the canonical gene/transcript identity layer that downstream variant and evidence loaders will join against.

## Test plan
- [x] 11 new unit tests pass (`cargo test --example hgnc_ensembl_loader`)
- [x] Lib suite unchanged at 2005 passing (`cargo test --lib`)
- [ ] Real-data smoke run against full HGNC TSV + Ensembl GFF3 (follow-up — requires data download)