### PR TITLE
Sync from mirrors: vector-search HNSW rebuild after snapshot import (+ Docker CI, v1.1.0)

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,80 @@
+name: Publish Docker Image
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/samyama-ai/samyama-graph
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  smoke-test:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull and start container
+        run: |
+          docker run -d --name samyama \
+            -p 6379:6379 -p 8080:8080 \
+            ghcr.io/samyama-ai/samyama-graph:latest
+
+      - name: Wait for healthy
+        run: |
+          for i in $(seq 1 20); do
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' samyama 2>/dev/null)
+            echo "Attempt $i: $STATUS"
+            [ "$STATUS" = "healthy" ] && exit 0
+            sleep 3
+          done
+          docker logs samyama
+          exit 1
+
+      - name: Check HTTP status endpoint
+        run: curl -sf http://localhost:8080/api/status
+
+      - name: Run a Cypher query via RESP
+        run: |
+          redis-cli -p 6379 GRAPH.QUERY testdb \
+            "CREATE (a:Person {name:'Alice'})-[:KNOWS]->(b:Person {name:'Bob'}) RETURN a.name"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -54,6 +54,20 @@ jobs:
     needs: build-and-push
     runs-on: ubuntu-latest
     steps:
+      # Auth lets the first release pull the package while it's still private.
+      # GHCR packages default to private on first publish — flip to public in
+      # GHCR package settings after the first release to skip needing this.
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # redis-tools (provides redis-cli) is not preinstalled on ubuntu-latest.
+      - name: Install redis-tools
+        run: sudo apt-get update && sudo apt-get install -y redis-tools
+
       - name: Pull and start container
         run: |
           docker run -d --name samyama \
@@ -78,3 +92,10 @@ jobs:
         run: |
           redis-cli -p 6379 GRAPH.QUERY testdb \
             "CREATE (a:Person {name:'Alice'})-[:KNOWS]->(b:Person {name:'Bob'}) RETURN a.name"
+
+      # Always dump container logs on failure so a failing curl/redis-cli
+      # step is diagnosable — without this, only the healthy-wait failure
+      # prints logs.
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker logs samyama

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["sdk/python"]
 
 [package]
 name = "samyama"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "High-performance distributed graph database with OpenCypher support"
