### PR TITLE
chore: add CODE_OF_CONDUCT.md and SECURITY.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[enquiry@samyama.ai](mailto:enquiry@samyama.ai).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+We take the security of Samyama Graph seriously. Thank you for helping keep the
+project and its users safe.
+
+## Supported versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.1.x   | ✅ Yes             |
+| < 1.1   | ❌ No (please upgrade) |
+
+Security fixes land on the latest `1.1.x` line. We recommend always running the
+most recent release.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.**
+
+Instead, use either of these private channels:
+
+1. **GitHub private vulnerability reporting** *(preferred)* — go to the
+   repository's **Security** tab → **Report a vulnerability**. This opens a
+   private advisory visible only to the maintainers.
+2. **Email** — [enquiry@samyama.ai](mailto:enquiry@samyama.ai) with the subject
+   line starting `SECURITY:`.
+
+Please include as much of the following as you can:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce (a minimal proof-of-concept helps a lot).
+- Affected version(s) or commit SHA.
+- Any suggested mitigation, if you have one.
+
+## What to expect
+
+- **Acknowledgement** of your report within **3 business days**.
+- An initial assessment and severity triage within **7 business days**.
+- Regular updates as we work on a fix, and credit in the release notes /
+  advisory once the issue is resolved (unless you prefer to remain anonymous).
+
+## Coordinated disclosure
+
+We follow a coordinated-disclosure model. Please give us reasonable time to
+investigate and release a fix before any public disclosure. We're happy to
+coordinate timing with you and to acknowledge your contribution.
+
+Thank you for acting responsibly and helping protect the Samyama Graph community.


### PR DESCRIPTION
Adds the two community-health files the repository still doesn't have.

### Scope reduced after #274

This PR originally carried 8 files. #274 landed `CONTRIBUTING.md`, both issue templates, the issue-template config and the PR template — which is what caused the conflict. I've rebased onto `main` and **dropped every file that #274 already provides**, rather than overwrite that work. Its `CONTRIBUTING.md` is more thorough than the one I had written (table of contents, benchmarks, code-quality gate), so there was nothing worth carrying over.

What's left is **2 files, +181, no deletions, no conflicts**:

| File | Why it's still needed |
|---|---|
| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1, enforcement contact `enquiry@samyama.ai`. #274 describes expected conduct *inline* in CONTRIBUTING.md, which reads well but doesn't satisfy GitHub's **Community Standards** check — that looks for the file at the repo root. Several awesome-list curators require it as a submission gate too. |
| `SECURITY.md` | Enables the **"Report a vulnerability"** path on the Security tab, with `enquiry@samyama.ai` as the fallback and a supported-version table. Without it there's no private disclosure route, so security reports tend to arrive as public issues. |

Both files use `enquiry@samyama.ai` as the contact — happy to point them elsewhere if there's a better address.

Ready to merge. 🙏
