### PR TITLE
docs: add v1.7.0 release notes

### DIFF
--- a/docs/release-notes/1.7.0.md
+++ b/docs/release-notes/1.7.0.md
@@ -1,0 +1,31 @@
+# Release Notes — v1.7.0
+
+**Date:** 2026-07-20
+
+## Added
+
+- **IMDB Movies knowledge graph case study** — [`case_studies/imdb-movies`](../../case_studies/imdb-movies)
+  - Scale: 1,940,360 nodes · 2,634,125 edges (49.8 MB snapshot)
+  - Node labels: Movie, Person, AlternateTitle, Series, Rating, Genre
+  - Relationships: `HAS_ALTERNATE_TITLE`, `ACTED_IN`, `DIRECTED`, `WROTE`, `PRODUCED`, `HAS_RATING`, `HAS_GENRE`
+  - Highlight: director–actor collaboration network as a first-class queryable structure
+  - Source: [IMDB Non-Commercial Datasets](https://developer.imdb.com/non-commercial-datasets/)
+  - Snapshot: `imdb.sgsnap`, published on [`kg-snapshots-v8`](https://github.com/samyama-ai/samyama-graph/releases/tag/kg-snapshots-v8)
+
+- **Football (World Cup) knowledge graph case study** — [`case_studies/football`](../../case_studies/football)
+  - Scale: 16,150 nodes · 12,384 edges (0.4 MB snapshot)
+  - Node labels: Player, Manager, Goal, Stadium, Team, Match, Country, Tournament
+  - Relationships: `SCORED_IN`, `SCORED_BY`, `IN_TOURNAMENT`, `HOME_TEAM`, `AWAY_TEAM`, `PLAYED_AT`, `HOSTED_BY`, `FROM`
+  - Source: [DataHub World Cup Datasets](https://datahub.io/football/worldcup) (Open Data Commons PDDL)
+  - Snapshot: `football.sgsnap`, published on [`kg-snapshots-v8`](https://github.com/samyama-ai/samyama-graph/releases/tag/kg-snapshots-v8)
+
+- **[`docs/TROUBLESHOOTING.md`](../TROUBLESHOOTING.md)** — embedding configuration, container startup issues, port conflicts, and image pull failures, plus support contact channels.
+
+## Changed
+
+- README Quickstart reworked into two options: Docker Compose walkthrough (prerequisites, image pull, compose file, start/verify, optional sample dataset import) and build-from-source.
+- Samyama Visualizer connection steps updated for [graph.samyama.cloud](https://graph.samyama.cloud/).
+
+## Links
+
+- [Full diff on GitHub](https://github.com/samyama-ai/samyama-graph/compare/v1.1.0...v1.7.0)


### PR DESCRIPTION
## Summary
- Add `docs/release-notes/1.7.0.md` documenting what's shipping in v1.7.0: the IMDB Movies and Football knowledge graph case studies, `docs/TROUBLESHOOTING.md`, and the reworked README Quickstart (Docker Compose walkthrough + visualizer connection steps).

## Test plan
- [ ] Preview docs/release-notes/1.7.0.md rendering on GitHub
- [ ] Verify all links resolve (case study folders, kg-snapshots-v8 release, compare URL)