@@ -85,14 +85,14 @@ samyama-optimization = { path = "crates/samyama-optimization", version = "1.1.0"
 uuid = { version = "1.8", features = ["v4"] }
 tokio-stream = "0.1"
 futures = "0.3"
-samyama-graph-algorithms = { path = "crates/samyama-graph-algorithms", version = "1.0.0" }
+samyama-graph-algorithms = { path = "crates/samyama-graph-algorithms", version = "1.1.0" }
 ndarray = "0.15"
 reqwest = { version = "0.13.1", features = ["json"] }
 
 [dev-dependencies]
 tempfile = "3.8"
 criterion = "0.5"
-samyama-sdk = { path = "crates/samyama-sdk", version = "1.0.0" }
+samyama-sdk = { path = "crates/samyama-sdk", version = "1.1.0" }
 http-body-util = "0.1"
 
 [[bench]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     libstdc++6 \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -46,9 +47,9 @@ EXPOSE 8080
 # Set environment variables
 ENV RUST_LOG=info
 
-# Healthcheck via RESP PING
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD echo "PING" | nc -w1 localhost 6379 | grep -q PONG || exit 1
+# Healthcheck via HTTP status endpoint
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD curl -sf http://localhost:8080/api/status || exit 1
 
 # Run the server, binding to 0.0.0.0 so it's reachable from outside the container
 CMD ["samyama", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -70,7 +70,12 @@ One query family — reachability, criticality, N-1 contingency — runs identic
 A graph-vector database written in Rust. OpenCypher queries, Redis protocol, vector search, graph algorithms — one binary, no JVM, no GC pauses.
 
 ```bash
-# Install and run (30 seconds)
+# Run with Docker (no Rust toolchain needed)
+docker run -d -p 6379:6379 -p 8080:8080 ghcr.io/samyama-ai/samyama-graph:latest
+```
+
+```bash
+# Or build from source
 git clone https://github.com/samyama-ai/samyama-graph && cd samyama-graph
 cargo build --release
 ./target/release/samyama    # RESP on :6379, HTTP on :8080

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-cli"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "CLI for Samyama Graph Database"
@@ -12,7 +12,7 @@ name = "samyama-cli"
 path = "src/main.rs"
 
 [dependencies]
-samyama-sdk = { path = "../crates/samyama-sdk", version = "1.0.0" }
+samyama-sdk = { path = "../crates/samyama-sdk", version = "1.1.0" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/crates/samyama-graph-algorithms/Cargo.toml
+++ b/crates/samyama-graph-algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-graph-algorithms"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Graph algorithms (PageRank, WCC, BFS, Dijkstra) for Samyama Graph Database"

--- a/crates/samyama-sdk/Cargo.toml
+++ b/crates/samyama-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-sdk"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Client SDK for Samyama Graph Database — embedded and remote modes"
@@ -25,13 +25,13 @@ reqwest = { version = "0.13.1", features = ["json"] }
 thiserror = "1.0"
 
 # Core graph database (for EmbeddedClient)
-samyama = { path = "../..", version = "1.0.0" }
+samyama = { path = "../..", version = "1.1.0" }
 
 # Graph algorithms (for AlgorithmClient)
-samyama-graph-algorithms = { path = "../samyama-graph-algorithms", version = "1.0.0" }
+samyama-graph-algorithms = { path = "../samyama-graph-algorithms", version = "1.1.0" }
 
 # Optimization engine (re-exported for examples)
-samyama-optimization = { path = "../samyama-optimization", version = "1.0.0" }
+samyama-optimization = { path = "../samyama-optimization", version = "1.1.0" }
 
 # Numeric arrays (re-exported for optimization problems)
 ndarray = "0.15"

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "samyama-python"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Python bindings for the Samyama Graph Database SDK"
@@ -14,6 +14,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.22", features = ["extension-module"] }
-samyama-sdk = { path = "../../crates/samyama-sdk", version = "1.0.0" }
+samyama-sdk = { path = "../../crates/samyama-sdk", version = "1.1.0" }
 tokio = { version = "1.35", features = ["rt-multi-thread"] }
 serde_json = "1.0"

--- a/src/embed/client.rs
+++ b/src/embed/client.rs
@@ -13,6 +13,7 @@ pub struct EmbeddingClient {
     model: String,
     api_key: Option<String>,
     api_base_url: String,
+    dimensions: Option<usize>,
 }
 
 impl EmbeddingClient {
@@ -39,12 +40,17 @@ impl EmbeddingClient {
              return Err(EmbedError::ConfigError("AzureOpenAI requires api_base_url".to_string()));
         }
 
+        // Only pass dimensions when not using the model's native default (1536 for text-embedding-3-small).
+        // OpenAI ignores the field for models that don't support it (e.g. ada-002).
+        let dimensions = if config.vector_dimension > 0 { Some(config.vector_dimension) } else { None };
+
         Ok(Self {
             client,
             provider: config.provider.clone(),
             model: config.embedding_model.clone(),
             api_key: config.api_key.clone(),
             api_base_url,
+            dimensions,
         })
     }
 
@@ -78,6 +84,8 @@ impl EmbeddingClient {
         struct OpenAIRequest<'a> {
             input: &'a [String],
             model: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            dimensions: Option<usize>,
         }
 
         #[derive(Deserialize)]
@@ -98,6 +106,7 @@ impl EmbeddingClient {
             .json(&OpenAIRequest {
                 input: texts,
                 model: &self.model,
+                dimensions: self.dimensions,
             })
             .send()
             .await

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -2036,6 +2036,70 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         self.invalidate_statistics_cache();
     }
 
+    /// Rebuild all HNSW vector indices from node HashMap properties.
+    ///
+    /// Snapshot import (create_node_stub / create_node) bypasses the event loop
+    /// that normally calls add_vector, so Vector properties land in node.properties
+    /// but the HNSW graph stays empty — queryNodes returns 0 rows even though the
+    /// vectors are present and readable via Cypher. This is the vector equivalent
+    /// of rebuild_edge_type_index: a post-import scan that brings the HNSW indices
+    /// into sync with the node data. No-op when no vector indices are registered.
+    pub fn rebuild_vector_index(&mut self) {
+        let index_keys = self.vector_index.list_indices();
+        if index_keys.is_empty() {
+            return;
+        }
+        for key in &index_keys {
+            let nodes = self.get_nodes_by_label(&crate::graph::types::Label::new(&key.label));
+            let mut vectors: Vec<(crate::graph::types::NodeId, Vec<f32>)> = Vec::new();
+            for node in &nodes {
+                if let Some(crate::graph::property::PropertyValue::Vector(vec)) =
+                    node.get_property(&key.property_key)
+                {
+                    vectors.push((node.id, vec.clone()));
+                }
+            }
+            let _ = self.vector_index.rebuild_for_label(
+                &key.label,
+                &key.property_key,
+                &vectors,
+            );
+        }
+    }
+
+    /// Discover all (label, property_key, dims) tuples from node Vector properties,
+    /// register any missing HNSW indices, then populate them.
+    /// This is the correct post-import call when no indices were pre-registered.
+    pub fn rebuild_vector_index_full(&mut self) -> usize {
+        use std::collections::HashMap as HMap;
+
+        // Pass 1: collect (label, property_key, dims) — immutable scan ends before mutations
+        let mut discovered: HMap<(String, String), usize> = HMap::new();
+        for node in self.all_nodes() {
+            let label = node.labels.iter().next().map(|l| l.as_str().to_string()).unwrap_or_default();
+            if label.is_empty() {
+                continue;
+            }
+            for (k, v) in node.properties.iter() {
+                if let PropertyValue::Vector(vec) = v {
+                    discovered.entry((label.clone(), k.clone())).or_insert(vec.len());
+                }
+            }
+        }
+
+        // Pass 2: register missing HNSW indices (mutable only on vector_index)
+        for ((label, prop), dims) in &discovered {
+            if self.vector_index.get_index(label, prop).is_none() {
+                let _ = self.vector_index.create_index(label, prop, *dims, DistanceMetric::Cosine);
+            }
+        }
+
+        let count = discovered.len();
+        // Pass 3: populate using the existing rebuild logic
+        self.rebuild_vector_index();
+        count
+    }
+
     pub fn compute_statistics(&self) -> GraphStatistics {
         let total_nodes = self.node_count();
         let total_edges = self.edge_count();

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -677,6 +677,11 @@ pub async fn restore_snapshot_handler(
                 }
             }
 
+            // Automatically rebuild HNSW indices from any Vector properties in the snapshot.
+            // Snapshot import bypasses the add_vector event loop, so without this call
+            // vector search would return empty results even when embeddings are present.
+            let vector_indices_rebuilt = store_guard.rebuild_vector_index_full();
+
             Json(json!({
                 "status": "ok",
                 "nodes_imported": stats.node_count,
@@ -684,6 +689,7 @@ pub async fn restore_snapshot_handler(
                 "edges_imported": stats.edge_count,
                 "labels": stats.labels,
                 "edge_types": stats.edge_types,
+                "vector_indices_rebuilt": vector_indices_rebuilt,
             }))
             .into_response()
         }

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -508,6 +508,15 @@ pub fn import_tenant_with_dedup(
         store.rebuild_edge_type_index();
     }
 
+    // Backfill HNSW vector indices from imported node properties.
+    // create_node_stub / create_node bypass the event loop that normally calls
+    // add_vector, so Vector properties are readable via Cypher but invisible to
+    // queryNodes. Rebuild here mirrors rebuild_edge_type_index above.
+    // No-op when no vector indices are registered (common case).
+    if imported_node_count > 0 {
+        store.rebuild_vector_index();
+    }
+
     if merged_node_count > 0 {
         eprintln!("[dedup] Merged {} duplicate nodes (reused existing)", merged_node_count);
     }
@@ -881,6 +890,57 @@ mod tests {
         assert_eq!(
             nodes[0].get_property("embedding"),
             Some(&PropertyValue::Vector(vec![1.0, 2.5, 3.0]))
+        );
+    }
+
+    #[test]
+    fn test_vector_index_populated_after_import() {
+        // Regression: snapshot import stored Vector props in node.properties but
+        // never called add_vector, so queryNodes returned 0 rows even when the
+        // vector index existed. rebuild_vector_index() at import end fixes this.
+        use crate::vector::index::DistanceMetric;
+
+        // Source store: vector index + one Problem node with a 4-dim embedding
+        let mut src = GraphStore::new();
+        src.vector_index
+            .create_index("Problem", "embedding", 4, DistanceMetric::Cosine)
+            .unwrap();
+        let nid = src.create_node("Problem");
+        src.get_node_mut(nid)
+            .unwrap()
+            .set_property("embedding", PropertyValue::Vector(vec![1.0, 0.0, 0.0, 0.0]));
+        src.get_node_mut(nid)
+            .unwrap()
+            .set_property("title", PropertyValue::String("Test Problem".into()));
+
+        // Export to snapshot
+        let mut buf = Vec::new();
+        export_tenant(&src, &mut buf).unwrap();
+
+        // Import into a fresh store that has the same index pre-registered
+        let mut dst = GraphStore::new();
+        dst.vector_index
+            .create_index("Problem", "embedding", 4, DistanceMetric::Cosine)
+            .unwrap();
+        let stats = import_tenant(&mut dst, Cursor::new(&buf)).unwrap();
+        assert_eq!(stats.node_count, 1);
+
+        // Vector property must be readable (was already working before the fix)
+        let nodes = dst.all_nodes();
+        assert_eq!(
+            nodes[0].get_property("embedding"),
+            Some(&PropertyValue::Vector(vec![1.0, 0.0, 0.0, 0.0]))
+        );
+
+        // HNSW index must now be populated — this was the bug (returned 0 results)
+        let results = dst
+            .vector_index
+            .search("Problem", "embedding", &[1.0, 0.0, 0.0, 0.0], 1)
+            .unwrap();
+        assert_eq!(
+            results.len(),
+            1,
+            "queryNodes must return 1 hit after import — HNSW index was empty before fix"
         );
     }
 

--- a/src/vector/manager.rs
+++ b/src/vector/manager.rs
@@ -95,6 +95,48 @@ impl VectorIndexManager {
         indices.keys().cloned().collect()
     }
 
+    /// Drop and rebuild a specific HNSW index from a caller-supplied vector list.
+    ///
+    /// Snapshot import (create_node_stub / create_node) bypasses the event loop
+    /// that normally calls add_vector, leaving the HNSW empty even though node
+    /// properties carry Vector values. Rebuilding from scratch is idempotent and
+    /// avoids the duplicate entries that would occur if add_vector were called on
+    /// top of a partially-populated index.
+    pub fn rebuild_for_label(
+        &self,
+        label: &str,
+        property_key: &str,
+        vectors: &[(NodeId, Vec<f32>)],
+    ) -> VectorResult<()> {
+        let key = IndexKey {
+            label: label.to_string(),
+            property_key: property_key.to_string(),
+        };
+        // Read dims + metric under a short read lock, then release before building.
+        let (dims, metric) = {
+            let indices = self.indices.read().unwrap();
+            match indices.get(&key) {
+                Some(idx_lock) => {
+                    let idx = idx_lock.read().unwrap();
+                    (idx.dimensions(), idx.metric())
+                }
+                None => return Ok(()), // no index registered for this key — nothing to do
+            }
+        };
+        // Build a fresh HNSW outside any lock (potentially expensive for large datasets).
+        let mut new_index = VectorIndex::new(dims, metric);
+        for (node_id, vec) in vectors {
+            new_index.add(*node_id, vec)?;
+        }
+        // Swap in via write lock on the existing Arc so concurrent readers see
+        // the updated index without needing to re-acquire the outer map lock.
+        let indices = self.indices.read().unwrap();
+        if let Some(idx_lock) = indices.get(&key) {
+            *idx_lock.write().unwrap() = new_index;
+        }
+        Ok(())
+    }
+
     /// Save all indices to a directory
     pub fn dump_all(&self, path: &std::path::Path) -> VectorResult<()> {
         if !path.exists() {


### PR DESCRIPTION
Brings GitHub `main` up to the Gitea/GitLab mirrors (`3c9e25c`), which were 7 commits ahead.

**Primary fix — vector search bug (SGE #378 sync):** snapshot/bulk-load paths use `create_node_stub`/`create_node`, bypassing the `add_vector` event loop. Vector properties survived into node storage (readable via Cypher) but the HNSW graph was empty, so `queryNodes` returned 0 rows. Fix rebuilds HNSW indices after snapshot import:
- `src/graph/store.rs`: `rebuild_vector_index()` + `rebuild_vector_index_full()`
- `src/vector/manager.rs`: `rebuild_for_label()` (builds outside lock, swaps under it)
- `src/snapshot/mod.rs`: rebuild after `import_tenant_with_dedup`
- `src/http/handler.rs`: rebuild on restore-snapshot handler
- `src/embed/client.rs`: only pass OpenAI `dimensions` when `vector_dimension > 0`

Also included (already merged on mirrors): Docker publish CI workflow, healthcheck fix, version bump to 1.1.0.