### PR TITLE
docs(adr): add ADR-035 multi-hop query and ADR-036 data-load optimiza…

### DIFF
--- a/docs/ADR/ADR-035-multi-hop-query-optimization.md
+++ b/docs/ADR/ADR-035-multi-hop-query-optimization.md
@@ -1,0 +1,136 @@
+# ADR-035: Multi-Hop Query Optimization
+
+## Status
+**Proposed**
+
+## Date
+2026-07-31
+
+## Objective
+
+Improve the performance of two-hop and deeper graph queries by reducing the number of intermediate results carried between expansion steps.
+
+## Context
+
+### The problem
+
+For selective multi-hop patterns, the executor can expand far more intermediate rows than the query ultimately returns. Every surplus row costs expansion work, memory, and — when the query sorts or aggregates — sorting and grouping work on rows that will be discarded.
+
+Example:
+
+```cypher
+MATCH (person:Person {id: $personId})
+      -[:KNOWS]->(friend)
+      -[:KNOWS]->(candidate)
+WHERE candidate.status = 'ACTIVE'
+RETURN candidate
+LIMIT 20
+```
+
+### What already exists
+
+Three of the techniques below are already implemented in some form. This ADR is about closing the *gaps* in them, not introducing them from scratch:
+
+| Capability | Where | State |
+|---|---|---|
+| Predicate pushdown (inline, AND-chain decomposition during `plan_match`) | `src/query/executor/planner.rs` (QP-01, `can_pushdown_match`) | Shipped, on by default |
+| Predicate pushdown below `Expand` (logical rewrite) | `src/query/executor/logical_optimizer.rs` (`test_predicate_pushdown_below_expand`) | Shipped, but reached only via `plan_enumerator`, which is **gated behind `SAMYAMA_GRAPH_NATIVE=true` and off by default** (`src/query/mod.rs:199`) |
+| Cardinality / selectivity estimation per plan node | `src/query/executor/cost_model.rs` + `GraphCatalog` (`estimate_label_scan`, `estimate_expand_out`, `estimate_expand_in`) | Shipped, same gating |
+| Early `LIMIT` propagation into scans | `src/query/executor/planner.rs` (QP-04, `try_push_limit`, `NodeScanOperator::with_early_limit`) | Shipped, on by default |
+| Plan visibility | `EXPLAIN` / `PROFILE` (ADR-014) | Shipped |
+| **Top-N for `ORDER BY … LIMIT`** | — | **Missing.** `SortOperator` (`src/query/executor/operator.rs:4353`) buffers every input row into `records: Vec<Record>` and sorts the full set before `LimitOperator` discards the tail. |
+| Filter pushdown across a `WITH` boundary | Explicitly deferred (`src/query/executor/adjacency_agg_detector.rs:334`, `:1007`) | Missing |
+
+So the honest framing is: the machinery is largely built, but the strongest form of it is behind a default-off flag, one operator (`Sort`) has no bounded variant at all, and one boundary (`WITH`) is uncovered.
+
+## Decision
+
+Pursue four workstreams, in rough priority order.
+
+### 1. Add a Top-N operator
+
+Replace `Sort → Limit` with a bounded Top-N (heap of size `skip + limit`) when the plan has `ORDER BY` with a constant `LIMIT` and no intervening operator that needs the full sorted set. This is the only item here that is genuinely new code rather than an extension, and it is the clearest win: memory drops from O(rows) to O(limit), and sorting cost from O(n log n) to O(n log k).
+
+### 2. Promote the cost-based path toward default-on
+
+Decide what `SAMYAMA_GRAPH_NATIVE` needs before it can flip to on-by-default: benchmark coverage, regression thresholds, and a documented fallback. Until it flips, the pushdown-below-expand and cost-model work described above benefits nobody in a default deployment. If flipping it is not the intent, say so explicitly — a permanently-off optimizer path is a maintenance cost with no user.
+
+### 3. Extend pushdown coverage
+
+Filter kinds to confirm or add as pushable: equality, range, property-existence, node-label, relationship-type. Then close the `WITH`-boundary gap noted above (post-`WITH` `WHERE`), which currently forces conservative plans in aggregation-shaped queries.
+
+### 4. Sharpen per-hop estimation
+
+The cost model uses fixed default selectivities in several branches (`0.5` for a generic filter, `0.1^k` for TrieJoin). Replace the ones that matter with statistics-backed estimates — average degree per `(label, relationship type)` is the highest-value one for multi-hop.
+
+## Implementation Tasks
+
+* [ ] Profile current two-hop and deeper queries; record a baseline
+* [ ] Add a Top-N operator and plan it for `ORDER BY … LIMIT`
+* [ ] Inventory which filter kinds are pushable on each path (default vs graph-native)
+* [ ] Close the post-`WITH` `WHERE` pushdown gap
+* [ ] Replace default selectivities with degree statistics where they drive multi-hop plans
+* [ ] Define the exit criteria for `SAMYAMA_GRAPH_NATIVE` defaulting to on
+* [ ] Surface pushed predicates and Top-N in `EXPLAIN` / `PROFILE`
+* [ ] Add correctness and performance tests
+
+## Configuration
+
+Samyama configures the query path through environment variables and `ServerConfig` (`src/main.rs`), not a YAML file. Any new switch should follow that convention:
+
+```sh
+SAMYAMA_GRAPH_NATIVE=true      # existing: enables the cost-based planner path
+SAMYAMA_QUERY_TIMEOUT=30       # existing
+```
+
+New flags, if any, should be named in the same `SAMYAMA_*` style and default to preserving current behavior.
+
+## Testing
+
+Benchmarks must cover:
+
+* Two-hop and three-hop queries
+* Low- and high-selectivity filters
+* Queries with and without filters
+* Queries using `ORDER BY` and `LIMIT` (the Top-N path)
+* Both planner paths (`SAMYAMA_GRAPH_NATIVE` on and off)
+* At least two dataset sizes
+
+LDBC SNB Interactive already provides multi-hop shapes at SF1/SF10 (`benches/ldbc_benchmark.rs`, `docs/BENCHMARKS.md`) — extend that rather than inventing a new harness.
+
+Validate that optimized and existing plans return identical results.
+
+## Consequences
+
+**Easier:** selective multi-hop queries get bounded memory and lower latency; sorted-limited queries stop materializing the full result set; plan quality becomes measurable rather than assumed.
+
+**Harder:** two planner paths must stay behaviorally identical while only one is optimized, which doubles the correctness surface — a reason to resolve item 2 rather than let the split persist. Statistics-backed estimation adds a maintenance burden: stale statistics produce worse plans than fixed defaults.
+
+## Acceptance Criteria
+
+* [ ] `ORDER BY … LIMIT` uses bounded memory proportional to the limit, not the result set
+* [ ] Filters are applied during expansion wherever valid on the default path
+* [ ] Selective multi-hop queries show measurable latency improvement against the recorded baseline
+* [ ] Intermediate row count and memory usage are reduced
+* [ ] Query plans show pushed predicates and Top-N
+* [ ] Queries without filters do not materially regress
+* [ ] Single-hop and indexed lookup queries do not regress
+* [ ] Results remain functionally identical across both planner paths
+* [ ] Benchmarks cover multiple hop depths and dataset sizes
+
+## Out of Scope
+
+* Data-loading optimization — see [ADR-036](./ADR-036-data-load-time-to-ready-optimization.md)
+* Index-building optimization
+* Hardware scaling
+* Single-hop query optimization
+* Unrelated query correctness defects
+
+## Related Decisions
+
+* [ADR-007](./ADR-007-volcano-iterator-execution.md) — Volcano iterator execution model
+* [ADR-012](./ADR-012-late-materialization.md) — late materialization (why intermediate rows are `NodeRef`, not clones)
+* [ADR-014](./ADR-014-explain-profile-queries.md) — `EXPLAIN` / `PROFILE`
+* [ADR-015](./ADR-015-graph-native-query-planning.md) — the graph-native planner this ADR proposes promoting
+* [ADR-017](./ADR-017-adjacency-aware-aggregation-planning.md) — adjacency-aware aggregation planning
+* [ADR-027](./ADR-027-aggregation-with-pushdown.md) — aggregation `WITH` pushdown

