### PR TITLE
docs: point quickstart step 6 to the Samyama cloud visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,15 @@ docker logs -f samyama-graph
 
 You should see `samyama-graph` with status `Up`.
 
-**Step 6 — Open the visualizer**
+**Step 6 — Samyama Visualizer**
 
-Open http://localhost:8080 in your browser.
+Visualize your imported graph data using the Samyama cloud visualizer at https://graph.samyama.cloud/
+
+1. Open https://graph.samyama.cloud/ in your browser.
+2. Sign up for a new account, or sign in if you already have one.
+3. From the left sidebar, click **Home**.
+4. In the connection field, enter your local graph server URL: `http://localhost:8080`.
+5. Click **Connect** — the status will change to **Connected**.
 
 <details>
 <summary><strong>Step 7 — Optional: Load sample dataset</strong> <sub>Optional</sub></summary>


### PR DESCRIPTION
PR description:
## Summary
- Update README Quickstart Step 6 to walk through connecting the Samyama cloud visualizer (https://graph.samyama.cloud/) to a local server, instead of pointing users at `http://localhost:8080`.
- Numbered steps: open the visualizer, sign up/sign in, go to Home, enter `http://localhost:8080` as the connection URL, click Connect.

## Test plan
- [ ] Preview README.md rendering on GitHub
- [ ] Manually follow the steps against a running local server to confirm the visualizer connects successfully