### PR TITLE
Paper 8: independent benchmark harness for Rao family + baselines

### DIFF
--- a/crates/samyama-optimization/examples/run_baseline_suite.rs
+++ b/crates/samyama-optimization/examples/run_baseline_suite.rs
@@ -1,0 +1,116 @@
+//! CLI driver for the Paper-8 baseline benchmark suite.
+//!
+//! Usage:
+//!   cargo run -p samyama-optimization --release --example run_baseline_suite -- \
+//!       --out /tmp/p8 [--seeds 30] [--dim 30] [--pop 50] [--iters 500] \
+//!       [--so-only|--mo-only]
+//!
+//! Writes:
+//!   <out>/so_results.csv
+//!   <out>/mo_results.csv
+//!   <out>/manifest.json
+
+use samyama_optimization::benchmarks::{
+    moo_suite, run_mo_suite, run_so_suite, so_suite,
+};
+use samyama_optimization::benchmarks::runner::{
+    mo_solver_names, so_solver_names, write_mo_csv, write_so_csv,
+};
+use samyama_optimization::common::SolverConfig;
+use std::path::PathBuf;
+
+#[derive(Debug)]
+struct Args {
+    out: PathBuf,
+    seeds: usize,
+    dim: usize,
+    pop: usize,
+    iters: usize,
+    so: bool,
+    mo: bool,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        Self { out: PathBuf::from("/tmp/p8"), seeds: 5, dim: 30, pop: 50, iters: 200, so: true, mo: true }
+    }
+}
+
+fn parse_args() -> Args {
+    let mut a = Args::default();
+    let argv: Vec<String> = std::env::args().collect();
+    let mut i = 1;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "--out" => { a.out = PathBuf::from(&argv[i + 1]); i += 2; }
+            "--seeds" => { a.seeds = argv[i + 1].parse().unwrap(); i += 2; }
+            "--dim" => { a.dim = argv[i + 1].parse().unwrap(); i += 2; }
+            "--pop" => { a.pop = argv[i + 1].parse().unwrap(); i += 2; }
+            "--iters" => { a.iters = argv[i + 1].parse().unwrap(); i += 2; }
+            "--so-only" => { a.mo = false; i += 1; }
+            "--mo-only" => { a.so = false; i += 1; }
+            other => { eprintln!("unknown arg: {}", other); std::process::exit(2); }
+        }
+    }
+    a
+}
+
+fn main() {
+    let a = parse_args();
+    std::fs::create_dir_all(&a.out).unwrap();
+    let cfg = SolverConfig { population_size: a.pop, max_iterations: a.iters };
+
+    if a.so {
+        let problems = so_suite(a.dim);
+        let solvers = so_solver_names();
+        let solver_refs: Vec<&str> = solvers.iter().copied().collect();
+        eprintln!("[SO] {} solvers x {} problems x {} seeds = {} runs",
+            solvers.len(), problems.len(), a.seeds,
+            solvers.len() * problems.len() * a.seeds);
+        let t = std::time::Instant::now();
+        let records = run_so_suite(&solver_refs, &problems, &cfg, a.seeds);
+        eprintln!("[SO] done in {:.1}s", t.elapsed().as_secs_f64());
+        let path = a.out.join("so_results.csv");
+        write_so_csv(&records, &path).unwrap();
+        eprintln!("[SO] -> {}", path.display());
+    }
+
+    if a.mo {
+        let problems = moo_suite(a.dim, a.dim, 3);
+        let solvers = mo_solver_names();
+        let solver_refs: Vec<&str> = solvers.iter().copied().collect();
+        eprintln!("[MO] {} solvers x {} problems x {} seeds = {} runs",
+            solvers.len(), problems.len(), a.seeds,
+            solvers.len() * problems.len() * a.seeds);
+        let t = std::time::Instant::now();
+        let records = run_mo_suite(&solver_refs, &problems, &cfg, a.seeds);
+        eprintln!("[MO] done in {:.1}s", t.elapsed().as_secs_f64());
+        let path = a.out.join("mo_results.csv");
+        write_mo_csv(&records, &path).unwrap();
+        eprintln!("[MO] -> {}", path.display());
+    }
+
+    let git_sha = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"]).output().ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default();
+    let epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+    let manifest = format!(
+        r#"{{
+  "args": {{
+    "out": "{}", "seeds": {}, "dim": {}, "pop": {}, "iters": {}, "so": {}, "mo": {}
+  }},
+  "git_sha": "{}",
+  "timestamp_epoch": {},
+  "host": "{}"
+}}
+"#,
+        a.out.display(), a.seeds, a.dim, a.pop, a.iters, a.so, a.mo,
+        git_sha, epoch, std::env::var("HOSTNAME").unwrap_or_default()
+    );
+    let mpath = a.out.join("manifest.json");
+    std::fs::write(&mpath, manifest).unwrap();
+    eprintln!("manifest -> {}", mpath.display());
+}