--- a/docs/ADR/ADR-036-data-load-time-to-ready-optimization.md
+++ b/docs/ADR/ADR-036-data-load-time-to-ready-optimization.md
@@ -1,0 +1,181 @@
+# ADR-036: Data Load and Time-to-Ready Optimization
+
+## Status
+**Proposed**
+
+## Date
+2026-07-31
+
+## Objective
+
+Improve data-ingestion throughput and reduce the total time from "start loading a dataset" to "the dataset answers queries correctly".
+
+## Context
+
+### The problem
+
+The load path is sequential end to end:
+
+```text
+Load all data
+    ↓
+Build indexes
+    ↓
+Validate
+    ↓
+Dataset ready
+```
+
+The loaders in `examples/` (`ldbc_loader`, `imdb_loader`, `football_loader`, `aact_loader`, `cricket_loader`, …) drive ingestion single-threaded — none of them use `rayon` or spawn workers — so wall-clock time to ready is the sum of every stage.
+
+Suspected sources of avoidable overhead, none of them yet confirmed by profiling:
+
+* Single-threaded ingestion
+* Small write operations
+* Frequent commits
+* Repeated serialization
+* Limited batching
+* No overlap between loading and index construction
+
+**This ADR should not be accepted until stage-level profiling exists.** Everything below is a hypothesis about where the time goes; the first task is to replace that guess with measurement.
+
+### The structural constraint
+
+`GraphStore` mutation is `&mut self` — `create_node`, `create_edge`, `set_property` all take exclusive ownership. That makes the store a single-writer structure by construction, so "parallel node writes" and "parallel relationship writes" are **not** reachable by adding worker threads to the existing API. Any parallel-write design must first answer one of:
+
+* parse/transform in parallel, apply serially (parallelism on the expensive half only — cheapest change, and likely enough if profiling shows parsing dominates);
+* shard the store and merge (see ADR-009 partitioning); or
+* introduce interior mutability with per-partition locking on the hot maps.
+
+Naming the constraint up front prevents an implementation attempt that discovers it at the type-checker.
+
+Note also that a fast bulk path already exists: `create_node_stub` (`src/graph/store.rs:1002`) bypasses the event loop for snapshot import, and `rebuild_vector_index_full` (`:2092`) rebuilds indexes after a bulk insert. Measure against that path before building a new one — some of the wins below may already be available through snapshot import (ADR-022).
+
+## Decision
+
+### 1. Profile the load path first
+
+Add stage-level timing and throughput metrics for: file reading, parsing, validation, node creation, relationship creation, transaction commits, serialization, storage writes, index construction. Publish a baseline for at least two datasets before optimizing anything.
+
+### 2. Batch data writes
+
+Process nodes and relationships in configurable batches, with sizes chosen by benchmark rather than assumption.
+
+### 3. Add safe parallelism
+
+Separate parsing from writing, with bounded queues so memory stays capped. Given the constraint above, the realistic first shape is *parallel parse → serial apply*; anything beyond that requires the ownership decision named in Context.
+
+### 4. Reduce serialization overhead
+
+Remove repeated JSON parsing, duplicate object conversions, repeated property normalization, and unnecessary temporaries. Use streaming parsing where the input format allows.
+
+### 5. Overlap index construction
+
+Investigate incremental index updates during load, per-batch/per-partition index builds, or starting index construction while the tail of the data is still loading. The dataset must only be marked ready once all required indexes are complete and validated.
+
+### Recommended flow
+
+```text
+Read and parse input (parallel)
+    ↓
+Create batches
+    ↓
+Write nodes (serial into GraphStore)
+    ↓
+Write relationships
+    ↓
+Build indexes incrementally or in parallel
+    ↓
+Validate data and indexes
+    ↓
+Mark dataset ready
+```
+
+## Implementation Tasks
+
+* [ ] Profile the current ingestion pipeline and publish a baseline
+* [ ] Add stage-level timing and throughput metrics
+* [ ] Benchmark the existing snapshot-import path as the comparison point
+* [ ] Add configurable node and relationship batch sizes
+* [ ] Add parallel parsing with bounded queues ahead of serial apply
+* [ ] Decide and record the parallel-write ownership approach (or rule it out)
+* [ ] Reduce repeated serialization and transformation
+* [ ] Investigate incremental indexing
+* [ ] Implement load/index overlap where safe
+* [ ] Add dataset integrity validation
+* [ ] Add performance and correctness tests
+
+## Dataset States
+
+No dataset lifecycle state exists in the engine today — this introduces new API surface (and, if it must survive restart, new persisted state). Proposed states:
+
+```text
+CREATED
+LOADING_NODES
+LOADING_RELATIONSHIPS
+INDEXING
+VALIDATING
+READY
+FAILED
+```
+
+A dataset must not enter `READY` until data loading is complete, required indexes are complete, and validation passes. Open questions to settle before implementing: is the state per-tenant or per-store, is it exposed over RESP and HTTP, does it survive restart, and what does a query against a non-`READY` dataset do — block, error, or serve partial results?
+
+## Configuration
+
+Samyama configures through environment variables and `ServerConfig` (`src/main.rs`), not a YAML file. Ingestion knobs should follow that convention, for example:
+
+```sh
+SAMYAMA_INGEST_NODE_BATCH_SIZE=5000
+SAMYAMA_INGEST_REL_BATCH_SIZE=5000
+SAMYAMA_INGEST_PARSER_WORKERS=4
+```
+
+Every knob defaults to current behavior, and every default is justified by a benchmark.
+
+## Testing
+
+Benchmarks must cover:
+
+* At least two dataset sizes
+* Multiple batch sizes
+* Different worker counts
+* Sequential index build vs. overlapping/incremental build
+
+Validate node count, relationship count, property values, index-entry count, indexed query results, and the absence of missing or duplicate records.
+
+## Consequences
+
+**Easier:** large datasets become usable sooner; ingestion cost becomes visible per stage instead of a single opaque number; batch sizes become tunable for a given machine.
+
+**Harder:** a staged, parallel loader has more failure modes than a sequential one — partial loads, a dataset stuck in `INDEXING`, and back-pressure tuning all become real. The `FAILED` state implies a cleanup story that does not exist yet. Bounded queues trade peak throughput for predictable memory, and that trade needs to be a documented default rather than an accident.
+
+## Acceptance Criteria
+
+* [ ] A profiling baseline exists and is published before optimization work lands
+* [ ] Data-load throughput improves measurably against that baseline
+* [ ] Batched writes reduce transaction overhead
+* [ ] Parallel parsing improves throughput where supported
+* [ ] Memory usage remains bounded under back-pressure
+* [ ] No records are lost or duplicated
+* [ ] Index construction overlaps with loading or runs incrementally
+* [ ] Index correctness is preserved
+* [ ] Total time-to-ready is measurably reduced
+* [ ] At least two dataset sizes are benchmarked
+* [ ] The optimized loader produces a byte-identical dataset to the existing loader
+
+## Out of Scope
+
+* Multi-hop query optimization — see [ADR-035](./ADR-035-multi-hop-query-optimization.md)
+* Query-planner changes
+* Hardware scaling
+* Distributed ingestion
+* Unrelated correctness defects
+
+## Related Decisions
+
+* [ADR-002](./ADR-002-use-rocksdb-for-persistence.md) — RocksDB persistence
+* [ADR-009](./ADR-009-graph-partitioning-strategy.md) — partitioning, if sharded ingestion is pursued
+* [ADR-021](./ADR-021-columnar-property-store.md) — columnar property store (the write target for bulk scalar properties)
+* [ADR-022](./ADR-022-snapshot-format.md) — snapshot import, the existing fast bulk-load path
+* [ADR-029](./ADR-029-index-manager.md) — index construction

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -51,6 +51,9 @@ Links to related ADRs
 | [014](./ADR-014-explain-profile-queries.md) | EXPLAIN and PROFILE Query Plan Visualization | Implemented | 2026-02-16 |
 | [015](./ADR-015-graph-native-query-planning.md) | Graph-Native Query Planning | Implemented | 2026-03-06 |
 | [016](./ADR-016-billion-node-distributed-architecture.md) | Billion-Node Distributed Architecture | Proposed | 2026-03-23 |
