### PR TITLE
Paper 8: --export-snapshot flag on p5/p6/p7 demos

### DIFF
--- a/examples/amr_stewardship_demo.rs
+++ b/examples/amr_stewardship_demo.rs
@@ -54,6 +54,7 @@ struct Args {
     resistance_weight: f64,
     out: PathBuf,
     export_spec: Option<PathBuf>,
+    export_snapshot: Option<PathBuf>,
 }
 
 impl Default for Args {
@@ -67,6 +68,7 @@ impl Default for Args {
             resistance_weight: 0.001,
             out: PathBuf::from("/tmp/p8-amr-stewardship"),
             export_spec: None,
+            export_snapshot: None,
         }
     }
 }
@@ -85,6 +87,7 @@ fn parse_args() -> Args {
             "--resistance-weight" => { a.resistance_weight = argv[i + 1].parse().unwrap(); i += 2; }
             "--out" => { a.out = PathBuf::from(&argv[i + 1]); i += 2; }
             "--export-spec" => { a.export_spec = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            "--export-snapshot" => { a.export_snapshot = Some(PathBuf::from(&argv[i + 1])); i += 2; }
             other => { eprintln!("unknown arg: {}", other); std::process::exit(2); }
         }
     }
@@ -210,6 +213,13 @@ fn main() {
             _ => -1,
         };
         eprintln!("KG sanity — {} = {}", label, n);
+    }
+
+    if let Some(path) = &a.export_snapshot {
+        let f = File::create(path).expect("snapshot file");
+        let stats = samyama::snapshot::export_tenant(&store, f).expect("export");
+        eprintln!("snapshot -> {} ({} nodes, {} edges)", path.display(),
+            stats.node_count, stats.edge_count);
     }
 
     // Pre-materialise: count of genes per (subclass, pathogen).

--- a/examples/grid_dispatch_demo.rs
+++ b/examples/grid_dispatch_demo.rs
@@ -47,6 +47,7 @@ struct Args {
     ramp_penalty: f64,
     out: PathBuf,
     export_spec: Option<PathBuf>,
+    export_snapshot: Option<PathBuf>,
 }
 
 impl Default for Args {
@@ -59,6 +60,7 @@ impl Default for Args {
             ramp_penalty: 50.0,
             out: PathBuf::from("/tmp/p8-grid-dispatch"),
             export_spec: None,
+            export_snapshot: None,
         }
     }
 }
@@ -76,6 +78,7 @@ fn parse_args() -> Args {
             "--ramp-penalty" => { a.ramp_penalty = argv[i + 1].parse().unwrap(); i += 2; }
             "--out" => { a.out = PathBuf::from(&argv[i + 1]); i += 2; }
             "--export-spec" => { a.export_spec = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            "--export-snapshot" => { a.export_snapshot = Some(PathBuf::from(&argv[i + 1])); i += 2; }
             other => { eprintln!("unknown arg: {}", other); std::process::exit(2); }
         }
     }
@@ -260,6 +263,13 @@ fn main() {
     };
     eprintln!("KG sanity: total capacity = {:.0} MW, peak demand = {:.0} MW, total demand = {:.0} MWh",
         total_cap, peak_demand, total_demand);
+
+    if let Some(path) = &a.export_snapshot {
+        let f = File::create(path).expect("snapshot file");
+        let stats = samyama::snapshot::export_tenant(&store, f).expect("export");
+        eprintln!("snapshot -> {} ({} nodes, {} edges)", path.display(),
+            stats.node_count, stats.edge_count);
+    }
 
     if let Some(path) = &a.export_spec {
         let mut f = File::create(path).unwrap();

--- a/examples/wildfire_evac_demo.rs
+++ b/examples/wildfire_evac_demo.rs
@@ -52,6 +52,7 @@ struct Args {
     speed_kmh: f64,
     out: PathBuf,
     export_spec: Option<PathBuf>,
+    export_snapshot: Option<PathBuf>,
 }
 
 impl Default for Args {
@@ -67,6 +68,7 @@ impl Default for Args {
             speed_kmh: 40.0,
             out: PathBuf::from("/tmp/p8-wildfire-evac"),
             export_spec: None,
+            export_snapshot: None,
         }
     }
 }
@@ -87,6 +89,7 @@ fn parse_args() -> Args {
             "--speed-kmh" => { a.speed_kmh = argv[i + 1].parse().unwrap(); i += 2; }
             "--out" => { a.out = PathBuf::from(&argv[i + 1]); i += 2; }
             "--export-spec" => { a.export_spec = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            "--export-snapshot" => { a.export_snapshot = Some(PathBuf::from(&argv[i + 1])); i += 2; }
             other => { eprintln!("unknown arg: {}", other); std::process::exit(2); }
         }
     }
@@ -224,6 +227,13 @@ fn main() {
         Some(Value::Property(PropertyValue::Integer(i))) => *i, _ => -1,
     };
     eprintln!("Cypher sanity: count(:RoadNode) = {}", n_count);
+
+    if let Some(path) = &a.export_snapshot {
+        let f = File::create(path).expect("snapshot file");
+        let stats = samyama::snapshot::export_tenant(&store, f).expect("export");
+        eprintln!("snapshot -> {} ({} nodes, {} edges)", path.display(),
+            stats.node_count, stats.edge_count);
+    }
 
     // Pick centroids: top-N by degree (busy intersections).
     let mut ranked_by_deg: Vec<(&OsmNode, usize)> = nodes.iter()


### PR DESCRIPTION
Adds --export-snapshot PATH to grid_dispatch_demo, amr_stewardship_demo, and wildfire_evac_demo. Used to create the paper8-kg-snapshots-v1 release. Snapshots are reproducible from the existing loaders.