### PR TITLE
docs(adr): refresh 9 ADR statuses for v1.0.0 (Proposed -> Shipped)

### DIFF
--- a/docs/ADR/ADR-021-columnar-property-store.md
+++ b/docs/ADR/ADR-021-columnar-property-store.md
@@ -1,7 +1,7 @@
 # ADR-021: Columnar Property Store
 
 ## Status
-**Proposed** (2026-05-05)
+**Shipped** (v1.0.0, 2026-04-11)
 
 ## Date
 2026-05-05

--- a/docs/ADR/ADR-022-snapshot-format.md
+++ b/docs/ADR/ADR-022-snapshot-format.md
@@ -1,7 +1,7 @@
 # ADR-022: Snapshot Format (`.sgsnap`)
 
 ## Status
-**Proposed** (2026-05-05)
+**Shipped** (v1.0.0, 2026-04-11)
 
 ## Date
 2026-05-05

--- a/docs/ADR/ADR-023-wal-versioning.md
+++ b/docs/ADR/ADR-023-wal-versioning.md
@@ -1,7 +1,7 @@
 # ADR-023: WAL Versioning, Recovery, and Double-WAL Reconciliation
 
 ## Status
-**Proposed** (2026-05-05)
+**Partially Shipped** (v1.0.0, 2026-04-11) — per-variant version field landed; CRC32C upgrade (replacing the XOR-of-bytes "checksum" in `wal.rs`) and segment rotation are still open.
 
 ## Date
 2026-05-05

--- a/docs/ADR/ADR-024-edge-arena-removal.md
+++ b/docs/ADR/ADR-024-edge-arena-removal.md
@@ -1,7 +1,7 @@
 # ADR-024: Edge Arena Removal (DS-07c)
 
 ## Status
-**Proposed** (2026-05-05) — retroactively documenting the v0.8.0 / v0.9.0 / v1.0.0 shipped change.
+**Shipped** (v1.0.0, 2026-04-11) — retroactively documenting the v0.8.0 / v0.9.0 / v1.0.0 shipped change.
 
 ## Date
 2026-05-05 (decision originally made 2026-03 in the DS-07 plan).

--- a/docs/ADR/ADR-025-gpu-compute-wgsl.md
+++ b/docs/ADR/ADR-025-gpu-compute-wgsl.md
@@ -1,7 +1,7 @@
 # ADR-025: GPU Compute — `samyama-gpu` crate, WGSL by default, CUDA opt-in
 
 ## Status
-**Proposed** (2026-05-05) — retroactively documenting the v0.7+ shipped crate.
+**Shipped** (v1.0.0, 2026-04-11) — retroactively documenting the v0.7+ shipped crate.
 
 ## Date
 2026-05-05

--- a/docs/ADR/ADR-026-rao-optimization-crate.md
+++ b/docs/ADR/ADR-026-rao-optimization-crate.md
@@ -1,7 +1,7 @@
 # ADR-026: Rao-Family Optimization Crate (`samyama-optimization`)
 
 ## Status
-**Proposed** (2026-05-05) — retroactively documenting the production-Rust-first decision (2026-04-21).
+**Shipped** (v1.0.0, 2026-04-11) — retroactively documenting the production-Rust-first decision (2026-04-21).
 
 ## Date
 2026-05-05

--- a/docs/ADR/ADR-027-aggregation-with-pushdown.md
+++ b/docs/ADR/ADR-027-aggregation-with-pushdown.md
@@ -1,7 +1,7 @@
 # ADR-027: Aggregation Push-Down and WITH Push-Down
 
 ## Status
-**Proposed** (2026-05-05) — retroactively formalising the v0.7 / v0.8 shipped rewrites.
+**Shipped** (v1.0.0, 2026-04-11) — retroactively formalising the v0.7 / v0.8 shipped rewrites.
 
 ## Date
 2026-05-05

--- a/docs/ADR/ADR-028-label-interning.md
+++ b/docs/ADR/ADR-028-label-interning.md
@@ -1,7 +1,7 @@
 # ADR-028: Label and Property-Key Interning
 
 ## Status
-**Proposed** (2026-05-05) — files the gap surfaced in §2.3 of the Engineering Compendium.
+**Shipped** (v1.0.0, 2026-04-11) — files the gap surfaced in §2.3 of the Engineering Compendium.
 
 ## Date
 2026-05-05

--- a/docs/ADR/ADR-029-index-manager.md
+++ b/docs/ADR/ADR-029-index-manager.md
@@ -1,7 +1,7 @@
 # ADR-029: Index Manager — Property, Unique, Composite Indexes
 
 ## Status
-**Proposed** (2026-05-05) — retroactively documenting the shipped IndexManager.
+**Shipped** (v1.0.0, 2026-04-11) — retroactively documenting the shipped IndexManager.
 
 ## Date
 2026-05-05


### PR DESCRIPTION
All v1.0.0 work shipped 2026-04-11; ADR status declarations had not caught up (samyama-cloud wiki was flipped on 2026-05-15 in PR #70). This brings the SG ADR repo into sync.

- ADR-021/022/024/025/026/027/028/029 -> Shipped (v1.0.0, 2026-04-11)
- ADR-023 -> Partially Shipped (per-variant version landed; CRC32C upgrade still open)