### PR TITLE
Parse scientific-notation and leading-dot float literals

### DIFF
--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -188,7 +188,9 @@ value = {
 null = { ^"NULL" }
 boolean = { ^"TRUE" | ^"FALSE" }
 integer = @{ "-"? ~ ASCII_DIGIT+ }
-float = @{ "-"? ~ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ ~ (^"e" ~ ("-" | "+")? ~ ASCII_DIGIT+)? }
+// Float: digits.digits, leading-dot (.5), or exponent-without-decimal (1e-07),
+// each with an optional exponent. f64::parse handles all of these forms.
+float = @{ "-"? ~ ( (ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ ~ (^"e" ~ ("-" | "+")? ~ ASCII_DIGIT+)?) | (ASCII_DIGIT+ ~ ^"e" ~ ("-" | "+")? ~ ASCII_DIGIT+) | ("." ~ ASCII_DIGIT+ ~ (^"e" ~ ("-" | "+")? ~ ASCII_DIGIT+)?) ) }
 string = @{ "\"" ~ (!"\"" ~ ANY)* ~ "\"" | "'" ~ (!"'" ~ ANY)* ~ "'" }
 list = { "[" ~ (value ~ ("," ~ value)*)? ~ "]" }
 map = { "{" ~ (map_entry ~ ("," ~ map_entry)*)? ~ "}" }

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -3113,6 +3113,35 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_scientific_notation_float() {
+        // Exponent without a decimal point (1e-07), uppercase E, explicit +,
+        // and leading-dot forms must all parse as floats and round-trip via f64.
+        for (q, expected) in [
+            ("CREATE (n {r: 1e-07}) RETURN n", 1e-07_f64),
+            ("CREATE (n {x: 1.5E10}) RETURN n", 1.5E10_f64),
+            ("CREATE (n {y: 6e+3}) RETURN n", 6e+3_f64),
+            ("CREATE (n {z: .5}) RETURN n", 0.5_f64),
+            ("CREATE (n {w: 0.015}) RETURN n", 0.015_f64),
+        ] {
+            let parsed = parse_query(q);
+            assert!(parsed.is_ok(), "Failed to parse {q:?}: {:?}", parsed.err());
+            let props = parsed.unwrap().create_clause.unwrap().pattern.paths[0]
+                .start
+                .properties
+                .clone()
+                .expect("node should have properties");
+            let val = props.values().next().unwrap();
+            match val {
+                PropertyValue::Float(f) => assert!(
+                    (f - expected).abs() < 1e-12 * expected.abs().max(1.0),
+                    "{q}: got {f}, expected {expected}"
+                ),
+                other => panic!("{q}: expected Float, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
     fn test_parse_negative_integer() {
         let query = "MATCH (n) WHERE n.temperature < -10 RETURN n";
         let result = parse_query(query);


### PR DESCRIPTION
## Problem

The `float` grammar rule required a decimal point with digits on both sides (`ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+`). So exponent-without-decimal literals like `1e-07` and `1E10` never matched `float` — they fell through to `integer`, which matched the leading digit and then failed on the exponent (`expected null, boolean, or float`). Leading-dot forms (`.5`) also failed.

Surfaced loading real pglib-opf power-grid data, where small line impedances are written as `1e-07`.

## Fix

Broaden `float` to accept three forms, each with an optional exponent:
- `digits . digits` (existing)
- `digits exponent` (no decimal — e.g. `1e-07`, `1E10`)
- `. digits` (leading dot — e.g. `.5`)

`f64::parse` already handles all of them, so only the grammar changed.

## Tests

`test_parse_scientific_notation_float` covering `1e-07`, `1.5E10`, `6e+3`, `.5`, `0.015` (parse + f64 round-trip). All **2011** lib tests pass.