### PR TITLE
fix(planner): normalize reversed predicates, support any-node anchor s…

### DIFF
--- a/benches/ldbc_benchmark.rs
+++ b/benches/ldbc_benchmark.rs
@@ -62,7 +62,7 @@ fn ldbc_queries() -> Vec<LdbcQuery> {
             name: "Person Profile",
             category: "short",
             cypher: "\
-MATCH (p:Person {id: 2435})
+MATCH (p:Person {id: 933})
 RETURN p.firstName, p.lastName, p.birthday, p.locationIP, p.browserUsed, p.gender, p.creationDate",
         },
 
@@ -72,7 +72,7 @@ RETURN p.firstName, p.lastName, p.birthday, p.locationIP, p.browserUsed, p.gende
             category: "short",
             // Adapted: query Posts only (Comment variant would be a separate UNION)
             cypher: "\
-MATCH (p:Person {id: 2435})<-[:HAS_CREATOR]-(m:Post)
+MATCH (p:Person {id: 933})<-[:HAS_CREATOR]-(m:Post)
 RETURN m.id, m.content, m.creationDate
 ORDER BY m.creationDate DESC
 LIMIT 10",
@@ -83,7 +83,7 @@ LIMIT 10",
             name: "Friends of Person",
             category: "short",
             cypher: "\
-MATCH (p:Person {id: 2435})-[:KNOWS]-(friend:Person)
+MATCH (p:Person {id: 933})-[:KNOWS]-(friend:Person)
 RETURN friend.id, friend.firstName, friend.lastName
 ORDER BY friend.firstName, friend.lastName",
         },
@@ -139,7 +139,7 @@ LIMIT 20",
             category: "complex",
             // Friends up to distance 3 with a given first name
             cypher: "\
-MATCH (p:Person {id: 2435})-[:KNOWS*1..3]-(friend:Person {firstName: \"Mahinda\"})
+MATCH (p:Person {id: 933})-[:KNOWS*1..3]-(friend:Person {firstName: \"Mahinda\"})
 WHERE friend.id <> 933
 RETURN DISTINCT friend.id, friend.lastName, friend.birthday, friend.creationDate,
        friend.gender, friend.browserUsed, friend.locationIP
@@ -153,7 +153,7 @@ LIMIT 20",
             category: "complex",
             // Recent posts by direct friends
             cypher: "\
-MATCH (p:Person {id: 2435})-[:KNOWS]-(friend:Person)<-[:HAS_CREATOR]-(m:Post)
+MATCH (p:Person {id: 933})-[:KNOWS]-(friend:Person)<-[:HAS_CREATOR]-(m:Post)
 WHERE m.creationDate < 1354320000000
 RETURN friend.id, friend.firstName, friend.lastName,
        m.id, m.content, m.creationDate
@@ -167,7 +167,7 @@ LIMIT 20",
             category: "complex",
             // Friends who posted in two given countries within a date range
             cypher: "\
-MATCH (p:Person {id: 2435})-[:KNOWS*1..2]-(friend:Person)
+MATCH (p:Person {id: 933})-[:KNOWS*1..2]-(friend:Person)
 WHERE friend.id <> 933
 WITH DISTINCT friend
 MATCH (friend)<-[:HAS_CREATOR]-(m:Post)-[:IS_LOCATED_IN]->(place:Place)
@@ -184,7 +184,7 @@ LIMIT 20",
             category: "complex",
             // Tags on posts created by friends within a date window
             cypher: "\
-MATCH (p:Person {id: 2435})-[:KNOWS]-(friend:Person)<-[:HAS_CREATOR]-(post:Post)-[:HAS_TAG]->(tag:Tag)
+MATCH (p:Person {id: 933})-[:KNOWS]-(friend:Person)<-[:HAS_CREATOR]-(post:Post)-[:HAS_TAG]->(tag:Tag)
 WHERE post.creationDate >= 1338508800000 AND post.creationDate < 1341100800000
 RETURN tag.name, count(post) AS postCount
 ORDER BY postCount DESC
@@ -197,7 +197,7 @@ LIMIT 10",
             category: "complex",
             // Forums joined by friends-of-friends after a given date
             cypher: "\
-MATCH (p:Person {id: 2435})-[:KNOWS*1..2]-(friend:Person)
+MATCH (p:Person {id: 933})-[:KNOWS*1..2]-(friend:Person)
 WHERE friend.id <> 933
 WITH DISTINCT friend
 MATCH (friend)<-[:HAS_MEMBER]-(forum:Forum)
@@ -212,7 +212,7 @@ LIMIT 20",
             category: "complex",
             // Tags that co-occur with a given tag on posts by friends-of-friends
             cypher: "\
-MATCH (p:Person {id: 2435})-[:KNOWS*1..2]-(friend:Person)<-[:HAS_CREATOR]-(post:Post)-[:HAS_TAG]->(tag:Tag {name: \"Hamid_Karzai\"})
+MATCH (p:Person {id: 933})-[:KNOWS*1..2]-(friend:Person)<-[:HAS_CREATOR]-(post:Post)-[:HAS_TAG]->(tag:Tag {name: \"Hamid_Karzai\"})
 WHERE friend.id <> 933
 WITH DISTINCT post
 MATCH (post)-[:HAS_TAG]->(otherTag:Tag)
@@ -228,7 +228,7 @@ LIMIT 10",
             category: "complex",
             // People who liked a person's posts, with recency
             cypher: "\
-MATCH (p:Person {id: 2435})<-[:HAS_CREATOR]-(m:Post)<-[:LIKES]-(liker:Person)
+MATCH (p:Person {id: 933})<-[:HAS_CREATOR]-(m:Post)<-[:LIKES]-(liker:Person)
 RETURN liker.id, liker.firstName, liker.lastName, m.id, m.creationDate
 ORDER BY m.creationDate DESC
 LIMIT 20",
@@ -240,7 +240,7 @@ LIMIT 20",
             category: "complex",
             // Recent reply-comments to a person's posts
             cypher: "\
-MATCH (p:Person {id: 2435})<-[:HAS_CREATOR]-(m:Post)<-[:REPLY_OF]-(c:Comment)-[:HAS_CREATOR]->(author:Person)
+MATCH (p:Person {id: 933})<-[:HAS_CREATOR]-(m:Post)<-[:REPLY_OF]-(c:Comment)-[:HAS_CREATOR]->(author:Person)
 RETURN author.id, author.firstName, author.lastName, c.creationDate, c.id, c.content
 ORDER BY c.creationDate DESC
 LIMIT 20",
@@ -252,7 +252,7 @@ LIMIT 20",
             category: "complex",
             // Recent posts by friends-of-friends
             cypher: "\
-MATCH (p:Person {id: 2435})-[:KNOWS*1..2]-(friend:Person)<-[:HAS_CREATOR]-(m:Post)
+MATCH (p:Person {id: 933})-[:KNOWS*1..2]-(friend:Person)<-[:HAS_CREATOR]-(m:Post)
 WHERE friend.id <> 933 AND m.creationDate < 1354320000000
 RETURN DISTINCT friend.id, friend.firstName, friend.lastName,
        m.id, coalesce(m.content, m.imageFile), m.creationDate
@@ -266,7 +266,7 @@ LIMIT 20",
             category: "complex",
             // Full LDBC IC10: friends-of-friends NOT already friends, ranked by shared interests
             cypher: "\
-MATCH (p:Person {id: 2435})-[:KNOWS*2]-(stranger:Person)
+MATCH (p:Person {id: 933})-[:KNOWS*2]-(stranger:Person)
 WHERE stranger.id <> 933 AND NOT EXISTS { MATCH (p)-[:KNOWS]-(stranger) }
 WITH DISTINCT stranger
 MATCH (stranger)-[:HAS_INTEREST]->(tag:Tag)
@@ -281,7 +281,7 @@ LIMIT 10",
             category: "complex",
             // Friends-of-friends who worked at a company before a given year
             cypher: "\
-MATCH (p:Person {id: 2435})-[:KNOWS*1..2]-(friend:Person)-[wa:WORK_AT]->(org:Organisation)
+MATCH (p:Person {id: 933})-[:KNOWS*1..2]-(friend:Person)-[wa:WORK_AT]->(org:Organisation)
 WHERE friend.id <> 933 AND org.name = \"MDLR_Airlines\" AND wa.workFrom < 2012
 RETURN DISTINCT friend.id, friend.firstName, friend.lastName, wa.workFrom, org.name
 ORDER BY wa.workFrom
@@ -294,7 +294,7 @@ LIMIT 10",
             category: "complex",
             // Full LDBC IC12: friends who replied to posts tagged with a given tag class, count distinct replies
             cypher: "\
-MATCH (p:Person {id: 2435})-[:KNOWS]-(friend:Person)<-[:HAS_CREATOR]-(c:Comment)-[:REPLY_OF]->(post:Post)-[:HAS_TAG]->(tag:Tag)-[:HAS_TYPE]->(tc:TagClass)
+MATCH (p:Person {id: 933})-[:KNOWS]-(friend:Person)<-[:HAS_CREATOR]-(c:Comment)-[:REPLY_OF]->(post:Post)-[:HAS_TAG]->(tag:Tag)-[:HAS_TYPE]->(tc:TagClass)
 WHERE tc.name = \"MusicalArtist\"
 RETURN friend.id, friend.firstName, friend.lastName, count(DISTINCT c) AS replyCount
 ORDER BY replyCount DESC
@@ -307,7 +307,7 @@ LIMIT 10",
             name: "Single Shortest Path",
             category: "complex",
             cypher: "\
-MATCH p = shortestPath((p1:Person {id: 2435})-[:KNOWS*]-(p2:Person {id: 4139}))
+MATCH p = shortestPath((p1:Person {id: 933})-[:KNOWS*]-(p2:Person {id: 4139}))
 RETURN length(p) AS pathLength",
         },
 
@@ -317,7 +317,7 @@ RETURN length(p) AS pathLength",
             name: "Trusted Connection Paths",
             category: "complex",
             cypher: "\
-MATCH p = allShortestPaths((p1:Person {id: 2435})-[:KNOWS*]-(p2:Person {id: 4139}))
+MATCH p = allShortestPaths((p1:Person {id: 933})-[:KNOWS*]-(p2:Person {id: 4139}))
 RETURN length(p) AS pathLength, nodes(p) AS pathNodes",
         },
     ]
@@ -361,7 +361,7 @@ CREATE (f:Forum {id: 999998, title: \"Benchmark Forum\", creationDate: 170925120
             name: "Add Forum Member",
             category: "update",
             cypher: "\
-MATCH (f:Forum {id: 999998}), (p:Person {id: 2435})
+MATCH (f:Forum {id: 999998}), (p:Person {id: 933})
 CREATE (f)-[:HAS_MEMBER {joinDate: 1709251200000}]->(p)",
         },
         LdbcQuery {
@@ -383,7 +383,7 @@ CREATE (c:Comment {id: 999996, creationDate: 1709251200000, locationIP: \"1.2.3.
             name: "Add Friendship",
             category: "update",
             cypher: "\
-MATCH (p1:Person {id: 2435}), (p2:Person {id: 999999})
+MATCH (p1:Person {id: 933}), (p2:Person {id: 999999})
 CREATE (p1)-[:KNOWS {creationDate: 1709251200000}]->(p2)",
         },
     ]
@@ -410,7 +410,7 @@ DETACH DELETE p",
             name: "Delete Like (Post)",
             category: "delete",
             cypher: "\
-MATCH (p:Person {id: 2435})-[l:LIKES]->(m:Post {id: 1236950581248})
+MATCH (p:Person {id: 933})-[l:LIKES]->(m:Post {id: 1236950581248})
 DELETE l",
         },
         // DEL-3: Remove LIKES edge from Person to Comment
@@ -419,7 +419,7 @@ DELETE l",
             name: "Delete Like (Comment)",
             category: "delete",
             cypher: "\
-MATCH (p:Person {id: 2435})-[l:LIKES]->(c:Comment {id: 1236950581249})
+MATCH (p:Person {id: 933})-[l:LIKES]->(c:Comment {id: 1236950581249})
 DELETE l",
         },
         // DEL-4: Remove a Forum (cascading via DETACH DELETE)
@@ -437,7 +437,7 @@ DETACH DELETE f",
             name: "Delete Forum Member",
             category: "delete",
             cypher: "\
-MATCH (f:Forum {id: 999998})-[m:HAS_MEMBER]->(p:Person {id: 2435})
+MATCH (f:Forum {id: 999998})-[m:HAS_MEMBER]->(p:Person {id: 933})
 DELETE m",
         },
         // DEL-6: Remove a Post (cascading via DETACH DELETE)
