### PR TITLE
docs: add contributing guide and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Run '...'
+2. Execute query / command '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Minimal reproduction**
+If possible, include the Cypher query, RESP command, or code snippet that
+triggers the bug.
+
+**Logs / output**
+If applicable, paste the error output or logs (use code fences).
+
+**Environment:**
+ - OS: [e.g. Windows 11, Ubuntu 22.04, macOS 14]
+ - Rust version: [output of `rustc --version`]
+ - Samyama version / commit: [e.g. v1.1.0 or git SHA]
+ - Build: [debug / release]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 Community & Questions
+    url: https://chat.whatsapp.com/Jjjkb3uWRDi1YMdfffaD9d
+    about: For general questions, usage help, and discussion, please use the Samyama OSS community chat instead of opening an issue.
+  - name: 📖 Documentation (The Book)
+    url: https://graph.samyama.cloud/book/
+    about: Check the documentation before filing — your question may already be answered here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here. If this
+relates to Cypher support, an algorithm, or the query engine, please mention it.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Description 📝
+
+> Please provide a clear description of what this PR does and why.
+
+## Related Issue 🎟️
+
+> Link the issue this PR addresses, e.g. `Closes #123`.
+
+## Type of Change 🏷️
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactor / cleanup
+- [ ] CI / build / tooling
+
+## FYI 🙋
+
+> Tag (@) anyone who should be aware of this change.
+
+## Testing ✍️
+
+> How was this verified? Please confirm the following pass locally:
+
+- [ ] `cargo fmt -- --check`
+- [ ] `cargo clippy -- -D warnings`
+- [ ] `cargo test`
+- [ ] Added / updated tests for the change (if applicable)
+
+## Screenshots 📸
+
+> Add screenshots or output if it helps show the change (if applicable).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,205 @@
+# Contributing to Samyama Graph
+
+First off — thank you for taking the time to contribute! Samyama is an
+open-source (Apache-2.0) distributed graph + vector database written in Rust,
+and contributions of all sizes are welcome: bug reports, docs, tests, examples,
+and code.
+
+This guide explains how to get set up and how to get a change merged.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Ways to Contribute](#ways-to-contribute)
+- [Development Setup](#development-setup)
+- [Building, Testing, and Linting](#building-testing-and-linting)
+- [Making a Change](#making-a-change)
+- [Commit Message Convention](#commit-message-convention)
+- [Opening a Pull Request](#opening-a-pull-request)
+- [Where to Start](#where-to-start)
+- [Project Layout](#project-layout)
+
+## Code of Conduct
+
+Please be respectful and constructive in all interactions. Assume good intent,
+keep discussions technical, and help make this a welcoming project for
+newcomers.
+
+## Ways to Contribute
+
+You do **not** need to write Rust to be useful here:
+
+- **Report a bug** — open an issue with steps to reproduce, expected vs. actual
+  behavior, and your OS / Rust version (`rustc --version`).
+- **Improve docs** — the `docs/` directory, the `README`, and inline doc
+  comments can always be clearer.
+- **Add or improve tests** — the suite is large but coverage gaps exist; extra
+  test cases for existing modules are always welcome.
+- **Add an example / case study** — see `examples/` and `case_studies/`.
+- **Fix a bug or add a feature** — see [Where to Start](#where-to-start).
+
+If in doubt, **open an issue first** to discuss the change before investing time
+in a large PR.
+
+## Development Setup
+
+You will need a recent stable Rust toolchain (installed via
+[rustup](https://rustup.rs/)).
+
+Fork the repository on GitHub, then:
+
+```bash
+# Clone your fork
+git clone https://github.com/<your-username>/samyama-graph.git
+cd samyama-graph
+
+# Add the upstream repo so you can stay in sync
+git remote add upstream https://github.com/samyama-ai/samyama-graph.git
+git fetch upstream
+```
+
+Keep your `main` in sync with upstream before starting new work:
+
+```bash
+git checkout main
+git merge --ff-only upstream/main
+git push origin main
+```
+
+## Building, Testing, and Linting
+
+```bash
+# Build
+cargo build                    # Debug build
+cargo build --release          # Optimized build
+
+# Test (full suite)
+cargo test
+cargo test graph::node         # A specific module
+cargo test -- --nocapture      # Show test output
+
+# Benchmarks (Criterion + domain suites in benches/)
+cargo bench
+
+# Code quality — these must pass before you open a PR
+cargo fmt -- --check           # Formatting
+cargo clippy -- -D warnings    # Lints (warnings are treated as errors)
+```
+
+Integration tests require a running server:
+
+```bash
+cargo run                      # RESP on 127.0.0.1:6379, HTTP on :8080
+# in another terminal:
+cd tests/integration
+python3 test_resp_basic.py
+```
+
+For more detail on the architecture and available example demos, see
+[`CLAUDE.md`](CLAUDE.md) and [`docs/`](docs/).
+
+## Making a Change
+
+1. Create a topic branch off the latest upstream `main`:
+
+   ```bash
+   git checkout -b fix/short-description upstream/main
+   ```
+
+   Use a descriptive prefix: `fix/`, `feat/`, `docs/`, `test/`, `refactor/`.
+
+2. Make your change. Keep the diff focused — one logical change per PR.
+
+3. Before committing, make sure the checks pass:
+
+   ```bash
+   cargo fmt -- --check
+   cargo clippy -- -D warnings
+   cargo test
+   ```
+
+4. Add or update tests for any behavior you change.
+
+## Commit Message Convention
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/).
+The type prefix helps generate changelogs and communicates intent:
+
+```
+<type>(<optional scope>): <short summary>
+```
+
+Common types used in this repo:
+
+| Type       | Use for                                          |
+|------------|--------------------------------------------------|
+| `feat`     | A new feature                                    |
+| `fix`      | A bug fix                                         |
+| `docs`     | Documentation only                               |
+| `test`     | Adding or fixing tests                            |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `chore`    | Build, tooling, or maintenance                   |
+| `ci`       | CI configuration                                 |
+
+Examples from the project history:
+
+```
+feat(vector): add HNSW rebuild after snapshot import
+fix(scripts): correct example runner path
+docs(quickstart): clarify RESP connection steps
+```
+
+## Opening a Pull Request
+
+1. Push your branch to your fork:
+
+   ```bash
+   git push origin fix/short-description
+   ```
+
+2. Open a Pull Request against `samyama-ai/samyama-graph`'s `main` branch.
+
+3. In the PR description, explain **what** changed and **why**, and link any
+   related issue (e.g. `Closes #123`).
+
+4. Ensure CI is green. A maintainer (see [`CODEOWNERS`](CODEOWNERS)) will review
+   your change. Please respond to review feedback by pushing additional commits
+   to the same branch.
+
+Small, well-scoped PRs are reviewed and merged faster than large ones.
+
+## Where to Start
+
+Good first contributions, roughly easiest to hardest:
+
+1. **Docs & examples** — fix inaccuracies or fill gaps in `docs/` and `README`.
+2. **Tests** — add cases for an under-tested module.
+3. **Cypher functions** — the supported function list is in
+   [`CLAUDE.md`](CLAUDE.md); standard OpenCypher has more that could be added
+   (parser + executor + tests).
+4. **Open issues / roadmap items** — see [`ROADMAP.md`](ROADMAP.md) and known
+   gaps noted in `docs/CYPHER_COMPATIBILITY.md`.
+
+## Project Layout
+
+```
+src/
+├── graph/         # Property graph model (store, node, edge, property)
+├── query/         # OpenCypher engine (parser, planner, executor)
+├── protocol/      # RESP (Redis-compatible) protocol server
+├── persistence/   # RocksDB storage, WAL, multi-tenancy
+├── raft/          # High availability (openraft)
+├── nlq/           # Natural-language-to-Cypher pipeline
+├── vector/        # HNSW vector index
+├── snapshot/      # Portable .sgsnap export/import
+└── sharding/      # Tenant-level sharding
+
+benches/           # Criterion + domain benchmarks
+examples/          # Runnable demos and data loaders
+tests/             # Integration tests
+docs/              # Architecture docs, ADRs, compatibility notes
+```
+
+---
+
+Thanks again for contributing to Samyama Graph! 🙏

--- a/README.md
+++ b/README.md
@@ -338,6 +338,17 @@ Everything above is open source (Apache 2.0). [Samyama Enterprise](https://samya
 
 ---
 
+## Contributing
+
+Contributions are welcome — bug reports, docs, tests, and code. See
+**[CONTRIBUTING.md](CONTRIBUTING.md)** for development setup, build/test commands,
+and the pull request workflow. Good first areas are listed there.
+
+- 🐛 Found a bug or have an idea? [Open an issue](https://github.com/samyama-ai/samyama-graph/issues/new/choose).
+- 💬 Questions or general discussion? [Join the community chat](https://chat.whatsapp.com/Jjjkb3uWRDi1YMdfffaD9d).
+
+---
+
 ## License
 
 Apache License 2.0 — use it in production, contribute back if you'd like.


### PR DESCRIPTION
## Description 📝

This PR adds **community health files** this repository is missing. The
[Community Standards page](https://github.com/samyama-ai/samyama-graph/community)
currently shows **Contributing** and **Issue templates** as not set up — this PR
adds both, flipping them to ✅.

- **Contributing** — no `CONTRIBUTING.md` exists, so new contributors have no
  single place explaining setup, build/test commands, or the PR workflow. Added.
- **Issue templates** — none exist on the repo. Added Rust-adapted bug report +
  feature request templates, plus a `config.yml` chooser.
- **Pull request template** — the repo currently inherits the org-wide template
  from `samyama-ai/.github`, which links to an unrelated `VaidhyaMegha` issue.
  This PR adds a repo-specific template that overrides it with something
  appropriate to this Rust project (includes a `cargo fmt`/`clippy`/`test`
  checklist).

_(Code of conduct and Security policy are also still missing on that page; those
are better handled in a separate PR since they need maintainer-chosen contact
details.)_

**What this adds:**

- **`CONTRIBUTING.md`** (repo root) — development setup (fork + `upstream`
  remote), build/test/lint commands drawn from `CLAUDE.md`
  (`cargo build` / `test` / `fmt --check` / `clippy -D warnings`), the
  Conventional Commits convention already used in this repo, the pull request
  workflow, and a "where to start" list for new contributors.
- **`.github/ISSUE_TEMPLATE/bug_report.md`** — with Rust-specific environment
  fields (OS, `rustc --version`, Samyama version/commit, debug/release).
- **`.github/ISSUE_TEMPLATE/feature_request.md`**
- **`.github/ISSUE_TEMPLATE/config.yml`** — routes general questions to the
  community chat and the docs, keeping the issue tracker focused.
- **`.github/pull_request_template.md`** — a repo-specific template with a
  `cargo fmt` / `clippy` / `test` checklist. (This also replaces the inherited
  org-default template for this repo.)
- **README** — a short `## Contributing` section linking to `CONTRIBUTING.md`.

**Why Markdown templates (not YAML issue forms):** both are valid; Markdown fits
the project's current issue style and matches peer Rust projects (e.g. qdrant).
These can be upgraded to YAML issue forms later if issue volume grows — no rework
needed.

Documentation only — no code changes.

## Related Issue 🎟️

N/A — repository housekeeping. Happy to open a tracking issue if preferred.

## Type of Change 🏷️

- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] CI / build / tooling

## FYI 🙋

@sandeepkunkunuru — for review.

## Testing ✍️

Documentation only — no code changes, so no tests are affected. The
`cargo fmt`/`clippy`/`test` commands referenced in `CONTRIBUTING.md` and the PR
template are copied verbatim from the repository's own `CLAUDE.md`, so they match
the project's documented workflow (not independently re-run). The issue/PR
templates take effect once merged to the default branch.