### PR TITLE
docs(hier): correct two engine-gap descriptions, link follow-up issues

### DIFF
--- a/benchmarks/hier/README.md
+++ b/benchmarks/hier/README.md
@@ -96,10 +96,10 @@ magnitude while the engine aggregation pays O(subtree) every time.
 
 Reporting only H2 would be dishonest. Two classes are **slower** with the index:
 
-**H1 (order test) and H6 (anti-subsumption), 0.2×.** Two causes, both real:
+**H1 (order test) and H6 (anti-subsumption), 0.2×.** Two causes, both real (tracked in #349):
 
 1. The planner rewrite that turns a subsumption test into a `HierarchyOrderTest` over a
-   scan — rewrite #1 in ADR-035 §8 — **is specified but not implemented**. Only the
+   scan — rewrite 1 in ADR-035 §8 — **is specified but not implemented**. Only the
    roll-up and descendant-scan rewrites ship. So these queries run the `subsumes()`
    function form, which binds the root with a cartesian product and then pays a
    per-row index lookup: ~500 ns/row against ~120 ns/row for a native predicate.
@@ -134,17 +134,22 @@ encoding, not a performance one.
 
 Found while building the corpus; all pre-date ADR-035 and none are caused by it.
 
-1. **`CALL … YIELD node` does not compose** with a following `MATCH` (`Variable not found:
-   node`) or a following `WHERE` (parse error). This blocks class **H9**, hierarchy-filtered
-   vector search — the ANN call works and the subsumption predicate works, but they cannot
-   be put in one query. The four H9 queries are kept in `queries.json` with a `skip`
-   reason so the class stays visible rather than quietly vanishing from the table.
-2. **`NOT x STARTS WITH "y"`** evaluates as though the `NOT` binds the operand, returning
-   nothing. `NOT (x STARTS WITH "y")` is correct. A precedence bug.
-3. **`NOT EXISTS { MATCH (d)-[:T*0..]->(r {...}) }`** never matches — the EXISTS subquery
-   with a variable-length pattern always evaluates false.
-4. **`ORDER BY <scalar function> DESC LIMIT k`** returns a different top-k than the
-   equivalent aggregate ordering. The H8 queries therefore order without a `LIMIT`.
+1. **[#345] `ORDER BY sum(...) DESC` does not sort.** Repeating a `sum()` aggregate in
+   `ORDER BY` leaves the rows in natural order, so `LIMIT k` silently returns the wrong
+   top-k. Ordering by the *alias* is correct, and `count()` happens to work. The H8
+   queries therefore order without a `LIMIT`, since the class exists to measure roll-up
+   called in a loop rather than to test truncation.
+2. **[#346] Inline property maps inside `EXISTS { }` never match.**
+   `EXISTS { MATCH (d)-[:IS_A]->(r:T {code: "AB"}) }` returns nothing, so `NOT EXISTS`
+   returns every row. Not specific to variable-length patterns — a single hop reproduces
+   it — and the same constraint written as a `WHERE` inside the subquery works.
+3. **[#347] `NOT x STARTS WITH "y"`** parses as though `NOT` binds the operand.
+   `NOT (x STARTS WITH "y")` is correct. A precedence bug.
+4. **[#348] `CALL … YIELD` variables are not in scope for a following `WHERE`**
+   (`Variable not found: node`); a `WHERE` directly after `YIELD` is a parse error. This
+   blocks class **H9**, hierarchy-filtered vector search. The four H9 queries are kept in
+   `queries.json` with a `skip` reason so the class stays visible rather than quietly
+   vanishing from the table.
 
 ## Corpus
 
@@ -166,7 +171,7 @@ the generator; the JSON is committed so a run needs no Python.
 
 ## Not yet covered
 
-Stated rather than skipped:
+Stated rather than skipped, and tracked in #353:
 
 - **Neo4j / TigerGraph cross-engine baselines.** The corpus is Cypher and the dataset is
   generated, so porting it is mechanical, but it has not been run. `samyama-graph-competitor-benchmarks`

--- a/benchmarks/hier/generate_corpus.py
+++ b/benchmarks/hier/generate_corpus.py
@@ -202,9 +202,10 @@ for a, b in PAIRS:
         f'RETURN max(c.level) AS lvl')
 
 # ------------------------------------------------------- H8 top-k over roll-up
-# ORDER BY without LIMIT: the engine currently does not apply ORDER BY consistently to a
-# scalar-function projection when a LIMIT is present (see README, Known engine gaps), so
-# the corpus orders the full result rather than asserting a truncated one it cannot trust.
+# ORDER BY without LIMIT: `ORDER BY sum(...) DESC` does not sort in this engine (issue
+# #345), so a LIMIT would truncate an unsorted result and the two sides of the comparison
+# would disagree for reasons that have nothing to do with the index. The class exists to
+# measure roll-up called in a loop, which ordering the full result still does.
 n = 0
 for level in [1, 2, 3]:
     n += 1

--- a/docs/ADR/ADR-035-oeh-hierarchy-index.md
+++ b/docs/ADR/ADR-035-oeh-hierarchy-index.md
@@ -289,24 +289,26 @@ mode.
 
 ## Follow-ups
 
-1. **Order-test rewrite.** Detect `MATCH (d:L), (r:L {pin}) WHERE subsumes(d, r)` and emit
+1. **Order-test rewrite** (#349). Detect `MATCH (d:L), (r:L {pin}) WHERE subsumes(d, r)` and emit
    `LabelScan → HierarchyOrderTest` instead of a cartesian product. Highest-value
    remaining work; H1/H6 measure exactly what it is worth.
-2. **A hierarchy-driven plan for cross-hierarchy conjunctions.** HIER H4 runs at 1.1×
+2. **A hierarchy-driven plan for cross-hierarchy conjunctions** (#350). HIER H4 runs at 1.1×
    because the fact scan dominates both plans. Starting from `HierarchyDescendantScan` and
    driving into the fact table would make the paper's motivating query fast, not merely
    expressible.
-3. **`CALL … YIELD` composition** (engine gap, not ADR-035's). `CALL db.index.vector.queryNodes(...)
-   YIELD node` cannot be followed by a `MATCH` or `WHERE` referencing `node`, which blocks
+3. **`CALL … YIELD` composition** (engine gap, not ADR-035's, tracked as #348).
+   `YIELD`-bound variables are not in scope for a following `WHERE`, which blocks
    hierarchy-filtered vector search — HIER class H9 — entirely.
-4. **Online maintenance.** Incremental insert/delete instead of mark-stale-and-rebuild.
+4. **Online maintenance** (#351). Incremental insert/delete instead of mark-stale-and-rebuild.
    Nested-set intervals are the hard case; a gap-leaving labelling would absorb some
    inserts without a full relabel.
-5. **Cheaper MIN/MAX.** The sparse table costs O(n log n) and dominates index size
+5. **Cheaper MIN/MAX** (#352). The sparse table costs O(n log n) and dominates index size
    (7.5 MB of roll-up structures over 112 KB of order embedding on a 9,331-node ontology).
    A sqrt-decomposition or segment tree would trade a little query time for a lot of space.
-6. **Real-ontology validation and a PLL baseline** — see the "Not yet covered" section of
-   `benchmarks/hier/README.md`.
+6. **Real-ontology validation and a PLL baseline** (#353) — see the "Not yet covered"
+   section of `benchmarks/hier/README.md`.
+
+Tracked together in #354, with the four engine bugs the corpus surfaced (#345–#348).
 
 ## References
 


### PR DESCRIPTION
Follow-up to #344. While writing minimal repros for the issue reports, two of the four "known engine gaps" in `benchmarks/hier/README.md` turned out to be misattributed:

- **ORDER BY** — I blamed the scalar-function projection path. That path works. The broken one is the **aggregate** path: `ORDER BY sum(x) DESC` does not sort at all, so `LIMIT k` silently returns the wrong top-k. Ordering by the alias is correct, and `count()` happens to work. Filed as #345 with a self-contained repro.
- **EXISTS** — I blamed variable-length patterns. The actual cause is **inline property maps**: `EXISTS { MATCH (d)-[:IS_A]->(r:T {code: \"AB\"}) }` matches nothing with a single hop, and the same constraint in a `WHERE` inside the subquery works. Filed as #346.

Both are pre-existing engine bugs, unrelated to ADR-035 — only my descriptions of them were wrong. The H8 corpus queries are unaffected: they already order without a `LIMIT`, and the reason is now stated correctly.

Also links #345–#354 from the README, the corpus generator and the ADR follow-ups so the open work is reachable from the docs. Docs and one comment only; no code or corpus changes (`queries.json` regenerates byte-identical).