### PR TITLE
fix(query-engine): RETURN DISTINCT deduplicates; ungrouped count() is a scalar

### DIFF
--- a/src/query/executor/adjacency_agg_detector.rs
+++ b/src/query/executor/adjacency_agg_detector.rs
@@ -195,6 +195,18 @@ pub fn detect(query: &Query, store: &GraphStore) -> Option<AdjacencyAggPattern> 
 
     let (count_alias, count_arg_var, count_distinct) = count_info?;
 
+    // An aggregate with no grouping key is not a per-node degree.
+    //
+    // `MATCH (a)-[:R]->(b) RETURN count(b)` projects only the aggregate, so openCypher
+    // groups on nothing and the answer is a single scalar: the number of matched rows.
+    // `AdjacencyCountAggregateOperator` emits one record *per grouped node*, which for an
+    // ungrouped query is one row per `a` carrying its out-degree — the right numbers
+    // attached to the wrong question (#301). The generic Aggregate path answers this
+    // correctly, so decline and let it.
+    if group_by_items.is_empty() {
+        return None;
+    }
+
     // count(DISTINCT neighbor) is now supported via the operator's
     // with_count_distinct mode (per-group FxHashSet<NodeId> dedup,
     // handles parallel edges + same-neighbor-across-grouped-nodes).
@@ -517,6 +529,19 @@ pub fn detect_with_binding(query: &Query) -> Option<AdjacencyAggWithBindingPatte
     }
 
     let (count_alias, count_arg_var, count_distinct) = count_info?;
+
+    // An aggregate with no grouping key is not a per-node degree.
+    //
+    // `MATCH (a)-[:R]->(b) RETURN count(b)` projects only the aggregate, so openCypher
+    // groups on nothing and the answer is a single scalar: the number of matched rows.
+    // `AdjacencyCountAggregateOperator` emits one record *per grouped node*, which for an
+    // ungrouped query is one row per `a` carrying its out-degree — the right numbers
+    // attached to the wrong question (#301). The generic Aggregate path answers this
+    // correctly, so decline and let it.
+    if group_by_items.is_empty() {
+        return None;
+    }
+
     if count_arg_var != neighbor_var {
         return None;
     }

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -5693,6 +5693,82 @@ impl PhysicalOperator for DropIndexOperator {
     }
 }
 
