### PR TITLE
feat: --http-port/--data-path/--ephemeral flags + fix vector index rebuild (SK-27/28/30)

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -2050,13 +2050,32 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             return;
         }
         for key in &index_keys {
-            let nodes = self.get_nodes_by_label(&crate::graph::types::Label::new(&key.label));
+            let node_ids: Vec<crate::graph::types::NodeId> = self
+                .get_nodes_by_label(&crate::graph::types::Label::new(&key.label))
+                .iter()
+                .map(|n| n.id)
+                .collect();
             let mut vectors: Vec<(crate::graph::types::NodeId, Vec<f32>)> = Vec::new();
-            for node in &nodes {
-                if let Some(crate::graph::property::PropertyValue::Vector(vec)) =
-                    node.get_property(&key.property_key)
-                {
-                    vectors.push((node.id, vec.clone()));
+            for nid in node_ids {
+                // The embedding may live inline (just-imported, not yet compacted) OR
+                // in the column store (frozen by DS-07 compaction, which clears inline
+                // props). Read inline first, fall back to columnar — the union covers
+                // both tiers, so large labels (e.g. Problem) are no longer left empty.
+                let inline = self
+                    .get_node(nid)
+                    .and_then(|n| match n.get_property(&key.property_key) {
+                        Some(crate::graph::property::PropertyValue::Vector(v)) => Some(v.clone()),
+                        _ => None,
+                    });
+                let vec = match inline {
+                    Some(v) => Some(v),
+                    None => match self.node_columns.get_property(nid.as_u64() as usize, &key.property_key) {
+                        crate::graph::property::PropertyValue::Vector(v) => Some(v),
+                        _ => None,
+                    },
+                };
+                if let Some(vec) = vec {
+                    vectors.push((nid, vec));
                 }
             }
             let _ = self.vector_index.rebuild_for_label(
@@ -2082,7 +2101,13 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             }
             for (k, v) in node.properties.iter() {
                 if let PropertyValue::Vector(vec) = v {
-                    discovered.entry((label.clone(), k.clone())).or_insert(vec.len());
+                    // Use the MAX length seen for this (label, property): a stray
+                    // empty/short embedding must not set the index dimension and
+                    // cause every real vector to be skipped on rebuild.
+                    discovered
+                        .entry((label.clone(), k.clone()))
+                        .and_modify(|d| *d = (*d).max(vec.len()))
+                        .or_insert(vec.len());
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -433,6 +433,25 @@ async fn start_server() {
         .and_then(|p| p.parse().ok())
         .unwrap_or(6379);
 
+    // Parse --http-port (HTTP REST API port; default 8080).
+    let http_port: u16 = std::env::args()
+        .position(|a| a == "--http-port")
+        .and_then(|pos| std::env::args().nth(pos + 1))
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(8080);
+
+    // Parse --data-path <dir> (snapshot/RocksDB persistence dir) and --ephemeral
+    // (no persistence — guarantees an empty store, no CWD-relative ./samyama_data
+    // recovery). --ephemeral wins if both are given.
+    if std::env::args().any(|a| a == "--ephemeral") {
+        config.data_path = None;
+    } else if let Some(path) = std::env::args()
+        .position(|a| a == "--data-path")
+        .and_then(|pos| std::env::args().nth(pos + 1))
+    {
+        config.data_path = Some(path);
+    }
+
     // Parse --demo flag: social (rich schema) or large (scale stress test)
     let demo_mode: Option<String> = std::env::args()
         .position(|a| a == "--demo")
@@ -539,14 +558,14 @@ async fn start_server() {
         pm.start_indexer(&*store.read().await, rx);
     }
 
-    // Start HTTP server for Visualizer API on port 8080
+    // Start HTTP server for Visualizer API (port from --http-port, default 8080)
     let http_store = Arc::clone(&store);
     let http_tenants = Arc::clone(&shared_tenants);
     tokio::spawn(async move {
-        let http_server = HttpServer::new(http_store, 8080)
+        let http_server = HttpServer::new(http_store, http_port)
             .with_data_path(http_data_path)
             .with_tenant_manager(http_tenants);
-        println!("HTTP server starting on port 8080 (REST API; bundled visualizer deprecated — use https://graph.samyama.cloud)");
+        println!("HTTP server starting on port {} (REST API; bundled visualizer deprecated — use https://graph.samyama.cloud)", http_port);
         if let Err(e) = http_server.start().await {
             eprintln!("HTTP server error: {}", e);
         }

--- a/src/vector/manager.rs
+++ b/src/vector/manager.rs
@@ -124,9 +124,21 @@ impl VectorIndexManager {
             }
         };
         // Build a fresh HNSW outside any lock (potentially expensive for large datasets).
+        // Skip individual vectors that don't match the index dimension rather than
+        // aborting the whole rebuild — a single malformed embedding must not leave the
+        // entire index empty (which then returns 0 results / panics on search).
         let mut new_index = VectorIndex::new(dims, metric);
+        let mut skipped = 0usize;
         for (node_id, vec) in vectors {
-            new_index.add(*node_id, vec)?;
+            if new_index.add(*node_id, vec).is_err() {
+                skipped += 1;
+            }
+        }
+        if skipped > 0 {
+            eprintln!(
+                "[vector] rebuild {}.{}: indexed {} vectors, skipped {} with mismatched dimension (expected {})",
+                label, property_key, vectors.len() - skipped, skipped, dims
+            );
         }
         // Swap in via write lock on the existing Arc so concurrent readers see
         // the updated index without needing to re-acquire the outer map lock.


### PR DESCRIPTION
Engine fixes from the periodic-validation second pass (backlog SK-27, SK-28, SK-30).

**CLI flags**
- `--http-port N` — the HTTP REST port was hardcoded to 8080. Now configurable (lets you run >1 server, parallel imports, etc.).
- `--data-path <dir>` / `--ephemeral` — the data dir was unconfigurable and defaulted to a **CWD-relative** `./samyama_data` that auto-recovers on boot. `--ephemeral` guarantees an empty store; `--data-path` sets the dir.

**Vector index rebuild**
- `rebuild_vector_index` read only inline `node.properties`, which DS-07 compaction **clears for frozen (large-label) nodes** — leaving big embedding indexes empty. Now reads the **union of inline + column store**. Verified: dbms-research `Problem` collects **1053/1053** vectors (was 0).
- `rebuild_for_label` now **skips** dimension-mismatched vectors instead of aborting the whole index on the first bad embedding; discovery uses the **max** embedding length so a stray short vector can't set the index dimension.

**Verification:** full workspace suite **2238 passed / 0 failed**.

**Known remaining (filed SK-29/SK-30):** a separate async-compaction × HNSW-search race can still disrupt search on large *compacted* labels; small labels are unaffected (e.g. dbms-research Topic vector search works 6/6). Not fixed here.