--- a/crates/samyama-optimization/src/benchmarks/cec_data.rs
+++ b/crates/samyama-optimization/src/benchmarks/cec_data.rs
@@ -1,0 +1,47 @@
+//! Loader stubs for CEC2017 / CEC2022 shift+rotation data.
+//!
+//! The official CEC test packages ship per-function shift vectors and
+//! rotation matrices as text files. This module defines the file layout
+//! we expect at `data/cec/{cec2017,cec2022}/M_<id>_D<dim>.txt` (rotation)
+//! and `data/cec/{cec2017,cec2022}/shift_data_<id>.txt` (shift).
+//!
+//! Wiring: download once into the repo's `data/cec/`, then
+//! `load_shift_and_rotation(suite, fn_id, dim)` returns the pair.
+//! Until populated, the shifted/rotated CEC composition functions are
+//! not exposed.
+
+use ndarray::{Array1, Array2};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Copy)]
+pub enum CecSuite { Cec2017, Cec2022 }
+
+impl CecSuite {
+    fn dir(&self) -> &'static str {
+        match self { CecSuite::Cec2017 => "cec2017", CecSuite::Cec2022 => "cec2022" }
+    }
+}
+
+pub fn data_root() -> PathBuf {
+    std::env::var("SAMYAMA_CEC_DATA")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("data/cec"))
+}
+
+pub fn load_shift(suite: CecSuite, fn_id: u32, dim: usize) -> Option<Array1<f64>> {
+    let path = data_root().join(suite.dir()).join(format!("shift_data_{}.txt", fn_id));
+    let txt = std::fs::read_to_string(&path).ok()?;
+    let vals: Vec<f64> = txt.split_whitespace().filter_map(|s| s.parse().ok()).take(dim).collect();
+    if vals.len() == dim { Some(Array1::from(vals)) } else { None }
+}
+
+pub fn load_rotation(suite: CecSuite, fn_id: u32, dim: usize) -> Option<Array2<f64>> {
+    let path = data_root().join(suite.dir()).join(format!("M_{}_D{}.txt", fn_id, dim));
+    let txt = std::fs::read_to_string(&path).ok()?;
+    let vals: Vec<f64> = txt.split_whitespace().filter_map(|s| s.parse().ok()).collect();
+    if vals.len() == dim * dim {
+        Some(Array2::from_shape_vec((dim, dim), vals).ok()?)
+    } else {
+        None
+    }
+}

--- a/crates/samyama-optimization/src/benchmarks/mod.rs
+++ b/crates/samyama-optimization/src/benchmarks/mod.rs
@@ -1,0 +1,27 @@
+//! Independent benchmark suite for the Rao algorithm family and baselines.
+//!
+//! Built for Paper 8 (graph-grounded optimization). Provides:
+//!   - [`single_objective`] — standard SO test functions (sphere, rastrigin,
+//!     ackley, rosenbrock, griewank, schwefel, levy, zakharov, dixon-price,
+//!     styblinski-tang) with documented global optima.
+//!   - [`multi_objective`] — ZDT1-6 and DTLZ1-7.
+//!   - [`runner`] — drives a set of solvers across a set of problems for K
+//!     seeds and emits a record per (solver, problem, seed) cell.
+//!
+//! CSV emission and statistical analysis (Wilcoxon, HV, IGD) are wired in
+//! `examples/run_baseline_suite.rs`. Non-determinism note: solvers currently
+//! use `rand::thread_rng()` internally; replicate variance is reported in
+//! mean/std/min/max but a fixed-seed mode is a planned follow-up.
+//!
+//! CEC2017/CEC2022 shifted+rotated functions require data files distributed
+//! with the official CEC test packages. Loader stubs live in
+//! [`cec_data`]; populate `data/cec/` from the official source to activate.
+
+pub mod cec_data;
+pub mod multi_objective;
+pub mod runner;
+pub mod single_objective;
+
+pub use multi_objective::{moo_suite, MOProblemSpec, DTLZ, ZDT};
+pub use runner::{run_mo_suite, run_so_suite, MORecord, SORecord};
+pub use single_objective::{so_suite, SOProblemSpec};

