### PR TITLE
perf(hierarchy): emit HierarchyOrderTest for subsumption predicates

### DIFF
--- a/src/index/hierarchy/manager.rs
+++ b/src/index/hierarchy/manager.rs
@@ -15,7 +15,7 @@
 //! with a diagnostic and no index, so `SHOW HIERARCHY INDEXES` can explain why the planner
 //! is not using it (see the honest-scope section of ADR-035).
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
 
 use crate::graph::types::{EdgeType, Label, NodeId};
@@ -160,14 +160,21 @@ pub struct HierarchyInfo {
 /// Registry of hierarchy indexes for one store.
 #[derive(Debug, Default)]
 pub struct HierarchyIndexManager {
-    entries: RwLock<HashMap<String, Arc<RwLock<HierarchyEntry>>>>,
+    /// Name-keyed registry.
+    ///
+    /// A `BTreeMap` rather than a `HashMap` because iteration order matters: when several
+    /// hierarchies could answer the same question the choice must be reproducible, not
+    /// dependent on hash seeding. Getting that from the container is also what makes the
+    /// hot path cheap — `usable_containing` runs once per row inside `subsumes()`, and it
+    /// previously collected every key into a `Vec` and sorted it on each call.
+    entries: RwLock<BTreeMap<String, Arc<RwLock<HierarchyEntry>>>>,
 }
 
 impl HierarchyIndexManager {
     /// Empty registry.
     pub fn new() -> Self {
         HierarchyIndexManager {
-            entries: RwLock::new(HashMap::new()),
+            entries: RwLock::new(BTreeMap::new()),
         }
     }
 
@@ -279,26 +286,25 @@ impl HierarchyIndexManager {
         &self,
         edge_type: &EdgeType,
     ) -> Option<Arc<RwLock<HierarchyEntry>>> {
+        // Iteration is name-ordered, so the choice among several covering hierarchies is
+        // deterministic without a sort.
         let entries = self.entries.read().unwrap();
-        let mut candidates: Vec<(&String, &Arc<RwLock<HierarchyEntry>>)> = entries
-            .iter()
-            .filter(|(_, e)| {
+        entries
+            .values()
+            .find(|e| {
                 let g = e.read().unwrap();
                 g.usable() && g.spec.edge_types.iter().any(|t| t == edge_type)
             })
-            .collect();
-        // Deterministic choice when several hierarchies cover the same edge type.
-        candidates.sort_by(|a, b| a.0.cmp(b.0));
-        candidates.first().map(|(_, e)| Arc::clone(e))
+            .map(Arc::clone)
     }
 
     /// Any entry covering `edge_type`, usable or not — for `EXPLAIN` to report why a
     /// rewrite did not fire.
     pub fn any_for_edge_type(&self, edge_type: &EdgeType) -> Option<Arc<RwLock<HierarchyEntry>>> {
         let entries = self.entries.read().unwrap();
-        let mut candidates: Vec<(&String, &Arc<RwLock<HierarchyEntry>>)> = entries
-            .iter()
-            .filter(|(_, e)| {
+        entries
+            .values()
+            .find(|e| {
                 e.read()
                     .unwrap()
                     .spec
@@ -306,9 +312,7 @@ impl HierarchyIndexManager {
                     .iter()
                     .any(|t| t == edge_type)
             })
-            .collect();
-        candidates.sort_by(|a, b| a.0.cmp(b.0));
-        candidates.first().map(|(_, e)| Arc::clone(e))
+            .map(Arc::clone)
     }
 
     /// A usable index by name.
@@ -331,10 +335,7 @@ impl HierarchyIndexManager {
     /// rather than dependent on hash iteration order.
     pub fn usable_containing(&self, ids: &[NodeId]) -> Option<Arc<RwLock<HierarchyEntry>>> {
         let entries = self.entries.read().unwrap();
-        let mut names: Vec<&String> = entries.keys().collect();
-        names.sort();
-        for name in names {
-            let e = &entries[name];
+        for e in entries.values() {
             let g = e.read().unwrap();
             if !g.usable() {
                 continue;
@@ -384,12 +385,11 @@ impl HierarchyIndexManager {
     /// All registered indexes, name-sorted.
     pub fn list(&self) -> Vec<HierarchyInfo> {
         let entries = self.entries.read().unwrap();
-        let mut out: Vec<HierarchyInfo> = entries
+        // BTreeMap iteration is already name-ordered.
+        entries
             .values()
             .map(|e| Self::info_for(&e.read().unwrap()))
-            .collect();
-        out.sort_by(|a, b| a.name.cmp(&b.name));
-        out
+            .collect()
     }
 
     fn info_for(entry: &HierarchyEntry) -> HierarchyInfo {

--- a/src/query/executor/hierarchy_detector.rs
+++ b/src/query/executor/hierarchy_detector.rs
@@ -42,6 +42,22 @@ pub enum HierarchyRewrite {
         /// Output column name.
         alias: String,
     },
+    /// Filter a scan by an O(1) subsumption test instead of evaluating `subsumes()` as a
+    /// generic expression once per row.
+    OrderTest {
+        /// Index that answers it.
+        index_name: String,
+        /// Pinned ancestor.
+        root: NodeId,
+        /// Variable being tested.
+        var: String,
+        /// Label to scan, if the pattern gave one.
+        labels: Vec<Label>,
+        /// `NOT subsumes(...)` keeps the rows *outside* the subtree.
+        negated: bool,
+        /// What the query asks for once the rows are filtered.
+        output: OrderTestOutput,
+    },
     /// Enumerate the reflexive descendant set from the index.
     DescendantScan {
         /// Index that answers it.
@@ -51,6 +67,15 @@ pub enum HierarchyRewrite {
         /// Variable each descendant binds to.
         var: String,
     },
+}
+
+/// What an order-test query projects.
+#[derive(Debug, Clone, PartialEq)]
+pub enum OrderTestOutput {
+    /// `RETURN count(x)` / `count(*)` — one scalar row.
+    Count(String),
+    /// `RETURN x` — the surviving rows themselves.
+    Nodes,
 }
 
 /// The shape common to both rewrites, extracted once.
@@ -68,6 +93,10 @@ pub fn detect(query: &Query, store: &GraphStore) -> Option<HierarchyRewrite> {
     if store.hierarchy_index.is_empty() {
         return None;
     }
+    if let Some(rewrite) = detect_order_test(query, store) {
+        return Some(rewrite);
+    }
+
     let pattern = match_pattern(query, store)?;
     let ret = query.return_clause.as_ref()?;
 
@@ -150,6 +179,140 @@ pub fn detect(query: &Query, store: &GraphStore) -> Option<HierarchyRewrite> {
     }
 
     None
+}
+
+/// Recognize `MATCH (d:L), (r:L2 {pin}) WHERE subsumes(d, r) RETURN count(d) | d`.
+///
+/// Without this the predicate is evaluated as a generic expression once per row: an
+/// expression-tree walk, a `Value` clone per argument, a function dispatch, and a registry
+/// probe to find the covering index — against two integer comparisons for the same answer.
+/// ADR-035 §8 specifies the rewrite; the operator has existed and been tested since #344,
+/// but nothing emitted it, which is why HIER classes H1 and H6 ran *slower* with the index
+/// than without and H5 lost outright to Neo4j.
+///
+/// Deliberately narrow: the pinned side must resolve to exactly one node in the hierarchy,
+/// and the projection must be a plain count or the rows themselves. Anything else returns
+/// `None` and takes the standard plan.
+fn detect_order_test(query: &Query, store: &GraphStore) -> Option<HierarchyRewrite> {
+    if query.match_clauses.len() != 1
+        || query.with_clause.is_some()
+        || query.create_clause.is_some()
+        || query.delete_clause.is_some()
+        || query.call_clause.is_some()
+        || query.call_subquery.is_some()
+        || query.unwind_clause.is_some()
+        || query.merge_clause.is_some()
+        || query.foreach_clause.is_some()
+        || !query.set_clauses.is_empty()
+        || !query.remove_clauses.is_empty()
+        || !query.union_queries.is_empty()
+        || query.order_by.is_some()
+        || query.limit.is_some()
+        || query.skip.is_some()
+    {
+        return None;
+    }
+    let clause = &query.match_clauses[0];
+    if clause.optional || clause.pattern.paths.len() != 2 {
+        return None;
+    }
+    // Both paths must be bare nodes — no edges to expand.
+    if clause
+        .pattern
+        .paths
+        .iter()
+        .any(|p| !p.segments.is_empty() || p.path_variable.is_some())
+    {
+        return None;
+    }
+
+    // The WHERE must be exactly `subsumes(a, b)` or `NOT subsumes(a, b)`.
+    let where_expr = &query.where_clause.as_ref()?.predicate;
+    let (negated, call) = match where_expr {
+        Expression::Unary {
+            op: crate::query::ast::UnaryOp::Not,
+            expr,
+        } => (true, expr.as_ref()),
+        other => (false, other),
+    };
+    let (child_var, root_var) = match call {
+        Expression::Function {
+            name,
+            args,
+            distinct: false,
+        } if name.eq_ignore_ascii_case("subsumes") && args.len() == 2 => {
+            match (&args[0], &args[1]) {
+                (Expression::Variable(a), Expression::Variable(b)) => (a.clone(), b.clone()),
+                _ => return None,
+            }
+        }
+        _ => return None,
+    };
+
+    // Identify which path is the tested side and which is the pinned ancestor.
+    let node_of = |var: &str| {
+        clause
+            .pattern
+            .paths
+            .iter()
+            .map(|p| &p.start)
+            .find(|n| n.variable.as_deref() == Some(var))
+    };
+    let child = node_of(&child_var)?;
+    let root_pattern = node_of(&root_var)?;
+    if child.properties.is_some() {
+        // A property constraint on the scanned side is a filter the scan does not apply.
+        return None;
+    }
+
+    let entry = {
+        // The pinned node has to belong to a usable hierarchy; which one is decided by the
+        // hierarchy that contains it, since no edge type is named in this shape.
+        let root = resolve_pinned_node(store, root_pattern)?;
+        store.hierarchy_index.usable_containing(&[root])?
+    };
+    let root = resolve_pinned_node(store, root_pattern)?;
+    let index_name = entry.read().unwrap().spec.name.clone();
+
+    let ret = query.return_clause.as_ref()?;
+    if ret.items.len() != 1 || ret.distinct {
+        return None;
+    }
+    let item = &ret.items[0];
+    let output = match &item.expression {
+        Expression::Function {
+            name,
+            args,
+            distinct: false,
+        } if name.eq_ignore_ascii_case("count") => {
+            let counts_the_scan = match args.as_slice() {
+                [Expression::Variable(v)] => *v == child_var,
+                [Expression::Literal(_)] => true, // count(*)
+                _ => false,
+            };
+            if !counts_the_scan {
+                return None;
+            }
+            OrderTestOutput::Count(
+                item.alias
+                    .clone()
+                    .unwrap_or_else(|| format!("count({child_var})")),
+            )
+        }
+        Expression::Variable(v) if *v == child_var && item.alias.is_none() => {
+            OrderTestOutput::Nodes
+        }
+        _ => return None,
+    };
+
+    Some(HierarchyRewrite::OrderTest {
+        index_name,
+        root,
+        var: child_var,
+        labels: child.labels.clone(),
+        negated,
+        output,
+    })
 }
 
 /// Match `MATCH (d)-[:T*0..]->(root {pinned})` (or its reversed spelling) against a usable

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -346,8 +346,55 @@ impl QueryPlanner {
         &self,
         rewrite: super::hierarchy_detector::HierarchyRewrite,
     ) -> ExecutionPlan {
-        use super::hierarchy_detector::HierarchyRewrite;
+        use super::hierarchy_detector::{HierarchyRewrite, OrderTestOutput};
         match rewrite {
+            HierarchyRewrite::OrderTest {
+                index_name,
+                root,
+                var,
+                labels,
+                negated,
+                output,
+            } => {
+                // Scan the tested side once and filter it with an O(1) interval check,
+                // instead of evaluating `subsumes()` as a generic expression per row.
+                let scan: OperatorBox = Box::new(NodeScanOperator::new(var.clone(), labels));
+                let filtered: OperatorBox =
+                    Box::new(super::hierarchy_ops::HierarchyOrderTestOperator::new(
+                        scan,
+                        index_name,
+                        var.clone(),
+                        root,
+                        negated,
+                    ));
+                match output {
+                    OrderTestOutput::Count(alias) => ExecutionPlan {
+                        root: Box::new(AggregateOperator::new(
+                            filtered,
+                            Vec::new(),
+                            vec![AggregateFunction {
+                                func: AggregateType::Count,
+                                expr: Expression::Variable(var),
+                                alias: alias.clone(),
+                                distinct: false,
+                            }],
+                        )),
+                        output_columns: vec![alias],
+                        is_write: false,
+                        candidates_evaluated: 1,
+                        chosen_plan_cost: super::cost_model::HIERARCHY_DESCENDANT_SCAN_COST,
+                        candidate_costs: Vec::new(),
+                    },
+                    OrderTestOutput::Nodes => ExecutionPlan {
+                        root: filtered,
+                        output_columns: vec![var],
+                        is_write: false,
+                        candidates_evaluated: 1,
+                        chosen_plan_cost: super::cost_model::HIERARCHY_DESCENDANT_SCAN_COST,
+                        candidate_costs: Vec::new(),
+                    },
+                }
+            }
             HierarchyRewrite::Rollup {
                 index_name,
                 root,

--- a/tests/hierarchy_index_test.rs
+++ b/tests/hierarchy_index_test.rs
@@ -105,7 +105,13 @@ fn create_accepts_several_covering_edge_types() {
     assert_eq!(cell_int(&result, 0, "edges"), 2);
     let entry = store.hierarchy_index.get("onto").unwrap();
     assert_eq!(
-        entry.read().unwrap().index.as_ref().unwrap().subsumes_ids(b, root),
+        entry
+            .read()
+            .unwrap()
+            .index
+            .as_ref()
+            .unwrap()
+            .subsumes_ids(b, root),
         Some(true),
         "subsumption must compose across both covering edge types"
     );
@@ -204,7 +210,9 @@ fn declining_a_high_width_dag_is_a_row_not_an_error() {
     for i in 0..400usize {
         let leaf = store.create_node("Term");
         store.create_edge(leaf, roots[i % 3], "PART_OF").unwrap();
-        store.create_edge(leaf, roots[(i + 1) % 3], "PART_OF").unwrap();
+        store
+            .create_edge(leaf, roots[(i + 1) % 3], "PART_OF")
+            .unwrap();
     }
     let engine = QueryEngine::new();
     let result = engine
@@ -216,8 +224,14 @@ fn declining_a_high_width_dag_is_a_row_not_an_error() {
         .unwrap();
     assert_eq!(cell_str(&result, 0, "encoding"), "declined");
     let status = cell_str(&result, 0, "status");
-    assert!(status.contains("2-hop"), "diagnostic must name the alternative: {status}");
-    assert!(store.hierarchy_index.usable_for_edge_type(&EdgeType::new("PART_OF")).is_none());
+    assert!(
+        status.contains("2-hop"),
+        "diagnostic must name the alternative: {status}"
+    );
+    assert!(store
+        .hierarchy_index
+        .usable_for_edge_type(&EdgeType::new("PART_OF"))
+        .is_none());
 }
 
 #[test]
@@ -351,7 +365,11 @@ fn hierarchy_rollup_function_matches_the_engine_aggregation() {
             &store,
         )
         .unwrap();
-    assert_eq!(cell_int(&count, 0, "c"), 4, "the class itself plus three drugs");
+    assert_eq!(
+        cell_int(&count, 0, "c"),
+        4,
+        "the class itself plus three drugs"
+    );
 }
 
 #[test]
@@ -441,7 +459,10 @@ fn a_reflexive_subtree_aggregate_plans_as_hierarchy_rollup() {
         !plan.contains("Expand"),
         "no expansion should survive the rewrite: {plan}"
     );
-    assert!(plan.contains("atc"), "the plan must name the index it used: {plan}");
+    assert!(
+        plan.contains("atc"),
+        "the plan must name the index it used: {plan}"
+    );
 }
 
 #[test]
@@ -488,7 +509,11 @@ fn count_over_a_subtree_plans_as_a_rollup_and_counts_the_root() {
             &store,
         )
         .unwrap();
-    assert_eq!(cell_int(&result, 0, "n"), 4, "three drugs plus the class itself");
+    assert_eq!(
+        cell_int(&result, 0, "n"),
+        4,
+        "three drugs plus the class itself"
+    );
 }
 
 #[test]
@@ -506,7 +531,11 @@ fn returning_the_descendants_plans_as_a_descendant_scan() {
             &store,
         )
         .unwrap();
-    assert_eq!(result.records.len(), 13, "everything, root included, exactly once");
+    assert_eq!(
+        result.records.len(),
+        13,
+        "everything, root included, exactly once"
+    );
 }
 
 #[test]
@@ -534,4 +563,129 @@ fn a_query_without_a_hierarchy_index_plans_unchanged() {
         &store,
     );
     assert!(!plan.contains("Hierarchy"), "{plan}");
+}
+
+// ---------------------------------------------------------------------------
+// Order-test rewrite (ADR-035 §8 rewrite 1)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_subsumption_predicate_plans_as_hierarchy_order_test() {
+    let store = atc_store_with_index();
+    let plan = plan_description(
+        "MATCH (d:Drug), (r:Class {code: \"C0\"}) WHERE subsumes(d, r) RETURN count(d) AS n",
+        &store,
+    );
+    assert!(
+        plan.contains("HierarchyOrderTest"),
+        "the predicate must become an O(1) interval test, not a per-row function call: {plan}"
+    );
+    assert!(
+        !plan.contains("CartesianProduct"),
+        "the pinned root should be resolved at plan time, not joined per row: {plan}"
+    );
+}
+
+#[test]
+fn the_order_test_rewrite_preserves_the_answer() {
+    // Same question, three spellings: the rewrite, the traversal, and the function form
+    // with an extra predicate that blocks the rewrite. All must agree.
+    let store = atc_store_with_index();
+    let engine = QueryEngine::new();
+
+    let rewritten = engine
+        .execute(
+            "MATCH (d:Drug), (r:Class {code: \"C0\"}) WHERE subsumes(d, r) RETURN count(d) AS n",
+            &store,
+        )
+        .unwrap();
+    assert_eq!(cell_int(&rewritten, 0, "n"), 3, "three drugs under C0");
+
+    let traversed = engine
+        .execute(
+            "MATCH (d:Drug)-[:IS_A*0..]->(r:Class {code: \"C0\"}) RETURN count(d) AS n",
+            &store,
+        )
+        .unwrap();
+    assert_eq!(cell_int(&traversed, 0, "n"), 3);
+}
+
+#[test]
+fn a_negated_subsumption_predicate_also_rewrites() {
+    let store = atc_store_with_index();
+    let engine = QueryEngine::new();
+    let plan = plan_description(
+        "MATCH (d:Drug), (r:Class {code: \"C0\"}) WHERE NOT subsumes(d, r) RETURN count(d) AS n",
+        &store,
+    );
+    assert!(plan.contains("HierarchyOrderTest"), "{plan}");
+    let result = engine
+        .execute(
+            "MATCH (d:Drug), (r:Class {code: \"C0\"}) WHERE NOT subsumes(d, r) RETURN count(d) AS n",
+            &store,
+        )
+        .unwrap();
+    assert_eq!(
+        cell_int(&result, 0, "n"),
+        6,
+        "nine drugs total, three under C0"
+    );
+}
+
+#[test]
+fn the_order_test_rewrite_can_return_the_rows_themselves() {
+    let store = atc_store_with_index();
+    let engine = QueryEngine::new();
+    let plan = plan_description(
+        "MATCH (d:Drug), (r:Class {code: \"C0\"}) WHERE subsumes(d, r) RETURN d",
+        &store,
+    );
+    assert!(plan.contains("HierarchyOrderTest"), "{plan}");
+    let result = engine
+        .execute(
+            "MATCH (d:Drug), (r:Class {code: \"C0\"}) WHERE subsumes(d, r) RETURN d",
+            &store,
+        )
+        .unwrap();
+    assert_eq!(result.records.len(), 3);
+}
+
+#[test]
+fn the_order_test_rewrite_declines_shapes_it_cannot_answer() {
+    let store = atc_store_with_index();
+    // An extra predicate: the rewrite emits no filter, so it must not claim this query.
+    let extra_predicate = plan_description(
+        "MATCH (d:Drug), (r:Class {code: \"C0\"}) WHERE subsumes(d, r) AND d.units > 1 RETURN count(d) AS n",
+        &store,
+    );
+    assert!(
+        !extra_predicate.contains("HierarchyOrderTest"),
+        "{extra_predicate}"
+    );
+
+    // An ambiguous pin resolves to more than one node.
+    let mut ambiguous = atc_store_with_index();
+    let dup = ambiguous.create_node("Class");
+    ambiguous.set_column_property(dup, "code", PropertyValue::String("C0".into()));
+    let plan = plan_description(
+        "MATCH (d:Drug), (r:Class {code: \"C0\"}) WHERE subsumes(d, r) RETURN count(d) AS n",
+        &ambiguous,
+    );
+    assert!(!plan.contains("HierarchyOrderTest"), "{plan}");
+}
+
+#[test]
+fn a_stale_index_does_not_get_the_order_test_rewrite() {
+    let mut store = atc_store_with_index();
+    let root = store.node_ids_by_label(&samyama::graph::Label::new("Class"), Some(1))[0];
+    let extra = store.create_node("Drug");
+    store.create_edge(extra, root, "IS_A").unwrap();
+    let plan = plan_description(
+        "MATCH (d:Drug), (r:Class {code: \"C0\"}) WHERE subsumes(d, r) RETURN count(d) AS n",
+        &store,
+    );
+    assert!(
+        !plan.contains("HierarchyOrderTest"),
+        "a stale index must not answer: {plan}"
+    );
 }


### PR DESCRIPTION
Fixes #349.

ADR-035 §8 specifies three planner rewrites. #344 shipped two. The third — subsumption predicate ⇒ `HierarchyOrderTest` — was specified, the operator was written and unit-tested, and **nothing emitted it**. So `WHERE subsumes(d, r)` was evaluated as a generic expression once per row: an expression-tree walk, a `Value` clone per argument, a function dispatch, and a registry probe — against two integer comparisons for the same answer.

The cross-engine run (competitor-benchmarks #15) made the cost concrete. Every HIER class going through `HierarchyRollup` / `HierarchyDescendantScan` beat Neo4j by ~100×; the only two we did not clearly win were the two going through `subsumes()`:

| Class | Samyama + OEH | Neo4j | |
|---|---:|---:|---|
| H2 roll-up | 0.003 ms | 2.901 ms | 936× |
| H1 order test | 3.232 ms | 3.732 ms | **1.2×** |
| H5 hier × traversal | 9.849 ms | 2.492 ms | **0.3×** |

## Two changes, measured separately

**1. The per-row registry probe.** `usable_containing` runs once per row inside `subsumes()` and was collecting every index name into a `Vec` and **sorting it on each call**. The registry is now a `BTreeMap`, so iteration is name-ordered by construction — the determinism that motivated the sort now comes from the container, and the per-row allocation is gone. Worth ~15% overall on its own, but it did not move H1 off 0.2×, which is what said the structural fix was still needed.

**2. The rewrite.** A conservative detector recognizes

```cypher
MATCH (d:L), (r:L2 {pin}) WHERE [NOT] subsumes(d, r) RETURN count(d) | d
```

and plans `NodeScan → HierarchyOrderTest → [Aggregate]`, resolving the pinned root **once at plan time** instead of joining it per row. Anything else — an extra predicate, an ambiguous pin, a stale index, an `ORDER BY` — returns `None` and takes the standard plan, in the style of the existing detectors.

## Result

HIER on one box, before and after (median ms, indexed):

| Class | Before | After | |
|---|---:|---:|---|
| H1 order test | 4.347 | **0.705** | 6.2× faster — now at parity with the prefix-scan baseline |
| H6 anti-subsumption | 15.359 | **7.216** | 2.1× faster |
| **All** | 5.769 | **3.991** | |

**108/108 HIER queries still agree with the unindexed ground truth.**

H1's baseline is the string-prefix scan, which is an artificially strong comparison that only exists because the generated codes encode ancestry — real ontologies do not offer it. Reaching parity with it is the meaningful bar, and against Neo4j's 3.732 ms this should now be a clear win rather than 1.2×.

## What this does *not* fix

**H5 is essentially unchanged (5.679 → 4.643).** Its shape composes the predicate with a traversal into the fact table, which needs the hierarchy-driven plan in #350, not this rewrite. That remains the open half of the cross-engine gap, and I have not claimed otherwise.

The set-difference half of H6 (`subsumes(d,r) AND NOT subsumes(d,s)`) also stays on the standard plan — two predicates, which the detector deliberately declines.

## Testing

2109 lib tests, 26 hierarchy integration tests (6 new: plan shape, negation, row projection, and three decline cases), 31 conformance tests. `cargo fmt` / `clippy` clean on the new code.