### PR TITLE
bench(unified): 15-KG federation with entity dedup, cross-KG bridge, and combined-snapshot export

### DIFF
--- a/examples/unified_benchmark.rs
+++ b/examples/unified_benchmark.rs
@@ -200,7 +200,11 @@ async fn main() -> Result<(), Error> {
     let client = EmbeddedClient::new();
     let total_start = Instant::now();
 
-    // ── Phase 1: Import large snapshots ──
+    // ── Phase 1: Import bulk sources (plain, no dedup) ──
+    // These carry the mass of the graph (Articles, Persons, Visits, reports…) whose
+    // entities are unique to their source, so running them through the dedup index
+    // would cost a full-store scan per import for zero merges (mirrors enterprise
+    // ADR-018 Phase-1 / Phase-1.5 split).
     for (name, path) in &[
         ("PubMed", &pubmed_snap),
         ("Clinical Trials", &ct_snap),
@@ -212,6 +216,25 @@ async fn main() -> Result<(), Error> {
         ("Surveillance", &surv_snap),
         ("Health Determinants", &hd_snap),
         ("Health Systems", &hs_snap),
+    ] {
+        if let Some(ref p) = path {
+            eprint!("Importing {} snapshot... ", name);
+            let t0 = Instant::now();
+            let stats = client.import_snapshot("default", p).await?;
+            eprintln!(
+                "{} nodes, {} edges, {} merged in {:.1}s",
+                stats.node_count,
+                stats.edge_count,
+                stats.merged_count,
+                t0.elapsed().as_secs_f64()
+            );
+        }
+    }
+
+    // ── Phase 1.5: Import cross-KG entity sources (deduped when --dedup-keys set) ──
+    // These share entities with each other and with Phase 1 (Disease, Gene, Protein,
+    // Drug, Country…), so they are the ones worth merging.
+    for (name, path) in &[
         ("ClinVar", &clinvar_snap),
         ("ChEMBL", &chembl_snap),
         ("OpenTargets", &opentargets_snap),
@@ -231,9 +254,10 @@ async fn main() -> Result<(), Error> {
                 client.import_snapshot_dedup("default", p, &dedup_keys).await?
             };
             eprintln!(
-                "{} nodes, {} edges in {:.1}s",
+                "{} nodes, {} edges, {} MERGED in {:.1}s",
                 stats.node_count,
                 stats.edge_count,
+                stats.merged_count,
                 t0.elapsed().as_secs_f64()
             );
         }

--- a/examples/unified_benchmark.rs
+++ b/examples/unified_benchmark.rs
@@ -176,6 +176,17 @@ async fn main() -> Result<(), Error> {
     let mondo_snap = get_arg(&args, "--mondo-snap");
     let combined_snapshot = get_arg(&args, "--combined-snapshot");
     let skip_queries = args.iter().any(|a| a == "--skip-queries");
+    // Optional cross-KG entity dedup (ADR-018): merge nodes sharing any of these
+    // property keys within a label (e.g. Disease by mondo_id across ClinVar/OpenTargets/MONDO).
+    let dedup_keys_str: Option<String> = args
+        .iter()
+        .position(|a| a == "--dedup-keys")
+        .and_then(|i| args.get(i + 1))
+        .cloned();
+    let dedup_keys: Vec<&str> = dedup_keys_str
+        .as_deref()
+        .map(|s| s.split(',').map(|k| k.trim()).filter(|k| !k.is_empty()).collect())
+        .unwrap_or_default();
     let di_data = get_arg(&args, "--di-data");
     let surv_data = get_arg(&args, "--surv-data");
     let hd_data = get_arg(&args, "--hd-data");
@@ -208,9 +219,17 @@ async fn main() -> Result<(), Error> {
         ("MONDO", &mondo_snap),
     ] {
         if let Some(ref p) = path {
-            eprint!("Importing {} snapshot... ", name);
+            if dedup_keys.is_empty() {
+                eprint!("Importing {} snapshot... ", name);
+            } else {
+                eprint!("Importing {} snapshot (dedup {:?})... ", name, dedup_keys);
+            }
             let t0 = Instant::now();
-            let stats = client.import_snapshot("default", p).await?;
+            let stats = if dedup_keys.is_empty() {
+                client.import_snapshot("default", p).await?
+            } else {
+                client.import_snapshot_dedup("default", p, &dedup_keys).await?
+            };
             eprintln!(
                 "{} nodes, {} edges in {:.1}s",
                 stats.node_count,

--- a/examples/unified_benchmark.rs
+++ b/examples/unified_benchmark.rs
@@ -169,6 +169,11 @@ async fn main() -> Result<(), Error> {
     let surv_snap = get_arg(&args, "--surv-snap");
     let hd_snap = get_arg(&args, "--hd-snap");
     let hs_snap = get_arg(&args, "--hs-snap");
+    let clinvar_snap = get_arg(&args, "--clinvar-snap");
+    let chembl_snap = get_arg(&args, "--chembl-snap");
+    let opentargets_snap = get_arg(&args, "--opentargets-snap");
+    let hpo_snap = get_arg(&args, "--hpo-snap");
+    let mondo_snap = get_arg(&args, "--mondo-snap");
     let di_data = get_arg(&args, "--di-data");
     let surv_data = get_arg(&args, "--surv-data");
     let hd_data = get_arg(&args, "--hd-data");
@@ -194,6 +199,11 @@ async fn main() -> Result<(), Error> {
         ("Surveillance", &surv_snap),
         ("Health Determinants", &hd_snap),
         ("Health Systems", &hs_snap),
+        ("ClinVar", &clinvar_snap),
+        ("ChEMBL", &chembl_snap),
+        ("OpenTargets", &opentargets_snap),
+        ("HPO", &hpo_snap),
+        ("MONDO", &mondo_snap),
     ] {
         if let Some(ref p) = path {
             eprint!("Importing {} snapshot... ", name);
@@ -464,6 +474,9 @@ async fn main() -> Result<(), Error> {
         "faers-queries.csv",
         "omop-queries.csv",
         "mega-benchmark-queries.csv",
+        "public-health-complex-queries.csv",
+        "omics-complex-queries.csv",
+        "emr-clinical-complex-queries.csv",
     ] {
         let path = queries_dir.join(filename);
         let queries = parse_csv_queries(&path);

--- a/examples/unified_benchmark.rs
+++ b/examples/unified_benchmark.rs
@@ -200,52 +200,31 @@ async fn main() -> Result<(), Error> {
     let client = EmbeddedClient::new();
     let total_start = Instant::now();
 
-    // ── Phase 1: Import bulk sources (plain, no dedup) ──
-    // These carry the mass of the graph (Articles, Persons, Visits, reports…) whose
-    // entities are unique to their source, so running them through the dedup index
-    // would cost a full-store scan per import for zero merges (mirrors enterprise
-    // ADR-018 Phase-1 / Phase-1.5 split).
+    // ── Phase 1: Import cross-KG entity sources FIRST, with dedup ──
+    // Ordered small -> large deliberately. `import_tenant_with_dedup` rebuilds its
+    // index by scanning `store.all_nodes()` on EVERY import, so deduping while the
+    // store is still small keeps total scan cost ~65M node visits instead of ~2.5B
+    // (which is what deduping after the 207M-node bulk load would cost). See #316.
     for (name, path) in &[
-        ("PubMed", &pubmed_snap),
-        ("Clinical Trials", &ct_snap),
-        ("Pathways", &pw_snap),
-        ("FAERS", &faers_snap),
-        ("UniProt", &uniprot_snap),
-        ("OMOP", &omop_snap),
-        ("Drug Interactions", &di_snap),
-        ("Surveillance", &surv_snap),
-        ("Health Determinants", &hd_snap),
-        ("Health Systems", &hs_snap),
-    ] {
-        if let Some(ref p) = path {
-            eprint!("Importing {} snapshot... ", name);
-            let t0 = Instant::now();
-            let stats = client.import_snapshot("default", p).await?;
-            eprintln!(
-                "{} nodes, {} edges, {} merged in {:.1}s",
-                stats.node_count,
-                stats.edge_count,
-                stats.merged_count,
-                t0.elapsed().as_secs_f64()
-            );
-        }
-    }
-
-    // ── Phase 1.5: Import cross-KG entity sources (deduped when --dedup-keys set) ──
-    // These share entities with each other and with Phase 1 (Disease, Gene, Protein,
-    // Drug, Country…), so they are the ones worth merging.
-    for (name, path) in &[
-        ("ClinVar", &clinvar_snap),
-        ("ChEMBL", &chembl_snap),
-        ("OpenTargets", &opentargets_snap),
         ("HPO", &hpo_snap),
         ("MONDO", &mondo_snap),
+        ("Health Systems", &hs_snap),
+        ("Pathways", &pw_snap),
+        ("Health Determinants", &hd_snap),
+        ("Surveillance", &surv_snap),
+        ("Drug Interactions", &di_snap),
+        ("UniProt", &uniprot_snap),
+        ("OpenTargets", &opentargets_snap),
+        ("ChEMBL", &chembl_snap),
+        ("Clinical Trials", &ct_snap),
+        ("FAERS", &faers_snap),
+        ("ClinVar", &clinvar_snap),
     ] {
         if let Some(ref p) = path {
             if dedup_keys.is_empty() {
                 eprint!("Importing {} snapshot... ", name);
             } else {
-                eprint!("Importing {} snapshot (dedup {:?})... ", name, dedup_keys);
+                eprint!("Importing {} snapshot (dedup)... ", name);
             }
             let t0 = Instant::now();
             let stats = if dedup_keys.is_empty() {
@@ -258,6 +237,28 @@ async fn main() -> Result<(), Error> {
                 stats.node_count,
                 stats.edge_count,
                 stats.merged_count,
+                t0.elapsed().as_secs_f64()
+            );
+        }
+    }
+
+    // ── Phase 2: Import bulk sources LAST, plain ──
+    // Per the .sgsnap header inventory, PubMed (Article/Author/Chemical/Grant/
+    // Journal/MeSHTerm) and OMOP (Person/Visit/ConditionOccurrence/DrugExposure/
+    // Measurement/ProcedureOccurrence) share NO label with any other snapshot, so
+    // they can never merge — running them through dedup is pure cost.
+    for (name, path) in &[
+        ("PubMed", &pubmed_snap),
+        ("OMOP", &omop_snap),
+    ] {
+        if let Some(ref p) = path {
+            eprint!("Importing {} snapshot... ", name);
+            let t0 = Instant::now();
+            let stats = client.import_snapshot("default", p).await?;
+            eprintln!(
+                "{} nodes, {} edges in {:.1}s",
+                stats.node_count,
+                stats.edge_count,
                 t0.elapsed().as_secs_f64()
             );
         }

--- a/examples/unified_benchmark.rs
+++ b/examples/unified_benchmark.rs
@@ -174,6 +174,8 @@ async fn main() -> Result<(), Error> {
     let opentargets_snap = get_arg(&args, "--opentargets-snap");
     let hpo_snap = get_arg(&args, "--hpo-snap");
     let mondo_snap = get_arg(&args, "--mondo-snap");
+    let combined_snapshot = get_arg(&args, "--combined-snapshot");
+    let skip_queries = args.iter().any(|a| a == "--skip-queries");
     let di_data = get_arg(&args, "--di-data");
     let surv_data = get_arg(&args, "--surv-data");
     let hd_data = get_arg(&args, "--hd-data");
@@ -457,6 +459,18 @@ async fn main() -> Result<(), Error> {
         idx_ok,
         idx_start.elapsed().as_secs_f64()
     );
+
+    // ── Combined-snapshot export (optional) ──
+    if let Some(ref cs) = combined_snapshot {
+        eprintln!("Exporting combined snapshot to {} ...", cs.display());
+        let t0 = Instant::now();
+        client.export_snapshot("default", cs).await?;
+        eprintln!("Combined snapshot exported in {:.1}s", t0.elapsed().as_secs_f64());
+    }
+    if skip_queries {
+        eprintln!("--skip-queries set; skipping query phase.");
+        return Ok(());
+    }
 
     // ── Phase 4: Load and run queries ──
     let mut all_queries = Vec::new();


### PR DESCRIPTION
Extends `examples/unified_benchmark.rs` so the biomedical federation benchmark can scale past 200M nodes and exercise cross-KG entity resolution. +79/-8 lines, one file, fully backward compatible (all new behaviour is opt-in via flags).

## What's in it

1. **Five more KG sources** — `--clinvar-snap`, `--chembl-snap`, `--opentargets-snap`, `--hpo-snap`, `--mondo-snap` (ClinVar/dbSNP alone adds 31.8M nodes), plus three new complex query suites (public-health / omics / EMR-clinical, 56 queries).
2. **`--combined-snapshot PATH` + `--skip-queries`** — export the fully-federated store as one `.sgsnap` after load+index.
3. **`--dedup-keys <csv>`** — routes imports through `import_snapshot_dedup`, giving OSS parity with the enterprise ADR-018 entity merge. Absent/empty ⇒ existing plain-import behaviour, unchanged.
4. **Phase split + ordering** — dedup the 13 small/overlapping sources **first**, bulk-load PubMed+OMOP **last**; log `ImportStats.merged_count` per import so merging is verified rather than assumed.

## Why the ordering matters (measured)

`import_tenant_with_dedup` rebuilds its dedup index by scanning `store.all_nodes()` on **every** import. Per the `.sgsnap` header label inventory, PubMed (`Article`/`Author`/…) and OMOP (`Person`/`Visit`/…) share **no label with any other snapshot**, so routing their 207M nodes through dedup is pure cost. Deduping small sources first (store grows 0→59M) then bulk-loading costs ~65M node visits instead of ~2.5B:

| | raw union | this branch (deduped) |
|---|---:|---:|
| nodes | 266,431,935 | **264,198,248** |
| edges | 1,353,570,661 | 1,353,570,661 |
| entities merged | 0 | **2,233,687** |
| **load time** | 3h11m | **1h23m** |

Node delta equals the merge count exactly, and two independent runs produced identical merge counts — the merge is deterministic.

## Query A/B (81 queries, identical suite, same `omop-180k`)

| | raw union | deduped + bridged |
|---|---:|---:|
| PASS | 47 | **50** |
| EMPTY | 18 | **15** |
| ERROR | 11 | 11 |

Three EMPTY→PASS, no regressions: **CX02** trial-drugs-by-PubMed-evidence (0→20 rows), **CX06** EMR→trial→PubMed (0→1), **PH09** public-health cross-KG (0→30). CX02/CX06 come from the `--study-refs` bridge (749,963 `REFERENCED_IN` edges), which resolved #302.

## Evidence this run produced

Closes #302. Provides the reproduction and measurements behind #316 (dedup index full-store rescan; plan merges from headers), #317 (dedup keyed on `labels.first()` — ChEMBL merged only 1,437 because `ChemblTarget` can't match `Protein`), #318 (FAERS merged **0** of 10.4M nodes: `Drug` overlaps four sources but its names carry no shared code), #319 (prep/merge separation), #320 (runtime federation architecture).

Known limitation, not addressed here: `--combined-snapshot` at 1.35B edges runs at ~0.77 MB/s (#314), so it is impractical until the writer is parallelised.

Full writeup, query CSVs and raw results: samyama-graph-competitor-benchmarks `benchmarks/large-scale/`.