### PR TITLE
docs: point quickstart at GHCR 1.7.0 and make the version badge dynamic

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     <strong>The graph database that queried 1 billion edges for $2.50</strong>
   </p>
   <p align="center">
-    <a href="https://github.com/samyama-ai/samyama-graph/releases"><img src="https://img.shields.io/badge/version-1.1.0-blue" alt="Version"></a>
+    <a href="https://github.com/samyama-ai/samyama-graph/releases"><img src="https://img.shields.io/github/v/release/samyama-ai/samyama-graph?label=version&color=blue" alt="Version"></a>
     <a href="https://github.com/samyama-ai/samyama-graph/actions"><img src="https://img.shields.io/badge/tests-2238_passing-brightgreen" alt="Tests"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache_2.0-blue" alt="License"></a>
     <a href="https://graph.samyama.cloud/book/"><img src="https://img.shields.io/badge/book-read_the_docs-orange" alt="Book"></a>
@@ -31,12 +31,12 @@ It brings together graph traversal, OpenCypher-style querying, vector search, gr
 **Step 1 — Prerequisites**
 
 - ✅ Docker Desktop installed and running — [Watch setup video →](https://samyama.dev/videos)
-- ✅ No AWS account or credentials needed — the image is publicly available
+- ✅ No account or credentials needed — the image is public on GitHub Container Registry
 
 **Step 2 — Pull the Docker image**
 
 ```bash
-docker pull public.ecr.aws/f9f6l5u4/samyama-graph:1.1.0
+docker pull ghcr.io/samyama-ai/samyama-graph:1.7.0
 ```
 
 **Step 3 — Docker Compose setup**
@@ -65,7 +65,7 @@ notepad docker-compose.yml
 version: "3.9"
 services:
   samyama-graph:
-    image: public.ecr.aws/f9f6l5u4/samyama-graph:1.1.0
+    image: ghcr.io/samyama-ai/samyama-graph:1.7.0
     container_name: samyama-graph
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Why

The README quickstart pulls `public.ecr.aws/f9f6l5u4/samyama-graph:1.1.0`, but our **CI publishes to GHCR, not ECR**. Two registries with entirely separate update paths, which is why the documented quickstart has drifted six releases behind.

Verified tags as of today:

| Registry | Tags |
|---|---|
| `ghcr.io/samyama-ai/samyama-graph` | `latest`, `1.7.0`, `1.7`, `1` |
| `public.ecr.aws/f9f6l5u4/samyama-graph` | `1.1.0` only |

The v1.7.0 **Publish Docker Image** run succeeded, so `1.7.0` is now on GHCR as a proper multi-arch index (`linux/amd64` + `linux/arm64`), and `latest` resolves to the same digest. Pointing the quickstart at GHCR means it now tracks the registry releases actually go to, instead of going stale on every release.

This also matters right now because our [Dev.to launch post](https://dev.to/samyama-ai/your-graphrag-stack-is-two-databases-it-should-be-one-31c6) tells readers to run the GHCR image — as written, anyone following the post to this repo hits contradictory instructions on arrival.

## What changed

- `docker pull` and the Compose `image:` → `ghcr.io/samyama-ai/samyama-graph:1.7.0`
- Prerequisite line no longer says "No AWS account" (no longer an AWS image)
- Version badge `version-1.1.0` (hardcoded) → `img.shields.io/github/v/release/...`, so it reads the latest release and cannot drift again

4 lines. No other content touched.

## Note for maintainers

If ECR is meant to stay the canonical distribution channel, the fix is the other direction — publish versioned images to ECR from CI — and I'm happy to close this and open that instead. Either way the two should stop disagreeing.