### PR TITLE
Paper 8: scale problem 1 (SIDER + edge export) + problem 2 demo

### DIFF
--- a/examples/clinical_trial_sites_demo.rs
+++ b/examples/clinical_trial_sites_demo.rs
@@ -1,0 +1,208 @@
+//! Paper 8 problem 2: clinical-trial site selection.
+//!
+//! Loads the public clinicaltrials snapshot (AACT / ClinicalTrials.gov bulk
+//! data) and poses:
+//!
+//!   maximize    | { t in TRIALS : ∃ s in SELECTED, (t)-[:CONDUCTED_AT]->(s) } |
+//!               + diversity_weight * |distinct countries in SELECTED|
+//!   subject to  |SELECTED| <= k
+//!
+//! evaluated against samyama-graph via Cypher per candidate vector.
+//!
+//! Usage:
+//!   cargo run --release --example clinical_trial_sites_demo -- \
+//!       [--snapshot PATH] [--candidates 100] [--k 10] [--seeds 3] \
+//!       [--diversity-weight 5.0]
+//!
+//! Default snapshot: ../clinicaltrials-kg/data/clinical-trials.sgsnap
+
+use ndarray::Array1;
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::optimization::CypherProblem;
+use samyama::query::QueryEngine;
+use samyama::query::executor::record::Value;
+use samyama_optimization::algorithms::{
+    BMWRSolver, EHRJayaSolver, JayaSolver, RaoSolver, RaoVariant, SAMPJayaSolver,
+};
+use samyama_optimization::common::{Problem, SolverConfig};
+use std::fs::File;
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+use std::time::Instant;
+
+#[derive(Debug)]
+struct Args {
+    snapshot: PathBuf,
+    candidates: usize,
+    k: usize,
+    seeds: usize,
+    diversity_weight: f64,
+    out: PathBuf,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        Self {
+            snapshot: PathBuf::from("../clinicaltrials-kg/data/clinical-trials.sgsnap"),
+            candidates: 100,
+            k: 10,
+            seeds: 3,
+            diversity_weight: 5.0,
+            out: PathBuf::from("/tmp/p8-clinical-sites"),
+        }
+    }
+}
+
+fn parse_args() -> Args {
+    let mut a = Args::default();
+    let argv: Vec<String> = std::env::args().collect();
+    let mut i = 1;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "--snapshot" => { a.snapshot = PathBuf::from(&argv[i + 1]); i += 2; }
+            "--candidates" => { a.candidates = argv[i + 1].parse().unwrap(); i += 2; }
+            "--k" => { a.k = argv[i + 1].parse().unwrap(); i += 2; }
+            "--seeds" => { a.seeds = argv[i + 1].parse().unwrap(); i += 2; }
+            "--diversity-weight" => { a.diversity_weight = argv[i + 1].parse().unwrap(); i += 2; }
+            "--out" => { a.out = PathBuf::from(&argv[i + 1]); i += 2; }
+            other => { eprintln!("unknown arg: {}", other); std::process::exit(2); }
+        }
+    }
+    a
+}
+
+fn make_subs(
+    x: &Array1<f64>,
+    facilities: &[String],
+    countries: &[String],
+    diversity_weight: f64,
+    k: usize,
+) -> Vec<(String, String)> {
+    let mut idxs: Vec<(usize, f64)> = x.iter().enumerate()
+        .filter(|(_, &v)| v > 0.5).map(|(i, &v)| (i, v)).collect();
+    idxs.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    let take = k.min(idxs.len());
+    let selected: Vec<usize> = idxs.iter().take(take).map(|(i, _)| *i).collect();
+    let list = selected.iter()
+        .map(|i| format!("'{}'", facilities[*i].replace('\'', "\\'")))
+        .collect::<Vec<_>>().join(",");
+    let list = if list.is_empty() { "'__NONE__'".to_string() } else { list };
+    let mut distinct: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for i in &selected { distinct.insert(countries[*i].as_str()); }
+    // diversity_term ENTERS the objective as -count, so we *subtract* diversity_weight * |distinct|.
+    let diversity_term = -diversity_weight * distinct.len() as f64;
+    vec![
+        ("$selected".to_string(), list),
+        ("$diversity_term".to_string(), format!("{:.6}", diversity_term)),
+    ]
+}
+
+fn main() {
+    let a = parse_args();
+    std::fs::create_dir_all(&a.out).unwrap();
+
+    eprintln!("loading {} ...", a.snapshot.display());
+    let mut store = GraphStore::new();
+    let t0 = Instant::now();
+    let f = File::open(&a.snapshot).expect("snapshot open");
+    let stats = samyama::snapshot::import_tenant(&mut store, f).expect("import");
+    let load_ms = t0.elapsed().as_millis();
+    eprintln!("loaded {} nodes, {} edges in {} ms",
+        stats.node_count, stats.edge_count, load_ms);
+
+    let engine = Arc::new(QueryEngine::new());
+
+    // Pick top-N candidate sites by trial-host count. Also pull their country
+    // for the Rust-side diversity term.
+    let cand_q = format!(
+        "MATCH (t:ClinicalTrial)-[:CONDUCTED_AT]->(s:Site) \
+         WITH s, count(t) AS deg \
+         ORDER BY deg DESC \
+         LIMIT {} \
+         RETURN s.facility AS facility, s.country AS country", a.candidates);
+    let batch = engine.execute(&cand_q, &store).expect("candidate query");
+    let mut facilities = Vec::new();
+    let mut countries = Vec::new();
+    for r in &batch.records {
+        let facility = match r.get("facility") {
+            Some(Value::Property(PropertyValue::String(s))) => s.clone(),
+            _ => continue,
+        };
+        let country = match r.get("country") {
+            Some(Value::Property(PropertyValue::String(s))) => s.clone(),
+            _ => String::from("Unknown"),
+        };
+        facilities.push(facility);
+        countries.push(country);
+    }
+    let dim = facilities.len();
+    eprintln!("got {} candidate sites; {} distinct countries",
+        dim, countries.iter().collect::<std::collections::HashSet<_>>().len());
+    assert!(dim > 0, "no candidate sites returned");
+
+    // Objective: -count of distinct trials hosted by selected sites + diversity_term.
+    let objective = "MATCH (t:ClinicalTrial)-[:CONDUCTED_AT]->(s:Site) \
+         WHERE s.facility IN [$selected] \
+         RETURN (-toFloat(count(DISTINCT t)) + $diversity_term) AS f";
+
+    let graph = Arc::new(RwLock::new(store));
+
+    let solvers: Vec<(&str, fn(SolverConfig, &CypherProblem) -> samyama_optimization::common::OptimizationResult)> = vec![
+        ("BMWR",      |c, p| BMWRSolver::new(c).solve(p)),
+        ("Jaya",      |c, p| JayaSolver::new(c).solve(p)),
+        ("SAMP-Jaya", |c, p| SAMPJayaSolver::new(c).solve(p)),
+        ("EHR-Jaya",  |c, p| EHRJayaSolver::new(c).solve(p)),
+        ("Rao-1",     |c, p| RaoSolver::new(c, RaoVariant::Rao1).solve(p)),
+    ];
+    let cfg = SolverConfig { population_size: 30, max_iterations: 100 };
+
+    let csv_path = a.out.join("results.csv");
+    use std::io::Write;
+    let mut csv = std::fs::File::create(&csv_path).unwrap();
+    writeln!(csv, "solver,seed,best_fitness,trial_count,distinct_countries,wall_ms,cache_hits,cache_misses,avg_eval_ms").unwrap();
+
+    println!("\n=== Trial-site selection (k <= {}, candidates={}, diversity_weight={}) ===",
+        a.k, a.candidates, a.diversity_weight);
+    println!("{:<12} {:>5} {:>10} {:>10} {:>10} {:>10} {:>10} {:>12}",
+        "solver", "seed", "fitness", "trials", "countries", "wall_ms", "misses", "avg_eval_ms");
+
+    for (name, run) in &solvers {
+        for seed in 0..a.seeds {
+            let prob = CypherProblem::new(
+                dim, Array1::zeros(dim), Array1::ones(dim),
+                objective,
+                graph.clone(), engine.clone(),
+            ).with_subs({
+                let f = facilities.clone();
+                let c = countries.clone();
+                let w = a.diversity_weight;
+                let k = a.k;
+                move |x: &Array1<f64>| make_subs(x, &f, &c, w, k)
+            });
+            let t0 = Instant::now();
+            let r = run(cfg.clone(), &prob);
+            let wall = t0.elapsed().as_millis();
+            let st = prob.stats();
+            let subs = make_subs(&r.best_variables, &facilities, &countries, a.diversity_weight, a.k);
+            let diversity_term: f64 = subs.iter().find(|(p, _)| p == "$diversity_term")
+                .map(|(_, v)| v.parse().unwrap_or(0.0)).unwrap_or(0.0);
+            let trial_count = -(r.best_fitness - diversity_term);
+            let countries_n = if a.diversity_weight > 0.0 { (-diversity_term / a.diversity_weight) as i64 } else { 0 };
+            let avg_eval = st.total_eval_ms as f64 / st.misses.max(1) as f64;
+            println!("{:<12} {:>5} {:>10.2} {:>10.0} {:>10} {:>10} {:>10} {:>12.2}",
+                name, seed, r.best_fitness, trial_count, countries_n, wall, st.misses, avg_eval);
+            writeln!(csv, "{},{},{:.4},{},{},{},{},{},{:.3}",
+                name, seed, r.best_fitness, trial_count, countries_n, wall, st.hits, st.misses, avg_eval).unwrap();
+        }
+    }
+    eprintln!("\nresults -> {}", csv_path.display());
+
+    let manifest = format!(
+        r#"{{"args": {{"snapshot": "{}", "candidates": {}, "k": {}, "seeds": {}, "diversity_weight": {}}}, "nodes_loaded": {}, "edges_loaded": {}, "load_ms": {}, "dim": {}, "distinct_countries_pool": {}}}
+"#,
+        a.snapshot.display(), a.candidates, a.k, a.seeds, a.diversity_weight,
+        stats.node_count, stats.edge_count, load_ms, dim,
+        countries.iter().collect::<std::collections::HashSet<_>>().len()
+    );
+    std::fs::write(a.out.join("manifest.json"), manifest).unwrap();
+}

