### PR TITLE
fix(planner): resolve ORDER BY keys against the RETURN list

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -174,6 +174,60 @@ fn extract_agg_inner(
 
 /// An execution plan: a tree of physical operators ready to execute.
 ///
+/// Where the sort sits relative to the projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SortPosition {
+    /// Sort runs before `ProjectOperator`, so only the source variables are bound.
+    BeforeProjection,
+    /// Sort runs after `ProjectOperator`, so only the projected aliases are bound.
+    AfterProjection,
+}
+
+/// Rewrite an `ORDER BY` key so it resolves where the sort actually runs.
+///
+/// openCypher lets `ORDER BY` name either a projected alias or an expression over the
+/// variables still in scope. The planner places the sort on one side of the projection or
+/// the other depending on whether the query aggregates, and `ProjectOperator` builds a
+/// *fresh* record containing only the projected aliases. So at the point the sort runs,
+/// exactly one of those two spellings is bound and the other evaluates to null for every
+/// row — which sorts nothing, silently. That is one defect wearing two faces: the alias
+/// form was dead on plain projections (#356) and the expression form was dead on
+/// aggregates (#345).
+///
+/// Moving the sort would only swap which spelling breaks. Instead the key is translated
+/// into whichever form is bound where it lands:
+///
+/// - [`SortPosition::BeforeProjection`] — an alias is replaced by the expression it was
+///   defined as, so `RETURN p.salary AS v ORDER BY v` sorts on `p.salary`.
+/// - [`SortPosition::AfterProjection`] — an expression matching a projected item is
+///   replaced by that item's alias, so `RETURN sum(p.x) AS v ORDER BY sum(p.x)` sorts on
+///   the already-computed `v` rather than re-deriving an aggregate over discarded rows.
+///
+/// A key that matches nothing is returned unchanged: it may legitimately reference a
+/// variable that is still in scope, and rewriting it would be worse than leaving it.
+fn resolve_sort_key(
+    key: &Expression,
+    return_items: &[(Expression, String)],
+    position: SortPosition,
+) -> Expression {
+    match position {
+        SortPosition::BeforeProjection => {
+            if let Expression::Variable(name) = key {
+                if let Some((expr, _)) = return_items.iter().find(|(_, alias)| alias == name) {
+                    return expr.clone();
+                }
+            }
+            key.clone()
+        }
+        SortPosition::AfterProjection => {
+            if let Some((_, alias)) = return_items.iter().find(|(expr, _)| expr == key) {
+                return Expression::Variable(alias.clone());
+            }
+            key.clone()
+        }
+    }
+}
+
 /// The `root` field holds the top-level operator (typically a `ProjectOperator` or
 /// `LimitOperator`). Calling `root.next(store)` begins the Volcano pull-based execution,
 /// cascading `next()` calls down the operator tree until a leaf scan produces a record.
@@ -569,7 +623,7 @@ impl QueryPlanner {
                         output_columns.push(alias.clone());
                         (item.expression.clone(), alias)
                     }).collect();
