### PR TITLE
Sync from Gitea PR #10: vector search HTTP endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "samyama"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "samyama-cli"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "samyama-graph-algorithms"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ndarray",
  "rand 0.8.5",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "samyama-sdk"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "ndarray",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build stage
 FROM rust:1.85-bookworm AS builder
 
@@ -18,8 +19,13 @@ COPY cli ./cli
 COPY benches ./benches
 COPY examples ./examples
 
-# Build the application
-RUN cargo build --release
+# Build the application — cache mounts keep the Cargo registry and build
+# artifacts across rebuilds so only changed crates recompile (~2 min vs ~15 min).
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release && \
+    cp target/release/samyama /samyama-bin
 
 # Runtime stage
 FROM debian:bookworm-slim
@@ -33,8 +39,8 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 
-# Copy the binary from builder
-COPY --from=builder /app/target/release/samyama /usr/local/bin/samyama
+# Copy the binary from builder (extracted outside the cache-mounted target dir)
+COPY --from=builder /samyama-bin /usr/local/bin/samyama
 
 # Create data directory for persistence
 RUN mkdir -p /data

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -723,6 +723,8 @@ mod tests {
             store: Arc::new(RwLock::new(GraphStore::new())),
             engine: Arc::new(QueryEngine::new()),
             data_path: None,
+            tenant_manager: None,
+            embed_pipeline: None,
         };
         let app = Router::new()
             .route("/api/query", post(query_handler))

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -5,6 +5,7 @@ pub mod handler;
 pub mod optimize;
 pub mod tenants;
 pub mod uc_problems;
+pub mod vector;
 
 pub use server::HttpServer;
 

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -10,6 +10,7 @@ use crate::persistence::TenantManager;
 use crate::query::QueryEngine;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use crate::embed::EmbedPipeline;
 use axum::extract::DefaultBodyLimit;
 use tower_http::cors::CorsLayer;
 use tracing::info;
@@ -18,6 +19,7 @@ use super::handler::{
     import_csv_handler, import_json_handler,
     export_snapshot_handler, restore_snapshot_handler,
 };
+use super::vector::{list_indexes_handler, create_index_handler, search_handler};
 
 /// HA-09: Build the tenant CRUD sub-router backed by the shared `TenantManager`.
 /// Exposed at the crate level so integration tests can mount it in isolation.
@@ -47,6 +49,10 @@ pub struct AppState {
     pub engine: Arc<QueryEngine>,
     /// Data directory for persisting snapshots (HA-08)
     pub data_path: Option<String>,
+    /// Tenant manager for multi-tenancy support
+    pub tenant_manager: Option<Arc<TenantManager>>,
+    /// Global embed pipeline (fallback when tenant has no embed_config)
+    pub embed_pipeline: Option<Arc<EmbedPipeline>>,
 }
 
 /// HTTP server managing the Visualizer API and static assets
@@ -82,6 +88,8 @@ impl HttpServer {
             store: Arc::clone(&self.store),
             engine: Arc::new(QueryEngine::new()),
             data_path: self.data_path.clone(),
+            tenant_manager: self.tenants.clone(),
+            embed_pipeline: None,
         };
 
         let optimize_state = Arc::new(super::optimize::OptimizeState::default());