--- a/examples/drug_repurposing_demo.rs
+++ b/examples/drug_repurposing_demo.rs
@@ -38,7 +38,9 @@ struct Args {
     targets: usize,
     k: usize,
     seeds: usize,
+    sider_weight: f64,
     out: PathBuf,
+    export_edges: Option<PathBuf>,
 }
 
 impl Default for Args {
@@ -49,7 +51,9 @@ impl Default for Args {
             targets: 10,
             k: 5,
             seeds: 5,
+            sider_weight: 0.0,
             out: PathBuf::from("/tmp/p8-drug-repurposing"),
+            export_edges: None,
         }
     }
 }
@@ -66,10 +70,37 @@ fn parse_args() -> Args {
             "--k" => { a.k = argv[i + 1].parse().unwrap(); i += 2; }
             "--seeds" => { a.seeds = argv[i + 1].parse().unwrap(); i += 2; }
             "--out" => { a.out = PathBuf::from(&argv[i + 1]); i += 2; }
+            "--sider-weight" => { a.sider_weight = argv[i + 1].parse().unwrap(); i += 2; }
+            "--export-edges" => { a.export_edges = Some(PathBuf::from(&argv[i + 1])); i += 2; }
             other => { eprintln!("unknown arg: {}", other); std::process::exit(2); }
         }
     }
     a
