### PR TITLE
ci: publish Docker images only from semver tags

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -7,10 +7,20 @@ on:
 
 jobs:
   build-and-push:
+    # Only publish from a semver tag. The `release: published` trigger also
+    # fires for data releases (kg-snapshots-*, paper*-kg-snapshots-*), whose
+    # tags are not semver — docker/metadata-action's `type=semver` patterns
+    # then match nothing, so those runs used to push a bare `latest` built
+    # from whatever main happened to be, and never produced a version tag.
+    # To publish by hand, dispatch this workflow with a vX.Y.Z tag as the ref.
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
 
     steps:
       - uses: actions/checkout@v4
@@ -68,11 +78,13 @@ jobs:
       - name: Install redis-tools
         run: sudo apt-get update && sudo apt-get install -y redis-tools
 
+      # Pin to the version just built. Pulling `:latest` here could smoke-test
+      # a different image than the one this run produced.
       - name: Pull and start container
         run: |
           docker run -d --name samyama \
             -p 6379:6379 -p 8080:8080 \
-            ghcr.io/samyama-ai/samyama-graph:latest
+            ghcr.io/samyama-ai/samyama-graph:${{ needs.build-and-push.outputs.version }}
 
       - name: Wait for healthy
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "High-performance distributed graph database with OpenCypher support"
 license = "Apache-2.0"
-repository = "https://github.com/VaidhyaMegha/samyama-graph"
+repository = "https://github.com/samyama-ai/samyama-graph"
 
 [dependencies]
 # Core dependencies


### PR DESCRIPTION
## The problem

`ghcr.io/samyama-ai/samyama-graph` currently has **exactly one tag: `latest`**. There has never been a versioned image, even though the repo carries 31 semver git tags and `Cargo.toml` is at `1.1.0`.

The cause is in this workflow. It triggers on `release: published` — but that fires for the **data** releases too (`kg-snapshots-*`, `paper8-kg-snapshots-v1`), and those tags aren't semver. When the ref isn't a semver tag, `docker/metadata-action`'s three `type=semver` patterns match nothing, so the only tag left standing is `type=raw,value=latest`.

So every dataset release quietly rebuilds the application image and overwrites `latest` with a build of whatever `main` happened to be at that moment. The workflow has, as far as I can tell, never once run on a version tag.

That has two effects worth caring about:

- **`latest` has no defined relationship to any released version.** Anyone running the README's `docker run … :latest` quickstart is getting an arbitrary snapshot of `main`, not a release.
- **There is no pinnable tag at all**, so nobody can reproduce a result against a fixed build.

## The change

1. **Gate `build-and-push` on a semver ref** (`if: startsWith(github.ref, 'refs/tags/v')`). Dataset releases stop touching the image, and `latest` only moves when a version is genuinely released. Manual publishing still works — dispatch the workflow with a `vX.Y.Z` tag as the ref rather than a branch.
2. **Pin the smoke-test to the image the run just built**, via a new `version` output from the metadata step. It previously pulled `:latest`, which can validate a *different* image than the one the run produced.
3. **Fix `Cargo.toml`'s `repository` URL**, which still pointed at the old `VaidhyaMegha` org. Happy to split this into its own PR if you'd rather keep this one purely CI.

`smoke-test` already `needs: build-and-push`, so it skips cleanly alongside it on non-semver releases. No new secrets or permissions.

## To actually get a versioned image

This PR stops the bleeding, but it can't backfill on its own — **the Releases list stops at `v0.7.0` (2 Apr)**, while `kg-snapshots-v8` currently holds the "Latest" badge.

One caveat worth flagging before anyone reaches for the obvious fix: **don't publish a Release for the existing `v1.1.0` tag.** It's dated 21 Apr, `main` is **159 commits ahead** of it, and the tree it points at actually contains `version = "1.0.0"` in `Cargo.toml` — the tag name and the version inside it disagree. Releasing it would build the image from April's code and move `latest` *backwards*.

The clean path is forward: bump `Cargo.toml` to `1.2.0` on `main`, tag `v1.2.0`, and publish that Release marked Latest. With this PR merged, that yields `1.2.0`, `1.2`, `1` and `latest` on GHCR from current `main` in a single step.

I've drafted full release notes covering everything since v0.7.0 (~138 commits — MVCC transactions, the vector-search HTTP API, the ADR-017 planner work, the case studies). Happy to open them as a PR or just paste them in a comment here — whichever you prefer.

Separately, it's worth publishing future data releases with **`make_latest=false`** so they stop outranking the software in the sidebar.
