### PR TITLE
chore: bump workspace version to 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "samyama"
-version = "1.1.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "samyama-cli"
-version = "1.1.0"
+version = "1.7.0"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "samyama-graph-algorithms"
-version = "1.1.0"
+version = "1.7.0"
 dependencies = [
  "ndarray",
  "rand 0.8.5",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "samyama-optimization"
-version = "1.1.0"
+version = "1.7.0"
 dependencies = [
  "criterion",
  "ndarray",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "samyama-sdk"
-version = "1.1.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "ndarray",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["sdk/python"]
 
 [package]
 name = "samyama"
-version = "1.1.0"
+version = "1.7.0"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "High-performance distributed graph database with OpenCypher support"
@@ -81,18 +81,18 @@ flate2 = "1.0"
 rayon = "1.10"
 
 # Optimization Engine (Phase 7)
-samyama-optimization = { path = "crates/samyama-optimization", version = "1.1.0" }
+samyama-optimization = { path = "crates/samyama-optimization", version = "1.7.0" }
 uuid = { version = "1.8", features = ["v4"] }
 tokio-stream = "0.1"
 futures = "0.3"
-samyama-graph-algorithms = { path = "crates/samyama-graph-algorithms", version = "1.1.0" }
+samyama-graph-algorithms = { path = "crates/samyama-graph-algorithms", version = "1.7.0" }
 ndarray = "0.15"
 reqwest = { version = "0.13.1", features = ["json"] }
 
 [dev-dependencies]
 tempfile = "3.8"
 criterion = "0.5"
-samyama-sdk = { path = "crates/samyama-sdk", version = "1.1.0" }
+samyama-sdk = { path = "crates/samyama-sdk", version = "1.7.0" }
 http-body-util = "0.1"
 
 [[bench]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-cli"
-version = "1.1.0"
+version = "1.7.0"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "CLI for Samyama Graph Database"
@@ -12,7 +12,7 @@ name = "samyama-cli"
 path = "src/main.rs"
 
 [dependencies]
-samyama-sdk = { path = "../crates/samyama-sdk", version = "1.1.0" }
+samyama-sdk = { path = "../crates/samyama-sdk", version = "1.7.0" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/crates/samyama-graph-algorithms/Cargo.toml
+++ b/crates/samyama-graph-algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-graph-algorithms"
-version = "1.1.0"
+version = "1.7.0"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Graph algorithms (PageRank, WCC, BFS, Dijkstra) for Samyama Graph Database"

--- a/crates/samyama-optimization/Cargo.toml
+++ b/crates/samyama-optimization/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-optimization"
-version = "1.1.0"
+version = "1.7.0"
 edition = "2021"
 authors = ["Sandeep Kunkunuru <sandeep@samyama.ai>"]
 description = "High-performance metaheuristic optimization algorithms (Jaya, Rao, TLBO, BMR, BWR, BMWR, QOJaya, ITLBO, SAMP-Jaya, EHR-Jaya, QO-Rao, SAPHR, MO-BMR/BWR/BMWR, MO-Rao+DE, NSGA-II) in Rust."

--- a/crates/samyama-sdk/Cargo.toml
+++ b/crates/samyama-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samyama-sdk"
-version = "1.1.0"
+version = "1.7.0"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Client SDK for Samyama Graph Database — embedded and remote modes"
@@ -25,13 +25,13 @@ reqwest = { version = "0.13.1", features = ["json"] }
 thiserror = "1.0"
 
 # Core graph database (for EmbeddedClient)
-samyama = { path = "../..", version = "1.1.0" }
+samyama = { path = "../..", version = "1.7.0" }
 
 # Graph algorithms (for AlgorithmClient)
-samyama-graph-algorithms = { path = "../samyama-graph-algorithms", version = "1.1.0" }
+samyama-graph-algorithms = { path = "../samyama-graph-algorithms", version = "1.7.0" }
 
 # Optimization engine (re-exported for examples)
-samyama-optimization = { path = "../samyama-optimization", version = "1.1.0" }
+samyama-optimization = { path = "../samyama-optimization", version = "1.7.0" }
 
 # Numeric arrays (re-exported for optimization problems)
 ndarray = "0.15"

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "samyama-python"
-version = "1.1.0"
+version = "1.7.0"
 edition = "2021"
 authors = ["Samyama Graph Database Team"]
 description = "Python bindings for the Samyama Graph Database SDK"
@@ -14,6 +14,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.22", features = ["extension-module"] }
-samyama-sdk = { path = "../../crates/samyama-sdk", version = "1.1.0" }
+samyama-sdk = { path = "../../crates/samyama-sdk", version = "1.7.0" }
 tokio = { version = "1.35", features = ["rt-multi-thread"] }
 serde_json = "1.0"


### PR DESCRIPTION
## What

Bumps every workspace crate from `1.1.0` to **`1.7.0`**, so that cutting the release is a clean one-click operation and the tag name matches the version the binaries report internally.

The version follows the **calendar-based scheme** (`1.<month>.0`) — this is the **July** release, hence `1.7.0`.

## Why

`main` is currently still internally `1.1.0`, while the newest `v1.1.0` **tag** points 159 commits behind `main` and its tree actually contains `version = "1.0.0"`. Tagging a release without this bump would reproduce exactly that name/contents mismatch.

Landing this first means the release tag, the crate versions, and the published Docker tags all agree.

## Scope

Versions only — **no code, no dependency changes**. `+19 / −19` across 7 files:

| File | Spots |
|---|---|
| `Cargo.toml` | package version + 3 internal pins |
| `cli/Cargo.toml` | package version + 1 internal pin |
| `crates/samyama-graph-algorithms/Cargo.toml` | package version |
| `crates/samyama-optimization/Cargo.toml` | package version |
| `crates/samyama-sdk/Cargo.toml` | package version + 3 internal pins |
| `sdk/python/Cargo.toml` | package version + 1 internal pin |
| `Cargo.lock` | the 5 workspace members |

Third-party crates that happen to sit at `1.2.0` (`scopeguard`) or `1.7.0` (`hyper`) are deliberately **untouched** — only the 5 workspace members in the lock were edited.

## Suggested merge order

1. ~~#281 — gate Docker publishing on semver tags~~ ✅ **merged**
2. **This PR** — so the internal version matches the tag
3. Tag & publish **v1.7.0**, ticking *"Set as latest release"*

Step 3 also displaces the `kg-snapshots-v8` **dataset** currently shown as "Latest" in the sidebar, and — now that #281 has landed — pushes properly versioned GHCR tags instead of only overwriting `:latest`.

Please do **not** reuse the existing `v1.1.0` tag for a release: it predates 159 commits of `main` and would move `:latest` backwards.