+/// `RETURN DISTINCT` — deduplicate whole result rows.
+///
+/// Sits above the projection, so it sees exactly the columns the user asked for and
+/// deduplicates on the tuple of those values. Deduplicating anywhere lower would be wrong:
+/// two rows that differ only in a column that is not projected are the *same* row as far
+/// as `DISTINCT` is concerned.
+///
+/// Streaming rather than materializing: a row is emitted the first time its key is seen
+/// and dropped thereafter, so `DISTINCT ... LIMIT k` stops as soon as `k` distinct rows
+/// exist instead of building the whole result first.
+///
+/// Null is a value here. openCypher deduplicates `NULL` against `NULL` even though
+/// `NULL = NULL` is unknown in a predicate — `DISTINCT` uses equivalence, not equality —
+/// and [`Value`]'s `Eq`/`Hash` already implement that, along with comparing nodes and
+/// edges by identity so a materialized `Node` and a lazy `NodeRef` for the same node
+/// deduplicate against each other.
+pub struct DistinctOperator {
+    input: OperatorBox,
+    seen: HashSet<Vec<(String, Value)>>,
+}
+
+impl DistinctOperator {
+    /// Wrap `input`, emitting each distinct row once.
+    pub fn new(input: OperatorBox) -> Self {
+        Self {
+            input,
+            seen: HashSet::new(),
+        }
+    }
+
+    /// The deduplication key: every binding, ordered by column name so that two records
+    /// that bound the same columns in a different order still collide.
+    fn key(record: &Record) -> Vec<(String, Value)> {
+        let mut key: Vec<(String, Value)> = record
+            .bindings()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        key.sort_by(|a, b| a.0.cmp(&b.0));
+        key
+    }
+}
+
+impl PhysicalOperator for DistinctOperator {
+    fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        while let Some(record) = self.input.next(store)? {
+            if self.seen.insert(Self::key(&record)) {
+                return Ok(Some(record));
+            }
+        }
+        Ok(None)
+    }
+
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        while let Some(record) = self.input.next_mut(store, tenant_id)? {
+            if self.seen.insert(Self::key(&record)) {
+                return Ok(Some(record));
+            }
+        }
+        Ok(None)
+    }
+
+    fn reset(&mut self) {
+        self.seen.clear();
+        self.input.reset();
+    }
+
+    fn describe(&self) -> OperatorDescription {
+        OperatorDescription {
+            name: "Distinct".to_string(),
+            details: String::new(),
+            children: vec![self.input.describe()],
+        }
+    }
+}
+
 /// Show indexes operator: SHOW INDEXES
 pub struct ShowIndexesOperator {
     results: Option<std::vec::IntoIter<Record>>,

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -62,7 +62,7 @@ use std::sync::Mutex;
 use crate::query::executor::{
     ExecutionError, ExecutionResult, OperatorBox,
     // Added CreateNodeOperator and CreateNodesAndEdgesOperator for CREATE statement support
-    operator::{NodeScanOperator, FilterOperator, ExpandOperator, ProjectOperator, LimitOperator, SkipOperator, CreateNodeOperator, CreateNodesAndEdgesOperator, CartesianProductOperator, VectorSearchOperator, JoinOperator, LeftOuterJoinOperator, CreateVectorIndexOperator, CreateIndexOperator, CompositeCreateIndexOperator, CreateConstraintOperator, DropIndexOperator, ShowIndexesOperator, ShowConstraintsOperator, ShowLabelsOperator, ShowRelationshipTypesOperator, ShowPropertyKeysOperator, SchemaVisualizationOperator, AlgorithmOperator, IndexScanOperator, AggregateOperator, AggregateType, AggregateFunction, SortOperator, DeleteOperator, SetPropertyOperator, RemovePropertyOperator, UnwindOperator, MergeOperator, ForeachOperator, ShortestPathOperator, VarLengthExpandOperator, WithBarrierOperator, LabelCountOperator, EdgeTypeCountOperator},
+    operator::{NodeScanOperator, FilterOperator, ExpandOperator, ProjectOperator, LimitOperator, SkipOperator, CreateNodeOperator, CreateNodesAndEdgesOperator, CartesianProductOperator, VectorSearchOperator, JoinOperator, LeftOuterJoinOperator, CreateVectorIndexOperator, CreateIndexOperator, CompositeCreateIndexOperator, CreateConstraintOperator, DropIndexOperator, ShowIndexesOperator, ShowConstraintsOperator, DistinctOperator, ShowLabelsOperator, ShowRelationshipTypesOperator, ShowPropertyKeysOperator, SchemaVisualizationOperator, AlgorithmOperator, IndexScanOperator, AggregateOperator, AggregateType, AggregateFunction, SortOperator, DeleteOperator, SetPropertyOperator, RemovePropertyOperator, UnwindOperator, MergeOperator, ForeachOperator, ShortestPathOperator, VarLengthExpandOperator, WithBarrierOperator, LabelCountOperator, EdgeTypeCountOperator},
 };
 use crate::graph::EdgeType;  // Added for CREATE edge support
 use std::collections::{HashMap, HashSet};  // Added for CREATE properties and JOIN logic
@@ -338,7 +338,24 @@ impl QueryPlanner {
     }
 
     /// Plan a query
+    /// Plan a query, then apply `RETURN DISTINCT` if the query asked for it.
+    ///
+    /// The deduplication is applied here, at the single point every planning path funnels
+    /// through, rather than inside the dozen-odd places that build a `ProjectOperator`.
+    /// That matters because several of those paths are specialized fast plans
+    /// (adjacency-count aggregation, hierarchy rewrites, label-count caches) that were
+    /// each individually capable of dropping the flag on the floor — which is how
+    /// `RETURN DISTINCT` came to be a complete no-op (#311). One choke point cannot
+    /// forget.
     pub fn plan(&self, query: &Query, store: &GraphStore) -> ExecutionResult<ExecutionPlan> {
+        let mut plan = self.plan_inner(query, store)?;
+        if query.return_clause.as_ref().is_some_and(|r| r.distinct) {
+            plan.root = Box::new(DistinctOperator::new(plan.root));
+        }
+        Ok(plan)
+    }
+
+    fn plan_inner(&self, query: &Query, store: &GraphStore) -> ExecutionResult<ExecutionPlan> {
         // Handle SHOW INDEXES
         if query.show_indexes {
             return Ok(ExecutionPlan {

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -1,0 +1,590 @@
+//! openCypher conformance suite for the **result-shaping stage**: projection, DISTINCT,
+//! implicit grouping keys, aggregation and ORDER BY.
+//!
+//! ## Why this file exists
+//!
+//! Six issues in `comp:query-engine` were open at once, all of the same kind — the engine
+//! returning *plausible but wrong* rows with no error: `RETURN DISTINCT` not deduplicating
+//! (#311), `count(var)` returning one row per implicit group instead of a scalar (#301),
+//! `ORDER BY sum(x)` not sorting (#345), inline properties inside `EXISTS { }` never
+//! matching (#346). Those are not four unrelated slips; they are what happens when a stage
+//! has no systematic semantics tests and is only exercised incidentally by feature tests
+//! that assert on one column at a time.
+//!
+//! So this suite asserts the *semantics* rather than any particular plan: one fixture,
+//! many small questions with arithmetically obvious answers. A query planner is free to
+//! answer them however it likes — with a specialized operator, a cache, or a full scan —
+//! but it must answer them the way openCypher says.
+//!
+//! ## Conventions
+//!
+//! - Every expected value is derivable by hand from the fixture below; no golden files.
+//! - Row order is only asserted where the query asks for an order.
+//! - Tests for behaviour that is *known broken and not fixed here* are `#[ignore]`d with
+//!   the issue number, so the semantics are recorded and the test turns into the
+//!   regression net the day someone fixes it. Run them with `cargo test -- --ignored`.
+
+use std::collections::BTreeMap;
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::record::Value;
+use samyama::query::QueryEngine;
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+//
+//  Person   dept    salary   city    KNOWS →
+//  ------   ------  ------   -----   ---------------------------
+//  Alice    Eng      100     NYC     Bob, Carol
+//  Bob      Eng      200     NYC     Alice
+//  Carol    Eng      300     LON     Alice
+//  Dave     Sales    150     NYC     Eve
+//  Eve      Sales    250     LON     Dave
+//  Frank    (none)  (none)   LON     (none)
+//
+//  6 people, 3 distinct cities → 2 (NYC, LON), 2 distinct depts + one absent,
+//  salary total 1000 over 5 people, 6 KNOWS edges.
+
+fn fixture() -> GraphStore {
+    let mut s = GraphStore::new();
+    let people: [(&str, Option<&str>, Option<i64>, &str); 6] = [
+        ("Alice", Some("Eng"), Some(100), "NYC"),
+        ("Bob", Some("Eng"), Some(200), "NYC"),
+        ("Carol", Some("Eng"), Some(300), "LON"),
+        ("Dave", Some("Sales"), Some(150), "NYC"),
+        ("Eve", Some("Sales"), Some(250), "LON"),
+        ("Frank", None, None, "LON"),
+    ];
+    let mut ids = BTreeMap::new();
+    for (name, dept, salary, city) in people {
+        let id = s.create_node("Person");
+        s.set_column_property(id, "name", PropertyValue::String(name.into()));
+        s.set_column_property(id, "city", PropertyValue::String(city.into()));
+        if let Some(d) = dept {
+            s.set_column_property(id, "dept", PropertyValue::String(d.into()));
+        }
+        if let Some(v) = salary {
+            s.set_column_property(id, "salary", PropertyValue::Integer(v));
+        }
+        ids.insert(name, id);
+    }
+    for (from, to) in [
+        ("Alice", "Bob"),
+        ("Alice", "Carol"),
+        ("Bob", "Alice"),
+        ("Carol", "Alice"),
+        ("Dave", "Eve"),
+        ("Eve", "Dave"),
+    ] {
+        s.create_edge(ids[from], ids[to], "KNOWS").unwrap();
+    }
+    s
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Render a value in a form that is stable to compare and readable when it fails.
+fn render(v: &Value) -> String {
+    match v {
+        Value::Property(PropertyValue::String(s)) => s.clone(),
+        Value::Property(PropertyValue::Integer(i)) => i.to_string(),
+        Value::Property(PropertyValue::Float(f)) => format!("{f:.4}"),
+        Value::Property(PropertyValue::Boolean(b)) => b.to_string(),
+        Value::Property(PropertyValue::Null) | Value::Null => "NULL".to_string(),
+        Value::Property(PropertyValue::Array(a)) => {
+            let mut parts: Vec<String> = a
+                .iter()
+                .map(|p| render(&Value::Property(p.clone())))
+                .collect();
+            parts.sort();
+            format!("[{}]", parts.join(","))
+        }
+        Value::Node(id, _) | Value::NodeRef(id) => format!("node:{}", id.as_u64()),
+        Value::Edge(id, _) | Value::EdgeRef(id, ..) => format!("edge:{}", id.as_u64()),
+        other => format!("{other:?}"),
+    }
+}
+
+/// Rows in engine order, each row rendered as `col=value` sorted by column.
+fn rows(store: &GraphStore, q: &str) -> Vec<String> {
+    let engine = QueryEngine::new();
+    let batch = engine
+        .execute(q, store)
+        .unwrap_or_else(|e| panic!("query failed: {q}\n  {e}"));
+    batch
+        .records
+        .iter()
+        .map(|r| {
+            let mut cells: Vec<String> = r
+                .bindings()
+                .iter()
+                .map(|(k, v)| format!("{k}={}", render(v)))
+                .collect();
+            cells.sort();
+            cells.join(" ")
+        })
+        .collect()
+}
+
+/// Rows as an order-independent multiset, for queries with no ORDER BY.
+fn bag(store: &GraphStore, q: &str) -> Vec<String> {
+    let mut r = rows(store, q);
+    r.sort();
+    r
+}
+
+/// The single scalar a query must return, failing loudly on any other shape.
+///
+/// The shape check is the point: `count(x)` returning three rows of the right *number* is
+/// exactly the failure mode of #301, and an assertion that only looked at `records[0]`
+/// would have passed straight through it.
+fn scalar(store: &GraphStore, q: &str) -> String {
+    let r = rows(store, q);
+    assert_eq!(
+        r.len(),
+        1,
+        "expected exactly one row from an ungrouped aggregate, got {}: {q}\n  {r:?}",
+        r.len()
+    );
+    r[0].clone()
+}
+
+// ---------------------------------------------------------------------------
+// Projection basics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn projects_a_property_once_per_matched_node() {
+    assert_eq!(
+        rows(&fixture(), "MATCH (p:Person) RETURN p.city AS c").len(),
+        6
+    );
+}
+
+#[test]
+fn projects_a_missing_property_as_null_not_as_a_dropped_row() {
+    let s = fixture();
+    let r = bag(&s, "MATCH (p:Person) RETURN p.name AS n, p.dept AS d");
+    assert_eq!(r.len(), 6, "Frank must still produce a row");
+    assert!(r.contains(&"d=NULL n=Frank".to_string()), "{r:?}");
+}
+
+#[test]
+fn an_alias_renames_the_column_and_nothing_else() {
+    let s = fixture();
+    let aliased = bag(
+        &s,
+        "MATCH (p:Person) WHERE p.name = \"Alice\" RETURN p.salary AS pay",
+    );
+    assert_eq!(aliased, vec!["pay=100"]);
+}
+
+// ---------------------------------------------------------------------------
+// DISTINCT  (#311)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn distinct_deduplicates_a_projected_property() {
+    // 6 people live in 2 distinct cities.
+    let s = fixture();
+    assert_eq!(
+        bag(&s, "MATCH (p:Person) RETURN DISTINCT p.city AS c"),
+        vec!["c=LON", "c=NYC"]
+    );
+}
+
+#[test]
+fn distinct_deduplicates_across_a_join_that_multiplies_rows() {
+    // 6 KNOWS edges, but only 4 distinct people are ever a target, in 2 cities.
+    let s = fixture();
+    assert_eq!(
+        bag(
+            &s,
+            "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN DISTINCT b.city AS c"
+        ),
+        vec!["c=LON", "c=NYC"]
+    );
+    assert_eq!(
+        bag(
+            &s,
+            "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN DISTINCT b.name AS n"
+        ),
+        vec!["n=Alice", "n=Bob", "n=Carol", "n=Dave", "n=Eve"]
+    );
+}
+
+#[test]
+fn distinct_deduplicates_whole_nodes() {
+    // Alice is the target of two KNOWS edges; DISTINCT must return her once.
+    let s = fixture();
+    let r = bag(
+        &s,
+        "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN DISTINCT b",
+    );
+    assert_eq!(r.len(), 5, "5 distinct people are known by someone: {r:?}");
+}
+
+#[test]
+fn distinct_applies_to_the_whole_row_not_to_each_column() {
+    // (dept, city) pairs: Eng/NYC twice, Eng/LON, Sales/NYC, Sales/LON, NULL/LON → 5.
+    let s = fixture();
+    let r = bag(
+        &s,
+        "MATCH (p:Person) RETURN DISTINCT p.dept AS d, p.city AS c",
+    );
+    assert_eq!(r.len(), 5, "{r:?}");
+    assert!(r.contains(&"c=NYC d=Eng".to_string()), "{r:?}");
+    assert!(
+        r.contains(&"c=LON d=NULL".to_string()),
+        "Frank's null dept is a value: {r:?}"
+    );
+}
+
+#[test]
+fn distinct_treats_null_as_equal_to_null_for_deduplication() {
+    // openCypher: DISTINCT groups NULLs together even though NULL = NULL is unknown.
+    let s = fixture();
+    let r = bag(&s, "MATCH (p:Person) RETURN DISTINCT p.dept AS d");
+    assert_eq!(r, vec!["d=Eng", "d=NULL", "d=Sales"], "{r:?}");
+}
+
+#[test]
+fn distinct_on_already_unique_rows_changes_nothing() {
+    let s = fixture();
+    assert_eq!(
+        bag(&s, "MATCH (p:Person) RETURN DISTINCT p.name AS n").len(),
+        6
+    );
+}
+
+#[test]
+fn distinct_composes_with_order_by_at_least_as_far_as_deduplicating() {
+    // The dedup half works today; the ordering half is blocked on #356. Asserting the
+    // multiset here keeps the DISTINCT coverage live instead of parking it behind an
+    // unrelated bug.
+    let s = fixture();
+    assert_eq!(
+        bag(
+            &s,
+            "MATCH (p:Person) RETURN DISTINCT p.city AS c ORDER BY c"
+        ),
+        vec!["c=LON", "c=NYC"]
+    );
+}
+
+#[test]
+#[ignore = "blocked on #356: ORDER BY <alias> is silently ignored"]
+fn distinct_composes_with_order_by() {
+    let s = fixture();
+    assert_eq!(
+        rows(
+            &s,
+            "MATCH (p:Person) RETURN DISTINCT p.city AS c ORDER BY c"
+        ),
+        vec!["c=LON", "c=NYC"]
+    );
+}
+
+#[test]
+fn distinct_composes_with_limit() {
+    // LIMIT applies after deduplication, so 2 distinct cities LIMIT 5 gives 2 rows —
+    // not 5 rows of duplicates.
+    let s = fixture();
+    assert_eq!(
+        rows(&s, "MATCH (p:Person) RETURN DISTINCT p.city AS c LIMIT 5").len(),
+        2
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Implicit grouping keys and aggregation  (#301)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_return_containing_only_aggregates_produces_exactly_one_row() {
+    let s = fixture();
+    assert_eq!(scalar(&s, "MATCH (p:Person) RETURN count(p) AS n"), "n=6");
+    assert_eq!(scalar(&s, "MATCH (p:Person) RETURN count(*) AS n"), "n=6");
+    assert_eq!(
+        scalar(&s, "MATCH (p:Person) RETURN sum(p.salary) AS v"),
+        "v=1000"
+    );
+}
+
+#[test]
+fn counting_one_endpoint_of_a_pattern_is_still_a_single_scalar() {
+    // The #301 shape. 6 KNOWS edges, so count over either endpoint is 6 — one row.
+    // Returning one row per `a` with its out-degree is the bug.
+    let s = fixture();
+    assert_eq!(
+        scalar(
+            &s,
+            "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN count(b) AS n"
+        ),
+        "n=6"
+    );
+    assert_eq!(
+        scalar(
+            &s,
+            "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN count(a) AS n"
+        ),
+        "n=6"
+    );
+    assert_eq!(
+        scalar(
+            &s,
+            "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN count(*) AS n"
+        ),
+        "n=6"
+    );
+}
+
+#[test]
+fn count_distinct_over_an_endpoint_is_a_single_scalar() {
+    // 6 edges, 5 distinct targets (Alice appears twice).
+    let s = fixture();
+    assert_eq!(
+        scalar(
+            &s,
+            "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN count(DISTINCT b) AS n"
+        ),
+        "n=5"
+    );
+}
+
+#[test]
+fn a_non_aggregate_item_becomes_the_grouping_key() {
+    // Eng 3, Sales 2, no dept 1.
+    let s = fixture();
+    let r = bag(&s, "MATCH (p:Person) RETURN p.dept AS d, count(p) AS n");
+    assert_eq!(r, vec!["d=Eng n=3", "d=NULL n=1", "d=Sales n=2"], "{r:?}");
+}
+
+#[test]
+fn grouping_over_a_pattern_counts_edges_per_group() {
+    // KNOWS targets by city: NYC targets are Alice(x2) and Bob = 3; LON are Carol, Dave...
+    // by target city: Alice NYC x2, Bob NYC x1, Carol LON x1, Dave NYC x1, Eve LON x1
+    //   → NYC 4, LON 2
+    let s = fixture();
+    let r = bag(
+        &s,
+        "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN b.city AS c, count(a) AS n",
+    );
+    assert_eq!(r, vec!["c=LON n=2", "c=NYC n=4"], "{r:?}");
+}
+
+#[test]
+fn two_grouping_keys_group_on_the_pair() {
+    let s = fixture();
+    let r = bag(
+        &s,
+        "MATCH (p:Person) RETURN p.dept AS d, p.city AS c, count(p) AS n",
+    );
+    assert_eq!(r.len(), 5, "five distinct (dept, city) pairs: {r:?}");
+}
+
+#[test]
+fn several_aggregates_share_one_ungrouped_row() {
+    // Shape and the three aggregates that handle nulls correctly. `min` is split out
+    // below because it is broken for a reason unrelated to grouping (#357).
+    let s = fixture();
+    let r = rows(
+        &s,
+        "MATCH (p:Person) RETURN count(p) AS c, sum(p.salary) AS s, max(p.salary) AS mx",
+    );
+    assert_eq!(r.len(), 1, "{r:?}");
+    assert_eq!(r[0], "c=6 mx=300 s=1000");
+}
+
+#[test]
+fn count_of_a_node_counts_rows() {
+    let s = fixture();
+    assert_eq!(scalar(&s, "MATCH (p:Person) RETURN count(p) AS n"), "n=6");
+    assert_eq!(scalar(&s, "MATCH (p:Person) RETURN count(*) AS n"), "n=6");
+}
+
+#[test]
+#[ignore = "blocked on #358: count(expr) counts rows instead of non-null values"]
+fn count_of_a_property_skips_nulls() {
+    let s = fixture();
+    assert_eq!(
+        scalar(&s, "MATCH (p:Person) RETURN count(p.salary) AS n"),
+        "n=5"
+    );
+    // collect() skips nulls too — render() sorts the array so this is order-independent
+    assert_eq!(
+        rows(&s, "MATCH (p:Person) RETURN collect(p.salary) AS a"),
+        vec!["a=[100,150,200,250,300]"]
+    );
+}
+
+#[test]
+fn sum_and_max_ignore_nulls() {
+    let s = fixture();
+    assert_eq!(
+        scalar(&s, "MATCH (p:Person) RETURN sum(p.salary) AS v"),
+        "v=1000"
+    );
+    assert_eq!(
+        scalar(&s, "MATCH (p:Person) RETURN max(p.salary) AS v"),
+        "v=300"
+    );
+    // avg divides by the 5 non-null salaries, not by 6 rows
+    assert_eq!(
+        scalar(&s, "MATCH (p:Person) RETURN avg(p.salary) AS v"),
+        "v=200.0000"
+    );
+}
+
+#[test]
+#[ignore = "blocked on #357: min() returns NULL when any row is null"]
+fn min_ignores_nulls() {
+    let s = fixture();
+    assert_eq!(
+        scalar(&s, "MATCH (p:Person) RETURN min(p.salary) AS v"),
+        "v=100"
+    );
+}
+
+#[test]
+fn a_filtered_empty_match_still_yields_one_row_for_count_and_zero_for_a_bare_projection() {
+    let s = fixture();
+    assert_eq!(
+        scalar(
+            &s,
+            "MATCH (p:Person) WHERE p.name = \"Nobody\" RETURN count(p) AS n"
+        ),
+        "n=0"
+    );
+    assert_eq!(
+        rows(
+            &s,
+            "MATCH (p:Person) WHERE p.name = \"Nobody\" RETURN p.name AS n"
+        )
+        .len(),
+        0
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ORDER BY
+// ---------------------------------------------------------------------------
+
+#[test]
+fn order_by_a_property_expression_sorts() {
+    // The spelling that works today, kept live so a regression here is caught even while
+    // the alias form (#356) is parked.
+    let s = fixture();
+    let r = rows(
+        &s,
+        "MATCH (p:Person) RETURN p.name AS n, p.salary AS v ORDER BY p.salary DESC",
+    );
+    assert_eq!(r[0], "n=Carol v=300", "highest salary first: {r:?}");
+}
+
+#[test]
+#[ignore = "blocked on #356: ORDER BY <alias> is silently ignored"]
+fn order_by_a_projected_alias_sorts() {
+    let s = fixture();
+    let r = rows(
+        &s,
+        "MATCH (p:Person) RETURN p.name AS n, p.salary AS v ORDER BY v DESC",
+    );
+    assert_eq!(r[0], "n=Carol v=300", "highest salary first: {r:?}");
+    assert_eq!(
+        r[r.len() - 1],
+        "n=Frank v=NULL",
+        "nulls sort last on DESC: {r:?}"
+    );
+}
+
+#[test]
+fn order_by_an_aggregate_alias_sorts_groups() {
+    let s = fixture();
+    let r = rows(
+        &s,
+        "MATCH (p:Person) RETURN p.dept AS d, count(p) AS n ORDER BY n DESC",
+    );
+    assert_eq!(r[0], "d=Eng n=3", "{r:?}");
+}
+
+#[test]
+#[ignore = "blocked on #356: ORDER BY <alias> is silently ignored"]
+fn order_by_with_limit_returns_the_true_top_k() {
+    let s = fixture();
+    let r = rows(
+        &s,
+        "MATCH (p:Person) RETURN p.name AS n, p.salary AS v ORDER BY v DESC LIMIT 2",
+    );
+    assert_eq!(r, vec!["n=Carol v=300", "n=Bob v=200"], "{r:?}");
+}
+
+#[test]
+#[ignore = "blocked on #345: ORDER BY sum(...) DESC does not sort; use the alias"]
+fn order_by_a_repeated_aggregate_expression_sorts_like_its_alias() {
+    let s = fixture();
+    let by_expr = rows(
+        &s,
+        "MATCH (p:Person) RETURN p.dept AS d, sum(p.salary) AS v ORDER BY sum(p.salary) DESC",
+    );
+    let by_alias = rows(
+        &s,
+        "MATCH (p:Person) RETURN p.dept AS d, sum(p.salary) AS v ORDER BY v DESC",
+    );
+    assert_eq!(by_expr, by_alias);
+}
+
+// ---------------------------------------------------------------------------
+// Neighbouring semantics this stage depends on — recorded, not fixed here
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "blocked on #346: inline property maps inside EXISTS { } never match"]
+fn exists_subquery_applies_inline_property_constraints() {
+    let s = fixture();
+    assert_eq!(
+        scalar(
+            &s,
+            "MATCH (p:Person) WHERE EXISTS { MATCH (p)-[:KNOWS]->(o:Person {name: \"Alice\"}) } RETURN count(p) AS n"
+        ),
+        "n=2",
+        "Bob and Carol both know Alice"
+    );
+}
+
+#[test]
+#[ignore = "blocked on #347: NOT binds tighter than STARTS WITH"]
+fn not_binds_looser_than_string_comparison() {
+    let s = fixture();
+    assert_eq!(
+        scalar(
+            &s,
+            "MATCH (p:Person) WHERE NOT p.name STARTS WITH \"A\" RETURN count(p) AS n"
+        ),
+        "n=5"
+    );
+}
+
+#[test]
+fn is_not_null_matches_only_nodes_carrying_the_property() {
+    // #312 claims this over-matches on mixed-schema data; it holds on this fixture, so the
+    // assertion stays as a guard while that issue is narrowed.
+    let s = fixture();
+    assert_eq!(
+        scalar(
+            &s,
+            "MATCH (p:Person) WHERE p.dept IS NOT NULL RETURN count(p) AS n"
+        ),
+        "n=5"
+    );
+    assert_eq!(
+        scalar(
+            &s,
+            "MATCH (p:Person) WHERE p.dept IS NULL RETURN count(p) AS n"
+        ),
+        "n=1"
+    );
+}


### PR DESCRIPTION
Fixes #311. Fixes #301.

Two silent-wrongness bugs in the result-shaping stage, plus the conformance suite that should have caught them — and which found three more on its first run.

## #311 — `RETURN DISTINCT` was a complete no-op

```cypher
-- 6 people living in 2 distinct cities
MATCH (p:Person) RETURN DISTINCT p.city AS c
-- before: 6 rows          after: 2 rows
```

`ProjectOperator` has no notion of distinctness and the AST flag was never read on the plain `RETURN` path. It failed on properties, on whole nodes, and on multi-column rows — the keyword did nothing at all.

Adds a streaming `DistinctOperator` above the projection, keyed on the whole projected row. It sits above the projection deliberately: two rows differing only in a column that is *not* projected are the same row as far as `DISTINCT` is concerned. `Value` already hashes nodes and edges by identity and treats `NULL` as equal to `NULL`, which is exactly openCypher's `DISTINCT` equivalence (as opposed to equality, where `NULL = NULL` is unknown).

It is applied in `QueryPlanner::plan` — the single point every planning path funnels through — rather than at the dozen sites that build a `ProjectOperator`. Several of those are specialized fast plans (adjacency-count aggregation, hierarchy rewrites, label-count caches) and each was individually capable of dropping the flag. That is how this became a no-op in the first place; one choke point cannot forget.

## #301 — ungrouped `count()` returned one row per implicit group

```cypher
-- 6 KNOWS edges
MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN count(b) AS n
-- before: 3 rows of n=2   after: 1 row of n=6
```

The ADR-017 adjacency-count detector fired on a `RETURN` containing **no grouping key at all**. `AdjacencyCountAggregateOperator` emits one record per grouped node, so an ungrouped query got one row per `a` carrying its out-degree — the right numbers attached to the wrong question. `count(*)` and `sum(expr)` were unaffected, which is why this survived; only `count(<variable>)` over a multi-variable pattern took the bad path.

Both detector entry points now decline when `group_by_items` is empty and let the generic `Aggregate` path answer it.

## The conformance suite

`tests/cypher_projection_semantics.rs` — one fixture, small questions with arithmetically obvious answers, asserting **semantics rather than plan shape**. A planner is free to answer them with a specialized operator, a cache or a full scan; it must answer them the way openCypher says.

Six `comp:query-engine` issues were open at once, all of the same kind: plausible-but-wrong rows, no error. That is not six unrelated slips — it is what happens when a stage has no systematic semantics tests and is exercised only incidentally by feature tests that assert one column at a time. One detail worth calling out: the `scalar()` helper asserts the result has exactly **one row**, not just the right number in `records[0]`. An assertion that only read the first row would have passed straight through #301.

It found three further bugs on its first run, now filed with self-contained repros and marked `#[ignore]` against their issue numbers, so each becomes the regression net the day it is fixed:

| | |
|---|---|
| #356 | `ORDER BY <alias>` is silently ignored — `ORDER BY <expression>` works. The mirror of #345, where the aggregate case is the opposite way round; between them neither spelling works universally, which suggests one underlying cause. |
| #357 | `min()` returns `NULL` when any row is null; `max`/`sum`/`avg` correctly ignore nulls |
| #358 | `count(<expr>)` counts rows instead of non-null values; `collect()` keeps a `NULL` element |

Where a test covered both working and broken behaviour I split it rather than ignoring the whole thing, so the live coverage stays live — e.g. `sum`/`max`/`avg` null handling is asserted today while `min` is parked against #357.

## Testing

24 conformance tests pass, 8 ignored against #345/#346/#347/#356/#357/#358. 2109 lib tests pass. `cargo fmt` and `cargo clippy` clean on the new code.

Two tests fail in a full `cargo test --no-fail-fast` run — `age_plan_executor_test::parallel_group_shares_wall_time` and `graph::store::tests::test_vector_search_with_data`. Both are load-sensitive flakes, not regressions: the lib binary passes 2109/2109 twice both with and without this change, and each test passes in isolation on both revisions.