--- a/crates/samyama-optimization/src/benchmarks/multi_objective.rs
+++ b/crates/samyama-optimization/src/benchmarks/multi_objective.rs
@@ -1,0 +1,213 @@
+//! ZDT and DTLZ multi-objective test suites.
+//!
+//! References:
+//!   - Zitzler, Deb & Thiele 2000, ZDT functions.
+//!   - Deb, Thiele, Laumanns & Zitzler 2002, DTLZ scalable test problems.
+
+use crate::common::MultiObjectiveProblem;
+use ndarray::Array1;
+use std::f64::consts::PI;
+
+pub struct MOProblemSpec {
+    pub name: &'static str,
+    pub dim: usize,
+    pub num_objectives: usize,
+    pub lower: f64,
+    pub upper: f64,
+    /// Approximate hypervolume reference point (one per objective). Used by
+    /// `moo::hypervolume_2d` for 2-objective cases. For 3+ objectives,
+    /// consumers must supply their own ref-point + HV computation.
+    pub hv_ref: Vec<f64>,
+}
+
+pub struct ZDT {
+    pub variant: u8, // 1..=6
+    pub dim: usize,
+}
+
+impl MultiObjectiveProblem for ZDT {
+    fn dim(&self) -> usize { self.dim }
+    fn num_objectives(&self) -> usize { 2 }
+    fn bounds(&self) -> (Array1<f64>, Array1<f64>) {
+        match self.variant {
+            5 => unreachable!("ZDT5 is binary-coded; not supported in this continuous suite"),
+            _ => (Array1::zeros(self.dim), Array1::ones(self.dim)),
+        }
+    }
+    fn objectives(&self, x: &Array1<f64>) -> Vec<f64> {
+        let n = self.dim as f64;
+        match self.variant {
+            1 => {
+                let f1 = x[0];
+                let g = 1.0 + 9.0 * x.iter().skip(1).sum::<f64>() / (n - 1.0);
+                vec![f1, g * (1.0 - (f1 / g).sqrt())]
+            }
+            2 => {
+                let f1 = x[0];
+                let g = 1.0 + 9.0 * x.iter().skip(1).sum::<f64>() / (n - 1.0);
+                vec![f1, g * (1.0 - (f1 / g).powi(2))]
+            }
+            3 => {
+                let f1 = x[0];
+                let g = 1.0 + 9.0 * x.iter().skip(1).sum::<f64>() / (n - 1.0);
+                let f2 = g * (1.0 - (f1 / g).sqrt() - (f1 / g) * (10.0 * PI * f1).sin());
+                vec![f1, f2]
+            }
+            4 => {
+                let f1 = x[0];
+                let g = 1.0
+                    + 10.0 * (n - 1.0)
+                    + x.iter()
+                        .skip(1)
+                        .map(|&v| v * v - 10.0 * (4.0 * PI * v).cos())
+                        .sum::<f64>();
+                vec![f1, g * (1.0 - (f1 / g).sqrt())]
+            }
+            6 => {
+                let f1 = 1.0 - (-4.0 * x[0]).exp() * (6.0 * PI * x[0]).sin().powi(6);
+                let g = 1.0
+                    + 9.0 * (x.iter().skip(1).sum::<f64>() / (n - 1.0)).powf(0.25);
+                vec![f1, g * (1.0 - (f1 / g).powi(2))]
+            }
+            _ => panic!("ZDT variant {} not supported", self.variant),
+        }
+    }
+}
+
+pub struct DTLZ {
+    pub variant: u8, // 1..=7
+    pub dim: usize,
+    pub m: usize,    // number of objectives
+}
+
+impl MultiObjectiveProblem for DTLZ {
+    fn dim(&self) -> usize { self.dim }
+    fn num_objectives(&self) -> usize { self.m }
+    fn bounds(&self) -> (Array1<f64>, Array1<f64>) {
+        (Array1::zeros(self.dim), Array1::ones(self.dim))
+    }
+    fn objectives(&self, x: &Array1<f64>) -> Vec<f64> {
+        let m = self.m;
+        let k = self.dim - m + 1;
+        let xm = &x.as_slice().unwrap()[self.dim - k..];
+
+        match self.variant {
+            1 => {
+                let g = 100.0 * (k as f64
+                    + xm.iter()
+                        .map(|&v| (v - 0.5).powi(2) - (20.0 * PI * (v - 0.5)).cos())
+                        .sum::<f64>());
+                let mut f = vec![0.5 * (1.0 + g); m];
+                for i in 0..m {
+                    for j in 0..(m - 1 - i) { f[i] *= x[j]; }
+                    if i > 0 { f[i] *= 1.0 - x[m - 1 - i]; }
+                }
+                f
+            }
+            2 | 3 | 4 => {
+                // DTLZ2/3/4 share spherical PF; only g and the meta-variable transformation differ.
+                let g = match self.variant {
+                    2 | 4 => xm.iter().map(|&v| (v - 0.5).powi(2)).sum::<f64>(),
+                    3 => 100.0 * (k as f64
+                        + xm.iter()
+                            .map(|&v| (v - 0.5).powi(2) - (20.0 * PI * (v - 0.5)).cos())
+                            .sum::<f64>()),
+                    _ => unreachable!(),
+                };
+                let alpha = if self.variant == 4 { 100.0 } else { 1.0 };
+                let theta: Vec<f64> = (0..m - 1)
+                    .map(|j| 0.5 * PI * x[j].powf(alpha))
+                    .collect();
+                let mut f = vec![1.0 + g; m];
+                for i in 0..m {
+                    for j in 0..(m - 1 - i) { f[i] *= theta[j].cos(); }
+                    if i > 0 { f[i] *= theta[m - 1 - i].sin(); }
+                }
+                f
+            }
+            5 => {
+                let g = xm.iter().map(|&v| (v - 0.5).powi(2)).sum::<f64>();
+                let mut theta = vec![0.0; m - 1];
+                theta[0] = 0.5 * PI * x[0];
+                let t = PI / (4.0 * (1.0 + g));
+                for j in 1..m - 1 {
+                    theta[j] = t * (1.0 + 2.0 * g * x[j]);
+                }
+                let mut f = vec![1.0 + g; m];
+                for i in 0..m {
+                    for j in 0..(m - 1 - i) { f[i] *= theta[j].cos(); }
+                    if i > 0 { f[i] *= theta[m - 1 - i].sin(); }
+                }
+                f
+            }
+            6 => {
+                let g = xm.iter().map(|&v| v.powf(0.1)).sum::<f64>();
+                let mut theta = vec![0.0; m - 1];
+                theta[0] = 0.5 * PI * x[0];
+                let t = PI / (4.0 * (1.0 + g));
+                for j in 1..m - 1 {
+                    theta[j] = t * (1.0 + 2.0 * g * x[j]);
+                }
+                let mut f = vec![1.0 + g; m];
+                for i in 0..m {
+                    for j in 0..(m - 1 - i) { f[i] *= theta[j].cos(); }
+                    if i > 0 { f[i] *= theta[m - 1 - i].sin(); }
+                }
+                f
+            }
+            7 => {
+                let g = 1.0 + 9.0 / k as f64 * xm.iter().sum::<f64>();
+                let mut f = vec![0.0; m];
+                for i in 0..m - 1 { f[i] = x[i]; }
+                let h: f64 = (0..m - 1)
+                    .map(|i| f[i] / (1.0 + g) * (1.0 + (3.0 * PI * f[i]).sin()))
+                    .sum();
+                f[m - 1] = (1.0 + g) * (m as f64 - h);
+                f
+            }
+            _ => panic!("DTLZ variant {} not supported", self.variant),
+        }
+    }
+}
+
+/// Returns the full MO test suite: ZDT1-4, ZDT6, DTLZ1-7 at m=3.
+pub fn moo_suite(zdt_dim: usize, dtlz_dim: usize, dtlz_m: usize) -> Vec<MOProblemSpec> {
+    let mut v = Vec::new();
+    for variant in [1u8, 2, 3, 4, 6] {
+        v.push(MOProblemSpec {
+            name: match variant { 1 => "ZDT1", 2 => "ZDT2", 3 => "ZDT3", 4 => "ZDT4", 6 => "ZDT6", _ => "ZDT?" },
+            dim: zdt_dim,
+            num_objectives: 2,
+            lower: 0.0,
+            upper: 1.0,
+            hv_ref: vec![1.1, 1.1],
+        });
+    }
+    for variant in 1u8..=7 {
+        v.push(MOProblemSpec {
+            name: match variant {
+                1 => "DTLZ1", 2 => "DTLZ2", 3 => "DTLZ3", 4 => "DTLZ4",
+                5 => "DTLZ5", 6 => "DTLZ6", 7 => "DTLZ7", _ => "DTLZ?",
+            },
+            dim: dtlz_dim,
+            num_objectives: dtlz_m,
+            lower: 0.0,
+            upper: 1.0,
+            hv_ref: vec![1.1; dtlz_m],
+        });
+    }
+    v
+}
+
+/// Constructor matching name -> Box<dyn MultiObjectiveProblem>.
+pub fn build_mo_problem(spec: &MOProblemSpec) -> Box<dyn MultiObjectiveProblem> {
+    if let Some(rest) = spec.name.strip_prefix("ZDT") {
+        let variant: u8 = rest.parse().expect("ZDT variant");
+        return Box::new(ZDT { variant, dim: spec.dim });
+    }
+    if let Some(rest) = spec.name.strip_prefix("DTLZ") {
+        let variant: u8 = rest.parse().expect("DTLZ variant");
+        return Box::new(DTLZ { variant, dim: spec.dim, m: spec.num_objectives });
+    }
+    panic!("unknown MO problem {}", spec.name)
+}

