### PR TITLE
fix: restore cargo test compile + harden vector search recall for small indexes

### DIFF
--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -725,6 +725,7 @@ mod tests {
             data_path: None,
             tenant_manager: None,
             embed_pipeline: None,
+            embed_cache: Arc::new(RwLock::new(std::collections::HashMap::new())),
         };
         let app = Router::new()
             .route("/api/query", post(query_handler))

--- a/src/vector/index.rs
+++ b/src/vector/index.rs
@@ -198,7 +198,11 @@ impl VectorIndex {
             });
         }
         
-        let ef_search = k * 2;
+        // ef_search must be >= k; a tight k*2 under-explores tiny/low-k indexes and
+        // can return fewer than k neighbours (HNSW only ever returns from the ef
+        // candidate set). Floor it so small graphs are explored exhaustively and
+        // recall stays high for small k. hnsw_rs caps ef to the graph size internally.
+        let ef_search = (k * 2).max(64);
         let results = self.hnsw.search(query, k, ef_search);
         
         let mut neighbors = Vec::new();


### PR DESCRIPTION
Surfaced by a periodic full-workspace validation on a clean clone.

## 1. `cargo test` no longer compiled on `main`
PR #261 (vector-search HTTP endpoints) added `embed_cache` to `AppState` but missed the `#[cfg(test)]` initializer in `src/http/handler.rs`. `cargo build --release` passed (field only used in non-test construction), masking the breakage — but `cargo test --workspace` failed with `E0063: missing field embed_cache`. Added the field to the test initializer.

## 2. Vector search could return < k neighbours on small indexes
`ef_search = k * 2` (e.g. 4 for k=2). HNSW only returns from the `ef` candidate set, so a tiny / low-k index could be under-explored and yield fewer than k results — flaky under parallel load (`test_vector_index_create_and_search`, expected 2 got 1). Floored `ef_search` at 64 so small indexes are explored exhaustively; recall stays high for small k and hnsw_rs caps ef to the graph size internally.

## Verification
Full workspace suite on a clean clone (r7i.8xlarge): **2238 passed, 0 failed, exit 0**.