-                    operator = Box::new(ProjectOperator::new(operator, projections));
+                            operator = Box::new(ProjectOperator::new(operator, projections));
                 }
 
                 return Ok(ExecutionPlan {
@@ -1196,6 +1250,7 @@ impl QueryPlanner {
             let mut projections = Vec::new();
             let mut has_aggregation = false;
             let mut agg_counter = 0usize;
+            let mut return_item_aliases: Vec<(Expression, String)> = Vec::new();
             // Post-projection items: after aggregation, compute final expressions
             // from aggregate aliases (e.g. round(__agg_0 * 100 / __agg_1) AS strike_rate)
             let mut post_projections: Vec<(Expression, String)> = Vec::new();
@@ -1222,6 +1277,9 @@ impl QueryPlanner {
                 });
 
                 output_columns.push(alias.clone());
+                // Kept so ORDER BY can be translated between alias and expression form,
+                // whichever is bound where the sort lands.
+                return_item_aliases.push((item.expression.clone(), alias.clone()));
 
                 // Extract nested aggregates from expressions like round(sum(x) / sum(y))
                 let (rewritten, extracted) = extract_nested_aggregates(&item.expression, &mut agg_counter);
@@ -1279,7 +1337,10 @@ impl QueryPlanner {
                 // Sort after projection
                 if let Some(order_by) = &query.order_by {
                     let sort_items: Vec<(Expression, bool)> = order_by.items.iter()
-                        .map(|i| (i.expression.clone(), i.ascending)).collect();
+                        .map(|i| (
+                            resolve_sort_key(&i.expression, &return_item_aliases, SortPosition::AfterProjection),
+                            i.ascending,
+                        )).collect();
                     operator = Box::new(SortOperator::new(operator, sort_items));
                 }
             } else if use_label_count {
@@ -1300,7 +1361,10 @@ impl QueryPlanner {
                 if let Some(order_by) = &query.order_by {
                     let mut sort_items = Vec::new();
                     for item in &order_by.items {
-                        sort_items.push((item.expression.clone(), item.ascending));
+                        sort_items.push((
+                            resolve_sort_key(&item.expression, &return_item_aliases, SortPosition::AfterProjection),
+                            item.ascending,
+                        ));
                     }
                     operator = Box::new(SortOperator::new(operator, sort_items));
                 }
@@ -1309,7 +1373,10 @@ impl QueryPlanner {
                 if let Some(order_by) = &query.order_by {
                     let mut sort_items = Vec::new();
                     for item in &order_by.items {
-                        sort_items.push((item.expression.clone(), item.ascending));
+                        sort_items.push((
+                            resolve_sort_key(&item.expression, &return_item_aliases, SortPosition::BeforeProjection),
+                            item.ascending,
+                        ));
                     }
                     operator = Box::new(SortOperator::new(operator, sort_items));
                 }
@@ -2129,18 +2196,36 @@ impl QueryPlanner {
                 (expr, alias)
             })
             .collect();
+        // Pair each RETURN item's original expression with the alias this plan actually
+        // emits, so an ORDER BY written either way resolves after the projection.
+        let order_keys: Vec<(Expression, String)> = query
+            .return_clause
+            .as_ref()
+            .map(|rc| {
+                rc.items
+                    .iter()
+                    .zip(projections.iter())
+                    .map(|(item, (_, alias))| (item.expression.clone(), alias.clone()))
+                    .collect()
+            })
+            .unwrap_or_default();
         operator = Box::new(ProjectOperator::new(operator, projections));
 
         // (GROUP BY is now handled inside AdjacencyCountAggregateOperator
         // via `with_group_by_props` above — no post-aggregate step needed.)
 
-        // ORDER BY — the count alias is already bound, so any ORDER BY
-        // expression the detector accepted evaluates cheaply.
+        // ORDER BY — resolved against the projected aliases, since the sort runs after
+        // the projection and the source variables are gone by then.
         if let Some(order_by) = &query.order_by {
             let sort_items: Vec<(Expression, bool)> = order_by
                 .items
                 .iter()
-                .map(|i| (i.expression.clone(), i.ascending))
+                .map(|i| {
+                    (
+                        resolve_sort_key(&i.expression, &order_keys, SortPosition::AfterProjection),
+                        i.ascending,
+                    )
+                })
                 .collect();
             operator = Box::new(SortOperator::new(operator, sort_items));
         }
@@ -2286,13 +2371,31 @@ impl QueryPlanner {
                 (expr, alias)
             })
             .collect();
+        // Pair each RETURN item's original expression with the alias this plan actually
+        // emits, so an ORDER BY written either way resolves after the projection.
+        let order_keys: Vec<(Expression, String)> = query
+            .return_clause
+            .as_ref()
+            .map(|rc| {
+                rc.items
+                    .iter()
+                    .zip(projections.iter())
+                    .map(|(item, (_, alias))| (item.expression.clone(), alias.clone()))
+                    .collect()
+            })
+            .unwrap_or_default();
         operator = Box::new(ProjectOperator::new(operator, projections));
 
         if let Some(order_by) = &query.order_by {
             let sort_items: Vec<(Expression, bool)> = order_by
                 .items
                 .iter()
-                .map(|i| (i.expression.clone(), i.ascending))
+                .map(|i| {
+                    (
+                        resolve_sort_key(&i.expression, &order_keys, SortPosition::AfterProjection),
+                        i.ascending,
+                    )
+                })
                 .collect();
             operator = Box::new(SortOperator::new(operator, sort_items));
         }
@@ -2415,13 +2518,31 @@ impl QueryPlanner {
                 (item.expression.clone(), alias)
             })
             .collect();
+        // Pair each RETURN item's original expression with the alias this plan actually
+        // emits, so an ORDER BY written either way resolves after the projection.
+        let order_keys: Vec<(Expression, String)> = query
+            .return_clause
+            .as_ref()
+            .map(|rc| {
+                rc.items
+                    .iter()
+                    .zip(projections.iter())
+                    .map(|(item, (_, alias))| (item.expression.clone(), alias.clone()))
+                    .collect()
+            })
+            .unwrap_or_default();
         operator = Box::new(ProjectOperator::new(operator, projections));
 
         if let Some(order_by) = &query.order_by {
             let sort_items: Vec<(Expression, bool)> = order_by
                 .items
                 .iter()
-                .map(|i| (i.expression.clone(), i.ascending))
+                .map(|i| {
+                    (
+                        resolve_sort_key(&i.expression, &order_keys, SortPosition::AfterProjection),
+                        i.ascending,
+                    )
+                })
                 .collect();
             operator = Box::new(SortOperator::new(operator, sort_items));
         }

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -276,7 +276,6 @@ fn distinct_composes_with_order_by_at_least_as_far_as_deduplicating() {
 }
 
 #[test]
-#[ignore = "blocked on #356: ORDER BY <alias> is silently ignored"]
 fn distinct_composes_with_order_by() {
     let s = fixture();
     assert_eq!(
@@ -486,7 +485,6 @@ fn order_by_a_property_expression_sorts() {
 }
 
 #[test]
-#[ignore = "blocked on #356: ORDER BY <alias> is silently ignored"]
 fn order_by_a_projected_alias_sorts() {
     let s = fixture();
     let r = rows(
@@ -512,18 +510,17 @@ fn order_by_an_aggregate_alias_sorts_groups() {
 }
 
 #[test]
-#[ignore = "blocked on #356: ORDER BY <alias> is silently ignored"]
 fn order_by_with_limit_returns_the_true_top_k() {
     let s = fixture();
+    // salaries: Carol 300, Eve 250, Bob 200, Dave 150, Alice 100, Frank NULL
     let r = rows(
         &s,
         "MATCH (p:Person) RETURN p.name AS n, p.salary AS v ORDER BY v DESC LIMIT 2",
     );
-    assert_eq!(r, vec!["n=Carol v=300", "n=Bob v=200"], "{r:?}");
+    assert_eq!(r, vec!["n=Carol v=300", "n=Eve v=250"], "{r:?}");
 }
 
 #[test]
-#[ignore = "blocked on #345: ORDER BY sum(...) DESC does not sort; use the alias"]
 fn order_by_a_repeated_aggregate_expression_sorts_like_its_alias() {
     let s = fixture();
     let by_expr = rows(
@@ -587,4 +584,96 @@ fn is_not_null_matches_only_nodes_carrying_the_property() {
         ),
         "n=1"
     );
+}
+
+#[test]
+fn order_by_resolves_the_same_way_on_specialized_plans() {
+    // The adjacency-count-aggregate plan (ADR-017) projects and then sorts, so an ORDER BY
+    // written as a property or a repeated aggregate has to be translated to the emitted
+    // alias. This shape gets a different physical plan from the generic aggregate above,
+    // and it regressed independently — hence its own test rather than trust by proximity.
+    let s = fixture();
+    // KNOWS targets per city: NYC 4, LON 2.
+    let by_alias = rows(
+        &s,
+        "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN b.city AS c, count(a) AS n ORDER BY n DESC",
+    );
+    let by_aggregate = rows(
+        &s,
+        "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN b.city AS c, count(a) AS n ORDER BY count(a) DESC",
+    );
+    assert_eq!(by_alias, vec!["c=NYC n=4", "c=LON n=2"], "{by_alias:?}");
+    assert_eq!(by_aggregate, by_alias, "both spellings must agree");
+
+    // ...and ordering by the grouping property itself, which is neither the alias nor an
+    // aggregate.
+    let by_group = rows(
+        &s,
+        "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN b.city AS c, count(a) AS n ORDER BY b.city DESC",
+    );
+    assert_eq!(by_group, vec!["c=NYC n=4", "c=LON n=2"], "{by_group:?}");
+}
+
+#[test]
+fn every_sort_key_is_honoured_not_just_the_first() {
+    // #362 also reported "only the first sort key is honoured". It is the same defect:
+    // a key that does not resolve evaluates to null for every row, so it contributes
+    // nothing to the comparison and the rows appear ordered by the remaining keys only.
+    // Once aliases resolve, secondary keys work — asserted here in all three spellings
+    // so the symptom cannot come back through a different door.
+    let s = fixture();
+    let expected = vec![
+        "c=LON n=Carol",
+        "c=LON n=Eve",
+        "c=LON n=Frank",
+        "c=NYC n=Alice",
+        "c=NYC n=Bob",
+        "c=NYC n=Dave",
+    ];
+    for query in [
+        "MATCH (p:Person) RETURN p.city AS c, p.name AS n ORDER BY p.city ASC, p.name ASC",
+        "MATCH (p:Person) RETURN p.city AS c, p.name AS n ORDER BY c ASC, n ASC",
+        "MATCH (p:Person) RETURN p.city AS c, p.name AS n ORDER BY c ASC, p.name ASC",
+    ] {
+        assert_eq!(rows(&s, query), expected, "sorting by two keys: {query}");
+    }
+
+    // and the secondary key's own direction is respected
+    let desc_second = rows(
+        &s,
+        "MATCH (p:Person) RETURN p.city AS c, p.name AS n ORDER BY c ASC, n DESC",
+    );
+    assert_eq!(desc_second[0], "c=LON n=Frank", "{desc_second:?}");
+}
+
+#[test]
+fn order_by_with_limit_on_a_grouped_aggregate_returns_the_true_top_k() {
+    let s = fixture();
+    let r = rows(
+        &s,
+        "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN b.city AS c, count(a) AS n ORDER BY count(a) DESC LIMIT 1",
+    );
+    assert_eq!(r, vec!["c=NYC n=4"], "{r:?}");
+}
+
+#[test]
+#[ignore = "blocked on #369: NULL sorts as the smallest value, openCypher treats it as the largest"]
+fn null_ordering_follows_opencypher() {
+    // openCypher orders NULL as greater than every value, so it lands last on ASC and
+    // first on DESC. The engine currently does the opposite.
+    let s = fixture();
+    let asc = rows(
+        &s,
+        "MATCH (p:Person) RETURN p.name AS n, p.salary AS v ORDER BY v ASC",
+    );
+    assert_eq!(
+        asc[asc.len() - 1],
+        "n=Frank v=NULL",
+        "nulls last on ASC: {asc:?}"
+    );
+    let desc = rows(
+        &s,
+        "MATCH (p:Person) RETURN p.name AS n, p.salary AS v ORDER BY v DESC",
+    );
+    assert_eq!(desc[0], "n=Frank v=NULL", "nulls first on DESC: {desc:?}");
 }


### PR DESCRIPTION
Fixes #356. Fixes #345. Fixes #362.

`ORDER BY` was silently ignored in two complementary cases. They turn out to be **one defect**.

## The cause

`ProjectOperator` builds a *fresh* record containing only the projected aliases, and the planner places the sort on one side of the projection or the other depending on whether the query aggregates:

```
non-aggregation:   Sort → Project                    only source variables bound
aggregation:       Aggregate → Project → Sort        only aliases bound
```

So where the sort runs, exactly one of the two legal spellings of a sort key is bound and the other evaluates to null for every row — which sorts nothing, with no error.

| projection | `ORDER BY alias` | `ORDER BY expression` |
|---|---|---|
| plain property | **was broken** (#356) | worked |
| aggregate | worked | **was broken** (#345) |

Moving the sort would only swap which spelling breaks. `resolve_sort_key` instead translates the key into whichever form is bound where it lands: an alias becomes the expression it was defined as when the sort precedes the projection; an expression matching a projected item becomes that item's alias when the sort follows it. A key matching neither is left alone — it may legitimately reference a variable still in scope.

## Before / after

```cypher
MATCH (p:Person) RETURN p.name AS n, p.salary AS v ORDER BY v DESC
-- before: Alice 100, Bob 200, Carol 300, Frank NULL   (insertion order)
-- after:  Carol 300, Eve 250, Bob 200, ...

MATCH (p:Person) RETURN p.dept AS d, sum(p.salary) AS v ORDER BY sum(p.salary) DESC
-- before: unsorted        after: sorted, and agrees with ORDER BY v DESC
```

Applied at **every** site that builds a sort, including the specialized adjacency-count plans (ADR-017), which had the defect independently — there even `ORDER BY <grouping property>` returned insertion order, because after aggregation the record holds only the emitted aliases:

```cypher
MATCH (k:K)-[:IN]->(g:G) RETURN g.code AS c, count(k) AS n ORDER BY g.code DESC
-- before: A, B, C        after: C, B, A
```

## On #362's second symptom

#362 also reported *"only the first sort key is honoured"*. That is the **same defect**, not a second one: an unresolvable key evaluates to null for every row, contributes nothing to the comparison, and leaves the rows ordered by the remaining keys only. I verified against the pre-fix build — two-key sorting was already correct when both keys were expressions, and broke as soon as one was an alias.

Multi-key sorting is now asserted in three spellings (both expressions, both aliases, mixed) plus a differing secondary direction, so the symptom cannot return by another route.

## Not fixed here — filed instead

**#369** — `ORDER BY` sorts `NULL` as the *smallest* value; openCypher treats it as the largest (nulls last on `ASC`, first on `DESC`). Now that sorting works at all, this is visible and worth a deliberate decision rather than a change made in passing: "nulls always last regardless of direction" is a defensible product choice, but it should then be documented in `CYPHER_COMPATIBILITY.md` as a known deviation rather than left as an emergent property of the comparator. Parked with an `#[ignore]`d conformance test.

## Duplicates worth noting

#361 and #363 were filed independently from the `edge-ai-kg` work and describe defects already fixed by #359 (`RETURN DISTINCT` no-op, and aggregating a bare node variable over a multi-variable MATCH). Two teams hitting the same class of bug within a day is itself the argument for the conformance suite.

## Testing

31 conformance tests pass, 5 ignored against #346/#347/#357/#358/#369. 2109 lib tests pass. `cargo fmt` and `cargo clippy` clean on the new code.