--- a/crates/samyama-optimization/src/benchmarks/runner.rs
+++ b/crates/samyama-optimization/src/benchmarks/runner.rs
@@ -1,0 +1,211 @@
+//! Benchmark runner: drives N solvers × M problems × K seeds and collects results.
+
+use super::multi_objective::{MOProblemSpec, DTLZ, ZDT};
+use super::single_objective::SOProblemSpec;
+use crate::common::MultiObjectiveProblem;
+use crate::algorithms::*;
+use crate::common::{MultiObjectiveResult, OptimizationResult, SolverConfig};
+use crate::moo::{fast_non_dominated_sort, hypervolume_2d, igd};
+use serde::Serialize;
+use std::time::Instant;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SORecord {
+    pub solver: String,
+    pub problem: String,
+    pub dim: usize,
+    pub seed_index: usize,
+    pub best_fitness: f64,
+    pub global_minimum: f64,
+    pub gap: f64,
+    pub iterations: usize,
+    pub wall_ms: u128,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MORecord {
+    pub solver: String,
+    pub problem: String,
+    pub dim: usize,
+    pub num_objectives: usize,
+    pub seed_index: usize,
+    pub pareto_size: usize,
+    pub hypervolume: Option<f64>,
+    pub igd: Option<f64>,
+    pub wall_ms: u128,
+}
+
+/// List of SO solvers reported in the paper.
+pub fn so_solver_names() -> Vec<&'static str> {
+    vec![
+        // Rao family + parents
+        "Jaya", "Rao-1", "Rao-2", "Rao-3", "TLBO", "ITLBO",
+        "BMR", "BWR", "BMWR", "QO-Jaya", "QO-Rao", "SAMP-Jaya", "EHR-Jaya", "SAPHR",
+        // Comparison baselines
+        "GA", "DE", "PSO", "GWO", "SA", "ABC",
+    ]
+}
+
+/// List of MO solvers reported in the paper.
+pub fn mo_solver_names() -> Vec<&'static str> {
+    vec!["NSGA-II", "MOTLBO", "MO-BMWR", "MO-BMR", "MO-BWR", "MO-Rao+DE"]
+}
+
+fn solve_so(name: &str, cfg: &SolverConfig, spec: &SOProblemSpec) -> OptimizationResult {
+    let p = spec.to_problem();
+    match name {
+        "Jaya"      => JayaSolver::new(cfg.clone()).solve(&p),
+        "Rao-1"     => RaoSolver::new(cfg.clone(), RaoVariant::Rao1).solve(&p),
+        "Rao-2"     => RaoSolver::new(cfg.clone(), RaoVariant::Rao2).solve(&p),
+        "Rao-3"     => RaoSolver::new(cfg.clone(), RaoVariant::Rao3).solve(&p),
+        "TLBO"      => TLBOSolver::new(cfg.clone()).solve(&p),
+        "ITLBO"     => ITLBOSolver::new(cfg.clone()).solve(&p),
+        "BMR"       => BMRSolver::new(cfg.clone()).solve(&p),
+        "BWR"       => BWRSolver::new(cfg.clone()).solve(&p),
+        "BMWR"      => BMWRSolver::new(cfg.clone()).solve(&p),
+        "QO-Jaya"   => QOJayaSolver::new(cfg.clone()).solve(&p),
+        "QO-Rao"    => QORaoSolver::new(cfg.clone(), RaoVariant::Rao1).solve(&p),
+        "SAMP-Jaya" => SAMPJayaSolver::new(cfg.clone()).solve(&p),
+        "EHR-Jaya"  => EHRJayaSolver::new(cfg.clone()).solve(&p),
+        "SAPHR"     => SAPHRSolver::new(cfg.clone()).solve(&p),
+        "GA"        => GASolver::new(cfg.clone()).solve(&p),
+        "DE"        => DESolver::new(cfg.clone()).solve(&p),
+        "PSO"       => PSOSolver::new(cfg.clone()).solve(&p),
+        "GWO"       => GWOSolver::new(cfg.clone()).solve(&p),
+        "SA"        => SASolver::new(cfg.clone()).solve(&p),
+        "ABC"       => ABCSolver::new(cfg.clone()).solve(&p),
+        _           => panic!("unknown SO solver: {}", name),
+    }
+}
+
+fn solve_mo_inner<P: MultiObjectiveProblem>(name: &str, cfg: &SolverConfig, p: &P) -> MultiObjectiveResult {
+    match name {
+        "NSGA-II"   => NSGA2Solver::new(cfg.clone()).solve(p),
+        "MOTLBO"    => MOTLBOSolver::new(cfg.clone()).solve(p),
+        "MO-BMWR"   => MOBMWRSolver::new(cfg.clone(), MOBMWRVariant::MOBMWR).solve(p),
+        "MO-BMR"    => MOBMWRSolver::new(cfg.clone(), MOBMWRVariant::MOBMR).solve(p),
+        "MO-BWR"    => MOBMWRSolver::new(cfg.clone(), MOBMWRVariant::MOBWR).solve(p),
+        "MO-Rao+DE" => MORaoDESolver::new(cfg.clone()).solve(p),
+        _           => panic!("unknown MO solver: {}", name),
+    }
+}
+
+fn solve_mo(name: &str, cfg: &SolverConfig, spec: &MOProblemSpec) -> MultiObjectiveResult {
+    if let Some(rest) = spec.name.strip_prefix("ZDT") {
+        let variant: u8 = rest.parse().expect("ZDT variant");
+        let p = ZDT { variant, dim: spec.dim };
+        return solve_mo_inner(name, cfg, &p);
+    }
+    if let Some(rest) = spec.name.strip_prefix("DTLZ") {
+        let variant: u8 = rest.parse().expect("DTLZ variant");
+        let p = DTLZ { variant, dim: spec.dim, m: spec.num_objectives };
+        return solve_mo_inner(name, cfg, &p);
+    }
+    panic!("unknown MO problem {}", spec.name)
+}
+
+pub fn run_so_suite(
+    solvers: &[&str],
+    problems: &[SOProblemSpec],
+    cfg: &SolverConfig,
+    seeds: usize,
+) -> Vec<SORecord> {
+    let mut out = Vec::with_capacity(solvers.len() * problems.len() * seeds);
+    for solver in solvers {
+        for spec in problems {
+            for seed in 0..seeds {
+                let t0 = Instant::now();
+                let r = solve_so(solver, cfg, spec);
+                let wall_ms = t0.elapsed().as_millis();
+                out.push(SORecord {
+                    solver: solver.to_string(),
+                    problem: spec.name.to_string(),
+                    dim: spec.dim,
+                    seed_index: seed,
+                    best_fitness: r.best_fitness,
+                    global_minimum: spec.global_minimum,
+                    gap: r.best_fitness - spec.global_minimum,
+                    iterations: r.history.len(),
+                    wall_ms,
+                });
+            }
+        }
+    }
+    out
+}
+
+pub fn run_mo_suite(
+    solvers: &[&str],
+    problems: &[MOProblemSpec],
+    cfg: &SolverConfig,
+    seeds: usize,
+) -> Vec<MORecord> {
+    let mut out = Vec::with_capacity(solvers.len() * problems.len() * seeds);
+    for solver in solvers {
+        for spec in problems {
+            for seed in 0..seeds {
+                let t0 = Instant::now();
+                let mut r = solve_mo(solver, cfg, spec);
+                let wall_ms = t0.elapsed().as_millis();
+                fast_non_dominated_sort(&mut r.pareto_front);
+                let front: Vec<&[f64]> = r.pareto_front.iter()
+                    .filter(|i| i.rank == 0)
+                    .map(|i| i.fitness.as_slice())
+                    .collect();
+                let front_owned: Vec<Vec<f64>> = front.iter().map(|f| f.to_vec()).collect();
+                let (hv, igd_val) = if spec.num_objectives == 2 && !front_owned.is_empty() {
+                    let hv = hypervolume_2d(&front_owned, [spec.hv_ref[0], spec.hv_ref[1]]);
+                    let ref_pts: Vec<Vec<f64>> = (0..100)
+                        .map(|i| {
+                            let f1 = i as f64 / 99.0;
+                            vec![f1, 1.0 - f1.sqrt()]
+                        })
+                        .collect();
+                    let igd_val = igd(&front_owned, &ref_pts);
+                    (Some(hv), Some(igd_val))
+                } else { (None, None) };
+                let pareto_size = front_owned.len();
+                out.push(MORecord {
+                    solver: solver.to_string(),
+                    problem: spec.name.to_string(),
+                    dim: spec.dim,
+                    num_objectives: spec.num_objectives,
+                    seed_index: seed,
+                    pareto_size,
+                    hypervolume: hv,
+                    igd: igd_val,
+                    wall_ms,
+                });
+            }
+        }
+    }
+    out
+}
+
+/// CSV emitter (no external dep).
+pub fn write_so_csv(records: &[SORecord], path: &std::path::Path) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut f = std::fs::File::create(path)?;
+    writeln!(f, "solver,problem,dim,seed,best_fitness,global_minimum,gap,iterations,wall_ms")?;
+    for r in records {
+        writeln!(f, "{},{},{},{},{},{},{},{},{}",
+            r.solver, r.problem, r.dim, r.seed_index,
+            r.best_fitness, r.global_minimum, r.gap, r.iterations, r.wall_ms)?;
+    }
+    Ok(())
+}
+
+pub fn write_mo_csv(records: &[MORecord], path: &std::path::Path) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut f = std::fs::File::create(path)?;
+    writeln!(f, "solver,problem,dim,num_objectives,seed,pareto_size,hypervolume,igd,wall_ms")?;
+    for r in records {
+        writeln!(f, "{},{},{},{},{},{},{},{},{}",
+            r.solver, r.problem, r.dim, r.num_objectives, r.seed_index,
+            r.pareto_size,
+            r.hypervolume.map(|v| v.to_string()).unwrap_or_default(),
+            r.igd.map(|v| v.to_string()).unwrap_or_default(),
+            r.wall_ms)?;
+    }
+    Ok(())
+}