+| … | *ADRs 017–034 are on disk but not yet listed here* | — | — |
+| [035](./ADR-035-multi-hop-query-optimization.md) | Multi-Hop Query Optimization | Proposed | 2026-07-31 |
+| [036](./ADR-036-data-load-time-to-ready-optimization.md) | Data Load and Time-to-Ready Optimization | Proposed | 2026-07-31 |
 
 ## Decision Process
 


### PR DESCRIPTION
docs: add ADR-035 (multi-hop query) and ADR-036 (data load) performance ADRs

  PR description

  ## Summary

  Two **Proposed** ADRs scoping the next round of performance work. Docs only — no code
  changes, no behavior change.

  - **[ADR-035](docs/ADR/ADR-035-multi-hop-query-optimization.md)** — reduce intermediate
    results in two-hop and deeper queries.
  - **[ADR-036](docs/ADR/ADR-036-data-load-time-to-ready-optimization.md)** — improve
    ingestion throughput and time-to-query-ready.

  Both were written by first checking the claims against the code, so they scope the
  *remaining* gap rather than re-proposing shipped features. That's the part worth
  reviewing.

  ## ADR-035: what's already built vs. what isn't

  Three commonly-proposed optimizations are already in the tree:

  | Capability | Where | State |
  |---|---|---|
  | Predicate pushdown (AND-chain decomposition) | `planner.rs` QP-01, `can_pushdown_match` | Shipped, default-on |
  | Predicate pushdown below `Expand` | `logical_optimizer.rs` | Shipped, **default-off** |
  | Cardinality / selectivity estimation | `cost_model.rs` + `GraphCatalog` | Shipped, **default-off** |
  | Early `LIMIT` propagation | `planner.rs` QP-04, `try_push_limit` | Shipped, default-on |
  | **Top-N for `ORDER BY … LIMIT`** | — | **Missing** |
  | Filter pushdown across `WITH` | `adjacency_agg_detector.rs:334` | Explicitly deferred |

  Two findings drive the ADR's priorities:

  1. **`SortOperator` has no bounded variant.** `operator.rs:4353` collects every input row
     into `records: Vec<Record>` and sorts the full set; `LimitOperator` then discards the
     tail. A Top-N heap takes memory from O(rows) to O(limit) and sorting from O(n log n)
     to O(n log k).
  2. **The cost-based path is behind a default-off flag.** `logical_optimizer` is reached
     only via `plan_enumerator`, gated on `SAMYAMA_GRAPH_NATIVE=true` (`src/query/mod.rs:199`).
     The pushdown-below-`Expand` and cost-model work therefore benefits no default
     deployment today. The ADR proposes deciding the exit criteria to flip it on — or
     stating explicitly that it stays off, since a permanently-off optimizer path is
     maintenance cost with no user.

  ## ADR-036: the constraint that shapes the design

  `GraphStore` mutation is `&mut self` throughout (`create_node`, `create_edge`,
  `set_property`), making it **single-writer by construction**. Parallel node/relationship
  writes are not reachable by adding worker threads — they require parallel-parse/serial-apply,
  store sharding (ADR-009), or interior mutability with per-partition locking. The ADR names
  this up front so an implementation doesn't discover it at the type-checker.

  2. **The cost-based path is behind a default-off flag.** `logical_optimizer` is reached
     only via `plan_enumerator`, gated on `SAMYAMA_GRAPH_NATIVE=true` (`src/query/mod.rs:199`).
     The pushdown-below-`Expand` and cost-model work therefore benefits no default
     deployment today. The ADR proposes deciding the exit criteria to flip it on — or
     stating explicitly that it stays off, since a permanently-off optimizer path is
     maintenance cost with no user.

  ## ADR-036: the constraint that shapes the design

  `GraphStore` mutation is `&mut self` throughout (`create_node`, `create_edge`,
  `set_property`), making it **single-writer by construction**. Parallel node/relationship
  writes are not reachable by adding worker threads — they require parallel-parse/serial-apply,
  store sharding (ADR-009), or interior mutability with per-partition locking. The ADR names
  this up front so an implementation doesn't discover it at the type-checker.

  It also points at `create_node_stub` (`store.rs:1002`) + `rebuild_vector_index_full` — the
  existing snapshot-import bulk path — as the baseline any new loader must beat, and makes
  stage-level profiling a precondition for accepting the ADR rather than one task among ten.

  ## Also in this PR

  `docs/ADR/README.md`'s index table stopped at ADR-016. Added rows for 035 and 036 plus a
  placeholder marking that 017–034 are on disk but unlisted.

  ## Review notes

  - Status is **Proposed** on both — this is scoping, not a commitment to a schedule.
  - The config sections use `SAMYAMA_*` env vars, matching how the engine is actually
    configured (there is no YAML config in this repo).
  - Every cross-linked ADR path was verified to exist.

  ## Open question for reviewers

  Should `SAMYAMA_GRAPH_NATIVE` be on a path to default-on? ADR-035's priority ordering
  depends on the answer — if it's never flipping, workstreams 3 and 4 lose most of their
  value.