### PR TITLE
fix(scripts): repair run_all_examples.sh stale targets (benchmarks moved, persistence removed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,7 @@ cargo run --example smart_manufacturing_demo  # Digital twin + scheduling
 cargo run --example social_network_demo       # Social network analysis
 cargo run --example knowledge_graph_demo      # Enterprise knowledge graph
 cargo run --example enterprise_soc_demo       # Security operations center
-cargo run --example agentic_enrichment_demo   # GAK (Generation-Augmented Knowledge)
-cargo run --example persistence_demo          # Persistence & multi-tenancy
+cargo run --example agentic_enrichment_demo   # GAK (Generation-Augmented Knowledge; needs `claude` CLI)
 cargo run --example cluster_demo              # Raft clustering
 cargo run --example ldbc_loader               # Load LDBC SNB SF1 dataset
 cargo run --example finbench_loader           # Load/generate FinBench dataset

--- a/scripts/run_all_examples.sh
+++ b/scripts/run_all_examples.sh
@@ -203,19 +203,23 @@ function run_all_batch() {
     echo -e "${YELLOW}--- Knowledge & AI ---${NC}"
     run_rust_example "knowledge_graph_demo" "Knowledge Graph Demo"
     run_rust_example "social_network_demo" "Social Network Demo"
-    run_rust_example "agentic_enrichment_demo" "Agentic Enrichment Demo (GAK)"
+    # GAK shells out to the `claude` CLI; skip (not fail) when it isn't available
+    # (CI / fresh clone without Claude Code installed).
+    if command -v claude &>/dev/null; then
+        run_rust_example "agentic_enrichment_demo" "Agentic Enrichment Demo (GAK)"
+    else
+        echo -e "${YELLOW}Skipping Agentic Enrichment Demo (GAK): requires the 'claude' CLI.${NC}"
+        EXAMPLE_RESULTS+=("SKIP  0s  Agentic Enrichment Demo (GAK) — needs 'claude' CLI")
+    fi
 
     # Core Infrastructure
     echo -e "${YELLOW}--- Core Infrastructure ---${NC}"
     run_rust_example "cluster_demo" "Cluster Demo"
-    run_rust_example "persistence_demo" "Persistence Demo"
 
-    # Benchmarks
-    echo -e "${YELLOW}--- Benchmarks ---${NC}"
-    run_rust_example "full_benchmark" "Full Benchmark Suite"
-    run_rust_example "vector_benchmark" "Vector Search Benchmark"
-    run_rust_example "mvcc_benchmark" "MVCC Benchmark"
-    run_rust_example "graph_optimization_benchmark" "Graph Optimization Benchmark"
+    # Benchmarks live in benches/, not examples/ — run them with `cargo bench`:
+    #   cargo bench --bench vector_benchmark | mvcc_benchmark | rao_family_benchmark
+    #   cargo bench --bench graphalytics_benchmark | graph_optimization_benchmark
+    echo -e "${YELLOW}--- Benchmarks: run via 'cargo bench --bench <name>' (see benches/) ---${NC}"
 
     # Python Client (requires server)
     echo -e "${YELLOW}--- Connectivity ---${NC}"
@@ -267,20 +271,15 @@ while true; do
     echo ""
     echo -e "${YELLOW}--- Core Infrastructure ---${NC}"
     echo "8.  Cluster Demo (Raft HA)"
-    echo "9.  Persistence Demo (Multi-tenant Storage)"
-    echo ""
-    echo -e "${YELLOW}--- Benchmarks ---${NC}"
-    echo "10. Full Benchmark Suite"
-    echo "11. Vector Search Benchmark"
-    echo "12. MVCC Benchmark"
-    echo "13. Graph Optimization Benchmark"
     echo ""
     echo -e "${YELLOW}--- Connectivity ---${NC}"
-    echo "14. Python Client Demo"
+    echo "9.  Python Client Demo"
     echo ""
     echo -e "${YELLOW}--- System ---${NC}"
-    echo "15. Reset Database (Restart Server & Clean Data)"
-    echo "16. View Server Logs"
+    echo "10. Reset Database (Restart Server & Clean Data)"
+    echo "11. View Server Logs"
+    echo ""
+    echo -e "${YELLOW}Benchmarks moved to 'cargo bench --bench <name>' (see benches/).${NC}"
     echo "a.  Run All Examples (batch)"
     echo "q.  Quit"
     echo -e "${GREEN}==============================================${NC}"
@@ -295,14 +294,9 @@ while true; do
         6) run_rust_example "social_network_demo" "Social Network Demo" ;;
         7) run_rust_example "agentic_enrichment_demo" "Agentic Enrichment Demo (GAK)" ;;
         8) run_rust_example "cluster_demo" "Cluster Demo" ;;
-        9) run_rust_example "persistence_demo" "Persistence Demo" ;;
-        10) run_rust_example "full_benchmark" "Full Benchmark Suite" ;;
-        11) run_rust_example "vector_benchmark" "Vector Search Benchmark" ;;
-        12) run_rust_example "mvcc_benchmark" "MVCC Benchmark" ;;
-        13) run_rust_example "graph_optimization_benchmark" "Graph Optimization Benchmark" ;;
-        14) run_python_client ;;
-        15) reset_environment; read -p "Environment Reset. Press Enter..." ;;
-        16) echo "--- Last 30 lines of server.log ---"; tail -n 30 server.log; read -p "Press Enter..." ;;
+        9) run_python_client ;;
+        10) reset_environment; read -p "Environment Reset. Press Enter..." ;;
+        11) echo "--- Last 30 lines of server.log ---"; tail -n 30 server.log; read -p "Press Enter..." ;;
         a) run_all_batch ;;
         q) cleanup_exit ;;
         *) echo "Invalid option"; sleep 1 ;;


### PR DESCRIPTION
Periodic validation found `./scripts/run_all_examples.sh --batch` failing 5 entries with exit 127: it still ran the four benchmarks (now in `benches/`) and a removed `persistence_demo` as compiled examples, and hard-failed the GAK demo when the `claude` CLI isn't installed.

Fix: drop the moved benchmarks (point users to `cargo bench`), drop `persistence_demo` (batch list + interactive menu + CLAUDE.md), and **skip** GAK gracefully when `claude` is unavailable. Result on a clean clone: **8 PASS + 1 SKIP, 0 FAIL.**