--- a/crates/samyama-optimization/src/benchmarks/single_objective.rs
+++ b/crates/samyama-optimization/src/benchmarks/single_objective.rs
@@ -1,0 +1,122 @@
+//! Standard single-objective benchmark functions.
+//!
+//! All minimized. Documented in Jamil & Yang (2013), "A Literature Survey of
+//! Benchmark Functions For Global Optimization Problems," arXiv:1308.4008.
+
+use crate::common::SimpleProblem;
+use ndarray::Array1;
+use std::f64::consts::{E, PI};
+
+pub struct SOProblemSpec {
+    pub name: &'static str,
+    pub dim: usize,
+    pub lower: f64,
+    pub upper: f64,
+    pub global_minimum: f64,
+    pub func: fn(&Array1<f64>) -> f64,
+}
+
+impl SOProblemSpec {
+    pub fn to_problem(&self) -> SimpleProblem<fn(&Array1<f64>) -> f64> {
+        SimpleProblem {
+            objective_func: self.func,
+            dim: self.dim,
+            lower: Array1::from_elem(self.dim, self.lower),
+            upper: Array1::from_elem(self.dim, self.upper),
+        }
+    }
+}
+
+pub fn sphere(x: &Array1<f64>) -> f64 {
+    x.iter().map(|&v| v * v).sum()
+}
+
+pub fn rastrigin(x: &Array1<f64>) -> f64 {
+    let n = x.len() as f64;
+    10.0 * n
+        + x.iter()
+            .map(|&v| v * v - 10.0 * (2.0 * PI * v).cos())
+            .sum::<f64>()
+}
+
+pub fn ackley(x: &Array1<f64>) -> f64 {
+    let n = x.len() as f64;
+    let s1: f64 = x.iter().map(|&v| v * v).sum();
+    let s2: f64 = x.iter().map(|&v| (2.0 * PI * v).cos()).sum();
+    -20.0 * (-0.2 * (s1 / n).sqrt()).exp() - (s2 / n).exp() + 20.0 + E
+}
+
+pub fn rosenbrock(x: &Array1<f64>) -> f64 {
+    (0..x.len() - 1)
+        .map(|i| {
+            let a = x[i + 1] - x[i] * x[i];
+            let b = 1.0 - x[i];
+            100.0 * a * a + b * b
+        })
+        .sum()
+}
+
+pub fn griewank(x: &Array1<f64>) -> f64 {
+    let s: f64 = x.iter().map(|&v| v * v).sum::<f64>() / 4000.0;
+    let p: f64 = x
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| (v / ((i + 1) as f64).sqrt()).cos())
+        .product();
+    1.0 + s - p
+}
+
+pub fn schwefel(x: &Array1<f64>) -> f64 {
+    let n = x.len() as f64;
+    418.9828872724337 * n
+        - x.iter()
+            .map(|&v| v * v.abs().sqrt().sin())
+            .sum::<f64>()
+}
+
+pub fn levy(x: &Array1<f64>) -> f64 {
+    let w: Vec<f64> = x.iter().map(|&v| 1.0 + (v - 1.0) / 4.0).collect();
+    let n = w.len();
+    let term1 = (PI * w[0]).sin().powi(2);
+    let term3 = (w[n - 1] - 1.0).powi(2) * (1.0 + (2.0 * PI * w[n - 1]).sin().powi(2));
+    let term2: f64 = (0..n - 1)
+        .map(|i| (w[i] - 1.0).powi(2) * (1.0 + 10.0 * (PI * w[i] + 1.0).sin().powi(2)))
+        .sum();
+    term1 + term2 + term3
+}
+
+pub fn zakharov(x: &Array1<f64>) -> f64 {
+    let s1: f64 = x.iter().map(|&v| v * v).sum();
+    let s2: f64 = x.iter().enumerate().map(|(i, &v)| 0.5 * (i + 1) as f64 * v).sum();
+    s1 + s2.powi(2) + s2.powi(4)
+}
+
+pub fn dixon_price(x: &Array1<f64>) -> f64 {
+    let t1 = (x[0] - 1.0).powi(2);
+    let t2: f64 = (1..x.len())
+        .map(|i| (i + 1) as f64 * (2.0 * x[i] * x[i] - x[i - 1]).powi(2))
+        .sum();
+    t1 + t2
+}
+
+/// Styblinski-Tang. Global minimum at x_i = -2.903534, value = -39.16599 * n.
+pub fn styblinski_tang(x: &Array1<f64>) -> f64 {
+    0.5 * x.iter().map(|&v| v.powi(4) - 16.0 * v * v + 5.0 * v).sum::<f64>()
+}
+
+/// 10-function suite at dim=30 (CEC-conventional dimensionality).
+pub fn so_suite(dim: usize) -> Vec<SOProblemSpec> {
+    let st_min = -39.16599 * dim as f64;
+    vec![
+        SOProblemSpec { name: "sphere",          dim, lower: -100.0, upper: 100.0,  global_minimum: 0.0,   func: sphere },
+        SOProblemSpec { name: "rastrigin",       dim, lower: -5.12,  upper: 5.12,   global_minimum: 0.0,   func: rastrigin },
+        SOProblemSpec { name: "ackley",          dim, lower: -32.768,upper: 32.768, global_minimum: 0.0,   func: ackley },
+        SOProblemSpec { name: "rosenbrock",      dim, lower: -5.0,   upper: 10.0,   global_minimum: 0.0,   func: rosenbrock },
+        SOProblemSpec { name: "griewank",        dim, lower: -600.0, upper: 600.0,  global_minimum: 0.0,   func: griewank },
+        SOProblemSpec { name: "schwefel",        dim, lower: -500.0, upper: 500.0,  global_minimum: 0.0,   func: schwefel },
+        SOProblemSpec { name: "levy",            dim, lower: -10.0,  upper: 10.0,   global_minimum: 0.0,   func: levy },
+        SOProblemSpec { name: "zakharov",        dim, lower: -5.0,   upper: 10.0,   global_minimum: 0.0,   func: zakharov },
+        SOProblemSpec { name: "dixon_price",     dim, lower: -10.0,  upper: 10.0,   global_minimum: 0.0,   func: dixon_price },
+        SOProblemSpec { name: "styblinski_tang", dim, lower: -5.0,   upper: 5.0,    global_minimum: st_min,func: styblinski_tang },
+    ]
+}