+}
+
+/// Map a decision vector to (selected drug-id list, sider cost) Cypher substitutions.
+fn make_subs(
+    x: &Array1<f64>,
+    candidates: &[String],
+    sider_counts: &[f64],
+    sider_weight: f64,
+    k: usize,
+) -> Vec<(String, String)> {
+    let mut idxs: Vec<(usize, f64)> = x.iter().enumerate()
+        .filter(|(_, &v)| v > 0.5)
+        .map(|(i, &v)| (i, v)).collect();
+    idxs.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    let take = k.min(idxs.len());
+    let selected: Vec<usize> = idxs.iter().take(take).map(|(i, _)| *i).collect();
+    let list = selected.iter()
+        .map(|i| format!("'{}'", candidates[*i].replace('\'', "\\'")))
+        .collect::<Vec<_>>().join(",");
+    let list = if list.is_empty() { "'__NONE__'".to_string() } else { list };
+    let sider_cost: f64 = selected.iter().map(|i| sider_counts[*i]).sum::<f64>() * sider_weight;
+    vec![
+        ("$selected".to_string(), list),
+        ("$sider_cost".to_string(), format!("{:.6}", sider_cost)),
+    ]
 }
 
 /// Pull a list of strings from the first column of a query result.
@@ -122,15 +153,69 @@ fn main() {
     eprintln!("got {} target genes: {:?}", targets.len(), targets);
     assert!(!targets.is_empty(), "no targets returned");
 
-    // 4. Build objective template with two placeholders: $selected and $targets.
-    //    Targets are fixed across the run; selected varies per candidate vector.
+    // 4. Side-effect counts per candidate (Vec aligned with `candidates`).
+    let mut sider_counts: Vec<f64> = vec![0.0; candidates.len()];
+    let mut id_to_idx = std::collections::HashMap::new();
+    for (i, id) in candidates.iter().enumerate() {
+        id_to_idx.insert(id.clone(), i);
+    }
+    let se_q = "MATCH (d:Drug)-[:HAS_SIDE_EFFECT]->(s) \
+                RETURN d.drugbank_id AS id, count(s) AS n";
+    let se_batch = engine.execute(se_q, &store).expect("side-effect query");
+    for r in &se_batch.records {
+        if let (Some(Value::Property(samyama::graph::PropertyValue::String(id))),
+                Some(Value::Property(samyama::graph::PropertyValue::Integer(n)))) =
+            (r.get("id"), r.get("n"))
+        {
+            if let Some(&idx) = id_to_idx.get(id) { sider_counts[idx] = *n as f64; }
+        }
+    }
+    let mean_se: f64 = sider_counts.iter().sum::<f64>() / sider_counts.len() as f64;
+    eprintln!("side-effect counts per candidate: mean={:.1}, max={:.0}",
+        mean_se, sider_counts.iter().cloned().fold(0.0f64, f64::max));
+
+    // 5. Optional edge-export for the OR-tools baseline.
+    if let Some(path) = &a.export_edges {
+        let edge_q = format!(
+            "MATCH (d:Drug)-[:INTERACTS_WITH_GENE]->(g:Gene) \
+             WHERE d.drugbank_id IN [{}] AND g.gene_name IN [{}] \
+             RETURN d.drugbank_id AS drug, g.gene_name AS gene",
+            candidates.iter().map(|c| format!("'{}'", c.replace('\'', "\\'")))
+                .collect::<Vec<_>>().join(","),
+            targets.iter().map(|t| format!("'{}'", t.replace('\'', "\\'")))
+                .collect::<Vec<_>>().join(","));
+        let edge_batch = engine.execute(&edge_q, &store).expect("edge export");
+        use std::io::Write as _;
+        let mut f = std::fs::File::create(path).unwrap();
+        writeln!(f, r#"{{"k": {}, "sider_weight": {}, "candidates": [{}], "targets": [{}], "side_effects": [{}], "edges": ["#,
+            a.k, a.sider_weight,
+            candidates.iter().map(|c| format!("\"{}\"", c)).collect::<Vec<_>>().join(","),
+            targets.iter().map(|t| format!("\"{}\"", t)).collect::<Vec<_>>().join(","),
+            sider_counts.iter().map(|n| n.to_string()).collect::<Vec<_>>().join(",")).unwrap();
+        let mut first = true;
+        for r in &edge_batch.records {
+            if let (Some(Value::Property(samyama::graph::PropertyValue::String(d))),
+                    Some(Value::Property(samyama::graph::PropertyValue::String(g)))) =
+                (r.get("drug"), r.get("gene")) {
+                if !first { writeln!(f, ",").unwrap(); }
+                write!(f, r#"  {{"drug": "{}", "gene": "{}"}}"#, d, g).unwrap();
+                first = false;
+            }
+        }
+        writeln!(f, "\n]}}").unwrap();
+        eprintln!("edges -> {} ({} drug-gene edges)", path.display(), edge_batch.records.len());
+    }
+
+    // 6. Build objective template. Targets are fixed; $selected and $sider_cost
+    //    vary per candidate. $sider_cost is the Rust-computed penalty injected
+    //    as a numeric literal so the Cypher query stays simple (no sum-over-CASE).
     let targets_list = targets.iter()
         .map(|g| format!("'{}'", g.replace('\'', "\\'")))
         .collect::<Vec<_>>().join(",");
     let objective = format!(
         "MATCH (d:Drug)-[:INTERACTS_WITH_GENE]->(g:Gene) \
          WHERE d.drugbank_id IN [$selected] AND g.gene_name IN [{}] \
-         RETURN -toFloat(count(DISTINCT g)) AS f", targets_list);
+         RETURN (-toFloat(count(DISTINCT g)) + $sider_cost) AS f", targets_list);
 
     let graph = Arc::new(RwLock::new(store));
     let candidates_for_sub = candidates.clone();
@@ -148,21 +233,12 @@ fn main() {
         objective,
         graph.clone(),
         engine.clone(),
-    ).with_subs(move |x: &Array1<f64>| {
-        // Selected indices, by descending decision value, up to k.
-        let mut idxs: Vec<(usize, f64)> = x.iter().enumerate()
-            .filter(|(_, &v)| v > 0.5)
-            .map(|(i, &v)| (i, v))
-            .collect();
-        idxs.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-        let take = k_for_sub.min(idxs.len());
-        let list = idxs.iter().take(take)
-            .map(|(i, _)| format!("'{}'", candidates_for_sub[*i].replace('\'', "\\'")))
-            .collect::<Vec<_>>()
-            .join(",");
-        // If nothing selected, IN [] would be invalid; emit a sentinel that matches nothing.
-        let list = if list.is_empty() { "'__NONE__'".to_string() } else { list };
-        vec![("$selected".to_string(), list)]
+    ).with_subs({
+        let candidates_for_sub = candidates_for_sub.clone();
+        let sider_counts = sider_counts.clone();
+        let sider_weight = a.sider_weight;
+        let k = k_for_sub;
+        move |x: &Array1<f64>| make_subs(x, &candidates_for_sub, &sider_counts, sider_weight, k)
     });
 
     // 6. Run a small panel of Rao-family solvers.
@@ -178,14 +254,14 @@ fn main() {
     let csv_path = a.out.join("results.csv");
     use std::io::Write;
     let mut csv = std::fs::File::create(&csv_path).unwrap();
-    writeln!(csv, "solver,seed,best_coverage,wall_ms,cache_hits,cache_misses,avg_eval_ms").unwrap();
+    writeln!(csv, "solver,seed,best_fitness,coverage_only,sider_cost,wall_ms,cache_hits,cache_misses,avg_eval_ms").unwrap();
 
-    println!("\n=== Drug repurposing (k <= {}; candidates={}, targets={}) ===",
-        a.k, a.candidates, a.targets);
+    println!("\n=== Drug repurposing (k <= {}; candidates={}, targets={}, sider_weight={}) ===",
+        a.k, a.candidates, a.targets, a.sider_weight);
     println!("targets: {:?}", targets);
     println!("");
-    println!("{:<12} {:>5} {:>10} {:>10} {:>10} {:>10} {:>12}",
-        "solver", "seed", "coverage", "wall_ms", "hits", "misses", "avg_eval_ms");
+    println!("{:<12} {:>5} {:>10} {:>10} {:>10} {:>10} {:>10} {:>12}",
+        "solver", "seed", "fitness", "coverage", "sider", "wall_ms", "misses", "avg_eval_ms");
 
     for (name, run) in &solvers {
         for seed in 0..a.seeds {
@@ -195,31 +271,26 @@ fn main() {
                 problem.objective_template.clone(),
                 graph.clone(), engine.clone(),
             ).with_subs({
-                let candidates_for_sub = candidates.clone();
-                let k_for_sub = a.k;
-                move |x: &Array1<f64>| {
-                    let mut idxs: Vec<(usize, f64)> = x.iter().enumerate()
-                        .filter(|(_, &v)| v > 0.5)
-                        .map(|(i, &v)| (i, v)).collect();
-                    idxs.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-                    let take = k_for_sub.min(idxs.len());
-                    let list = idxs.iter().take(take)
-                        .map(|(i, _)| format!("'{}'", candidates_for_sub[*i].replace('\'', "\\'")))
-                        .collect::<Vec<_>>().join(",");
-                    let list = if list.is_empty() { "'__NONE__'".to_string() } else { list };
-                    vec![("$selected".to_string(), list)]
-                }
+                let cands = candidates.clone();
+                let se = sider_counts.clone();
+                let w = a.sider_weight;
+                let k = a.k;
+                move |x: &Array1<f64>| make_subs(x, &cands, &se, w, k)
             });
             let t0 = Instant::now();
             let r = run(cfg.clone(), &prob);
             let wall = t0.elapsed().as_millis();
             let stats = prob.stats();
-            let coverage = -r.best_fitness;  // we minimized -count
+            // Recover coverage and SIDER components from the best variables.
+            let subs = make_subs(&r.best_variables, &candidates, &sider_counts, a.sider_weight, a.k);
+            let sider_cost: f64 = subs.iter().find(|(p, _)| p == "$sider_cost")
+                .map(|(_, v)| v.parse().unwrap_or(0.0)).unwrap_or(0.0);
+            let coverage = -(r.best_fitness - sider_cost);
             let avg_eval = stats.total_eval_ms as f64 / stats.misses.max(1) as f64;
-            println!("{:<12} {:>5} {:>10.0} {:>10} {:>10} {:>10} {:>12.2}",
-                name, seed, coverage, wall, stats.hits, stats.misses, avg_eval);
-            writeln!(csv, "{},{},{},{},{},{},{:.3}",
-                name, seed, coverage, wall, stats.hits, stats.misses, avg_eval).unwrap();
+            println!("{:<12} {:>5} {:>10.2} {:>10.0} {:>10.2} {:>10} {:>10} {:>12.2}",
+                name, seed, r.best_fitness, coverage, sider_cost, wall, stats.misses, avg_eval);
+            writeln!(csv, "{},{},{:.4},{},{:.4},{},{},{},{:.3}",
+                name, seed, r.best_fitness, coverage, sider_cost, wall, stats.hits, stats.misses, avg_eval).unwrap();
         }
     }
     eprintln!("\nresults -> {}", csv_path.display());


### PR DESCRIPTION
Extends problem 1 with a SIDER side-effect penalty + edge JSON export, and adds the problem 2 (clinical-trial site selection) demo skeleton.

## Problem 1 — drug repurposing, scaled

`drug_repurposing_demo`:
- `--candidates` scales to 200+
- `--sider-weight` enables side-effect penalty (per-candidate counts precomputed from KG, injected per-eval as `$sider_cost` literal)
- `--export-edges` dumps the (candidates, targets, side_effects, edges) JSON spec consumed by the OR-tools baseline (separate Python script in samyama-research)
- CSV reports best_fitness, coverage, sider_cost separately

### Smoke run (candidates=100, k=5, sider_weight=0.05, seeds=2)

| Solver | coverage | sider | wall (s) |
|---|---:|---:|---:|
| BMWR | 10 | 2-3 (tradeoff) | 8.4 |
| Jaya | **9 (stuck)** | 0 | 10.6 |
| SAMP-Jaya | 10 | 0 | 10.6 |
| EHR-Jaya | 10 | 0 | 11.4 |
| Rao-1 | 10 | 0 | 11.7 |
| **OR-tools CP-SAT** | **10 (with only 2 drugs)** | 0 | **0.015** |

Strong paper observation: OR-tools dominates this discrete/MILP-friendly size; the metaheuristics' value will emerge on the non-convex problems (4/5/6/7).

## Problem 2 — clinical-trial site selection demo

`clinical_trial_sites_demo.rs`:
- Loads clinicaltrials snapshot (745 MB; AACT bulk download)
- Picks top-N sites by trial-host degree
- Country-diversity term added Rust-side via `CypherProblem` custom subs

Builds and exits cleanly. Smoke run was killed at 30 min — per-eval Cypher on 45M-node KG is ~600 ms (3000 evals/run = 30 min per solver). Next session: shrink candidates or pre-materialise the per-site trial-count map.