### PR TITLE
chore(sdk/python): sync samyama_mcp __version__ to 0.7.0 (PR 3 of #321)

### DIFF
--- a/sdk/python/samyama_mcp/__init__.py
+++ b/sdk/python/samyama_mcp/__init__.py
@@ -1,6 +1,6 @@
 """Samyama MCP Server — auto-generated MCP tools from graph schema."""
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"
 
 from samyama_mcp.server import SamyamaMCPServer
 from samyama_mcp.schema import CypherSchemaDiscovery, GraphSchema


### PR DESCRIPTION
Part of #321 — final step (version bump). Completes the MCP-to-OSS work after #324 (generator docs) and #326 (mcp-demo example).

## What this PR does
One-line fix: `samyama_mcp/__init__.py` `__version__` was **stale at 0.6.1** while the package version in `pyproject.toml` is already **0.7.0**. Sync the module string so `import samyama_mcp; samyama_mcp.__version__` reports the real version.

## Honest scope note
- **Not** a new release / renumbering — `pyproject.toml` is unchanged (stays 0.7.0). This only fixes the drift.
- The originally-discussed "0.6.2" would have been a **downgrade** (package is already 0.7.0), so syncing the stale module string up to 0.7.0 is the correct bump.

Closes #321.