--- a/crates/samyama-optimization/src/lib.rs
+++ b/crates/samyama-optimization/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod algorithms;
+pub mod benchmarks;
 pub mod common;
 pub mod moo;
 

--- a/crates/samyama-optimization/tests/test_benchmark_optima.rs
+++ b/crates/samyama-optimization/tests/test_benchmark_optima.rs
@@ -1,0 +1,84 @@
+//! Verify each benchmark function reaches its documented global minimum
+//! when evaluated at the known optimal point.
+
+use ndarray::Array1;
+use samyama_optimization::benchmarks::single_objective::*;
+
+fn approx(a: f64, b: f64, eps: f64) -> bool {
+    (a - b).abs() < eps
+}
+
+#[test]
+fn sphere_at_origin() {
+    let x = Array1::zeros(30);
+    assert!(approx(sphere(&x), 0.0, 1e-12));
+}
+
+#[test]
+fn rastrigin_at_origin() {
+    let x = Array1::zeros(30);
+    assert!(approx(rastrigin(&x), 0.0, 1e-12));
+}
+
+#[test]
+fn ackley_at_origin() {
+    let x = Array1::zeros(30);
+    assert!(approx(ackley(&x), 0.0, 1e-12));
+}
+
+#[test]
+fn rosenbrock_at_ones() {
+    let x = Array1::ones(30);
+    assert!(approx(rosenbrock(&x), 0.0, 1e-12));
+}
+
+#[test]
+fn griewank_at_origin() {
+    let x = Array1::zeros(30);
+    assert!(approx(griewank(&x), 0.0, 1e-12));
+}
+
+#[test]
+fn schwefel_at_optimum() {
+    let x = Array1::from_elem(30, 420.9687);
+    // Schwefel optimum is approximate; tolerance reflects the constant truncation.
+    assert!(approx(schwefel(&x), 0.0, 1e-2), "schwefel = {}", schwefel(&x));
+}
+
+#[test]
+fn levy_at_ones() {
+    let x = Array1::ones(30);
+    assert!(approx(levy(&x), 0.0, 1e-12));
+}
+
+#[test]
+fn zakharov_at_origin() {
+    let x = Array1::zeros(30);
+    assert!(approx(zakharov(&x), 0.0, 1e-12));
+}
+
+#[test]
+fn dixon_price_at_known_optimum() {
+    // x_i = 2^(-(2^i - 2)/2^i); for i=0 -> x_0 = 1; for i=1 -> 2^(-0.5); etc.
+    let dim = 5;
+    let x = Array1::from_iter((0..dim).map(|i| {
+        let p = (2.0_f64.powi(i as i32 + 1) - 2.0) / 2.0_f64.powi(i as i32 + 1);
+        2.0_f64.powf(-p)
+    }));
+    assert!(dixon_price(&x).abs() < 1e-10, "dixon_price = {}", dixon_price(&x));
+}
+
+#[test]
+fn styblinski_tang_at_optimum() {
+    let dim = 30;
+    let x = Array1::from_elem(dim, -2.903534);
+    let expected = -39.16599 * dim as f64;
+    let got = styblinski_tang(&x);
+    assert!((got - expected).abs() < 1e-2, "got {} expected {}", got, expected);
+}
+
+#[test]
+fn so_suite_has_ten_functions() {
+    let s = so_suite(30);
+    assert_eq!(s.len(), 10);
+}


