### PR TITLE
docs: polish README first screen and add community-health files

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,7 @@
+# Adds a "Sponsor" button to the repo. Uncomment and fill in the handles you use.
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+# github: [your-github-sponsors-username]      # GitHub Sponsors
+# open_collective: samyama                      # Open Collective slug
+# ko_fi: yourname
+# custom: ["https://samyama.dev/contact"]        # e.g. a contact/support page

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: 🐛 Bug report
+description: Report something that isn't working as expected
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! Please fill in as much as you can —
+        a minimal reproduction (Cypher query, snapshot, or code) helps us fix it fast.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+      placeholder: When I run … I expected … but got …
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Commands, Cypher queries, or a minimal code sample.
+      render: shell
+      placeholder: |
+        1. Start server: ./target/release/samyama
+        2. GRAPH.QUERY mydb "..."
+        3. See error
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: Output of `samyama --version`, the release tag, or the commit SHA.
+      placeholder: "1.1.0 / commit abc1234"
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: How are you running it?
+      options:
+        - Built from source (cargo)
+        - Docker image (ghcr.io)
+        - Rust SDK (embedded / remote)
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS / architecture
+      placeholder: "Ubuntu 22.04 x86_64 / macOS 14 arm64 / Windows 11"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or error output
+      description: Paste any server/client logs. This will be rendered as code automatically.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 WhatsApp community
+    url: https://chat.whatsapp.com/Jjjkb3uWRDi1YMdfffaD9d
+    about: Questions, help, and updates from the Samyama OSS community.
+  - name: 🗣️ GitHub Discussions
+    url: https://github.com/samyama-ai/samyama-graph/discussions
+    about: Ask questions, share ideas, and discuss design before filing an issue.
+  - name: 📚 Documentation (The Book)
+    url: https://graph.samyama.cloud/book/
+    about: Read the docs — Cypher compatibility, benchmarks, architecture, and guides.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: 💡 Feature request
+description: Suggest an idea, enhancement, or new integration
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping shape Samyama Graph! Please describe the problem you're
+        trying to solve, not only the solution — it helps us find the best design.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: The use case or pain point behind this request.
+      placeholder: I'm building … and I need …
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you'd like to see — a Cypher feature, algorithm, integration, API, etc.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Cypher / query engine
+        - Vector search (HNSW)
+        - Graph algorithms
+        - Persistence / snapshots
+        - Protocol / RESP / HTTP API
+        - Raft / clustering
+        - NLQ (natural language → Cypher)
+        - SDK / integrations (LangChain, LlamaIndex, Python/TS, …)
+        - Docs / examples / case studies
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you've tried or thought about.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!-- Thanks for contributing to Samyama Graph! Please fill in the sections below. -->
+
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+Fixes #<!-- issue number, if applicable -->
+
+## Type of change
+
+- [ ] 🐛 Bug fix
+- [ ] ✨ New feature
+- [ ] ⚡ Performance improvement
+- [ ] 📖 Documentation / examples
+- [ ] 🔧 Refactor / chore
+- [ ] 💥 Breaking change
+
+## How was this tested?
+
+<!-- Describe the tests you ran, new tests you added, or benchmarks if perf-related. -->
+
+## Checklist
+
+- [ ] `cargo fmt --all` — code is formatted
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — no lint warnings
+- [ ] `cargo test --workspace` — tests pass
+- [ ] `cargo deny check` — license/advisory checks pass (if dependencies changed)
+- [ ] I updated docs / examples where relevant
+- [ ] My commits follow the Conventional Commits style (`feat:`, `fix:`, `docs:`, …)
+
+## Notes for reviewers
+
+<!-- Anything that needs special attention, follow-up work, or context. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[enquiry@samyama.ai](mailto:enquiry@samyama.ai).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,136 @@
+# Contributing to Samyama Graph
+
+First off — thank you for taking the time to contribute! 🙌 Samyama Graph is an
+open-source, Rust-native graph-vector database, and it gets better with every
+issue, example, benchmark, and pull request from the community.
+
+This guide explains how to get set up and how to send changes we can merge quickly.
+
+---
+
+## Ways to contribute
+
+You don't have to write Rust to help:
+
+- 🐛 **Report bugs** or 💡 **request features** — open an [issue](../../issues/new/choose).
+- 📖 **Improve docs, examples, or case studies** — often the highest-leverage contribution.
+- 🔌 **Build integrations** — LangChain, LlamaIndex, Python/TS SDK helpers, importers.
+- ⚡ **Extend the engine** — Cypher coverage, graph algorithms, vector search, connectors.
+- 🌱 **Pick a [`good first issue`](../../labels/good%20first%20issue)** if you're new here.
+
+New contributors: start with an issue labelled `good first issue` or `help wanted`,
+and feel free to comment to claim it before you start.
+
+---
+
+## Getting set up
+
+### Prerequisites
+
+- **Rust** (stable, edition 2021) via [rustup](https://rustup.rs).
+- A **C/C++ toolchain + LLVM/libclang** — the `rocksdb` crate compiles RocksDB from
+  source, so you need `clang`/`libclang` and a working C++ compiler:
+  - **Linux:** `build-essential clang libclang-dev cmake`
+  - **macOS:** `xcode-select --install` (Clang ships with the Command Line Tools)
+  - **Windows:** Visual Studio Build Tools (C++ workload) + [LLVM](https://releases.llvm.org/) + CMake
+- **Docker** (optional) if you'd rather run the prebuilt image than build locally.
+
+### Build & run
+
+```bash
+git clone https://github.com/samyama-ai/samyama-graph && cd samyama-graph
+cargo build --release
+./target/release/samyama        # RESP on :6379, HTTP on :8080
+```
+
+Connect with any Redis client:
+
+```bash
+redis-cli -p 6379
+GRAPH.QUERY mydb "CREATE (a:Person {name:'Alice'})-[:KNOWS]->(b:Person {name:'Bob'})"
+```
+
+### Run tests and examples
+
+```bash
+cargo test --workspace                 # full test suite
+cargo run --example banking_demo       # any of the demos in examples/
+cargo bench --bench vector_benchmark   # self-contained benchmarks (see benches/)
+```
+
+---
+
+## Before you open a pull request
+
+Please make sure these pass locally — they're the same gates we expect on review:
+
+```bash
+cargo fmt --all                                       # formatting
+cargo clippy --all-targets --all-features -- -D warnings   # lints
+cargo test --workspace                                # tests
+cargo deny check                                      # license + advisory audit (see deny.toml)
+```
+
+If your change affects performance, include a relevant `cargo bench` result in the PR.
+
+---
+
+## Project layout
+
+Samyama Graph is a Cargo workspace:
+
+| Path | What it is |
+|------|-----------|
+| `src/` | The `samyama` engine (server binary + core library) |
+| `crates/samyama-graph-algorithms/` | PageRank, BFS, Dijkstra, WCC, SCC, LCC, CDLP, Triangle Count (rayon-parallel) |
+| `crates/samyama-optimization/` | Metaheuristic solvers (Jaya, Rao, GWO, NSGA-II, TLBO, …) |
+| `crates/samyama-sdk/` | Rust SDK (embedded + remote clients) |
+| `cli/` | Command-line interface |
+| `examples/` | Runnable domain demos + data loaders |
+| `benches/` | Benchmarks (vector, LDBC, micro, MVCC, …) |
+| `case_studies/` | One-command, download-and-run public knowledge graphs |
+| `docs/` | The Book source, ADRs, compatibility notes |
+
+Core engine modules (inside `src/`): `graph/` (property graph model), `query/`
+(OpenCypher engine — grammar, executor, planner), `protocol/` (RESP3 server),
+`persistence/` (RocksDB + WAL + multi-tenancy), `vector/` (HNSW), `snapshot/`
+(`.sgsnap` format), `raft/` (consensus), `nlq/` (natural language → Cypher).
+
+See [`ROADMAP.md`](ROADMAP.md) for where the project is headed.
+
+---
+
+## Pull request process
+
+1. **Branch from `main`** with a descriptive name: `feat/…`, `fix/…`, `docs/…`, `perf/…`.
+2. **Keep PRs focused and small** — easier to review, faster to merge.
+3. **Reference the issue** it addresses (`Fixes #123`).
+4. **Describe what changed and why.** Include a repro, test, or benchmark where relevant.
+5. Ensure the local checks above are green.
+6. A maintainer ([@sandeepkunkunuru](https://github.com/sandeepkunkunuru), see
+   [`CODEOWNERS`](CODEOWNERS)) will review. Address feedback with follow-up commits.
+
+### Commit messages
+
+We favour a lightweight [Conventional Commits](https://www.conventionalcommits.org)
+style — `feat:`, `fix:`, `docs:`, `perf:`, `refactor:`, `test:`, `chore:` — so the
+history stays readable and release notes are easy to assemble.
+
+---
+
+## Questions & community
+
+- 💬 [WhatsApp community](https://chat.whatsapp.com/Jjjkb3uWRDi1YMdfffaD9d) — questions, help, updates
+- 🗣️ [GitHub Discussions](../../discussions) — design questions, ideas, Q&A
+- 📚 [The Book](https://graph.samyama.cloud/book/) — full documentation
+
+---
+
+## Code of Conduct
+
+By participating, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## License
+
+Samyama Graph is licensed under the [Apache License 2.0](LICENSE). By submitting a
+contribution, you agree that it will be licensed under the same terms.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <h1 align="center">Samyama Graph </h1>
-  <P align ="center">A Rust-native graph-vector database for GraphRAG, knowledge graphs, and billion-edge analytics.</P>
+  <h1 align="center">Samyama Graph</h1>
+  <p align="center">A Rust-native graph-vector database for GraphRAG, knowledge graphs, and billion-edge analytics.</p>
   <p align="center">
     <strong>The graph database that queried 1 billion edges for $2.50</strong>
   </p>
@@ -18,6 +18,49 @@
 
 ---
 
+## What is Samyama Graph?
+
+Samyama Graph is a Rust-native graph-vector database that lets developers store, query, search, and analyze connected data in one system.
+
+It brings together graph traversal, OpenCypher-style querying, vector search, graph algorithms, and Redis-compatible access, making it useful for GraphRAG, knowledge graphs, AI agent memory, and large-scale relationship analytics.
+
+### Quickstart
+
+```bash
+# Run with Docker (no Rust toolchain needed)
+docker run -d -p 6379:6379 -p 8080:8080 ghcr.io/samyama-ai/samyama-graph:latest
+```
+
+```bash
+# Or build from source
+git clone https://github.com/samyama-ai/samyama-graph && cd samyama-graph
+cargo build --release
+./target/release/samyama    # RESP on :6379, HTTP on :8080
+```
+
+```bash
+# Connect with any Redis client
+redis-cli -p 6379
+GRAPH.QUERY mydb "CREATE (a:Person {name: 'Alice'})-[:KNOWS]->(b:Person {name: 'Bob'})"
+GRAPH.QUERY mydb "MATCH (a)-[:KNOWS]->(b) RETURN a.name, b.name"
+```
+
+## What can you build with Samyama Graph?
+
+Samyama Graph is useful when your application needs both connected-data reasoning and semantic retrieval.
+
+You can use it to build:
+
+- **GraphRAG systems** that combine vector search with graph traversal
+- **Knowledge graph applications** for enterprise, research, healthcare, and operations data
+- **AI agent memory** where entities, tools, actions, and context are stored as a graph
+- **Biomedical and clinical graphs** across papers, trials, pathways, drugs, and conditions
+- **Fraud and investigation graphs** for relationship discovery and pattern analysis
+- **Infrastructure and dependency graphs** for impact analysis and root-cause exploration
+- **Large-scale graph analytics** using built-in graph algorithms
+
+---
+
 We loaded the entire PubMed corpus — every article published since 1966 — plus ClinicalTrials.gov, Reactome pathways, and DrugBank into **one graph**. Then we asked:
 
 > *"What drugs are most tested in cancer clinical trials?"*
@@ -30,17 +73,19 @@ RETURN i.name, count(DISTINCT t) AS trials
 ORDER BY trials DESC LIMIT 5
 ```
 
-| Drug | Trials |
-|------|--------|
-| Placebo | 521 |
+| Drug                    | Trials        |
+| ----------------------- | ------------- |
+| Placebo                 | 521           |
 | **Pembrolizumab** | **137** |
-| Carboplatin | 106 |
-| Paclitaxel | 106 |
-| Cyclophosphamide | 98 |
+| Carboplatin             | 106           |
+| Paclitaxel              | 106           |
+| Cyclophosphamide        | 98            |
 
 **5.2 seconds.** One query. Four databases. 74 million nodes. 1 billion edges. A single machine.
 
 [See all 100 benchmark queries →](https://graph.samyama.cloud/book/biomedical_benchmark.html)
+
+> ⭐ **Find this useful?** A GitHub star helps more developers discover Samyama Graph.
 
 ---
 
@@ -84,46 +129,20 @@ Each snapshot is small enough to run on a laptop; every query returns real rows.
 GIFs can't pause in a browser, so each domain also ships its `demo.cast` — replay
 it pausably (`space`) with `asciinema play case_studies/<domain>/demo.cast`.
 
-| Domain | Scale | Highlight | Snapshot | Demo |
-|--------|-------|-----------|----------|------|
-| [cricket](case_studies/cricket) | 37K / 1.4M | dismissal-rivalry networks, venues, awards | [`cricket.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v1/cricket.sgsnap) | [gif](case_studies/cricket/demo.gif) |
-| [drug-interactions](case_studies/drug-interactions) | 245K / 388K | polypharmacy shared-target risk, CYP hubs | [`druginteractions.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v5/druginteractions.sgsnap) | [gif](case_studies/drug-interactions/demo.gif) |
-| [surveillance](case_studies/surveillance) | 217K / 241K | WHO disease burden + immunization gaps | [`surveillance.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v4/surveillance.sgsnap) | [gif](case_studies/surveillance/demo.gif) |
-| [health-determinants](case_studies/health-determinants) | 240K / 240K | air, water, poverty — the upstream "why" | [`health-determinants.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v6/health-determinants.sgsnap) | [gif](case_studies/health-determinants/demo.gif) |
-| [health-systems](case_studies/health-systems) | 8.7K / 8.4K | WHO emergency-preparedness (SPAR) scores | [`health-systems.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v6/health-systems.sgsnap) | [gif](case_studies/health-systems/demo.gif) |
-| [pathways](case_studies/pathways) | 119K / 835K | protein hubs (TP53), pathway crosstalk | [`pathways.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v3/pathways.sgsnap) | [gif](case_studies/pathways/demo.gif) |
-| [dbms-research](case_studies/dbms-research) | 19K · 2 HNSW | **vector search** — semantic "nearest topics" | [`dbms-research.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v7/dbms-research.sgsnap) | [gif](case_studies/dbms-research/demo.gif) |
-| [imdb-movies](case_studies/imdb-movies) | 1.94M / 2.63M | top-rated films, director–actor power pairs, genre trends, decade arcs | [`imdb.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v8/imdb.sgsnap) | [gif](case_studies/imdb-movies/demo.gif) |
-| [football](case_studies/football) | 16K / 12K | top scorers, winning nations, busiest stadiums, multi-tournament veterans | [`football.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v8/football.sgsnap) | [gif](case_studies/football/demo.gif) |
+| Domain                                                 | Scale         | Highlight                                                                 | Snapshot                                                                                                                                  | Demo                                            |
+| ------------------------------------------------------ | ------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| [cricket](case_studies/cricket)                         | 37K / 1.4M    | dismissal-rivalry networks, venues, awards                                | [`cricket.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v1/cricket.sgsnap)                         | [gif](case_studies/cricket/demo.gif)             |
+| [drug-interactions](case_studies/drug-interactions)     | 245K / 388K   | polypharmacy shared-target risk, CYP hubs                                 | [`druginteractions.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v5/druginteractions.sgsnap)       | [gif](case_studies/drug-interactions/demo.gif)   |
+| [surveillance](case_studies/surveillance)               | 217K / 241K   | WHO disease burden + immunization gaps                                    | [`surveillance.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v4/surveillance.sgsnap)               | [gif](case_studies/surveillance/demo.gif)        |
+| [health-determinants](case_studies/health-determinants) | 240K / 240K   | air, water, poverty — the upstream "why"                                 | [`health-determinants.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v6/health-determinants.sgsnap) | [gif](case_studies/health-determinants/demo.gif) |
+| [health-systems](case_studies/health-systems)           | 8.7K / 8.4K   | WHO emergency-preparedness (SPAR) scores                                  | [`health-systems.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v6/health-systems.sgsnap)           | [gif](case_studies/health-systems/demo.gif)      |
+| [pathways](case_studies/pathways)                       | 119K / 835K   | protein hubs (TP53), pathway crosstalk                                    | [`pathways.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v3/pathways.sgsnap)                       | [gif](case_studies/pathways/demo.gif)            |
+| [dbms-research](case_studies/dbms-research)             | 19K · 2 HNSW | **vector search** — semantic "nearest topics"                      | [`dbms-research.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v7/dbms-research.sgsnap)             | [gif](case_studies/dbms-research/demo.gif)       |
+| [imdb-movies](case_studies/imdb-movies)                 | 1.94M / 2.63M | top-rated films, director–actor power pairs, genre trends, decade arcs   | [`imdb.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v8/imdb.sgsnap)                               | [gif](case_studies/imdb-movies/demo.gif)         |
+| [football](case_studies/football)                       | 16K / 12K     | top scorers, winning nations, busiest stadiums, multi-tournament veterans | [`football.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v8/football.sgsnap)                       | [gif](case_studies/football/demo.gif)            |
 
 *surveillance + health-determinants + health-systems federate by `Country.iso_code`
 into a public-health trifecta.* [Browse the catalogue →](case_studies)
-
----
-
-## What is Samyama Graph?
-
-Samyama Graph is a Rust-native graph-vector database that lets developers store, query, search, and analyze connected data in one system.
-It brings together graph traversal, OpenCypher-style querying, vector search, graph algorithms, and Redis-compatible access, making it useful for GraphRAG, knowledge graphs, AI agent memory, and large-scale relationship analytics.
-
-```bash
-# Run with Docker (no Rust toolchain needed)
-docker run -d -p 6379:6379 -p 8080:8080 ghcr.io/samyama-ai/samyama-graph:latest
-```
-
-```bash
-# Or build from source
-git clone https://github.com/samyama-ai/samyama-graph && cd samyama-graph
-cargo build --release
-./target/release/samyama    # RESP on :6379, HTTP on :8080
-```
-
-```bash
-# Connect with any Redis client
-redis-cli -p 6379
-GRAPH.QUERY mydb "CREATE (a:Person {name: 'Alice'})-[:KNOWS]->(b:Person {name: 'Bob'})"
-GRAPH.QUERY mydb "MATCH (a)-[:KNOWS]->(b) RETURN a.name, b.name"
-```
 
 ---
 
@@ -131,13 +150,13 @@ GRAPH.QUERY mydb "MATCH (a)-[:KNOWS]->(b) RETURN a.name, b.name"
 
 **If your data has relationships, you need a graph database.** If your graph database can't handle a billion edges on a single machine, you need Samyama.
 
-| What | How |
-|------|-----|
-| **74M nodes, 1B edges** | Loaded PubMed + ClinicalTrials.gov + Reactome + DrugBank on one r6a.8xlarge ($2.50 spot) |
-| **96/100 queries pass** | Point lookups, multi-hop traversals, cross-KG aggregations — [all verified](https://graph.samyama.cloud/book/biomedical_benchmark.html) |
-| **Parallel everything** | Rayon: PageRank 3.1x, LCC 9.1x, Triangle Count 6x. Parallel scan, filter, compaction |
-| **975 QPS concurrent** | 16-client read workload, p99 < 25ms, zero errors across 67K queries |
-| **LDBC certified** | SNB Interactive 21/21, FinBench 40/40, Graphalytics 12/12 |
+| What                          | How                                                                                                                                    |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **74M nodes, 1B edges** | Loaded PubMed + ClinicalTrials.gov + Reactome + DrugBank on one r6a.8xlarge ($2.50 spot)                                               |
+| **96/100 queries pass** | Point lookups, multi-hop traversals, cross-KG aggregations —[all verified](https://graph.samyama.cloud/book/biomedical_benchmark.html) |
+| **Parallel everything** | Rayon: PageRank 3.1x, LCC 9.1x, Triangle Count 6x. Parallel scan, filter, compaction                                                   |
+| **975 QPS concurrent**  | 16-client read workload, p99 < 25ms, zero errors across 67K queries                                                                    |
+| **LDBC certified**      | SNB Interactive 21/21, FinBench 40/40, Graphalytics 12/12                                                                              |
 
 ---
 
@@ -186,59 +205,59 @@ samyama-mcp-serve --demo cricket    # Instant AI agent tools for any graph
 **Run them:** `cargo bench --bench <name>` ([`benches/`](benches)). The vector,
 optimization, and micro/MVCC suites are self-contained; LDBC needs a data download.
 
-| Benchmark | Command | Measures | Data |
-|-----------|---------|----------|------|
-| Vector (HNSW) | `cargo bench --bench vector_benchmark` | build time, recall@k, search QPS (64–768 dim) | self-contained |
-| Rao family | `cargo bench --bench rao_family_benchmark` | Jaya/Rao/BMR/NSGA-II on ZDT/DTLZ | self-contained |
-| Graph optimization | `cargo bench --bench graph_optimization_benchmark` | 10+ metaheuristic solvers on allocation | self-contained |
-| Graphalytics | `cargo bench --bench graphalytics_benchmark` | BFS, PageRank, WCC, CDLP, LCC, SSSP | synthetic / LDBC |
-| Micro | `cargo bench --bench graph_benchmarks` | insertion, label scan, k-hop, filter, aggregate | self-contained |
-| MVCC & arena | `cargo bench --bench mvcc_benchmark` | 1M-node alloc, version access, time-travel | self-contained |
-| Late materialization | `cargo bench --bench late_materialization_bench` | raw vs lazy traversal vs Cypher | self-contained |
-| LDBC SNB Interactive | `cargo bench --bench ldbc_benchmark` | 21 IS/IC queries + 8 updates | needs SF1 download |
-| LDBC SNB BI | `cargo bench --bench ldbc_bi_benchmark` | 20 analytical (BI-1…20) | needs SF1 download |
-| LDBC FinBench | `cargo bench --bench finbench_benchmark` | 40+ CR/SR/RW/W on financial networks | synthetic / download |
+| Benchmark            | Command                                              | Measures                                        | Data                 |
+| -------------------- | ---------------------------------------------------- | ----------------------------------------------- | -------------------- |
+| Vector (HNSW)        | `cargo bench --bench vector_benchmark`             | build time, recall@k, search QPS (64–768 dim)  | self-contained       |
+| Rao family           | `cargo bench --bench rao_family_benchmark`         | Jaya/Rao/BMR/NSGA-II on ZDT/DTLZ                | self-contained       |
+| Graph optimization   | `cargo bench --bench graph_optimization_benchmark` | 10+ metaheuristic solvers on allocation         | self-contained       |
+| Graphalytics         | `cargo bench --bench graphalytics_benchmark`       | BFS, PageRank, WCC, CDLP, LCC, SSSP             | synthetic / LDBC     |
+| Micro                | `cargo bench --bench graph_benchmarks`             | insertion, label scan, k-hop, filter, aggregate | self-contained       |
+| MVCC & arena         | `cargo bench --bench mvcc_benchmark`               | 1M-node alloc, version access, time-travel      | self-contained       |
+| Late materialization | `cargo bench --bench late_materialization_bench`   | raw vs lazy traversal vs Cypher                 | self-contained       |
+| LDBC SNB Interactive | `cargo bench --bench ldbc_benchmark`               | 21 IS/IC queries + 8 updates                    | needs SF1 download   |
+| LDBC SNB BI          | `cargo bench --bench ldbc_bi_benchmark`            | 20 analytical (BI-1…20)                        | needs SF1 download   |
+| LDBC FinBench        | `cargo bench --bench finbench_benchmark`           | 40+ CR/SR/RW/W on financial networks            | synthetic / download |
 
 ### Scale: 74M Nodes, 1 Billion Edges
 
-| KG | Source | Nodes | Edges |
-|----|--------|-------|-------|
-| PubMed/MEDLINE | NLM | 66.2M | 1.04B |
-| Clinical Trials | ClinicalTrials.gov | 7.8M | 27M |
-| Pathways | Reactome | 119K | 835K |
-| Drug Interactions | DrugBank + ChEMBL + SIDER | 245K | 388K |
+| KG                | Source                    | Nodes | Edges |
+| ----------------- | ------------------------- | ----- | ----- |
+| PubMed/MEDLINE    | NLM                       | 66.2M | 1.04B |
+| Clinical Trials   | ClinicalTrials.gov        | 7.8M  | 27M   |
+| Pathways          | Reactome                  | 119K  | 835K  |
+| Drug Interactions | DrugBank + ChEMBL + SIDER | 245K  | 388K  |
 
 Loaded in 31 minutes from snapshots. **96 of 100 queries return real data** across all four KGs. [Full results →](https://graph.samyama.cloud/book/biomedical_benchmark.html)
 
 ### Cross-KG Query Highlights
 
-| Query | Time | Result |
-|-------|------|--------|
-| Cancer → Trial interventions | 5.2s | Pembrolizumab #1 (137 trials) |
-| Diabetes → Trial interventions | 2.4s | Metformin #1 (70 trials) |
-| Metformin → Trial adverse events | 2.1s | Diarrhoea (185 trials) — known side effect confirmed |
-| Cancer trial sites by country | 3.8s | US 4,062 · China 1,170 · France 827 |
-| NCI-funded → Trial drugs | 19.4s | Cyclophosphamide (517) · Radiation (362) |
-| Aspirin articles → Trials | 1.5s | NCT00000491 "Aspirin MI study" |
+| Query                             | Time  | Result                                                |
+| --------------------------------- | ----- | ----------------------------------------------------- |
+| Cancer → Trial interventions     | 5.2s  | Pembrolizumab#1 (137 trials)                          |
+| Diabetes → Trial interventions   | 2.4s  | Metformin#1 (70 trials)                               |
+| Metformin → Trial adverse events | 2.1s  | Diarrhoea (185 trials) — known side effect confirmed |
+| Cancer trial sites by country     | 3.8s  | US 4,062 · China 1,170 · France 827                 |
+| NCI-funded → Trial drugs         | 19.4s | Cyclophosphamide (517) · Radiation (362)             |
+| Aspirin articles → Trials        | 1.5s  | NCT00000491 "Aspirin MI study"                        |
 
 ### LDBC Compliance
 
-| Benchmark | Pass Rate | Dataset |
-|-----------|-----------|---------|
+| Benchmark       | Pass Rate              | Dataset                        |
+| --------------- | ---------------------- | ------------------------------ |
 | SNB Interactive | **21/21 (100%)** | SF1: 3.18M nodes, 17.26M edges |
-| SNB BI | **16/16 (100%)** | SF1 |
-| Graphalytics | **12/12 (100%)** | XS reference graphs |
-| FinBench | **40/40 (100%)** | 7.7K nodes, 42.2K edges |
+| SNB BI          | **16/16 (100%)** | SF1                            |
+| Graphalytics    | **12/12 (100%)** | XS reference graphs            |
+| FinBench        | **40/40 (100%)** | 7.7K nodes, 42.2K edges        |
 
 ![LDBC benchmark results](ldbc-benchmark-results.png)
 
 ### Concurrent Performance
 
-| Workload | 1 client | 16 clients | Scaling |
-|----------|----------|------------|---------|
-| Pure read | 145 QPS | 975 QPS | 6.7x |
-| Mixed 80/20 | 181 QPS | 722 QPS | 4.0x |
-| Write-heavy | 279 QPS | 482 QPS | 1.7x |
+| Workload    | 1 client | 16 clients | Scaling |
+| ----------- | -------- | ---------- | ------- |
+| Pure read   | 145 QPS  | 975 QPS    | 6.7x    |
+| Mixed 80/20 | 181 QPS  | 722 QPS    | 4.0x    |
+| Write-heavy | 279 QPS  | 482 QPS    | 1.7x    |
 
 ---
 
@@ -250,17 +269,17 @@ every example, starts a server, and runs each in turn with a pass/fail summary
 
 ### Domain Knowledge Graphs
 
-| Domain | Command | What it shows |
-|--------|---------|---------------|
-| Banking & Fraud | `cargo run --example banking_demo` | Fraud patterns, money laundering, OFAC, NLQ |
-| Clinical Trials | `cargo run --example clinical_trials_demo` | Patient-trial matching, drug interactions, vector search |
-| Supply Chain | `cargo run --example supply_chain_demo` | Disruption analysis, port optimization (Jaya) |
-| Manufacturing | `cargo run --example smart_manufacturing_demo` | Digital twin, failure cascades, scheduling |
-| Social Network | `cargo run --example social_network_demo` | Influence, communities, recommendations |
-| Enterprise SOC | `cargo run --example enterprise_soc_demo` | MITRE ATT&CK, attack paths, threat intel |
-| Knowledge Graph | `cargo run --example knowledge_graph_demo` | Enterprise RAG + semantic search |
-| Agentic (GAK) | `cargo run --example agentic_enrichment_demo` | Generation-augmented enrichment (needs `claude` CLI) |
-| Raft Cluster | `cargo run --example cluster_demo` | 3-node HA consensus |
+| Domain          | Command                                          | What it shows                                            |
+| --------------- | ------------------------------------------------ | -------------------------------------------------------- |
+| Banking & Fraud | `cargo run --example banking_demo`             | Fraud patterns, money laundering, OFAC, NLQ              |
+| Clinical Trials | `cargo run --example clinical_trials_demo`     | Patient-trial matching, drug interactions, vector search |
+| Supply Chain    | `cargo run --example supply_chain_demo`        | Disruption analysis, port optimization (Jaya)            |
+| Manufacturing   | `cargo run --example smart_manufacturing_demo` | Digital twin, failure cascades, scheduling               |
+| Social Network  | `cargo run --example social_network_demo`      | Influence, communities, recommendations                  |
+| Enterprise SOC  | `cargo run --example enterprise_soc_demo`      | MITRE ATT&CK, attack paths, threat intel                 |
+| Knowledge Graph | `cargo run --example knowledge_graph_demo`     | Enterprise RAG + semantic search                         |
+| Agentic (GAK)   | `cargo run --example agentic_enrichment_demo`  | Generation-augmented enrichment (needs`claude` CLI)    |
+| Raft Cluster    | `cargo run --example cluster_demo`             | 3-node HA consensus                                      |
 
 *19 demo examples + 11 data loaders in [`examples/`](examples); optimization/use-case
 demos: `grid_dispatch_demo`, `amr_stewardship_demo`, `healthcare_allocation_demo`,
@@ -268,15 +287,15 @@ demos: `grid_dispatch_demo`, `amr_stewardship_demo`, `healthcare_allocation_demo
 
 ### Data Loaders
 
-| Dataset | Command | Scale |
-|---------|---------|-------|
-| LDBC SNB SF1 | `cargo run --example ldbc_loader` | 3.2M nodes, 17.3M edges |
-| Clinical Trials | `cargo run --release --example aact_loader` | 7.8M nodes, 27M edges |
-| Drug Interactions | `cargo run --release --example druginteractions_loader` | 245K nodes, 388K edges |
-| Cricket | `cargo run --release --example cricket_loader` | 36K nodes, 1.4M edges |
-| FinBench | `cargo run --example finbench_loader` | 7.7K nodes, 42K edges |
-| IMDB Movies | `cargo run --release --example imdb_loader -- --data-dir <path>` | 1.94M nodes, 2.63M edges |
-| Football | `cargo run --release --example football_loader -- --data-dir <path>` | 16K nodes, 12K edges |
+| Dataset           | Command                                                                | Scale                    |
+| ----------------- | ---------------------------------------------------------------------- | ------------------------ |
+| LDBC SNB SF1      | `cargo run --example ldbc_loader`                                    | 3.2M nodes, 17.3M edges  |
+| Clinical Trials   | `cargo run --release --example aact_loader`                          | 7.8M nodes, 27M edges    |
+| Drug Interactions | `cargo run --release --example druginteractions_loader`              | 245K nodes, 388K edges   |
+| Cricket           | `cargo run --release --example cricket_loader`                       | 36K nodes, 1.4M edges    |
+| FinBench          | `cargo run --example finbench_loader`                                | 7.7K nodes, 42K edges    |
+| IMDB Movies       | `cargo run --release --example imdb_loader -- --data-dir <path>`     | 1.94M nodes, 2.63M edges |
+| Football          | `cargo run --release --example football_loader -- --data-dir <path>` | 16K nodes, 12K edges     |
 
 ### Related Repositories
 
@@ -306,6 +325,7 @@ samyama
 ```
 
 **Companion crates:**
+
 - [samyama-graph-algorithms](crates/samyama-graph-algorithms/) — PageRank, BFS, Dijkstra, WCC, SCC, LCC, CDLP, Triangle Count (all rayon-parallelized)
 - [samyama-optimization](crates/samyama-optimization/) — 15+ metaheuristic solvers (Jaya, Rao, GWO, NSGA-II, TLBO)
 - [samyama-sdk](crates/samyama-sdk/) — Rust SDK with embedded and remote clients
@@ -314,14 +334,14 @@ samyama
 
 ## Documentation
 
-| Resource | Link |
-|----------|------|
-| **The Book** | [graph.samyama.cloud/book](https://graph.samyama.cloud/book/) |
-| Biomedical Benchmark | [100 queries, 96 pass](https://graph.samyama.cloud/book/biomedical_benchmark.html) |
-| Cypher Compatibility | [docs/CYPHER_COMPATIBILITY.md](docs/CYPHER_COMPATIBILITY.md) |
-| LDBC Results | [docs/ldbc/](docs/ldbc/) |
-| Architecture Decisions | [docs/ADR/](docs/ADR/) |
-| API Spec | [api/openapi.yaml](api/openapi.yaml) |
+| Resource               | Link                                                                              |
+| ---------------------- | --------------------------------------------------------------------------------- |
+| **The Book**     | [graph.samyama.cloud/book](https://graph.samyama.cloud/book/)                      |
+| Biomedical Benchmark   | [100 queries, 96 pass](https://graph.samyama.cloud/book/biomedical_benchmark.html) |
+| Cypher Compatibility   | [docs/CYPHER_COMPATIBILITY.md](docs/CYPHER_COMPATIBILITY.md)                       |
+| LDBC Results           | [docs/ldbc/](docs/ldbc/)                                                           |
+| Architecture Decisions | [docs/ADR/](docs/ADR/)                                                             |
+| API Spec               | [api/openapi.yaml](api/openapi.yaml)                                               |
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+We take the security of Samyama Graph seriously. Thank you for helping keep the
+project and its users safe.
+
+## Supported versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.1.x   | ✅ Yes             |
+| < 1.1   | ❌ No (please upgrade) |
+
+Security fixes land on the latest `1.1.x` line. We recommend always running the
+most recent release.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.**
+
+Instead, use either of these private channels:
+
+1. **GitHub private vulnerability reporting** *(preferred)* — go to the
+   repository's **Security** tab → **Report a vulnerability**. This opens a
+   private advisory visible only to the maintainers.
+2. **Email** — [enquiry@samyama.ai](mailto:enquiry@samyama.ai) with the subject
+   line starting `SECURITY:`.
+
+Please include as much of the following as you can:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce (a minimal proof-of-concept helps a lot).
+- Affected version(s) or commit SHA.
+- Any suggested mitigation, if you have one.
+
+## What to expect
+
+- **Acknowledgement** of your report within **3 business days**.
+- An initial assessment and severity triage within **7 business days**.
+- Regular updates as we work on a fix, and credit in the release notes /
+  advisory once the issue is resolved (unless you prefer to remain anonymous).
+
+## Coordinated disclosure
+
+We follow a coordinated-disclosure model. Please give us reasonable time to
+investigate and release a fix before any public disclosure. We're happy to
+coordinate timing with you and to acknowledge your contribution.
+
+Thank you for acting responsibly and helping protect the Samyama Graph community.


### PR DESCRIPTION
## What & why

Sharpen the repository's first impression for new visitors and add the standard community-health files GitHub surfaces. **No source/engine changes** — docs and repo-meta only.

### README — first-screen conversion
- Fix malformed header HTML (stray `<h1>` trailing space, `<P align ="center">` → valid `<p>`).
- Move **What is Samyama Graph?** and **Quickstart** above the fold, right under the badges — a visitor learns what it is and how to run it within the first screen.
- Add a **What can you build?** use-case list (GraphRAG, knowledge graphs, agent memory, biomedical, fraud, infrastructure, analytics).
- Add a soft ⭐ star CTA at the benchmark payoff.

### Community-health files
- `CONTRIBUTING.md` — setup, build/test gates, project layout, PR process.
- `CODE_OF_CONDUCT.md` — Contributor Covenant.
- `SECURITY.md` — private vulnerability reporting (Security tab + email); supported-version table matches current `1.1.x`.
- `.github/ISSUE_TEMPLATE/` — bug-report + feature-request forms + config.
- `.github/PULL_REQUEST_TEMPLATE.md`.
- `.github/FUNDING.yml` — placeholder (all entries commented; no Sponsor button appears until handles are filled in).

### Notes for the reviewer
- The four existing README tables re-aligned to whitespace-padded columns via a markdown formatter — **cosmetic only**; GitHub renders them identically to before.
- `CONTRIBUTING.md` links to GitHub Discussions (`../../discussions`); that link resolves once Discussions is enabled on the repo.
