### PR TITLE
docs: add Docker Compose quickstart and troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,162 @@ It brings together graph traversal, OpenCypher-style querying, vector search, gr
 
 ### Quickstart
 
-```bash
-# Run with Docker (no Rust toolchain needed)
-docker run -d -p 6379:6379 -p 8080:8080 ghcr.io/samyama-ai/samyama-graph:latest
-```
+#### Option 1 — Run with Docker Compose
+
+**Step 1 — Prerequisites**
+
+- ✅ Docker Desktop installed and running — [Watch setup video →](https://samyama.dev/videos)
+- ✅ No AWS account or credentials needed — the image is publicly available
+
+**Step 2 — Pull the Docker image**
 
 ```bash
-# Or build from source
+docker pull public.ecr.aws/f9f6l5u4/samyama-graph:1.1.0
+```
+
+**Step 3 — Docker Compose setup**
+
+Create a clean folder, then create `docker-compose.yml` inside it.
+
+Linux & Mac:
+
+```bash
+mkdir -p samyama-graph
+cd samyama-graph
+touch docker-compose.yml
+```
+
+Windows (PowerShell):
+
+```powershell
+mkdir C:\samyama-graph
+cd C:\samyama-graph
+notepad docker-compose.yml
+```
+
+> ℹ️ Replace `<your-openai-api-key>` with your actual key. Generate one at [platform.openai.com/api-keys](https://platform.openai.com/api-keys).
+
+```yaml
+version: "3.9"
+services:
+  samyama-graph:
+    image: public.ecr.aws/f9f6l5u4/samyama-graph:1.1.0
+    container_name: samyama-graph
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+      - "8080:8080"
+    environment:
+      EMBED_ENABLED: "true"
+      EMBED_PROVIDER: openai
+      EMBED_MODEL: text-embedding-3-small
+      EMBED_API_KEY: <your-openai-api-key>
+      EMBED_DIMENSION: 1024
+    volumes:
+      - samyama-data:/app/samyama_data
+    networks:
+      - samyama-network
+networks:
+  samyama-network:
+    driver: bridge
+volumes:
+  samyama-data:
+```
+
+**Step 4 — Start the server**
+
+```bash
+docker compose up -d
+```
+
+Server will be available at http://localhost:8080
+
+**Step 5 — Verify it's running**
+
+```bash
+docker ps
+docker logs -f samyama-graph
+```
+
+You should see `samyama-graph` with status `Up`.
+
+**Step 6 — Open the visualizer**
+
+Open http://localhost:8080 in your browser.
+
+<details>
+<summary><strong>Step 7 — Optional: Load sample dataset</strong> <sub>Optional</sub></summary>
+
+**7a — Download snapshot**
+
+| Dataset | Description | File |
+|---------|-------------|------|
+| DBMS Research | Database management systems research knowledge graph | [`dbms-research.sgsnap`](https://github.com/samyama-ai/samyama-graph/releases/download/kg-snapshots-v7/dbms-research.sgsnap) |
+
+Tip: Save the file in the same folder as `docker-compose.yml` to avoid path errors.
+- Windows: `C:\samyama-graph\dbms-research.sgsnap`
+- Linux / Mac: `./samyama-graph/dbms-research.sgsnap`
+
+**7b — Create tenant**
+
+Linux & Mac:
+
+```bash
+curl -X POST http://localhost:8080/api/tenants \
+  -H "Content-Type: application/json" \
+  -d '{"id": "dbms-research", "name": "dbms-research"}'
+```
+
+Windows (PowerShell):
+
+```powershell
+curl.exe -X POST http://localhost:8080/api/tenants `
+  -H "Content-Type: application/json" `
+  -d '{"id": "dbms-research", "name": "dbms-research"}'
+```
+
+**7c — Import snapshot**
+
+Linux & Mac:
+
+```bash
+curl -X POST http://localhost:8080/api/snapshot/import \
+  -F "file=@./samyama-graph/dbms-research.sgsnap" \
+  -F "tenant_id=dbms-research"
+```
+
+Windows (PowerShell):
+
+```powershell
+curl.exe -X POST http://localhost:8080/api/snapshot/import `
+  -F "file=@C:\samyama-graph\dbms-research.sgsnap" `
+  -F "tenant_id=dbms-research"
+```
+
+Note: On Windows always use `curl.exe` — PowerShell's `curl` alias does not support `-F`.
+
+</details>
+
+**Step 8 — Stop / reset**
+
+Stop the server:
+
+```bash
+docker compose down
+```
+
+Reset all data (⚠️ deletes volume):
+
+```bash
+docker compose down -v
+```
+
+⚠️ This deletes all graph data stored in the Docker volume.
+
+#### Option 2 — Build from source
+
+```bash
+# Build from source
 git clone https://github.com/samyama-ai/samyama-graph && cd samyama-graph
 cargo build --release
 ./target/release/samyama    # RESP on :6379, HTTP on :8080
@@ -341,6 +490,7 @@ samyama
 | LDBC Results | [docs/ldbc/](docs/ldbc/) |
 | Architecture Decisions | [docs/ADR/](docs/ADR/) |
 | API Spec | [api/openapi.yaml](api/openapi.yaml) |
+| Troubleshooting & Support | [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) |
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,93 @@
+# Troubleshooting
+
+<details>
+<summary>▼ <strong>Troubleshooting</strong></summary>
+
+<details>
+<summary><strong>Issue 1 — Embedding not configured / Vector search not working</strong></summary>
+
+> If you see `Embedding pipeline not configured` or vector / semantic search returns no results, set the embed config manually on the tenant.
+
+Linux & Mac:
+
+```bash
+curl -X PATCH http://localhost:8080/api/tenants/dbms-research \
+  -H "Content-Type: application/json" \
+  -d '{"embed_config":{"provider":"OpenAI","embedding_model":"text-embedding-3-small","api_key":"<your-openai-api-key>","chunk_size":512,"chunk_overlap":50,"vector_dimension":1024,"embedding_policies":{}}}'
+```
+
+Windows (PowerShell):
+
+```powershell
+curl.exe -X PATCH http://localhost:8080/api/tenants/dbms-research `
+  -H "Content-Type: application/json" `
+  -d '{"embed_config":{"provider":"OpenAI","embedding_model":"text-embedding-3-small","api_key":"<your-openai-api-key>","chunk_size":512,"chunk_overlap":50,"vector_dimension":1024,"embedding_policies":{}}}'
+```
+
+Notes:
+- Replace `<your-openai-api-key>` with your actual OpenAI API key.
+- This must be re-applied every time the container is restarted.
+
+</details>
+
+<details>
+<summary><strong>Issue 2 — Container exits immediately</strong></summary>
+
+> Check the container logs:
+
+```bash
+docker logs -f samyama-graph
+```
+
+Note: Common causes: invalid API key, port already in use, or missing environment variables.
+
+</details>
+
+<details>
+<summary><strong>Issue 3 — Port already in use</strong></summary>
+
+> If ports 6379 or 8080 are already occupied, find the conflicting process:
+
+Linux & Mac:
+
+```bash
+lsof -i :8080
+```
+
+Windows (PowerShell):
+
+```powershell
+netstat -ano | findstr :8080
+```
+
+Note: Stop the conflicting process, or change the host port in `docker-compose.yml` — for example replace `"8080:8080"` with `"8081:8080"`.
+
+</details>
+
+<details>
+<summary><strong>Issue 4 — Image fails to pull</strong></summary>
+
+```bash
+docker pull public.ecr.aws/f9f6l5u4/samyama-graph:1.1.0
+```
+
+Note: Ensure Docker Desktop is running and you have an active internet connection. The image is public — no credentials are required.
+
+</details>
+
+</details>
+
+<details>
+<summary>▼ <strong>Contact & Support</strong></summary>
+
+### Need help?
+
+For questions, issues, or feedback, reach us through any of the channels below.
+
+| Channel | Link |
+|---------|------|
+| GitHub Issues | [github.com/samyama-ai/samyama-graph/issues](https://github.com/samyama-ai/samyama-graph/issues) |
+| Email | [enquiry@samyama.ai](mailto:enquiry@samyama.ai) |
+| Website | [samyama.ai](https://samyama.ai) |
+
+</details>

--- a/scripts/download_ldbc_snb.sh
+++ b/scripts/download_ldbc_snb.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Download the LDBC SNB Interactive SF1 dataset (CsvBasic, LongDateFormatter).
+#
+# Used by:
+#   examples/ldbc_loader.rs
+#   benches/ldbc_benchmark.rs     (SNB Interactive: IS1-IS7, IC1-IC14, INS1-INS8, DEL1-DEL8)
+#   benches/ldbc_bi_benchmark.rs  (SNB Business Intelligence: BI-1 through BI-20)
+#
+# All three expect the extracted dataset at:
+#   data/ldbc-sf1/social_network-sf1-CsvBasic-LongDateFormatter/
+#
+# Usage:
+#   ./scripts/download_ldbc_snb.sh                     # Download to default location
+#   ./scripts/download_ldbc_snb.sh /custom/data/dir     # Download to custom location
+#
+# After downloading, run:
+#   cargo run --release --example ldbc_loader -- --query
+#   cargo bench --bench ldbc_benchmark -- --runs 3
+#   cargo bench --bench ldbc_bi_benchmark -- --runs 3
+
+set -euo pipefail
+
+DATA_DIR="${1:-data/ldbc-sf1}"
+DATASET_NAME="social_network-sf1-CsvBasic-LongDateFormatter"
+ARCHIVE_URL="https://datasets.ldbcouncil.org/snb-interactive-v1/${DATASET_NAME}.tar.zst"
+ARCHIVE_PATH="${DATA_DIR}/${DATASET_NAME}.tar.zst"
+EXTRACT_DIR="${DATA_DIR}/${DATASET_NAME}"
+
+echo "================================================================"
+echo "  LDBC SNB Interactive SF1 Dataset Downloader — Samyama"
+echo "================================================================"
+echo ""
+echo "  Target directory: ${EXTRACT_DIR}"
+echo ""
+
+# ── Check if data already exists ─────────────────────────────────────
+if [ -d "${EXTRACT_DIR}/static" ] && [ -d "${EXTRACT_DIR}/dynamic" ]; then
+    echo "  [SKIP] SNB SF1 data already exists at ${EXTRACT_DIR}"
+    echo ""
+    echo "  To re-download, remove the directory first:"
+    echo "    rm -rf ${EXTRACT_DIR}"
+    echo ""
+    echo "  To run the benchmarks:"
+    echo "    cargo bench --bench ldbc_benchmark -- --runs 3"
+    echo "    cargo bench --bench ldbc_bi_benchmark -- --runs 3"
+    exit 0
+fi
+
+mkdir -p "${DATA_DIR}"
+
+# ── Download ─────────────────────────────────────────────────────────
+if ! command -v curl &>/dev/null; then
+    echo "  ERROR: 'curl' not found. Install curl and re-run."
+    exit 1
+fi
+
+echo "  Downloading ${DATASET_NAME}.tar.zst (~220MB compressed)..."
+echo "    ${ARCHIVE_URL}"
+echo ""
+
+curl --location \
+     --continue-at - \
+     --retry 5 \
+     --retry-delay 10 \
+     --retry-connrefused \
+     --retry-all-errors \
+     -o "${ARCHIVE_PATH}" \
+     "${ARCHIVE_URL}"
+
+echo ""
+echo "  Downloaded: $(du -h "${ARCHIVE_PATH}" | cut -f1)"
+echo ""
+
+# ── Extract ──────────────────────────────────────────────────────────
+echo "  Extracting..."
+
+if command -v zstd &>/dev/null && command -v tar &>/dev/null; then
+    # Standard path: native zstd + tar
+    tar -xv --use-compress-program=unzstd -f "${ARCHIVE_PATH}" -C "${DATA_DIR}"
+elif command -v 7z &>/dev/null; then
+    # Fallback for systems without zstd (e.g. Windows/Git Bash): 7z handles
+    # .zst decompression; pipe the decompressed tar stream into a second 7z
+    # invocation to unpack it, since 7z doesn't do both in one step.
+    ( cd "${DATA_DIR}" && 7z x -aoa "$(basename "${ARCHIVE_PATH}")" -so | 7z x -aoa -si -ttar -o. )
+else
+    echo "  ERROR: Need either 'zstd' (with 'tar') or '7z' to extract this archive."
+    echo "    Install zstd: apt install zstd (Linux) / brew install zstd (macOS) / scoop install zstd (Windows)"
+    echo "    Or install 7-Zip: https://www.7-zip.org/"
+    exit 1
+fi
+
+# ── Verify ───────────────────────────────────────────────────────────
+echo ""
+echo "================================================================"
+echo "  Dataset Summary"
+echo "================================================================"
+echo ""
+
+if [ -d "${EXTRACT_DIR}/static" ] && [ -d "${EXTRACT_DIR}/dynamic" ]; then
+    total_size=$(du -sh "${EXTRACT_DIR}" | cut -f1)
+    echo "  Extracted to: ${EXTRACT_DIR}"
+    echo "  Total size:   ${total_size}"
+    echo ""
+    echo "  Cleaning up archive..."
+    rm -f "${ARCHIVE_PATH}"
+    echo ""
+    echo "================================================================"
+    echo "  Download complete!"
+    echo ""
+    echo "  Run the loader / benchmarks:"
+    echo "    cargo run --release --example ldbc_loader -- --query"
+    echo "    cargo bench --bench ldbc_benchmark -- --runs 3"
+    echo "    cargo bench --bench ldbc_bi_benchmark -- --runs 3"
+    echo "================================================================"
+else
+    echo "  WARNING: Expected 'static/' and 'dynamic/' not found after extraction."
+    echo "  Contents of ${DATA_DIR}:"
+    ls -la "${DATA_DIR}/" 2>/dev/null || echo "    (directory not found)"
+    exit 1
+fi


### PR DESCRIPTION

PR description:
## Summary
- Rework the README Quickstart into two clearly labeled options: **Option 1** — Docker Compose (prerequisites, pulling the public ECR image, generating a compose file per-OS, starting/verifying the server, opening the visualizer, and an optional step to load the `dbms-research` sample snapshot), **Option 2** — the existing build-from-source + Redis client flow.
- Add `docs/TROUBLESHOOTING.md` with collapsible sections for common issues (embedding not configured, container exits immediately, port conflicts, image pull failures) plus a Contact & Support section (GitHub Issues, email, website).
- Link the new troubleshooting doc from the README Documentation table.

## Test plan
- [ ] Preview README.md and docs/TROUBLESHOOTING.md rendering on GitHub (collapsible `<details>` sections expand/collapse correctly)
- [ ] Verify all links resolve (video, OpenAI API keys page, GitHub issues, email, website)
- [ ] Manually walk through the Docker Compose steps end-to-end on Linux/Mac and Windows to confirm commands are accurate