@@ -464,7 +464,7 @@ DETACH DELETE c",
             name: "Delete Friendship",
             category: "delete",
             cypher: "\
-MATCH (p1:Person {id: 2435})-[k:KNOWS]->(p2:Person {id: 999999})
+MATCH (p1:Person {id: 933})-[k:KNOWS]->(p2:Person {id: 999999})
 DELETE k",
         },
     ]

--- a/src/query/executor/cost_model.rs
+++ b/src/query/executor/cost_model.rs
@@ -343,6 +343,7 @@ mod tests {
             variable: "n".to_string(),
             label: Label::new("Person"),
             property: "id".to_string(),
+            op: crate::query::ast::BinaryOp::Eq,
             value: Expression::Literal(crate::graph::PropertyValue::Integer(42)),
         };
         let cost = estimate_plan_cost(&plan, &catalog);

--- a/src/query/executor/logical_plan.rs
+++ b/src/query/executor/logical_plan.rs
@@ -43,6 +43,7 @@ pub enum LogicalPlanNode {
         variable: String,
         label: Label,
         property: String,
+        op: crate::query::ast::BinaryOp,
         value: Expression,
     },
     /// Expand from a bound node to discover new neighbors
@@ -307,6 +308,9 @@ impl LogicalPlanNode {
 pub struct PatternNode {
     pub variable: String,
     pub labels: Vec<Label>,
+    /// Inline property constraints from the pattern, e.g. `(n:Person {name: 'Alice'})`.
+    /// Treated the same as an equivalent `WHERE n.name = 'Alice'` predicate.
+    pub properties: Vec<(String, crate::graph::PropertyValue)>,
 }
 
 /// An edge in the pattern graph
@@ -348,9 +352,14 @@ impl PatternGraph {
             let start_var = path_pattern.start.variable.clone().unwrap_or_default();
             if !start_var.is_empty() {
                 let labels: Vec<Label> = path_pattern.start.labels.iter().cloned().collect();
+                let properties: Vec<(String, crate::graph::PropertyValue)> = path_pattern.start.properties
+                    .as_ref()
+                    .map(|p| p.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+                    .unwrap_or_default();
                 nodes.entry(start_var.clone()).or_insert_with(|| PatternNode {
                     variable: start_var.clone(),
                     labels,
+                    properties,
                 });
             }
 
@@ -360,9 +369,14 @@ impl PatternGraph {
                 let next_var = segment.node.variable.clone().unwrap_or_default();
                 if !next_var.is_empty() {
                     let labels: Vec<Label> = segment.node.labels.iter().cloned().collect();
+                    let properties: Vec<(String, crate::graph::PropertyValue)> = segment.node.properties
+                        .as_ref()
+                        .map(|p| p.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+                        .unwrap_or_default();
                     nodes.entry(next_var.clone()).or_insert_with(|| PatternNode {
                         variable: next_var.clone(),
                         labels,
+                        properties,
                     });
                 }
 

--- a/src/query/executor/physical_planner.rs
+++ b/src/query/executor/physical_planner.rs
@@ -7,7 +7,7 @@
 //! - ExpandInto → ExpandIntoOperator
 //! - Filter → FilterOperator
 
-use crate::query::ast::Direction;
+use crate::query::ast::{Direction, Expression};
 use super::logical_plan::{LogicalPlanNode, ExpandDirection};
 use super::operator::*;
 use super::leapfrog::{TrieJoinOperator, PhysicalTrieConstraint};
@@ -23,9 +23,22 @@ pub fn logical_to_physical(plan: &LogicalPlanNode) -> OperatorBox {
             Box::new(NodeScanOperator::new(variable.clone(), labels))
         }
 
-        LogicalPlanNode::IndexLookup { variable, label, .. } => {
-            // Fall back to label scan for now — index integration in Phase 3
-            Box::new(NodeScanOperator::new(variable.clone(), vec![label.clone()]))
+        LogicalPlanNode::IndexLookup { variable, label, property, op, value } => {
+            // The plan enumerator only ever emits IndexLookup after confirming an
+            // index exists for (label, property) and normalizing `value` to a
+            // literal (see plan_enumerator::normalize_index_predicate); by the time
+            // we reach physical planning, query parameters have already been
+            // substituted into literals as well (see executor::mod::substitute_params).
+            match value {
+                Expression::Literal(val) => Box::new(IndexScanOperator::new(
+                    variable.clone(),
+                    label.clone(),
+                    property.clone(),
+                    op.clone(),
+                    val.clone(),
+                )),
+                _ => Box::new(NodeScanOperator::new(variable.clone(), vec![label.clone()])),
+            }
         }
 
         LogicalPlanNode::Expand { input, source_var, target_var, edge_var, edge_types, direction } => {

--- a/src/query/executor/plan_enumerator.rs
+++ b/src/query/executor/plan_enumerator.rs
@@ -8,6 +8,7 @@
 use std::collections::HashSet;
 use crate::graph::catalog::GraphCatalog;
 use crate::graph::types::{Label, EdgeType};
+use crate::index::manager::IndexManager;
 use crate::query::ast::{WhereClause, Expression, BinaryOp};
 use super::cost_model::estimate_plan_cost;
 use super::logical_plan::{LogicalPlanNode, PatternGraph, PatternEdge, ExpandDirection};
@@ -35,18 +36,34 @@ pub fn enumerate_plans(
     pattern: &PatternGraph,
     where_clause: Option<&WhereClause>,
     catalog: &GraphCatalog,
+    index: &IndexManager,
     config: &EnumerationConfig,
 ) -> Vec<(LogicalPlanNode, f64)> {
     let mut candidates: Vec<(LogicalPlanNode, f64)> = Vec::new();
 
     // Flatten WHERE into individual AND predicates
-    let predicates = where_clause
+    let mut predicates = where_clause
         .map(|wc| flatten_and_predicates(&wc.predicate))
         .unwrap_or_default();
 
-    // Collect node names in deterministic order for reproducible plan enumeration
+    // Inline node properties, e.g. `(n:Person {name: 'Alice'})`, are treated as
+    // additional equality predicates so they participate in index selection the
+    // same way an equivalent WHERE clause would.
     let mut node_names: Vec<&String> = pattern.nodes.keys().collect();
     node_names.sort();
+    for var_name in &node_names {
+        let node = &pattern.nodes[*var_name];
+        for (prop, val) in &node.properties {
+            predicates.push(Expression::Binary {
+                left: Box::new(Expression::Property {
+                    variable: (*var_name).clone(),
+                    property: prop.clone(),
+                }),
+                op: BinaryOp::Eq,
+                right: Box::new(Expression::Literal(val.clone())),
+            });
+        }
+    }
 
     // For each node as a potential starting point
     for var_name in node_names {
@@ -54,7 +71,7 @@ pub fn enumerate_plans(
             break;
         }
 
-        let plan = build_plan_from_start(var_name, pattern, &predicates, catalog);
+        let plan = build_plan_from_start(var_name, pattern, &predicates, catalog, index);
         let optimized = optimize(plan);
         let cost = estimate_plan_cost(&optimized, catalog);
         candidates.push((optimized, cost));
@@ -79,18 +96,41 @@ fn build_plan_from_start(
     pattern: &PatternGraph,
     predicates: &[Expression],
     catalog: &GraphCatalog,
+    index: &IndexManager,
 ) -> LogicalPlanNode {
     let start_node = &pattern.nodes[start_var];
-
-    // Start with a LabelScan
     let label = start_node.labels.first().cloned();
-    let mut plan = LogicalPlanNode::LabelScan {
+
+    let mut used_predicates: HashSet<usize> = HashSet::new();
+
+    // Try to satisfy the start node via an index lookup before falling back to a
+    // full LabelScan. Matches both `n.prop OP literal` and `literal OP n.prop`.
+    let mut plan = None;
+    if let Some(l) = &label {
+        for (i, pred) in predicates.iter().enumerate() {
+            if let Some((property, op, value)) = normalize_index_predicate(pred, start_var) {
+                if matches!(op, BinaryOp::Eq | BinaryOp::Gt | BinaryOp::Ge | BinaryOp::Lt | BinaryOp::Le)
+                    && index.has_index(l, &property)
+                {
+                    plan = Some(LogicalPlanNode::IndexLookup {
+                        variable: start_var.to_string(),
+                        label: l.clone(),
+                        property,
+                        op: op.clone(),
+                        value,
+                    });
+                    used_predicates.insert(i);
+                    break;
+                }
+            }
+        }
+    }
+    let mut plan = plan.unwrap_or_else(|| LogicalPlanNode::LabelScan {
         variable: start_var.to_string(),
         label,
-    };
+    });
 
     // Push any predicates that only reference the start variable
-    let mut used_predicates: HashSet<usize> = HashSet::new();
     plan = push_applicable_predicates(plan, predicates, &mut used_predicates);
 
     // BFS through the pattern — process edges, checking visited at each step
@@ -131,7 +171,7 @@ fn build_plan_from_start(
                 } else {
                     // One endpoint bound → Expand with direction choice
                     processed_edges.insert(edge_idx);
-                    let direction = choose_direction(current_var, edge, &pattern.nodes, catalog);
+                    let direction = choose_direction(current_var, edge);
 
                     // source_var is always the BOUND variable (current_var),
                     // target_var is always the NEW variable (other_var).
@@ -186,59 +226,53 @@ fn build_plan_from_start(
     plan
 }
 
-/// Choose traversal direction based on catalog statistics.
+/// Determine which adjacency list to walk to discover `other_var` from `bound_var`
+/// along `edge`.
 ///
-/// Compares avg_out_degree (forward) vs avg_in_degree (reverse) from the bound
-/// node's perspective. Picks the direction with lower expected fan-out.
-fn choose_direction(
-    bound_var: &str,
-    edge: &PatternEdge,
-    nodes: &std::collections::HashMap<String, super::logical_plan::PatternNode>,
-    catalog: &GraphCatalog,
-) -> ExpandDirection {
-    let bound_label = nodes.get(bound_var).and_then(|n| n.labels.first());
-
-    // If no edge types specified, default to forward
-    if edge.edge_types.is_empty() {
-        return if edge.source_var == bound_var {
-            ExpandDirection::Forward
-        } else {
-            ExpandDirection::Reverse
-        };
-    }
-
-    let et = &edge.edge_types[0]; // Use first edge type for estimation
-
+/// This is *not* a cost tradeoff: the edge is stored as `source_var -> target_var`,
+/// so reaching the unbound endpoint from `bound_var` has exactly one correct
+/// direction — outgoing (Forward) when `bound_var` is the edge's source, incoming
+/// (Reverse) when `bound_var` is the edge's target. Picking the other direction
+/// would traverse a semantically different adjacency list and return wrong
+/// neighbors, not merely a slower plan. The catalog-driven cost comparison that
+/// actually matters for direction — whether it's cheaper to approach this edge
+/// from its source side or its target side — happens one level up, in
+/// `enumerate_plans`, by generating a separate start-from-every-node candidate
+/// for each pattern node and letting `estimate_plan_cost` pick the cheapest.
+fn choose_direction(bound_var: &str, edge: &PatternEdge) -> ExpandDirection {
     if edge.source_var == bound_var {
-        // We're at the source — forward means outgoing
-        // Compare forward (outgoing from source) vs reverse (incoming to target)
-        let forward_cost = bound_label
-            .map(|l| catalog.estimate_expand_out(l, et))
-            .unwrap_or(1.0);
-
-        let target_label = nodes.get(&edge.target_var).and_then(|n| n.labels.first());
-        let reverse_cost = target_label
-            .map(|l| catalog.estimate_expand_in(l, et))
-            .unwrap_or(1.0);
-
-        // Forward traversal from source is the natural direction
-        // Only reverse if the reverse scan from the target label's perspective is significantly cheaper
-        // Note: reverse from source means we'd have to start from target and scan incoming
-        // This only makes sense if we're building the plan from this bound var
         ExpandDirection::Forward
     } else {
-        // We're at the target — reverse means incoming to us
-        let reverse_cost = bound_label
-            .map(|l| catalog.estimate_expand_in(l, et))
-            .unwrap_or(1.0);
-
-        let source_label = nodes.get(&edge.source_var).and_then(|n| n.labels.first());
-        let forward_cost = source_label
-            .map(|l| catalog.estimate_expand_out(l, et))
-            .unwrap_or(1.0);
-
         ExpandDirection::Reverse
     }
+}
+
+/// If `pred` is an equality/range comparison between `var`'s property and a
+/// literal, return `(property, op, literal_expr)` normalized so `op` always
+/// reads left-to-right as `var.property OP literal` — regardless of which side
+/// the property appeared on in the source query. `5 < n.age` and `n.age > 5`
+/// both normalize to `("age", Gt, 5)`.
+pub(crate) fn normalize_index_predicate(pred: &Expression, var: &str) -> Option<(String, BinaryOp, Expression)> {
+    let Expression::Binary { left, op, right } = pred else { return None };
+
+    if let (Expression::Property { variable, property }, Expression::Literal(_)) = (left.as_ref(), right.as_ref()) {
+        if variable == var {
+            return Some((property.clone(), op.clone(), (**right).clone()));
+        }
+    }
+    if let (Expression::Literal(_), Expression::Property { variable, property }) = (left.as_ref(), right.as_ref()) {
+        if variable == var {
+            let flipped = match op {
+                BinaryOp::Gt => BinaryOp::Lt,
+                BinaryOp::Ge => BinaryOp::Le,
+                BinaryOp::Lt => BinaryOp::Gt,
+                BinaryOp::Le => BinaryOp::Ge,
+                other => other.clone(),
+            };
+            return Some((property.clone(), flipped, (**left).clone()));
+        }
+    }
+    None
 }
 
 /// Push filter predicates whose variables are all bound by the current plan
@@ -373,7 +407,7 @@ mod tests {
         let pg = PatternGraph::from_match_clause(&clause);
         let config = EnumerationConfig::default();
 
-        let plans = enumerate_plans(&pg, None, &catalog, &config);
+        let plans = enumerate_plans(&pg, None, &catalog, &crate::index::manager::IndexManager::new(), &config);
         assert_eq!(plans.len(), 1);
         match &plans[0].0 {
             LogicalPlanNode::LabelScan { variable, label } => {
@@ -399,7 +433,7 @@ mod tests {
         let pg = PatternGraph::from_match_clause(&clause);
         let config = EnumerationConfig::default();
 
-        let plans = enumerate_plans(&pg, None, &catalog, &config);
+        let plans = enumerate_plans(&pg, None, &catalog, &crate::index::manager::IndexManager::new(), &config);
         // Two starting points: a and b
         assert_eq!(plans.len(), 2);
         // Both should have a cost > 0
@@ -439,7 +473,7 @@ mod tests {
         let pg = PatternGraph::from_match_clause(&clause);
         let config = EnumerationConfig::default();
 
-        let plans = enumerate_plans(&pg, None, &catalog, &config);
+        let plans = enumerate_plans(&pg, None, &catalog, &crate::index::manager::IndexManager::new(), &config);
         assert_eq!(plans.len(), 2);
         // Cheapest plan should have lower cost
         let cheapest_cost = plans[0].1;
@@ -463,7 +497,7 @@ mod tests {
         };
         let config = EnumerationConfig::default();
 
-        let plans = enumerate_plans(&pg, Some(&where_clause), &catalog, &config);
+        let plans = enumerate_plans(&pg, Some(&where_clause), &catalog, &crate::index::manager::IndexManager::new(), &config);
         assert_eq!(plans.len(), 1);
         // Plan should have a Filter node
         match &plans[0].0 {
@@ -493,7 +527,7 @@ mod tests {
         let pg = PatternGraph::from_match_clause(&clause);
         let config = EnumerationConfig::default();
 
-        let plans = enumerate_plans(&pg, None, &catalog, &config);
+        let plans = enumerate_plans(&pg, None, &catalog, &crate::index::manager::IndexManager::new(), &config);
         // Three starting points: a, b, c
         assert_eq!(plans.len(), 3);
     }
@@ -511,7 +545,7 @@ mod tests {
         let pg = PatternGraph::from_match_clause(&clause);
         let config = EnumerationConfig { max_candidate_plans: 2 };
 
-        let plans = enumerate_plans(&pg, None, &catalog, &config);
+        let plans = enumerate_plans(&pg, None, &catalog, &crate::index::manager::IndexManager::new(), &config);
         assert!(plans.len() <= 2);
     }
 
@@ -551,14 +585,17 @@ mod tests {
         pg.nodes.insert("a".to_string(), super::super::logical_plan::PatternNode {
             variable: "a".to_string(),
             labels: vec![Label::new("Person")],
+            properties: Vec::new(),
         });
         pg.nodes.insert("b".to_string(), super::super::logical_plan::PatternNode {
             variable: "b".to_string(),
             labels: vec![Label::new("Person")],
+            properties: Vec::new(),
         });
         pg.nodes.insert("c".to_string(), super::super::logical_plan::PatternNode {
             variable: "c".to_string(),
             labels: vec![Label::new("Person")],
+            properties: Vec::new(),
         });
         pg.edges.push(PatternEdge {
             source_var: "a".to_string(),
@@ -583,7 +620,7 @@ mod tests {
         });
 
         let config = EnumerationConfig::default();
-        let plans = enumerate_plans(&pg, None, &catalog, &config);
+        let plans = enumerate_plans(&pg, None, &catalog, &crate::index::manager::IndexManager::new(), &config);
 
         // After WCO optimization, ExpandInto+Expand chains become TrieJoin.
         // At least one plan should contain a TrieJoin (upgraded from ExpandInto).

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -528,7 +528,17 @@ impl QueryPlanner {
 
         // Determine split point for WITH barrier
         let split = query.with_split_index.unwrap_or(query.match_clauses.len());
-        let pre_with_clauses = &query.match_clauses[..split];
+        // Propagate node labels/inline properties for variables shared across multiple
+        // MATCH clauses in this pre-WITH group, e.g.
+        //   MATCH (m:Post {id: 1})<-[:REPLY_OF]-(c:Comment)-[:HAS_CREATOR]->(author:Person)
+        //   MATCH (m)-[:HAS_CREATOR]->(op:Person)
+        // Without this, the second clause's bare `(m)` has no known label or index
+        // predicate and each MATCH clause is planned independently, so it falls back to
+        // an unrestricted all-nodes scan even though `m` is already typed (and pinned to
+        // one id) earlier in the same query. Same variable = same node, so inheriting
+        // constraints declared anywhere in the query is correctness-preserving, not a guess.
+        let enriched_pre_with_clauses = propagate_shared_variable_labels(&query.match_clauses[..split]);
+        let pre_with_clauses: &[MatchClause] = &enriched_pre_with_clauses;
         let post_with_clauses = &query.match_clauses[split..];
 
         // Pre-compute variable sets for each pre-WITH MATCH clause
@@ -1317,7 +1327,7 @@ impl QueryPlanner {
             max_candidate_plans: self.config.max_candidate_plans,
         };
 
-        let candidates = enumerate_plans(&pg, where_clause, catalog, &config);
+        let candidates = enumerate_plans(&pg, where_clause, catalog, &store.property_index, &config);
         if candidates.is_empty() {
             return Err(ExecutionError::PlanningError("No valid plans enumerated".to_string()));
         }
@@ -1407,14 +1417,53 @@ impl QueryPlanner {
 
         for &(path_idx, _) in &paths_with_cost {
             let path = &pattern.paths[path_idx];
-            // Start with node scan for this path
-            // Auto-generate variable names for anonymous nodes (e.g., `()` in patterns)
-            let start_var = path.start.variable.clone().unwrap_or_else(|| {
-                let name = format!("_anon_{}", anon_counter);
-                anon_counter += 1;
-                name
-            });
 
+            // Build the ordered list of pattern nodes (start + each segment's node),
+            // assigning variable names in written order (including anonymous nodes).
+            // This is computed up front so anchor selection below can consider any
+            // node in the pattern, not just the first one written.
+            let mut path_nodes: Vec<PathNodeRef> = Vec::with_capacity(path.segments.len() + 1);
+            path_nodes.push(PathNodeRef {
+                var: path.start.variable.clone().unwrap_or_else(|| {
+                    let name = format!("_anon_{}", anon_counter);
+                    anon_counter += 1;
+                    name
+                }),
+                labels: path.start.labels.clone(),
+                properties: path.start.properties.clone(),
+            });
+            for segment in &path.segments {
+                path_nodes.push(PathNodeRef {
+                    var: segment.node.variable.clone().unwrap_or_else(|| {
+                        let name = format!("_anon_{}", anon_counter);
+                        anon_counter += 1;
+                        name
+                    }),
+                    labels: segment.node.labels.clone(),
+                    properties: segment.node.properties.clone(),
+                });
+            }
+            let start_var = path_nodes[0].var.clone();
+
+            // QP-05: Anchor selection — pick the cheapest node in the pattern (by index
+            // lookup or label cardinality) to start the scan from, instead of always
+            // scanning from the first written node. Traversal toward earlier-written
+            // nodes then uses reversed edge direction. Restricted to simple linear
+            // chains: no variable-length hops, no shortestPath, no named path variable
+            // (path materialization assumes forward traversal order from the start).
+            let anchor_eligible = path.path_variable.is_none()
+                && !matches!(path.path_type, PathType::Shortest | PathType::AllShortest)
+                && !path.segments.iter().any(|s| s.edge.length.is_some());
+            let anchor_idx = if anchor_eligible {
+                choose_anchor_index(&path_nodes, &per_path_preds[path_idx], store)
+            } else {
+                0
+            };
+
+            let (mut path_operator, deferred_predicates): (OperatorBox, Vec<Expression>) =
+                if anchor_eligible && anchor_idx > 0 {
+                    self.build_path_from_anchor(path, &path_nodes, anchor_idx, &per_path_preds[path_idx], store)
+                } else {
             // Merge inline start node properties into predicates for index selection.
             // Without this, {prop: val} in MATCH patterns falls back to NodeScan + Filter
             // instead of IndexScan. See ADR-015 for context.
@@ -1431,55 +1480,20 @@ impl QueryPlanner {
                 }
             }
 
-            // Optimization: Check for index usage (using this path's assigned predicates)
-            let mut index_op: Option<OperatorBox> = None;
-            let mut remaining_predicates: Vec<Expression> = Vec::new();
+            // Optimization: Check for index usage (using this path's assigned predicates).
+            // Recognizes both `n.prop OP literal` and `literal OP n.prop` operand orders.
+            let mut remaining_predicates: Vec<Expression> = per_path_preds[path_idx].clone();
+            let mut path_operator: OperatorBox = if let Some((idx, label, property, op, val)) =
+                find_index_predicate(&start_var, &path.start.labels, &remaining_predicates, store)
             {
-                let predicates = &per_path_preds[path_idx];
-                let mut used_index = false;
-
-                for pred in predicates {
-                    if used_index {
-                        // Already found an index — push remaining predicates to filter
-                        remaining_predicates.push(pred.clone());
-                        continue;
-                    }
-                    if let Expression::Binary { left, op, right } = pred {
-                        if let (Expression::Property { variable, property }, Expression::Literal(val)) = (left.as_ref(), right.as_ref()) {
-                            if variable == &start_var {
-                                for label in &path.start.labels {
-                                    if store.property_index.has_index(label, property) {
-                                        match op {
-                                            BinaryOp::Eq | BinaryOp::Gt | BinaryOp::Ge | BinaryOp::Lt | BinaryOp::Le => {
-                                                index_op = Some(Box::new(IndexScanOperator::new(
-                                                    start_var.clone(),
-                                                    label.clone(),
-                                                    property.clone(),
-                                                    op.clone(),
-                                                    val.clone()
-                                                )));
-                                                used_index = true;
-                                            },
-                                            _ => {}
-                                        }
-                                        if used_index { break; }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    if !used_index {
-                        remaining_predicates.push(pred.clone());
-                    }
-                }
-            }
-
-            let mut path_operator = index_op.unwrap_or_else(|| {
+                remaining_predicates.remove(idx);
+                Box::new(IndexScanOperator::new(start_var.clone(), label, property, op, val))
+            } else {
                 Box::new(NodeScanOperator::new(
                     start_var.clone(),
                     path.start.labels.clone(),
                 ))
-            });
+            };
 
             // Note: start node inline properties are already merged into per_path_preds
             // above, so they're handled via IndexScan or remaining_predicates Filter.
@@ -1554,12 +1568,8 @@ impl QueryPlanner {
             } else {
                 // Normal path: use ExpandOperator for each segment
                 let mut current_var = start_var.clone();
-                for segment in &path.segments {
-                    let target_var = segment.node.variable.clone().unwrap_or_else(|| {
-                        let name = format!("_anon_{}", anon_counter);
-                        anon_counter += 1;
-                        name
-                    });
+                for (seg_idx, segment) in path.segments.iter().enumerate() {
+                    let target_var = path_nodes[seg_idx + 1].var.clone();
 
                     let edge_var = segment.edge.variable.clone();
                     let edge_types: Vec<String> = segment.edge.types.iter()
@@ -1629,6 +1639,8 @@ impl QueryPlanner {
                     current_var = target_var;
                 }
             }
+                    (path_operator, deferred_predicates)
+                };
 
             // Apply deferred WHERE predicates after all path expansions
             if !deferred_predicates.is_empty() {
@@ -1680,6 +1692,117 @@ impl QueryPlanner {
         }
 
         Ok(result)
+    }
+
+    /// Build a path plan anchored at `nodes[anchor_idx]` instead of the pattern's first
+    /// node. Traverses backward (reversed edge direction) toward earlier-written nodes
+    /// and forward (written direction) toward later-written nodes. Only invoked when
+    /// `choose_anchor_index` found a cheaper starting point than the first node.
+    fn build_path_from_anchor(
+        &self,
+        path: &PathPattern,
+        nodes: &[PathNodeRef],
+        anchor_idx: usize,
+        path_preds: &[Expression],
+        store: &GraphStore,
+    ) -> (OperatorBox, Vec<Expression>) {
+        let anchor = &nodes[anchor_idx];
+        let anchor_var = anchor.var.clone();
+
+        // Predicates referencing only the anchor variable can be evaluated at the
+        // anchor scan; everything else is deferred until the whole path is built,
+        // mirroring the conservative deferral used by the start-anchored builder.
+        let mut anchor_only_preds: Vec<Expression> = Vec::new();
+        let mut deferred_predicates: Vec<Expression> = Vec::new();
+        for pred in path_preds {
+            let mut pred_vars = HashSet::new();
+            Self::collect_expression_variables(pred, &mut pred_vars);
+            if pred_vars.iter().all(|v| v == &anchor_var) {
+                anchor_only_preds.push(pred.clone());
+            } else {
+                deferred_predicates.push(pred.clone());
+            }
+        }
+
+        let mut candidates: Vec<Expression> = Vec::new();
+        if let Some(props) = &anchor.properties {
+            for (prop_name, prop_value) in props {
+                candidates.push(Expression::Binary {
+                    left: Box::new(Expression::Property { variable: anchor_var.clone(), property: prop_name.clone() }),
+                    op: BinaryOp::Eq,
+                    right: Box::new(Expression::Literal(prop_value.clone())),
+                });
+            }
+        }
+        candidates.extend(anchor_only_preds);
+
+        let mut path_operator: OperatorBox = if let Some((idx, label, property, op, val)) =
+            find_index_predicate(&anchor_var, &anchor.labels, &candidates, store)
+        {
+            candidates.remove(idx);
+            Box::new(IndexScanOperator::new(anchor_var.clone(), label, property, op, val))
+        } else {
+            Box::new(NodeScanOperator::new(anchor_var.clone(), anchor.labels.clone()))
+        };
+        if !candidates.is_empty() {
+            let filter_expr = candidates.into_iter().reduce(|acc, pred| {
+                Expression::Binary { left: Box::new(acc), op: BinaryOp::And, right: Box::new(pred) }
+            }).unwrap();
+            path_operator = Box::new(FilterOperator::new(path_operator, filter_expr));
+        }
+
+        // Walk backward toward earlier-written nodes using reversed edge direction:
+        // the anchor is now the traversal source, so an originally-outgoing edge from
+        // the earlier node must be read as incoming from the anchor's perspective.
+        let mut current_var = anchor_var.clone();
+        for seg_idx in (0..anchor_idx).rev() {
+            let segment = &path.segments[seg_idx];
+            let target = &nodes[seg_idx];
+            let edge_var = segment.edge.variable.clone();
+            let edge_types: Vec<String> = segment.edge.types.iter().map(|t| t.as_str().to_string()).collect();
+            let reversed_dir = match segment.edge.direction {
+                Direction::Outgoing => Direction::Incoming,
+                Direction::Incoming => Direction::Outgoing,
+                Direction::Both => Direction::Both,
+            };
+            let expand = ExpandOperator::new(path_operator, current_var.clone(), target.var.clone(), edge_var, edge_types, reversed_dir);
+            path_operator = if !target.labels.is_empty() {
+                Box::new(expand.with_target_labels(target.labels.clone()))
+            } else {
+                Box::new(expand)
+            };
+            if let Some(ref props) = target.properties {
+                if !props.is_empty() {
+                    let filter_expr = self.build_property_filter(&target.var, props);
+                    path_operator = Box::new(FilterOperator::new(path_operator, filter_expr));
+                }
+            }
+            current_var = target.var.clone();
+        }
+
+        // Walk forward toward later-written nodes using the written edge direction.
+        let mut current_var = anchor_var;
+        for seg_idx in anchor_idx..path.segments.len() {
+            let segment = &path.segments[seg_idx];
+            let target = &nodes[seg_idx + 1];
+            let edge_var = segment.edge.variable.clone();
+            let edge_types: Vec<String> = segment.edge.types.iter().map(|t| t.as_str().to_string()).collect();
+            let expand = ExpandOperator::new(path_operator, current_var.clone(), target.var.clone(), edge_var, edge_types, segment.edge.direction.clone());
+            path_operator = if !target.labels.is_empty() {
+                Box::new(expand.with_target_labels(target.labels.clone()))
+            } else {
+                Box::new(expand)
+            };
+            if let Some(ref props) = target.properties {
+                if !props.is_empty() {
+                    let filter_expr = self.build_property_filter(&target.var, props);
+                    path_operator = Box::new(FilterOperator::new(path_operator, filter_expr));
+                }
+            }
+            current_var = target.var.clone();
+        }
+
+        (path_operator, deferred_predicates)
     }
 
     /// Build a filter expression from node properties.
@@ -2242,6 +2365,187 @@ impl Default for QueryPlanner {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Propagate node labels and inline properties for variables shared across multiple
+/// MATCH clauses (planned independently and later joined on the shared variable).
+/// If a variable is typed or constrained in one clause but referenced bare (e.g.
+/// `(m)`) in another, copy the known labels/properties over so the second clause's
+/// scan can also be narrowed/indexed instead of falling back to an all-nodes scan.
+/// Safe because the same variable name within a query always refers to the same
+/// node, so any constraint declared for it anywhere already applies everywhere.
+fn propagate_shared_variable_labels(clauses: &[MatchClause]) -> Vec<MatchClause> {
+    fn record_node(
+        var_labels: &mut HashMap<String, Vec<Label>>,
+        var_properties: &mut HashMap<String, HashMap<String, PropertyValue>>,
+        node: &NodePattern,
+    ) {
+        let var = match &node.variable {
+            Some(v) => v,
+            None => return,
+        };
+        if !node.labels.is_empty() {
+            var_labels.entry(var.clone()).or_insert_with(|| node.labels.clone());
+        }
+        if let Some(props) = &node.properties {
+            let entry = var_properties.entry(var.clone()).or_default();
+            for (k, v) in props {
+                entry.entry(k.clone()).or_insert_with(|| v.clone());
+            }
+        }
+    }
+
+    fn enrich_node(
+        var_labels: &HashMap<String, Vec<Label>>,
+        var_properties: &HashMap<String, HashMap<String, PropertyValue>>,
+        node: &mut NodePattern,
+    ) {
+        let var = match &node.variable {
+            Some(v) => v.clone(),
+            None => return,
+        };
+        if node.labels.is_empty() {
+            if let Some(labels) = var_labels.get(&var) {
+                node.labels = labels.clone();
+            }
+        }
+        if let Some(known_props) = var_properties.get(&var) {
+            let existing = node.properties.get_or_insert_with(HashMap::new);
+            for (k, v) in known_props {
+                existing.entry(k.clone()).or_insert_with(|| v.clone());
+            }
+        }
+    }
+
+    let mut var_labels: HashMap<String, Vec<Label>> = HashMap::new();
+    let mut var_properties: HashMap<String, HashMap<String, PropertyValue>> = HashMap::new();
+
+    for clause in clauses {
+        for path in &clause.pattern.paths {
+            record_node(&mut var_labels, &mut var_properties, &path.start);
+            for seg in &path.segments {
+                record_node(&mut var_labels, &mut var_properties, &seg.node);
+            }
+        }
+    }
+
+    if var_labels.is_empty() && var_properties.is_empty() {
+        return clauses.to_vec();
+    }
+
+    let mut result: Vec<MatchClause> = clauses.to_vec();
+    for clause in &mut result {
+        for path in &mut clause.pattern.paths {
+            enrich_node(&var_labels, &var_properties, &mut path.start);
+            for seg in &mut path.segments {
+                enrich_node(&var_labels, &var_properties, &mut seg.node);
+            }
+        }
+    }
+    result
+}
+
+/// A single node within a path pattern, resolved to a concrete variable name
+/// (anonymous nodes get an auto-generated `_anon_N` name). Used by anchor
+/// selection to consider indexing/scanning any node in the pattern, not just
+/// the first one written.
+struct PathNodeRef {
+    var: String,
+    labels: Vec<Label>,
+    properties: Option<HashMap<String, PropertyValue>>,
+}
+
+/// Flip a comparison operator to normalize a reversed-operand predicate.
+/// E.g. `5 < n.age` is equivalent to `n.age > 5`, so `Lt` flips to `Gt`.
+fn flip_comparison_op(op: &BinaryOp) -> BinaryOp {
+    match op {
+        BinaryOp::Lt => BinaryOp::Gt,
+        BinaryOp::Gt => BinaryOp::Lt,
+        BinaryOp::Le => BinaryOp::Ge,
+        BinaryOp::Ge => BinaryOp::Le,
+        other => other.clone(),
+    }
+}
+
+/// Find a predicate in `preds` usable as an index lookup for `var`, matching
+/// either operand order (`var.prop OP literal` or `literal OP var.prop`).
+/// Returns the predicate's index within `preds` plus the matched label,
+/// property, normalized operator, and literal value.
+fn find_index_predicate(
+    var: &str,
+    labels: &[Label],
+    preds: &[Expression],
+    store: &GraphStore,
+) -> Option<(usize, Label, String, BinaryOp, PropertyValue)> {
+    for (i, pred) in preds.iter().enumerate() {
+        if let Expression::Binary { left, op, right } = pred {
+            let matched = match (left.as_ref(), right.as_ref()) {
+                (Expression::Property { variable, property }, Expression::Literal(val)) if variable == var => {
+                    Some((property.clone(), op.clone(), val.clone()))
+                }
+                (Expression::Literal(val), Expression::Property { variable, property }) if variable == var => {
+                    Some((property.clone(), flip_comparison_op(op), val.clone()))
+                }
+                _ => None,
+            };
+            if let Some((property, norm_op, val)) = matched {
+                if matches!(norm_op, BinaryOp::Eq | BinaryOp::Gt | BinaryOp::Ge | BinaryOp::Lt | BinaryOp::Le) {
+                    for label in labels {
+                        if store.property_index.has_index(label, &property) {
+                            return Some((i, label.clone(), property, norm_op, val));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Choose the cheapest node in a path pattern to anchor the scan at: prefer a
+/// node with an indexable predicate (cost ~= label cardinality * selectivity),
+/// falling back to plain label-scan cardinality, and finally an all-nodes scan
+/// for label-free nodes. Ties favor the earliest (first-written) node so
+/// behavior is unchanged when no node is strictly cheaper than the start.
+fn choose_anchor_index(nodes: &[PathNodeRef], path_preds: &[Expression], store: &GraphStore) -> usize {
+    let stats = store.statistics();
+    let mut best_idx = 0usize;
+    let mut best_cost = f64::MAX;
+
+    for (i, node) in nodes.iter().enumerate() {
+        let mut candidates: Vec<Expression> = Vec::new();
+        if let Some(props) = &node.properties {
+            for (prop_name, prop_value) in props {
+                candidates.push(Expression::Binary {
+                    left: Box::new(Expression::Property { variable: node.var.clone(), property: prop_name.clone() }),
+                    op: BinaryOp::Eq,
+                    right: Box::new(Expression::Literal(prop_value.clone())),
+                });
+            }
+        }
+        candidates.extend(path_preds.iter().cloned());
+
+        let cost = if let Some((_, label, property, op, _)) = find_index_predicate(&node.var, &node.labels, &candidates, store) {
+            let base = stats.estimate_label_scan(&label) as f64;
+            let selectivity = if matches!(op, BinaryOp::Eq) {
+                stats.estimate_equality_selectivity(&label, &property)
+            } else {
+                0.3
+            };
+            (base * selectivity).max(1.0)
+        } else if let Some(label) = node.labels.first() {
+            stats.estimate_label_scan(label) as f64
+        } else {
+            f64::MAX
+        };
+
+        if cost < best_cost {
+            best_cost = cost;
+            best_idx = i;
+        }
+    }
+
+    best_idx
 }
 
 /// Flatten an AND-chain expression into a list of individual predicates.
@@ -3304,6 +3608,146 @@ mod tests {
     }
 
     #[test]
+    fn test_reversed_operand_eq_triggers_index_scan() {
+        // `'Person50' = n.name` is semantically identical to `n.name = 'Person50'` and
+        // should also use the index — operand order must not affect index selection.
+        let mut store = GraphStore::new();
+        for i in 0..100 {
+            let id = store.create_node("Person");
+            store.set_node_property("default", id, "name",
+                crate::graph::PropertyValue::String(format!("Person{}", i))).unwrap();
+        }
+        store.property_index.create_index(crate::graph::Label::new("Person"), "name".to_string());
+
+        use crate::query::executor::record::Value;
+        use crate::graph::PropertyValue;
+
+        let query = parse_query("EXPLAIN MATCH (n:Person) WHERE 'Person50' = n.name RETURN n").unwrap();
+        let executor = crate::query::executor::QueryExecutor::new(&store);
+        let result = executor.execute(&query).unwrap();
+        let plan_text = if let Some(Value::Property(PropertyValue::String(s))) = result.records[0].get("plan") {
+            s.clone()
+        } else { panic!("Expected plan text"); };
+
+        assert!(plan_text.contains("IndexScan"),
+            "Reversed-operand equality should use IndexScan: {}", plan_text);
+        assert!(!plan_text.contains("NodeScan"),
+            "Reversed-operand equality should not fall back to NodeScan: {}", plan_text);
+    }
+
+    #[test]
+    fn test_reversed_operand_comparison_triggers_index_scan() {
+        // `25 < n.age` is equivalent to `n.age > 25` — the comparison operator must be
+        // flipped (not just the operands) when normalizing to the indexed form.
+        let mut store = GraphStore::new();
+        store.property_index.create_index(crate::graph::Label::new("Person"), "age".to_string());
+        for i in 0..50 {
+            let id = store.create_node("Person");
+            store.set_node_property("default", id, "age", crate::graph::PropertyValue::Integer(i as i64)).unwrap();
+        }
+
+        use crate::query::executor::record::Value;
+        use crate::graph::PropertyValue;
+
+        let query = parse_query("EXPLAIN MATCH (n:Person) WHERE 25 < n.age RETURN n").unwrap();
+        let executor = crate::query::executor::QueryExecutor::new(&store);
+        let result = executor.execute(&query).unwrap();
+        let plan_text = if let Some(Value::Property(PropertyValue::String(s))) = result.records[0].get("plan") {
+            s.clone()
+        } else { panic!("Expected plan text"); };
+
+        assert!(plan_text.contains("IndexScan"),
+            "Reversed-operand comparison should use IndexScan: {}", plan_text);
+        assert!(!plan_text.contains("NodeScan"),
+            "Reversed-operand comparison should not fall back to NodeScan: {}", plan_text);
+
+        // Correctness: flipping `25 < n.age` to `n.age > 25` must preserve results —
+        // exercise actual execution, not just the plan shape.
+        let exec_query = parse_query("MATCH (n:Person) WHERE 25 < n.age RETURN n.age AS age").unwrap();
+        let exec = crate::query::executor::QueryExecutor::new(&store);
+        let rows = exec.execute(&exec_query).unwrap();
+        assert_eq!(rows.records.len(), 24, "Expected ages 26..49 to match 25 < n.age");
+    }
+
+    #[test]
+    fn test_anchor_selection_uses_index_on_non_start_node() {
+        // MATCH (a:Company)-[:WORKS_AT]->(b:Person) WHERE b.name = '...' — the predicate
+        // lands on the *second* pattern node. The planner should anchor the scan at `b`
+        // via its index and traverse the relationship in reverse, rather than always
+        // full-scanning `a`'s (much larger) label first.
+        let mut store = GraphStore::new();
+        store.property_index.create_index(crate::graph::Label::new("Person"), "name".to_string());
+        let mut company_ids = Vec::new();
+        for i in 0..500 {
+            let id = store.create_node("Company");
+            store.set_node_property("default", id, "name",
+                crate::graph::PropertyValue::String(format!("Company{}", i))).unwrap();
+            company_ids.push(id);
+        }
+        for i in 0..500 {
+            let id = store.create_node("Person");
+            store.set_node_property("default", id, "name",
+                crate::graph::PropertyValue::String(format!("Person{}", i))).unwrap();
+            store.create_edge(company_ids[i], id, "WORKS_AT").unwrap();
+        }
+
+        use crate::query::executor::record::Value;
+        use crate::graph::PropertyValue;
+
+        let query = parse_query(
+            "EXPLAIN MATCH (a:Company)-[:WORKS_AT]->(b:Person) WHERE b.name = 'Person250' RETURN a, b"
+        ).unwrap();
+        let executor = crate::query::executor::QueryExecutor::new(&store);
+        let result = executor.execute(&query).unwrap();
+        let plan_text = if let Some(Value::Property(PropertyValue::String(s))) = result.records[0].get("plan") {
+            s.clone()
+        } else { panic!("Expected plan text"); };
+
+        assert!(plan_text.contains("IndexScan"),
+            "Predicate on non-start node should still use IndexScan: {}", plan_text);
+
+        // Correctness: executing the query must still return the single matching row,
+        // with the relationship traversed to the correct company.
+        let exec_query = parse_query(
+            "MATCH (a:Company)-[:WORKS_AT]->(b:Person) WHERE b.name = 'Person250' RETURN a.name AS company, b.name AS person"
+        ).unwrap();
+        let exec = crate::query::executor::QueryExecutor::new(&store);
+        let rows = exec.execute(&exec_query).unwrap();
+        assert_eq!(rows.records.len(), 1);
+        assert_eq!(rows.records[0].get("company"),
+            Some(&Value::Property(PropertyValue::String("Company250".to_string()))));
+        assert_eq!(rows.records[0].get("person"),
+            Some(&Value::Property(PropertyValue::String("Person250".to_string()))));
+    }
+
+    #[test]
+    fn test_anchor_selection_reversed_direction_pattern() {
+        // Same as above but with the arrow written backward: (b:Person)<-[:WORKS_AT]-(a:Company).
+        // The reversed anchor traversal must flip the already-reversed direction correctly
+        // (Incoming written direction -> Outgoing effective direction from the anchor).
+        let mut store = GraphStore::new();
+        store.property_index.create_index(crate::graph::Label::new("Person"), "name".to_string());
+        let mut company_ids = Vec::new();
+        for i in 0..500 {
+            let id = store.create_node("Company");
+            company_ids.push(id);
+        }
+        for i in 0..500 {
+            let id = store.create_node("Person");
+            store.set_node_property("default", id, "name",
+                crate::graph::PropertyValue::String(format!("Person{}", i))).unwrap();
+            store.create_edge(company_ids[i], id, "WORKS_AT").unwrap();
+        }
+
+        let exec_query = parse_query(
+            "MATCH (b:Person)<-[:WORKS_AT]-(a:Company) WHERE b.name = 'Person250' RETURN a, b"
+        ).unwrap();
+        let exec = crate::query::executor::QueryExecutor::new(&store);
+        let rows = exec.execute(&exec_query).unwrap();
+        assert_eq!(rows.records.len(), 1, "Expected exactly one company employing Person250");
+    }
+
+    #[test]
     fn test_plan_edge_direction() {
         let store = GraphStore::new();
         let planner = QueryPlanner::new();
@@ -3606,7 +4050,7 @@ mod tests {
         let pg = PatternGraph::from_match_clause(match_clause);
         let catalog = store.catalog();
         let config = EnumerationConfig { max_candidate_plans: 64 };
-        let candidates = enumerate_plans(&pg, query.where_clause.as_ref(), catalog, &config);
+        let candidates = enumerate_plans(&pg, query.where_clause.as_ref(), catalog, &store.property_index, &config);
         assert!(candidates.len() >= 2, "Should have at least 2 candidate plans");
 
         for (plan_idx, (logical_plan, cost)) in candidates.iter().enumerate() {


### PR DESCRIPTION
# Summary

  Four independent planner defects caused queries that should have resolved to a
  property index to plan as full label or all-node scans instead. This fixes all
  four and removes a block of dead cost logic.

  ## What was broken

  | # | Cause | Effect |
  |---|-------|--------|
  | 1 | Index matching handled only `n.prop OP literal` | `'Alice' = n.name` and `25 < n.age` never used an index |
  | 2 | Path plans always anchored at the first-written node | A predicate on a later node still scanned the earlier node's label in full |
  | 3 | MATCH clauses planned independently | A variable typed in one clause but bare in another re-scanned all nodes |
  | 4 | `IndexLookup` was never lowered to an index operator | Physical planner always emitted `NodeScanOperator` |

  ## Changes

  **Operand normalization** — `find_index_predicate()` and `flip_comparison_op()`
  match both operand orders and flip the comparison operator, so `25 < n.age`
  normalizes to `n.age > 25`. Mirrored in the enumerator as
  `normalize_index_predicate()`. Replaces the inline index-detection block in
  `plan_path_pattern` with a single call.

  **Anchor selection (QP-05)** — `choose_anchor_index()` costs every node in a
  path and `build_path_from_anchor()` builds outward from the cheapest: backward
  with reversed edge direction, forward with the written direction. Ties favor the
  first node, so existing plans are unchanged when nothing is cheaper. Gated to
  simple linear chains; skipped for named path variables, `shortestPath` /
  `allShortestPaths`, and variable-length hops, since path materialization assumes
  forward order from the start.

  **Cross-clause propagation** — `propagate_shared_variable_labels()` copies labels
  and inline properties for variables shared across pre-WITH MATCH clauses. Safe
  because the same variable name in a query always denotes the same node.

  **IndexLookup lowering** — the physical planner emits `IndexScanOperator` instead
  of unconditionally falling back to `NodeScanOperator`. `IndexLookup` gains
  `op: BinaryOp`; `PatternNode` gains `properties` so inline pattern properties
  feed index selection; `enumerate_plans()` takes `&IndexManager`.

  **Dead code removal** — `choose_direction()` computed catalog-based forward and
  reverse costs and then ignored both. Direction is not a cost tradeoff: the wrong
  choice walks a different adjacency list and returns *wrong* neighbors, not a
  slower plan. It is now four lines. The real direction choice already happens in
  `enumerate_plans()` via start-from-every-node candidates.

  ## Files

  - `src/query/executor/planner.rs` — operand normalization, anchor selection, cross-clause propagation
  - `src/query/executor/plan_enumerator.rs` — predicate normalization, inline properties as predicates, `choose_direction` simplification
  - `src/query/executor/physical_planner.rs` — `IndexLookup` → `IndexScanOperator`
  - `src/query/executor/logical_plan.rs` — `IndexLookup.op`, `PatternNode.properties`
  - `src/query/executor/cost_model.rs` — test fixture updated for the new field

  ## Testing

  Four new planner tests:
  - `test_reversed_operand_eq_triggers_index_scan`
  - `test_reversed_operand_comparison_triggers_index_scan` — asserts the plan shape *and* executes the query, so the operator flip cannot silently invert
  results
  - `test_anchor_selection_uses_index_on_non_start_node` — asserts `IndexScan` and verifies the correct row is returned
  - `test_anchor_selection_reversed_direction_pattern` — backward-written arrow

  Existing enumerator tests updated for the new `enumerate_plans()` signature and
  the `PatternNode.properties` field.

  ## Notes for reviewers

  `propagate_shared_variable_labels()` operates on the whole pre-WITH clause slice.
  Please confirm `OPTIONAL MATCH` clauses cannot appear in that slice — pushing a
  label onto an optional pattern's variable would change semantics.
