### PR TITLE
snapshot: rebuild edge_type_index after import (planner fix)

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -1996,6 +1996,46 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         *self.statistics_cache.write().unwrap() = None;
     }
 
+    /// Rebuild `edge_type_index` from the compact `edge_type_ids` array.
+    ///
+    /// `create_edge_stub` (the bulk-load fast path used by snapshot import)
+    /// only writes to `edge_type_ids` for memory efficiency — it does not
+    /// touch `edge_type_index`. Without this index, the planner reports
+    /// 0 edges for every imported edge type and falls back to
+    /// `NodeScan(all labels)` for OPTIONAL MATCH expansions, producing
+    /// pathological plans on snapshot-imported graphs.
+    ///
+    /// Snapshot import calls this after `compact_adjacency()`.
+    pub fn rebuild_edge_type_index(&mut self) {
+        self.edge_type_index.clear();
+        let len = self.edge_type_ids.len();
+        for idx in 0..len {
+            let type_id = self.edge_type_ids[idx];
+            if type_id == Self::EDGE_TYPE_UNSET {
+                continue;
+            }
+            // Skip free-listed (deleted) edges — their endpoints are zeroed.
+            // edge_endpoints is grown in lockstep with edge_type_ids; absence
+            // implies the edge has not been allocated.
+            if idx >= self.edge_endpoints.len() {
+                continue;
+            }
+            let (src, tgt) = self.edge_endpoints[idx];
+            if src.as_u64() == 0 && tgt.as_u64() == 0 {
+                continue;
+            }
+            if (type_id as usize) >= self.edge_type_table.len() {
+                continue;
+            }
+            let edge_type = self.edge_type_table[type_id as usize].clone();
+            self.edge_type_index
+                .entry(edge_type)
+                .or_insert_with(HashSet::new)
+                .insert(EdgeId::new(idx as u64));
+        }
+        self.invalidate_statistics_cache();
+    }
+
     pub fn compute_statistics(&self) -> GraphStatistics {
         let total_nodes = self.node_count();
         let total_edges = self.edge_count();

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -500,6 +500,12 @@ pub fn import_tenant_with_dedup(
     // Compact adjacency lists to CSR for memory efficiency (DS-07)
     if imported_edge_count > 0 {
         store.compact_adjacency();
+        // Bulk-loaded edges go through create_edge_stub which intentionally
+        // skips edge_type_index updates for speed. Rebuild the index so the
+        // planner can see the imported edge types — without this, OPTIONAL
+        // MATCH plans against imported snapshots fall back to NodeScan(all)
+        // and time out on multi-million-node stores.
+        store.rebuild_edge_type_index();
     }
 
     if merged_node_count > 0 {
@@ -1147,6 +1153,38 @@ mod tests {
             let targets2 = store2.get_outgoing_edge_targets_owned(articles[1].id);
             !targets2.is_empty()
         }, "At least one article should have outgoing edges after v2 import");
+    }
+
+    #[test]
+    fn test_import_rebuilds_edge_type_index() {
+        // Regression: snapshot import previously used create_edge_stub which
+        // skipped edge_type_index, leaving the planner blind to imported
+        // edge types. The fix calls rebuild_edge_type_index after compact.
+        use crate::graph::EdgeType;
+
+        let mut producer = GraphStore::new();
+        let a = producer.create_node_stub("Person");
+        let b = producer.create_node_stub("Person");
+        let c = producer.create_node_stub("City");
+        producer.set_column_property(a, "name", PropertyValue::String("Alice".into()));
+        producer.set_column_property(b, "name", PropertyValue::String("Bob".into()));
+        producer.set_column_property(c, "name", PropertyValue::String("NYC".into()));
+        producer.create_edge_stub(a, b, "KNOWS").unwrap();
+        producer.create_edge_stub(b, a, "KNOWS").unwrap();
+        producer.create_edge_stub(a, c, "LIVES_IN").unwrap();
+        producer.compact_adjacency();
+
+        let mut buf = Vec::new();
+        export_tenant(&producer, &mut buf).unwrap();
+
+        let mut consumer = GraphStore::new();
+        import_tenant(&mut consumer, std::io::Cursor::new(&buf)).unwrap();
+
+        assert_eq!(consumer.edge_type_count(&EdgeType::new("KNOWS")), 2);
+        assert_eq!(consumer.edge_type_count(&EdgeType::new("LIVES_IN")), 1);
+        let stats = consumer.compute_statistics();
+        assert_eq!(stats.edge_type_counts.get(&EdgeType::new("KNOWS")), Some(&2));
+        assert_eq!(stats.edge_type_counts.get(&EdgeType::new("LIVES_IN")), Some(&1));
     }
 }
 


### PR DESCRIPTION
## Summary
Snapshot import uses `create_edge_stub` for the bulk-load fast path, which intentionally skips `edge_type_index` updates for memory/speed during the load. Nothing rebuilt the index after `compact_adjacency`, so the planner was blind to every edge type that came from a snapshot.

## Symptom (real, on chained_v3 — 40M nodes, 57M edges)
EXPLAIN reported only the freshly-created `REQUIRES_BIOMARKER` edges (7,759); every other type — SAME_AS, HAS_VARIANT, SUPPORTED_BY, IN_GENE, TESTS, ENCODES — was effectively absent. Without selectivity stats, plans with OPTIONAL MATCH fell back to `NodeScan(all labels)` over the full 40M-node store. Result: `03_cross_kg_dedup.cypher` row form timed out >5 min, even though the count form returned 396 in 78s.

## Fix
- `GraphStore::rebuild_edge_type_index()` walks `edge_type_ids` and populates `edge_type_index` from `edge_type_table`.
- `import_tenant_with_dedup` calls it after `compact_adjacency`.

## Test plan
- [x] New `test_import_rebuilds_edge_type_index` regression: stub-only export → fresh import → both `edge_type_count()` and `compute_statistics()` see the imported types.
- [x] Lib suite 2005 → 2006 passing, no regressions.
- [ ] Re-run chained_v3 + query 03 row form to confirm sub-second elapsed (follow-up, separate run).