### PR TITLE
case_studies/bank-model-risk: GraphRAG over regulation (vector index)

### DIFF
--- a/case_studies/README.md
+++ b/case_studies/README.md
@@ -52,7 +52,7 @@ laptop, so anyone can reproduce it.
 | [health-systems](health-systems) | WHO emergency-preparedness (SPAR) scores (cross-KG) | `health-systems.sgsnap` (0.2 MB) | 8.7K / 8.4K | ![](health-systems/demo.gif) |
 | [pathways](pathways) | Systems-biology protein hubs (TP53), pathway crosstalk | `pathways.sgsnap` (9 MB) | 119K / 835K | ![](pathways/demo.gif) |
 | [dbms-research](dbms-research) | **Vector search** over 1000+ open DBMS research problems | `dbms-research.sgsnap` (13 MB) | 19K nodes · 2 HNSW indices | ![](dbms-research/demo.gif) |
-| [bank-model-risk](bank-model-risk) | **Model governance** — lineage / blast-radius, regulatory coverage, open findings, explainability (*synthetic*) | `bank-model-risk.sgsnap` (28 KB) | 520 / 2.4K | ![](bank-model-risk/demo.gif) |
+| [bank-model-risk](bank-model-risk) | **Model governance** — lineage / blast-radius, regulatory coverage, open findings, explainability + **GraphRAG** over regulation (*synthetic*) | `bank-model-risk.sgsnap` (85 KB) | 520 / 2.4K · 1 HNSW index | ![](bank-model-risk/demo.gif) |
 
 *(Snapshots are GitHub release assets on
 [`samyama-ai/samyama-graph`](https://github.com/samyama-ai/samyama-graph/releases)

--- a/case_studies/bank-model-risk/README.md
+++ b/case_studies/bank-model-risk/README.md
@@ -51,6 +51,22 @@ Eight governance queries ship here — blast-radius, what-feeds-CCAR, open High 
 Tier-1 production models, regulatory coverage, explainability, SR 11-7 audit readiness,
 data-concentration risk, and owner accountability. Each is gated to return rows.
 
+## GraphRAG over regulation
+
+The snapshot also carries a **384-dim HNSW vector index** on `RegulatoryRequirement.embedding`
+(obligation text embedded with `all-MiniLM-L6-v2`). After import you can ask a governance
+question in natural language, retrieve the most relevant regulatory clauses by cosine
+similarity, and ground each in the graph (which models it governs, which controls satisfy it,
+which models carry open findings) — a deterministic, source-traced answer:
+
+```bash
+curl -X POST http://127.0.0.1:8080/api/vector-search -H 'Content-Type: application/json' \
+  -d '{"label":"RegulatoryRequirement","property_key":"embedding","query_vector":[…384 floats…],"k":3}'
+```
+
+The natural-language front end (embed query → retrieve → graph-ground → cite) lives in the
+generator repo: [`etl/graphrag.py`](https://github.com/samyama-ai/bank-model-risk-kg/blob/main/etl/graphrag.py).
+
 ## License
 
 Apache 2.0. All data is synthetic and generated; it represents no real institution.

--- a/case_studies/bank-model-risk/case.env
+++ b/case_studies/bank-model-risk/case.env
@@ -1,5 +1,5 @@
 # Bank Model-Risk Knowledge Graph — synthetic model governance, lineage & explainability
 DOMAIN=bank-model-risk
 SNAPSHOT_URL=https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v1/bank-model-risk.sgsnap
-SNAPSHOT_SHA256=3ddfeb1804227d52fd3da9e1a56f1fb00c6cc6b0d25914bcd6c72c9620cf7ede
+SNAPSHOT_SHA256=ea21918414a3380e1d10fd2f550e41457f59285b5be3dc81daa01a184b8fab57
 GRAPH=default


### PR DESCRIPTION
Follow-up to #270. The bank-model-risk snapshot now carries a **384-dim HNSW vector index** on `RegulatoryRequirement.embedding` (obligation text embedded with all-MiniLM-L6-v2). Enables semantic GraphRAG: NL governance question → cosine retrieval over regulatory clauses → graph-grounded, citable answer (governed models, satisfying controls, open findings).

- Updated `SNAPSHOT_SHA256` (snapshot re-uploaded to kg-snapshots-v1, 28 KB → 85 KB).
- Documented the flow; front end `etl/graphrag.py` lives in github.com/samyama-ai/bank-model-risk-kg.
- All 8 Cypher DoD queries still pass against the new snapshot (verified).
- Fully synthetic data; no real institution.