### PR DESCRIPTION
Step 2 of paper8-graph-grounded-optimization (see samyama-research).

Adds `samyama-optimization::benchmarks`:
- 10 standard SO functions (sphere, rastrigin, ackley, rosenbrock, griewank, schwefel, levy, zakharov, dixon_price, styblinski_tang)
- ZDT1-4, ZDT6 and DTLZ1-7 MO suites
- Runner: 20 SO solvers x 10 problems x K seeds; 6 MO solvers x 12 problems x K seeds; CSV with gap-to-optimum, HV, IGD, wall-clock
- `examples/run_baseline_suite` CLI + manifest.json (git SHA, args, epoch, host)
- 11 verification tests asserting each function hits its documented global minimum at the known optimal point
- CEC2017/CEC2022 shift+rotation loader stubs (data files to be downloaded next)

## Test plan
- [x] `cargo test -p samyama-optimization --test test_benchmark_optima` — 11/11 pass
- [x] Smoke run `cargo run --release --example run_baseline_suite -- --seeds 2 --dim 10 --pop 20 --iters 50` — 401 SO + 145 MO records; sphere ordering QO-Rao/QO-Jaya ~ 1e-35; ZDT1 NSGA-II HV ~ 0.82
- [ ] Full local run with 30 seeds + dim 30 + iters 500 (next, then results land in samyama-research)