@@ -94,6 +102,9 @@ impl HttpServer {
             .route("/api/sample", post(sample_handler))
             .route("/api/import/csv", post(import_csv_handler))
             .route("/api/import/json", post(import_json_handler))
+            .route("/api/vector/indexes", get(list_indexes_handler))
+            .route("/api/vector/indexes", post(create_index_handler))
+            .route("/api/vector-search", post(search_handler))
             .route("/api/snapshot/export", post(export_snapshot_handler))
             .route("/api/snapshot/import", post(restore_snapshot_handler)
                 // 64 GB cap. PubMed-v2 (11 GB) and trifecta-pubmed (12 GB) need
@@ -159,6 +170,8 @@ mod tests {
             store: Arc::new(RwLock::new(GraphStore::new())),
             engine: Arc::new(QueryEngine::new()),
             data_path: None,
+            tenant_manager: None,
+            embed_pipeline: None,
         };
 
         let cloned = state.clone();
@@ -174,6 +187,8 @@ mod tests {
             store: Arc::new(RwLock::new(GraphStore::new())),
             engine: Arc::new(QueryEngine::new()),
             data_path: None,
+            tenant_manager: None,
+            embed_pipeline: None,
         };
 
         let cloned = state.clone();
@@ -195,6 +210,8 @@ mod tests {
             store: Arc::new(RwLock::new(GraphStore::new())),
             engine: Arc::new(QueryEngine::new()),
             data_path: None,
+            tenant_manager: None,
+            embed_pipeline: None,
         };
 
         let c1 = state.clone();
@@ -214,6 +231,8 @@ mod tests {
             store: Arc::new(RwLock::new(GraphStore::new())),
             engine: Arc::new(QueryEngine::new()),
             data_path: None,
+            tenant_manager: None,
+            embed_pipeline: None,
         };
 
         // Write through the state
@@ -249,6 +268,8 @@ mod tests {
             store: Arc::new(RwLock::new(GraphStore::new())),
             engine: Arc::new(QueryEngine::new()),
             data_path: None,
+            tenant_manager: None,
+            embed_pipeline: None,
         };
 
         let _app: Router = Router::new()
@@ -265,6 +286,8 @@ mod tests {
             store: Arc::new(RwLock::new(GraphStore::new())),
             engine: Arc::new(QueryEngine::new()),
             data_path: None,
+            tenant_manager: None,
+            embed_pipeline: None,
         };
 
         let app = Router::new()

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -1,17 +1,18 @@
 //! HTTP server implementation for the Visualizer
 
 use axum::{
+    extract::DefaultBodyLimit,
+    response::{Html, IntoResponse},
     routing::{get, post},
     Router,
-    response::{Html, IntoResponse},
 };
+use crate::embed::EmbedPipeline;
 use crate::graph::GraphStore;
 use crate::persistence::TenantManager;
 use crate::query::QueryEngine;
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use crate::embed::EmbedPipeline;
-use axum::extract::DefaultBodyLimit;
 use tower_http::cors::CorsLayer;
 use tracing::info;
 use super::handler::{
@@ -24,7 +25,8 @@ use super::vector::{list_indexes_handler, create_index_handler, search_handler};
 /// HA-09: Build the tenant CRUD sub-router backed by the shared `TenantManager`.
 /// Exposed at the crate level so integration tests can mount it in isolation.
 pub fn build_tenant_router(tenants: Arc<TenantManager>) -> axum::Router {
-    super::tenants::router(tenants)
+    let cache = Arc::new(RwLock::new(HashMap::<String, Arc<EmbedPipeline>>::new()));
+    super::tenants::router(tenants, cache)
 }
 use rust_embed::RustEmbed;
 
@@ -53,6 +55,8 @@ pub struct AppState {
     pub tenant_manager: Option<Arc<TenantManager>>,
     /// Global embed pipeline (fallback when tenant has no embed_config)
     pub embed_pipeline: Option<Arc<EmbedPipeline>>,
+    /// Per-tenant EmbedPipeline cache; invalidated on PATCH /api/tenants/:id
+    pub embed_cache: Arc<RwLock<HashMap<String, Arc<EmbedPipeline>>>>,
 }
 
 /// HTTP server managing the Visualizer API and static assets
@@ -84,12 +88,16 @@ impl HttpServer {
 
     /// Start the HTTP server
     pub async fn start(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let embed_cache: Arc<RwLock<HashMap<String, Arc<EmbedPipeline>>>> =
+            Arc::new(RwLock::new(HashMap::new()));
+
         let state = AppState {
             store: Arc::clone(&self.store),
             engine: Arc::new(QueryEngine::new()),
             data_path: self.data_path.clone(),
             tenant_manager: self.tenants.clone(),
             embed_pipeline: None,
+            embed_cache: Arc::clone(&embed_cache),
         };
 
         let optimize_state = Arc::new(super::optimize::OptimizeState::default());
@@ -118,7 +126,7 @@ impl HttpServer {
             .merge(super::optimize::router().with_state(optimize_state));
 
         if let Some(tm) = self.tenants.as_ref() {
-            app = app.merge(super::tenants::router(Arc::clone(tm)));
+            app = app.merge(super::tenants::router(Arc::clone(tm), Arc::clone(&embed_cache)));
         }
 
         let app = app.layer(CorsLayer::permissive());
@@ -172,6 +180,7 @@ mod tests {
             data_path: None,
             tenant_manager: None,
             embed_pipeline: None,
+            embed_cache: Arc::new(RwLock::new(HashMap::new())),
         };
 
         let cloned = state.clone();
@@ -189,6 +198,7 @@ mod tests {
             data_path: None,
             tenant_manager: None,
             embed_pipeline: None,
+            embed_cache: Arc::new(RwLock::new(HashMap::new())),
         };
 
         let cloned = state.clone();
@@ -212,6 +222,7 @@ mod tests {
             data_path: None,
             tenant_manager: None,
             embed_pipeline: None,
+            embed_cache: Arc::new(RwLock::new(HashMap::new())),
         };
 
         let c1 = state.clone();
@@ -233,6 +244,7 @@ mod tests {
             data_path: None,
             tenant_manager: None,
             embed_pipeline: None,
+            embed_cache: Arc::new(RwLock::new(HashMap::new())),
         };
 
         // Write through the state
@@ -270,6 +282,7 @@ mod tests {
             data_path: None,
             tenant_manager: None,
             embed_pipeline: None,
+            embed_cache: Arc::new(RwLock::new(HashMap::new())),
         };
 
         let _app: Router = Router::new()
@@ -288,6 +301,7 @@ mod tests {
             data_path: None,
             tenant_manager: None,
             embed_pipeline: None,
+            embed_cache: Arc::new(RwLock::new(HashMap::new())),
         };
 
         let app = Router::new()

--- a/src/http/tenants.rs
+++ b/src/http/tenants.rs
@@ -16,15 +16,19 @@ use axum::{
     routing::{delete, get, patch, post},
     Json, Router,
 };
+use crate::embed::EmbedPipeline;
+use crate::persistence::{AutoEmbedConfig, ResourceQuotas, TenantError, TenantManager};
 use serde::Deserialize;
 use serde_json::json;
+use std::collections::HashMap;
 use std::sync::Arc;
-
-use crate::persistence::{AutoEmbedConfig, ResourceQuotas, TenantError, TenantManager};
+use tokio::sync::RwLock;
 
 #[derive(Clone)]
 pub struct TenantState {
     pub tenants: Arc<TenantManager>,
+    /// Shared with AppState; cleared on PATCH to avoid serving stale pipelines.
+    pub embed_cache: Arc<RwLock<HashMap<String, Arc<EmbedPipeline>>>>,
 }
 
 #[derive(Deserialize)]
@@ -133,14 +137,18 @@ pub async fn patch_tenant(
     Json(body): Json<PatchTenantBody>,
 ) -> impl IntoResponse {
     match state.tenants.update_embed_config(&id, body.embed_config) {
-        Ok(()) => match state.tenants.get_tenant(&id) {
-            Ok(t) => (StatusCode::OK, Json(tenant_to_json(&t))).into_response(),
-            Err(e) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({ "error": e.to_string() })),
-            )
-                .into_response(),
-        },
+        Ok(()) => {
+            // Invalidate cached pipeline so the next search rebuilds from the new config.
+            state.embed_cache.write().await.remove(&id);
+            match state.tenants.get_tenant(&id) {
+                Ok(t) => (StatusCode::OK, Json(tenant_to_json(&t))).into_response(),
+                Err(e) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": e.to_string() })),
+                )
+                    .into_response(),
+            }
+        }
         Err(TenantError::NotFound(_)) => (
             StatusCode::NOT_FOUND,
             Json(json!({ "error": format!("Tenant '{}' not found", id) })),
@@ -155,8 +163,11 @@ pub async fn patch_tenant(
 }
 
 /// Build the tenant CRUD router, parameterised on the shared `TenantManager`.
-pub fn router(tenants: Arc<TenantManager>) -> Router {
-    let state = TenantState { tenants };
+pub fn router(
+    tenants: Arc<TenantManager>,
+    embed_cache: Arc<RwLock<HashMap<String, Arc<EmbedPipeline>>>>,
+) -> Router {
+    let state = TenantState { tenants, embed_cache };
     Router::new()
         .route("/api/tenants", post(create_tenant).get(list_tenants))
         .route(

--- a/src/http/tenants.rs
+++ b/src/http/tenants.rs
@@ -13,14 +13,14 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::IntoResponse,
-    routing::{delete, get, post},
+    routing::{delete, get, patch, post},
     Json, Router,
 };
 use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
 
-use crate::persistence::{ResourceQuotas, TenantError, TenantManager};
+use crate::persistence::{AutoEmbedConfig, ResourceQuotas, TenantError, TenantManager};
 
 #[derive(Clone)]
 pub struct TenantState {
@@ -121,6 +121,39 @@ pub async fn delete_tenant(
     }
 }
 
+/// Request body for PATCH /api/tenants/:id — update embed_config
+#[derive(Deserialize)]
+pub struct PatchTenantBody {
+    pub embed_config: Option<AutoEmbedConfig>,
+}
+
+pub async fn patch_tenant(
+    State(state): State<TenantState>,
+    Path(id): Path<String>,
+    Json(body): Json<PatchTenantBody>,
+) -> impl IntoResponse {
+    match state.tenants.update_embed_config(&id, body.embed_config) {
+        Ok(()) => match state.tenants.get_tenant(&id) {
+            Ok(t) => (StatusCode::OK, Json(tenant_to_json(&t))).into_response(),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response(),
+        },
+        Err(TenantError::NotFound(_)) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": format!("Tenant '{}' not found", id) })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
 /// Build the tenant CRUD router, parameterised on the shared `TenantManager`.
 pub fn router(tenants: Arc<TenantManager>) -> Router {
     let state = TenantState { tenants };
@@ -128,7 +161,7 @@ pub fn router(tenants: Arc<TenantManager>) -> Router {
         .route("/api/tenants", post(create_tenant).get(list_tenants))
         .route(
             "/api/tenants/:id",
-            get(get_tenant).delete(delete_tenant),
+            get(get_tenant).delete(delete_tenant).patch(patch_tenant),
         )
         .with_state(state)
 }

--- a/src/http/vector.rs
+++ b/src/http/vector.rs
@@ -1,11 +1,12 @@
 //! HTTP handlers for vector index management and similarity search
 
 use axum::{extract::State, response::IntoResponse, Json};
+use crate::embed::EmbedPipeline;
 use crate::http::server::AppState;
 use crate::vector::DistanceMetric;
-use crate::embed::EmbedPipeline;
 use serde::Deserialize;
 use serde_json::json;
+use std::sync::Arc;
 use std::time::Instant;
 
 /// GET /api/vector/indexes — list all registered vector indexes
@@ -39,6 +40,23 @@ fn default_metric() -> String {
     "cosine".to_string()
 }
 
+fn parse_metric(s: &str) -> Option<DistanceMetric> {
+    match s.to_lowercase().as_str() {
+        "cosine" => Some(DistanceMetric::Cosine),
+        "l2" => Some(DistanceMetric::L2),
+        "inner_product" | "dot" => Some(DistanceMetric::InnerProduct),
+        _ => None,
+    }
+}
+
+fn canonical_metric(m: &DistanceMetric) -> &'static str {
+    match m {
+        DistanceMetric::Cosine => "cosine",
+        DistanceMetric::L2 => "l2",
+        DistanceMetric::InnerProduct => "inner_product",
+    }
+}
+
 /// POST /api/vector/indexes — create a new vector index
 pub async fn create_index_handler(
     State(state): State<AppState>,
@@ -59,20 +77,30 @@ pub async fn create_index_handler(
             .into_response();
     }
 
-    let metric = match payload.metric.to_lowercase().as_str() {
-        "l2" => DistanceMetric::L2,
-        "inner_product" | "dot" => DistanceMetric::InnerProduct,
-        _ => DistanceMetric::Cosine,
+    let metric = match parse_metric(&payload.metric) {
+        Some(m) => m,
+        None => {
+            return (
+                axum::http::StatusCode::BAD_REQUEST,
+                Json(json!({ "error": format!(
+                    "unknown metric '{}'; expected cosine, l2, or inner_product",
+                    payload.metric
+                ) })),
+            )
+                .into_response();
+        }
     };
 
-    let store = state.store.read().await;
+    let canonical = canonical_metric(&metric);
+    // write lock: create_vector_index mutates the index registry
+    let store = state.store.write().await;
     match store.create_vector_index(&payload.label, &payload.property_key, payload.dimensions, metric) {
         Ok(_) => Json(json!({
             "status": "ok",
             "label": payload.label,
             "property_key": payload.property_key,
             "dimensions": payload.dimensions,
-            "metric": payload.metric,
+            "metric": canonical,
         }))
         .into_response(),
         Err(e) => (
@@ -81,6 +109,10 @@ pub async fn create_index_handler(
         )
             .into_response(),
     }
+}
+
+fn default_graph() -> String {
+    "default".to_string()
 }
 
 /// Request body for POST /api/vector-search
@@ -97,15 +129,43 @@ pub struct VectorSearchRequest {
     /// Number of nearest neighbors to return (default: 10)
     pub k: Option<usize>,
     /// Tenant/graph to search. Defaults to "default".
-    #[serde(default)]
+    #[serde(default = "default_graph")]
     pub graph: String,
     /// If true, include the raw embedding vector in each result node's properties.
     #[serde(default)]
     pub include_vectors: bool,
 }
 
-/// POST /api/vector-search — enterprise-style k-nearest-neighbor vector search.
-/// Supports query_text → embedding conversion via per-tenant or global EmbedPipeline.
+/// Resolve an `EmbedPipeline` for the given tenant, consulting the AppState cache.
+/// Build order: per-tenant cache → tenant embed_config → global fallback pipeline.
+async fn resolve_embed_pipeline(state: &AppState, tenant_id: &str) -> Option<Arc<EmbedPipeline>> {
+    // 1. Warm-cache hit
+    {
+        let cache = state.embed_cache.read().await;
+        if let Some(p) = cache.get(tenant_id) {
+            return Some(Arc::clone(p));
+        }
+    }
+
+    // 2. Build from tenant embed_config and populate the cache
+    if let Some(ref tm) = state.tenant_manager {
+        if let Ok(tenant) = tm.get_tenant(tenant_id) {
+            if let Some(embed_config) = tenant.embed_config {
+                if let Ok(pipeline) = EmbedPipeline::new(embed_config) {
+                    let p = Arc::new(pipeline);
+                    state.embed_cache.write().await.insert(tenant_id.to_string(), Arc::clone(&p));
+                    return Some(p);
+                }
+            }
+        }
+    }
+
+    // 3. Global fallback
+    state.embed_pipeline.clone()
+}
+
+/// POST /api/vector-search — k-nearest-neighbor vector search.
+/// Accepts query_text (converted to embedding via EmbedPipeline) or a raw query_vector.
 pub async fn search_handler(
     State(state): State<AppState>,
     Json(payload): Json<VectorSearchRequest>,
@@ -113,37 +173,22 @@ pub async fn search_handler(
     let start = Instant::now();
 
     let k = payload.k.unwrap_or(10);
-    let tenant_id = if payload.graph.is_empty() {
-        "default".to_string()
-    } else {
-        payload.graph.clone()
-    };
+    if k == 0 {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "k must be > 0" })),
+        )
+            .into_response();
+    }
 
-    // Build per-tenant embed pipeline if the tenant has embed_config configured.
-    let tenant_embed_pipeline: Option<EmbedPipeline> =
-        if let Some(ref tm) = state.tenant_manager {
-            if let Ok(tenant) = tm.get_tenant(&tenant_id) {
-                if let Some(embed_config) = tenant.embed_config {
-                    EmbedPipeline::new(embed_config).ok()
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+    let tenant_id = &payload.graph;
+    let property_key = payload.property_key.as_deref().unwrap_or("embedding");
 
     // Resolve query vector from query_text or query_vector
-    let query_vector = if let Some(text) = &payload.query_text {
-        let pipeline_ref: Option<&EmbedPipeline> = tenant_embed_pipeline
-            .as_ref()
-            .or(state.embed_pipeline.as_ref().map(|p| p.as_ref()));
-
-        match pipeline_ref {
+    let (query_vector, mode) = if let Some(text) = &payload.query_text {
+        match resolve_embed_pipeline(&state, tenant_id).await {
             Some(pipeline) => match pipeline.process_text(text).await {
-                Ok(chunks) if !chunks.is_empty() => chunks[0].embedding.clone(),
+                Ok(chunks) if !chunks.is_empty() => (chunks[0].embedding.clone(), "text"),
                 Ok(_) => {
                     return (
                         axum::http::StatusCode::BAD_REQUEST,
@@ -175,7 +220,7 @@ pub async fn search_handler(
             )
                 .into_response();
         }
-        vec
+        (vec, "vector")
     } else {
         return (
             axum::http::StatusCode::BAD_REQUEST,
@@ -184,17 +229,8 @@ pub async fn search_handler(
             .into_response();
     };
 
-    if k == 0 {
-        return (
-            axum::http::StatusCode::BAD_REQUEST,
-            Json(json!({ "error": "k must be > 0" })),
-        )
-            .into_response();
-    }
-
     let store = state.store.read().await;
     let label = payload.label.as_deref().unwrap_or("Paper");
-    let property_key = payload.property_key.as_deref().unwrap_or("embedding");
 
     match store.vector_search(label, property_key, &query_vector, k) {
         Ok(results) => {
@@ -206,7 +242,9 @@ pub async fn search_handler(
                         .map(|n| {
                             let mut properties = serde_json::Map::new();
                             for (prop_key, v) in &n.properties {
-                                if prop_key != "embedding" || payload.include_vectors {
+                                // Use the caller-supplied property_key, not the literal "embedding",
+                                // so nodes indexed under a different key are correctly filtered.
+                                if prop_key != property_key || payload.include_vectors {
                                     properties.insert(prop_key.clone(), v.to_json());
                                 }
                             }
@@ -218,6 +256,8 @@ pub async fn search_handler(
                         })
                         .unwrap_or_else(|| json!({ "id": node_id.as_u64() }));
 
+                    // score = 1/(1+distance) is a monotonic similarity proxy.
+                    // Accurate for L2; an approximation for cosine and inner-product.
                     let score = 1.0_f32 / (1.0_f32 + distance);
                     json!({ "node": node_info, "distance": distance, "score": score })
                 })
@@ -227,7 +267,8 @@ pub async fn search_handler(
 
             Json(json!({
                 "results": search_results,
-                "query_text": payload.query_text,
+                "mode": mode,
+                "query_text": if mode == "text" { payload.query_text.as_deref() } else { None },
                 "k": k,
                 "execution_time_ms": elapsed,
             }))
@@ -246,3 +287,161 @@ pub async fn search_handler(
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request, routing::{get, post}, Router};
+    use crate::graph::GraphStore;
+    use crate::http::server::AppState;
+    use crate::query::QueryEngine;
+    use http_body_util::BodyExt;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+    use tower::util::ServiceExt;
+
+    fn test_state() -> AppState {
+        AppState {
+            store: Arc::new(RwLock::new(GraphStore::new())),
+            engine: Arc::new(QueryEngine::new()),
+            data_path: None,
+            tenant_manager: None,
+            embed_pipeline: None,
+            embed_cache: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    fn test_app(state: AppState) -> Router {
+        Router::new()
+            .route("/api/vector/indexes", get(list_indexes_handler).post(create_index_handler))
+            .route("/api/vector-search", post(search_handler))
+            .with_state(state)
+    }
+
+    async fn post_json(
+        app: Router,
+        uri: &str,
+        body: serde_json::Value,
+    ) -> (axum::http::StatusCode, serde_json::Value) {
+        let req = Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        (status, json)
+    }
+
+    #[tokio::test]
+    async fn test_search_missing_both_query_fields() {
+        let (status, body) = post_json(
+            test_app(test_state()),
+            "/api/vector-search",
+            json!({ "label": "Node", "property_key": "embedding", "k": 5 }),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        assert!(body["error"].as_str().unwrap().contains("query_text or query_vector"));
+    }
+
+    #[tokio::test]
+    async fn test_search_empty_query_vector() {
+        let (status, body) = post_json(
+            test_app(test_state()),
+            "/api/vector-search",
+            json!({ "query_vector": [], "label": "Node", "property_key": "embedding" }),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        assert!(body["error"].as_str().unwrap().contains("must not be empty"));
+    }
+
+    #[tokio::test]
+    async fn test_search_query_text_no_pipeline() {
+        let (status, body) = post_json(
+            test_app(test_state()),
+            "/api/vector-search",
+            json!({ "query_text": "find something", "label": "Node", "k": 3 }),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::SERVICE_UNAVAILABLE);
+        assert!(body["error"].as_str().unwrap().contains("Embedding pipeline not configured"));
+    }
+
+    #[tokio::test]
+    async fn test_search_k_zero() {
+        let (status, body) = post_json(
+            test_app(test_state()),
+            "/api/vector-search",
+            json!({ "query_vector": [0.1_f32, 0.2_f32], "k": 0 }),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        assert!(body["error"].as_str().unwrap().contains("k must be > 0"));
+    }
+
+    #[tokio::test]
+    async fn test_create_index_unknown_metric() {
+        let (status, body) = post_json(
+            test_app(test_state()),
+            "/api/vector/indexes",
+            json!({ "label": "Node", "property_key": "vec", "dimensions": 128, "metric": "manhattan" }),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        assert!(body["error"].as_str().unwrap().contains("unknown metric"));
+    }
+
+    #[tokio::test]
+    async fn test_create_index_zero_dimensions() {
+        let (status, body) = post_json(
+            test_app(test_state()),
+            "/api/vector/indexes",
+            json!({ "label": "Node", "property_key": "vec", "dimensions": 0 }),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        assert!(body["error"].as_str().unwrap().contains("dimensions must be > 0"));
+    }
+
+    #[tokio::test]
+    async fn test_create_index_empty_label() {
+        let (status, body) = post_json(
+            test_app(test_state()),
+            "/api/vector/indexes",
+            json!({ "label": "", "property_key": "vec", "dimensions": 64 }),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        assert!(body["error"].as_str().unwrap().contains("label and property_key are required"));
+    }
+
+    #[tokio::test]
+    async fn test_create_index_echoes_canonical_metric() {
+        let (status, body) = post_json(
+            test_app(test_state()),
+            "/api/vector/indexes",
+            json!({ "label": "Doc", "property_key": "emb", "dimensions": 64, "metric": "inner_product" }),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(body["metric"].as_str().unwrap(), "inner_product");
+    }
+
+    #[tokio::test]
+    async fn test_create_index_dot_alias_unknown() {
+        // "dot" is a recognised alias for inner_product in parse_metric
+        let (status, _) = post_json(
+            test_app(test_state()),
+            "/api/vector/indexes",
+            json!({ "label": "Doc", "property_key": "emb", "dimensions": 64, "metric": "dot" }),
+        )
+        .await;
+        // dot is accepted
+        assert_eq!(status, axum::http::StatusCode::OK);
+    }
+}

--- a/src/http/vector.rs
+++ b/src/http/vector.rs
@@ -1,0 +1,248 @@
+//! HTTP handlers for vector index management and similarity search
+
+use axum::{extract::State, response::IntoResponse, Json};
+use crate::http::server::AppState;
+use crate::vector::DistanceMetric;
+use crate::embed::EmbedPipeline;
+use serde::Deserialize;
+use serde_json::json;
+use std::time::Instant;
+
+/// GET /api/vector/indexes — list all registered vector indexes
+pub async fn list_indexes_handler(State(state): State<AppState>) -> impl IntoResponse {
+    let store = state.store.read().await;
+    let keys = store.vector_index.list_indices();
+    let indexes: Vec<_> = keys
+        .iter()
+        .map(|k| {
+            json!({
+                "label": k.label,
+                "property_key": k.property_key,
+            })
+        })
+        .collect();
+    Json(json!({ "indexes": indexes, "count": indexes.len() }))
+}
+
+/// Request body for POST /api/vector/indexes
+#[derive(Deserialize)]
+pub struct CreateIndexRequest {
+    pub label: String,
+    pub property_key: String,
+    pub dimensions: usize,
+    /// "cosine" (default), "l2", or "inner_product"
+    #[serde(default = "default_metric")]
+    pub metric: String,
+}
+
+fn default_metric() -> String {
+    "cosine".to_string()
+}
+
+/// POST /api/vector/indexes — create a new vector index
+pub async fn create_index_handler(
+    State(state): State<AppState>,
+    Json(payload): Json<CreateIndexRequest>,
+) -> impl IntoResponse {
+    if payload.label.is_empty() || payload.property_key.is_empty() {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "label and property_key are required" })),
+        )
+            .into_response();
+    }
+    if payload.dimensions == 0 {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "dimensions must be > 0" })),
+        )
+            .into_response();
+    }
+
+    let metric = match payload.metric.to_lowercase().as_str() {
+        "l2" => DistanceMetric::L2,
+        "inner_product" | "dot" => DistanceMetric::InnerProduct,
+        _ => DistanceMetric::Cosine,
+    };
+
+    let store = state.store.read().await;
+    match store.create_vector_index(&payload.label, &payload.property_key, payload.dimensions, metric) {
+        Ok(_) => Json(json!({
+            "status": "ok",
+            "label": payload.label,
+            "property_key": payload.property_key,
+            "dimensions": payload.dimensions,
+            "metric": payload.metric,
+        }))
+        .into_response(),
+        Err(e) => (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+/// Request body for POST /api/vector-search
+#[derive(Deserialize)]
+pub struct VectorSearchRequest {
+    /// Natural language query to convert to a vector via the embed pipeline
+    pub query_text: Option<String>,
+    /// Raw query vector (alternative to query_text)
+    pub query_vector: Option<Vec<f32>>,
+    /// Label of nodes to search within (defaults to "Paper")
+    pub label: Option<String>,
+    /// Property key that holds the vector embedding (defaults to "embedding")
+    pub property_key: Option<String>,
+    /// Number of nearest neighbors to return (default: 10)
+    pub k: Option<usize>,
+    /// Tenant/graph to search. Defaults to "default".
+    #[serde(default)]
+    pub graph: String,
+    /// If true, include the raw embedding vector in each result node's properties.
+    #[serde(default)]
+    pub include_vectors: bool,
+}
+
+/// POST /api/vector-search — enterprise-style k-nearest-neighbor vector search.
+/// Supports query_text → embedding conversion via per-tenant or global EmbedPipeline.
+pub async fn search_handler(
+    State(state): State<AppState>,
+    Json(payload): Json<VectorSearchRequest>,
+) -> impl IntoResponse {
+    let start = Instant::now();
+
+    let k = payload.k.unwrap_or(10);
+    let tenant_id = if payload.graph.is_empty() {
+        "default".to_string()
+    } else {
+        payload.graph.clone()
+    };
+
+    // Build per-tenant embed pipeline if the tenant has embed_config configured.
+    let tenant_embed_pipeline: Option<EmbedPipeline> =
+        if let Some(ref tm) = state.tenant_manager {
+            if let Ok(tenant) = tm.get_tenant(&tenant_id) {
+                if let Some(embed_config) = tenant.embed_config {
+                    EmbedPipeline::new(embed_config).ok()
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+    // Resolve query vector from query_text or query_vector
+    let query_vector = if let Some(text) = &payload.query_text {
+        let pipeline_ref: Option<&EmbedPipeline> = tenant_embed_pipeline
+            .as_ref()
+            .or(state.embed_pipeline.as_ref().map(|p| p.as_ref()));
+
+        match pipeline_ref {
+            Some(pipeline) => match pipeline.process_text(text).await {
+                Ok(chunks) if !chunks.is_empty() => chunks[0].embedding.clone(),
+                Ok(_) => {
+                    return (
+                        axum::http::StatusCode::BAD_REQUEST,
+                        Json(json!({ "error": "Failed to generate embedding: empty result" })),
+                    )
+                        .into_response()
+                }
+                Err(e) => {
+                    return (
+                        axum::http::StatusCode::BAD_REQUEST,
+                        Json(json!({ "error": format!("Embedding generation failed: {}", e) })),
+                    )
+                        .into_response()
+                }
+            },
+            None => {
+                return (
+                    axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json!({ "error": "Embedding pipeline not configured. Provide query_vector directly or configure embed_config on the tenant." })),
+                )
+                    .into_response()
+            }
+        }
+    } else if let Some(vec) = payload.query_vector {
+        if vec.is_empty() {
+            return (
+                axum::http::StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "query_vector must not be empty" })),
+            )
+                .into_response();
+        }
+        vec
+    } else {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "Either query_text or query_vector must be provided" })),
+        )
+            .into_response();
+    };
+
+    if k == 0 {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "k must be > 0" })),
+        )
+            .into_response();
+    }
+
+    let store = state.store.read().await;
+    let label = payload.label.as_deref().unwrap_or("Paper");
+    let property_key = payload.property_key.as_deref().unwrap_or("embedding");
+
+    match store.vector_search(label, property_key, &query_vector, k) {
+        Ok(results) => {
+            let search_results: Vec<_> = results
+                .iter()
+                .map(|(node_id, distance)| {
+                    let node_info = store
+                        .get_node(*node_id)
+                        .map(|n| {
+                            let mut properties = serde_json::Map::new();
+                            for (prop_key, v) in &n.properties {
+                                if prop_key != "embedding" || payload.include_vectors {
+                                    properties.insert(prop_key.clone(), v.to_json());
+                                }
+                            }
+                            json!({
+                                "id": node_id.as_u64(),
+                                "labels": n.labels.iter().map(|l| l.as_str()).collect::<Vec<_>>(),
+                                "properties": properties,
+                            })
+                        })
+                        .unwrap_or_else(|| json!({ "id": node_id.as_u64() }));
+
+                    let score = 1.0_f32 / (1.0_f32 + distance);
+                    json!({ "node": node_info, "distance": distance, "score": score })
+                })
+                .collect();
+
+            let elapsed = start.elapsed().as_secs_f64() * 1000.0;
+
+            Json(json!({
+                "results": search_results,
+                "query_text": payload.query_text,
+                "k": k,
+                "execution_time_ms": elapsed,
+            }))
+            .into_response()
+        }
+        Err(e) => (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": format!(
+                    "Vector search failed: {}. Index may not be built for label '{}' property '{}'.",
+                    e, label, property_key
+                )
+            })),
+        )
+            .into_response(),
+    }
+}
+


### PR DESCRIPTION
Mirrors [Gitea PR #10](https://git.samyama.ai/Samyama.ai/samyama-graph/pulls/10) (already merged upstream, 2026-06-17). Two commits cherry-picked verbatim — Naresh's original `feat:` and the follow-up `fix:` addressing AI-reviewer blockers.

## Summary

Adds HTTP REST endpoints for vector search to the OSS HTTP surface. Previously OSS users could do vector search only via Cypher `CALL db.index.vector.queryNodes(...)` over RESP / `/api/query`. After this PR, OSS exposes parity with the enterprise REST surface:

- **`POST /api/vector-search`** — accepts `query_text` (plain English), auto-embeds it via the tenant's configured embedding provider (OpenAI / Gemini / Ollama), runs HNSW similarity search, returns ranked results. `query_vector` fallback still supported for clients that pre-compute embeddings.
- **`GET /api/vector/indexes`** — list all registered HNSW vector indexes (label + property key)
- **`POST /api/vector/indexes`** — create a new vector index with configurable dimensions and distance metric (`cosine` / `l2` / `inner_product`)
- **`PATCH /api/tenants/:id`** — configure per-tenant embedding provider, model, and API key at runtime without restart
- **Dockerfile**: BuildKit `--mount=type=cache` for Cargo registry + target dir — cuts `cargo build --release` rebuild time from ~15 min to ~2 min.

## Response shape

```json
{
  "results": [
    { "node": { "id": 1, "labels": ["Gene"], "properties": {...} }, "distance": 0.12, "score": 0.88 }
  ],
  "query_text": "proteins involved in apoptosis",
  "k": 10,
  "execution_time_ms": 43
}
```

## Key design decisions

- `query_text → embedding → HNSW` is all server-side; clients send plain text, not raw vectors
- Tenant routing via `graph` param — each tenant can have its own embed config (different model/provider)
- `include_vectors: true` optionally returns the raw embedding in results for debugging

## AI-reviewer fixes already folded in (second commit)

- Cache `EmbedPipeline` per tenant in `AppState` to avoid rebuilding HTTP clients on every `/api/vector-search` request; invalidate on PATCH
- Use write lock in `create_index_handler` (was using read lock for a mutating operation)
- Use caller-supplied `property_key` instead of hardcoded `"embedding"` literal when filtering embedding properties from results
- Return 400 on unknown metric strings instead of silently defaulting to cosine
- Echo canonical metric name (`cosine` / `l2` / `inner_product`) in response
- Add `mode` field to response; omit `query_text` when `query_vector` used
- 8 handler tests covering error paths (400/503) and canonical metric echo

## Files

| File | Change |
|---|---|
| `src/http/vector.rs` | **New** (447 lines) — all vector endpoint handlers |
| `src/http/server.rs` | +41 / -4 — register new routes |
| `src/http/tenants.rs` | +50 / -6 — extend `PATCH /api/tenants/:id` |
| `src/http/handler.rs` | +2 — `pub use vector;` |
| `src/http/mod.rs` | +1 — register `vector` module |
| `Dockerfile` | +10 / -4 — BuildKit cache mounts |
| `Cargo.lock` | +4 / -4 — dep version bump artifact |

Authored by @nareshkolimi26 (Naresh) on Gitea; mirrored to GitHub OSS for parity.