### PR TITLE
Implement variable-length traversal in MATCH (VarLengthExpand operator)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2846,6 +2846,240 @@ impl PhysicalOperator for ExpandOperator {
     }
 }
 
+/// Variable-length expand operator: `(a)-[:R*min..max]-(b)`.
+///
+/// For each input record it performs a breadth-first traversal from the source
+/// node along the given direction/edge-types and emits one output record per
+/// **distinct** target node reachable in `[min, max]` hops (BFS guarantees the
+/// shortest depth is seen first, so each target is emitted once). This is the
+/// node-reachability semantics relied on by traversal/failure-propagation
+/// queries; enumerating every distinct path is the job of `shortestPath` /
+/// `allShortestPaths` instead.
+///
+/// `target_labels` restrict only the *emitted* endpoint (intermediate nodes are
+/// unrestricted, matching Cypher). An optional `path_variable` is materialized
+/// with the BFS route (shortest path source→target).
+pub struct VarLengthExpandOperator {
+    input: OperatorBox,
+    source_var: String,
+    target_var: String,
+    edge_types: Vec<String>,
+    target_labels: Vec<Label>,
+    direction: Direction,
+    min_hops: usize,
+    max_hops: usize,
+    path_variable: Option<String>,
+    /// Output records buffered for the current input record.
+    pending: std::collections::VecDeque<Record>,
+}
+
+impl VarLengthExpandOperator {
+    /// Create a new variable-length expand operator. `max_hops == usize::MAX`
+    /// means unbounded (BFS still terminates via the visited set).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        input: OperatorBox,
+        source_var: String,
+        target_var: String,
+        edge_types: Vec<String>,
+        direction: Direction,
+        min_hops: usize,
+        max_hops: usize,
+    ) -> Self {
+        Self {
+            input,
+            source_var,
+            target_var,
+            edge_types,
+            target_labels: Vec::new(),
+            direction,
+            min_hops,
+            max_hops,
+            path_variable: None,
+            pending: std::collections::VecDeque::new(),
+        }
+    }
+
+    /// Set target node labels to filter the emitted endpoint.
+    pub fn with_target_labels(mut self, labels: Vec<Label>) -> Self {
+        self.target_labels = labels;
+        self
+    }
+
+    /// Set path variable for named-path materialization.
+    pub fn with_path_variable(mut self, var: String) -> Self {
+        self.path_variable = Some(var);
+        self
+    }
+
+    /// One-hop neighbours of `node` honouring direction + edge-type filter,
+    /// returned as `(neighbour_node, edge_id)` pairs.
+    fn neighbors(&self, node: NodeId, store: &GraphStore) -> Vec<(NodeId, crate::graph::EdgeId)> {
+        let raw: Vec<(crate::graph::EdgeId, NodeId, NodeId, EdgeType)> = match self.direction {
+            Direction::Outgoing => store.get_outgoing_edge_targets_owned(node),
+            Direction::Incoming => store.get_incoming_edge_sources_owned(node),
+            Direction::Both => {
+                let mut all = store.get_outgoing_edge_targets_owned(node);
+                all.extend(store.get_incoming_edge_sources_owned(node));
+                all
+            }
+        };
+        raw.into_iter()
+            .filter(|(_, _, _, et)| {
+                self.edge_types.is_empty() || self.edge_types.iter().any(|t| et.as_str() == t)
+            })
+            .map(|(eid, src, tgt, _)| {
+                let other = match self.direction {
+                    Direction::Outgoing => tgt,
+                    Direction::Incoming => src,
+                    Direction::Both => {
+                        if src == node {
+                            tgt
+                        } else {
+                            src
+                        }
+                    }
+                };
+                (other, eid)
+            })
+            .collect()
+    }
+
+    /// BFS from the source bound in `record`, buffering one output record per
+    /// distinct reachable target in `[min_hops, max_hops]`.
+    fn expand_from(&mut self, record: &Record, store: &GraphStore) -> ExecutionResult<()> {
+        let source_id = record
+            .get(&self.source_var)
+            .ok_or_else(|| ExecutionError::VariableNotFound(self.source_var.clone()))?
+            .node_id()
+            .ok_or_else(|| {
+                ExecutionError::TypeError(format!("{} is not a node", self.source_var))
+            })?;
+
+        // parent[node] = (predecessor, edge used) for path reconstruction.
+        let mut parent: std::collections::HashMap<NodeId, (NodeId, crate::graph::EdgeId)> =
+            std::collections::HashMap::new();
+        let mut visited: std::collections::HashSet<NodeId> = std::collections::HashSet::new();
+        visited.insert(source_id);
+
+        // Depth 0 endpoint (only relevant when min_hops == 0).
+        if self.min_hops == 0 && self.emit_ok(source_id, store) {
+            self.buffer(record, source_id, &parent, source_id);
+        }
+
+        let mut frontier = vec![source_id];
+        let mut depth = 0usize;
+        while !frontier.is_empty() && depth < self.max_hops {
+            depth += 1;
+            let mut next = Vec::new();
+            for &cur in &frontier {
+                for (nb, eid) in self.neighbors(cur, store) {
+                    if visited.insert(nb) {
+                        parent.insert(nb, (cur, eid));
+                        next.push(nb);
+                        if depth >= self.min_hops && self.emit_ok(nb, store) {
+                            self.buffer(record, nb, &parent, source_id);
+                        }
+                    }
+                }
+            }
+            frontier = next;
+        }
+        Ok(())
+    }
+
+    /// Whether `node` qualifies as an emitted endpoint (target-label filter).
+    fn emit_ok(&self, node: NodeId, store: &GraphStore) -> bool {
+        if self.target_labels.is_empty() {
+            return true;
+        }
+        match store.get_node(node) {
+            Some(n) => self.target_labels.iter().all(|l| n.has_label(l)),
+            None => false,
+        }
+    }
+
+    /// Build and buffer an output record binding the target (and optional path).
+    fn buffer(
+        &mut self,
+        base: &Record,
+        target: NodeId,
+        parent: &std::collections::HashMap<NodeId, (NodeId, crate::graph::EdgeId)>,
+        source: NodeId,
+    ) {
+        let mut rec = base.clone();
+        rec.bind(self.target_var.clone(), Value::NodeRef(target));
+        if let Some(ref pv) = self.path_variable {
+            let (nodes, edges) = reconstruct_path(parent, source, target);
+            rec.bind(pv.clone(), Value::Path { nodes, edges });
+        }
+        self.pending.push_back(rec);
+    }
+}
+
+/// Reconstruct the BFS path source→target from a parent map.
+fn reconstruct_path(
+    parent: &std::collections::HashMap<NodeId, (NodeId, crate::graph::EdgeId)>,
+    source: NodeId,
+    target: NodeId,
+) -> (Vec<NodeId>, Vec<crate::graph::EdgeId>) {
+    let mut nodes = vec![target];
+    let mut edges = Vec::new();
+    let mut cur = target;
+    while cur != source {
+        if let Some(&(prev, eid)) = parent.get(&cur) {
+            edges.push(eid);
+            nodes.push(prev);
+            cur = prev;
+        } else {
+            break;
+        }
+    }
+    nodes.reverse();
+    edges.reverse();
+    (nodes, edges)
+}
+
+impl PhysicalOperator for VarLengthExpandOperator {
+    fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        loop {
+            if let Some(rec) = self.pending.pop_front() {
+                return Ok(Some(rec));
+            }
+            match self.input.next(store)? {
+                Some(record) => self.expand_from(&record, store)?,
+                None => return Ok(None),
+            }
+        }
+    }
+
+    fn reset(&mut self) {
+        self.input.reset();
+        self.pending.clear();
+    }
+
+    fn describe(&self) -> OperatorDescription {
+        let types = if self.edge_types.is_empty() {
+            "*".to_string()
+        } else {
+            self.edge_types.join("|")
+        };
+        let max = if self.max_hops == usize::MAX {
+            String::new()
+        } else {
+            self.max_hops.to_string()
+        };
+        OperatorDescription {
+            name: "VarLengthExpand".to_string(),
+            details: format!(
+                "({})-[:{}*{}..{}]-({})",
+                self.source_var, types, self.min_hops, max, self.target_var
+            ),
+            children: vec![self.input.describe()],
+        }
+    }
+}
+
 /// Project operator: RETURN n.name, n.age
 pub struct ProjectOperator {
     /// Input operator

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -62,7 +62,7 @@ use std::sync::Mutex;
 use crate::query::executor::{
     ExecutionError, ExecutionResult, OperatorBox,
     // Added CreateNodeOperator and CreateNodesAndEdgesOperator for CREATE statement support
-    operator::{NodeScanOperator, FilterOperator, ExpandOperator, ProjectOperator, LimitOperator, SkipOperator, CreateNodeOperator, CreateNodesAndEdgesOperator, CartesianProductOperator, VectorSearchOperator, JoinOperator, LeftOuterJoinOperator, CreateVectorIndexOperator, CreateIndexOperator, CompositeCreateIndexOperator, CreateConstraintOperator, DropIndexOperator, ShowIndexesOperator, ShowConstraintsOperator, ShowLabelsOperator, ShowRelationshipTypesOperator, ShowPropertyKeysOperator, SchemaVisualizationOperator, AlgorithmOperator, IndexScanOperator, AggregateOperator, AggregateType, AggregateFunction, SortOperator, DeleteOperator, SetPropertyOperator, RemovePropertyOperator, UnwindOperator, MergeOperator, ForeachOperator, ShortestPathOperator, WithBarrierOperator, LabelCountOperator, EdgeTypeCountOperator},
+    operator::{NodeScanOperator, FilterOperator, ExpandOperator, ProjectOperator, LimitOperator, SkipOperator, CreateNodeOperator, CreateNodesAndEdgesOperator, CartesianProductOperator, VectorSearchOperator, JoinOperator, LeftOuterJoinOperator, CreateVectorIndexOperator, CreateIndexOperator, CompositeCreateIndexOperator, CreateConstraintOperator, DropIndexOperator, ShowIndexesOperator, ShowConstraintsOperator, ShowLabelsOperator, ShowRelationshipTypesOperator, ShowPropertyKeysOperator, SchemaVisualizationOperator, AlgorithmOperator, IndexScanOperator, AggregateOperator, AggregateType, AggregateFunction, SortOperator, DeleteOperator, SetPropertyOperator, RemovePropertyOperator, UnwindOperator, MergeOperator, ForeachOperator, ShortestPathOperator, VarLengthExpandOperator, WithBarrierOperator, LabelCountOperator, EdgeTypeCountOperator},
 };
 use crate::graph::EdgeType;  // Added for CREATE edge support
 use std::collections::{HashMap, HashSet};  // Added for CREATE properties and JOIN logic
@@ -1565,6 +1565,37 @@ impl QueryPlanner {
                     let edge_types: Vec<String> = segment.edge.types.iter()
                         .map(|t| t.as_str().to_string())
                         .collect();
+
+                    if let Some(ref length) = segment.edge.length {
+                        // Variable-length traversal: BFS expand over [min, max] hops.
+                        let min_hops = length.min.unwrap_or(1);
+                        let max_hops = length.max.unwrap_or(usize::MAX);
+                        let mut expand = VarLengthExpandOperator::new(
+                            path_operator,
+                            current_var.clone(),
+                            target_var.clone(),
+                            edge_types,
+                            segment.edge.direction.clone(),
+                            min_hops,
+                            max_hops,
+                        );
+                        if let Some(ref pv) = path.path_variable {
+                            expand = expand.with_path_variable(pv.clone());
+                        }
+                        path_operator = if !segment.node.labels.is_empty() {
+                            Box::new(expand.with_target_labels(segment.node.labels.clone()))
+                        } else {
+                            Box::new(expand)
+                        };
+                        if let Some(ref props) = segment.node.properties {
+                            if !props.is_empty() {
+                                let filter_expr = self.build_property_filter(&target_var, props);
+                                path_operator = Box::new(FilterOperator::new(path_operator, filter_expr));
+                            }
+                        }
+                        current_var = target_var;
+                        continue;
+                    }
 
                     let mut expand = ExpandOperator::new(
                         path_operator,
@@ -3949,6 +3980,48 @@ mod tests {
             "Expected 3 results (countries 0,1,2), got {}",
             batch.records.len()
         );
+    }
+
+    #[test]
+    fn test_variable_length_expand_reachability() {
+        use crate::query::QueryExecutor;
+        // Path graph: a -> b -> c -> d (KNOWS chain) plus a branch a -> e.
+        let mut store = GraphStore::new();
+        let mk = |s: &mut GraphStore, name: &str| {
+            let n = s.create_node("Person");
+            s.get_node_mut(n)
+                .unwrap()
+                .set_property("name", PropertyValue::String(name.to_string()));
+            n
+        };
+        let a = mk(&mut store, "a");
+        let b = mk(&mut store, "b");
+        let c = mk(&mut store, "c");
+        let d = mk(&mut store, "d");
+        let e = mk(&mut store, "e");
+        store.create_edge(a, b, "KNOWS").unwrap();
+        store.create_edge(b, c, "KNOWS").unwrap();
+        store.create_edge(c, d, "KNOWS").unwrap();
+        store.create_edge(a, e, "KNOWS").unwrap();
+
+        let count = |cypher: &str| {
+            let q = parse_query(cypher).unwrap();
+            QueryExecutor::new(&store).execute(&q).unwrap().records.len()
+        };
+
+        // Outgoing reachability from a within k hops (distinct endpoints):
+        //   *1..1 -> {b,e}            (2)
+        //   *1..2 -> {b,e,c}          (3)
+        //   *1..3 -> {b,e,c,d}        (4)
+        //   *2..2 -> {c}              (1)   (regression guard: NOT the 1-hop set)
+        //   *2..3 -> {c,d}            (2)
+        assert_eq!(count("MATCH (a:Person {name:'a'})-[:KNOWS*1..1]->(o:Person) RETURN o.name"), 2);
+        assert_eq!(count("MATCH (a:Person {name:'a'})-[:KNOWS*1..2]->(o:Person) RETURN o.name"), 3);
+        assert_eq!(count("MATCH (a:Person {name:'a'})-[:KNOWS*1..3]->(o:Person) RETURN o.name"), 4);
+        assert_eq!(count("MATCH (a:Person {name:'a'})-[:KNOWS*2..2]->(o:Person) RETURN o.name"), 1);
+        assert_eq!(count("MATCH (a:Person {name:'a'})-[:KNOWS*2..3]->(o:Person) RETURN o.name"), 2);
+        // Undirected expansion reaches the whole component from any node.
+        assert_eq!(count("MATCH (d:Person {name:'d'})-[:KNOWS*1..9]-(o:Person) RETURN o.name"), 4);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Variable-length patterns like `(a)-[:R*1..3]-(b)` parse and plan, but the normal MATCH path built a single `ExpandOperator` and **ignored the length pattern** — so `*1..k` silently collapsed to a single hop. For example `*2..2` returned the 1-hop neighbours instead of the 2-hop set, and full-graph reachability returned only direct neighbours. Only `shortestPath`/`allShortestPaths` (a separate operator) handled multi-hop.

Surfaced while building a power-grid KG benchmark (failure-propagation / N-1 contingency) where multi-hop reachability is core.

## Fix

Add `VarLengthExpandOperator`: a BFS expand over `[min, max]` hops that emits one row per **distinct** reachable target (shortest depth first, visited-set dedup), with optional target-label filter and named-path materialization. Wire it into the planner's normal-path segment loop when `edge.length.is_some()`.

Semantics: distinct-node reachability (path enumeration remains the job of `allShortestPaths`). Endpoint label filter restricts only the emitted node; intermediates are unrestricted (matches Cypher).

## Tests

- New `test_variable_length_expand_reachability` over a known path graph, including a **regression guard** that `*2..2` returns the 2-hop set, not the 1-hop set.
- All **2010** lib tests pass; no regressions (877 executor tests green).

Verified end-to-end on real IEEE-14 grid data: full slack-bus reachability now returns the whole connected component (was stuck at direct neighbours), and an N-1 contingency analysis dropped from 85s (Python BFS workaround) to 0.76s using engine-native var-length.