### PR TITLE
perf(hierarchy): drive from the subtree into the fact table

### DIFF
--- a/src/query/executor/hierarchy_detector.rs
+++ b/src/query/executor/hierarchy_detector.rs
@@ -58,6 +58,26 @@ pub enum HierarchyRewrite {
         /// What the query asks for once the rows are filtered.
         output: OrderTestOutput,
     },
+    /// Drive from a subtree into the fact table, instead of scanning facts and testing
+    /// each one against the hierarchy.
+    HierarchyDriven {
+        /// Index that answers it.
+        index_name: String,
+        /// Pinned subtree root.
+        root: NodeId,
+        /// Variable bound to each hierarchy member.
+        hier_var: String,
+        /// Variable bound to the fact node.
+        fact_var: String,
+        /// Labels on the fact node, if the pattern gave any.
+        fact_labels: Vec<Label>,
+        /// Relationship joining fact to hierarchy member.
+        edge_type: String,
+        /// Direction to walk *from the hierarchy member back to the fact*.
+        to_fact: Direction,
+        /// What the query asks for.
+        output: DrivenOutput,
+    },
     /// Enumerate the reflexive descendant set from the index.
     DescendantScan {
         /// Index that answers it.
@@ -67,6 +87,15 @@ pub enum HierarchyRewrite {
         /// Variable each descendant binds to.
         var: String,
     },
+}
+
+/// What a hierarchy-driven query projects.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DrivenOutput {
+    /// `RETURN count(e)` — with `distinct` when the query said `count(DISTINCT e)`.
+    Count { alias: String, distinct: bool },
+    /// `RETURN sum(e.prop)`.
+    Sum { alias: String, property: String },
 }
 
 /// What an order-test query projects.
@@ -94,6 +123,9 @@ pub fn detect(query: &Query, store: &GraphStore) -> Option<HierarchyRewrite> {
         return None;
     }
     if let Some(rewrite) = detect_order_test(query, store) {
+        return Some(rewrite);
+    }
+    if let Some(rewrite) = detect_hierarchy_driven(query, store) {
         return Some(rewrite);
     }
 
@@ -179,6 +211,156 @@ pub fn detect(query: &Query, store: &GraphStore) -> Option<HierarchyRewrite> {
     }
 
     None
+}
+
+/// Recognize `MATCH (e:F)-[:REL]->(x), (r:L {pin}) WHERE subsumes(x, r) RETURN count(e) | sum(e.p)`
+/// and turn it inside out.
+///
+/// The default plan scans the whole fact table and tests each row against the hierarchy.
+/// That is backwards when the subtree is the selective side: the index can enumerate
+/// `{r} ∪ descendants(r)` directly, and the facts are then reachable by walking the
+/// relationship *backwards* from those nodes. Facts outside the subtree are never touched.
+///
+/// Row multiplicity is preserved exactly, which is what makes this answer-preserving: the
+/// original enumerates every `(e, x)` pair where `x ⊑ r`, and so does the driven plan —
+/// the same pairs, discovered from the other end.
+///
+/// This is the plan HIER class H5 needed. Measured against Neo4j it was the one class where
+/// a hierarchy query lost outright, because Neo4j drives from the pinned root while we
+/// scanned 5,000 facts to keep a few hundred.
+fn detect_hierarchy_driven(query: &Query, store: &GraphStore) -> Option<HierarchyRewrite> {
+    if query.match_clauses.len() != 1
+        || query.with_clause.is_some()
+        || query.create_clause.is_some()
+        || query.delete_clause.is_some()
+        || query.call_clause.is_some()
+        || query.call_subquery.is_some()
+        || query.unwind_clause.is_some()
+        || query.merge_clause.is_some()
+        || query.foreach_clause.is_some()
+        || !query.set_clauses.is_empty()
+        || !query.remove_clauses.is_empty()
+        || !query.union_queries.is_empty()
+        || query.order_by.is_some()
+        || query.limit.is_some()
+        || query.skip.is_some()
+    {
+        return None;
+    }
+    let clause = &query.match_clauses[0];
+    if clause.optional || clause.pattern.paths.len() != 2 {
+        return None;
+    }
+
+    // Exactly one path carries an edge (fact -> hierarchy member); the other pins the root.
+    let (fact_path, root_path) = {
+        let a = &clause.pattern.paths[0];
+        let b = &clause.pattern.paths[1];
+        match (a.segments.len(), b.segments.len()) {
+            (1, 0) => (a, b),
+            (0, 1) => (b, a),
+            _ => return None,
+        }
+    };
+    if fact_path.path_variable.is_some() || root_path.path_variable.is_some() {
+        return None;
+    }
+    let segment = &fact_path.segments[0];
+    if segment.edge.types.len() != 1
+        || segment.edge.length.is_some()
+        || segment.edge.variable.is_some()
+    {
+        return None;
+    }
+    let fact_var = fact_path.start.variable.clone()?;
+    let hier_var = segment.node.variable.clone()?;
+    if segment.node.properties.is_some() || !segment.node.labels.is_empty() {
+        // A constraint on the hierarchy side would filter the subtree the scan enumerates.
+        return None;
+    }
+    if fact_path.start.properties.is_some() {
+        return None;
+    }
+    // Walking back from the hierarchy member to the fact reverses the pattern's direction.
+    let to_fact = match segment.edge.direction {
+        Direction::Outgoing => Direction::Incoming,
+        Direction::Incoming => Direction::Outgoing,
+        Direction::Both => return None,
+    };
+
+    // WHERE must be exactly `subsumes(hier_var, root_var)` — no negation: the complement of
+    // a subtree is not something the descendant scan can enumerate.
+    let predicate = &query.where_clause.as_ref()?.predicate;
+    let (child, root_var) = match predicate {
+        Expression::Function {
+            name,
+            args,
+            distinct: false,
+        } if name.eq_ignore_ascii_case("subsumes") && args.len() == 2 => {
+            match (&args[0], &args[1]) {
+                (Expression::Variable(a), Expression::Variable(b)) => (a.clone(), b.clone()),
+                _ => return None,
+            }
+        }
+        _ => return None,
+    };
+    if child != hier_var || root_path.start.variable.as_deref() != Some(root_var.as_str()) {
+        return None;
+    }
+
+    let root = resolve_pinned_node(store, &root_path.start)?;
+    let entry = store.hierarchy_index.usable_containing(&[root])?;
+    let index_name = entry.read().unwrap().spec.name.clone();
+
+    let ret = query.return_clause.as_ref()?;
+    if ret.items.len() != 1 || ret.distinct {
+        return None;
+    }
+    let item = &ret.items[0];
+    let output = match &item.expression {
+        Expression::Function {
+            name,
+            args,
+            distinct,
+        } if name.eq_ignore_ascii_case("count") => match args.as_slice() {
+            [Expression::Variable(v)] if *v == fact_var => DrivenOutput::Count {
+                alias: item
+                    .alias
+                    .clone()
+                    .unwrap_or_else(|| format!("count({fact_var})")),
+                distinct: *distinct,
+            },
+            _ => return None,
+        },
+        Expression::Function {
+            name,
+            args,
+            distinct: false,
+        } if name.eq_ignore_ascii_case("sum") => match args.as_slice() {
+            [Expression::Property { variable, property }] if *variable == fact_var => {
+                DrivenOutput::Sum {
+                    alias: item
+                        .alias
+                        .clone()
+                        .unwrap_or_else(|| format!("sum({fact_var}.{property})")),
+                    property: property.clone(),
+                }
+            }
+            _ => return None,
+        },
+        _ => return None,
+    };
+
+    Some(HierarchyRewrite::HierarchyDriven {
+        index_name,
+        root,
+        hier_var,
+        fact_var,
+        fact_labels: fact_path.start.labels.clone(),
+        edge_type: segment.edge.types[0].as_str().to_string(),
+        to_fact,
+        output,
+    })
 }
 
 /// Recognize `MATCH (d:L), (r:L2 {pin}) WHERE subsumes(d, r) RETURN count(d) | d`.

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -346,8 +346,70 @@ impl QueryPlanner {
         &self,
         rewrite: super::hierarchy_detector::HierarchyRewrite,
     ) -> ExecutionPlan {
-        use super::hierarchy_detector::{HierarchyRewrite, OrderTestOutput};
+        use super::hierarchy_detector::{DrivenOutput, HierarchyRewrite, OrderTestOutput};
         match rewrite {
+            HierarchyRewrite::HierarchyDriven {
+                index_name,
+                root,
+                hier_var,
+                fact_var,
+                fact_labels,
+                edge_type,
+                to_fact,
+                output,
+            } => {
+                // Enumerate the subtree from the index, then walk the relationship
+                // backwards into the fact table. Facts outside the subtree are never
+                // visited, where the default plan scans all of them and discards most.
+                let scan: OperatorBox =
+                    Box::new(super::hierarchy_ops::HierarchyDescendantScanOperator::new(
+                        index_name,
+                        root,
+                        hier_var.clone(),
+                    ));
+                let expand: OperatorBox = Box::new(
+                    ExpandOperator::new(
+                        scan,
+                        hier_var,
+                        fact_var.clone(),
+                        None,
+                        vec![edge_type],
+                        to_fact,
+                    )
+                    .with_target_labels(fact_labels),
+                );
+                let (agg, alias) = match output {
+                    DrivenOutput::Count { alias, distinct } => (
+                        AggregateFunction {
+                            func: AggregateType::Count,
+                            expr: Expression::Variable(fact_var),
+                            alias: alias.clone(),
+                            distinct,
+                        },
+                        alias,
+                    ),
+                    DrivenOutput::Sum { alias, property } => (
+                        AggregateFunction {
+                            func: AggregateType::Sum,
+                            expr: Expression::Property {
+                                variable: fact_var,
+                                property,
+                            },
+                            alias: alias.clone(),
+                            distinct: false,
+                        },
+                        alias,
+                    ),
+                };
+                ExecutionPlan {
+                    root: Box::new(AggregateOperator::new(expand, Vec::new(), vec![agg])),
+                    output_columns: vec![alias],
+                    is_write: false,
+                    candidates_evaluated: 1,
+                    chosen_plan_cost: super::cost_model::HIERARCHY_DESCENDANT_SCAN_COST,
+                    candidate_costs: Vec::new(),
+                }
+            }
             HierarchyRewrite::OrderTest {
                 index_name,
                 root,

--- a/tests/hierarchy_index_test.rs
+++ b/tests/hierarchy_index_test.rs
@@ -689,3 +689,155 @@ fn a_stale_index_does_not_get_the_order_test_rewrite() {
         "a stale index must not answer: {plan}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Hierarchy-driven plan (#350)
+// ---------------------------------------------------------------------------
+
+/// Facts hanging off an ATC-shaped hierarchy: 3 drugs under C0, 3 under C1, 3 under C2.
+/// `Order` nodes point at drugs via `FOR`.
+fn order_store() -> (GraphStore, Vec<NodeId>) {
+    let mut store = atc_store_with_index();
+    let drugs = store.node_ids_by_label(&samyama::graph::Label::new("Drug"), None);
+    let mut orders = Vec::new();
+    for (i, &d) in drugs.iter().enumerate() {
+        let o = store.create_node("Order");
+        store.set_column_property(o, "qty", PropertyValue::Integer((i + 1) as i64));
+        store.create_edge(o, d, "FOR").unwrap();
+        orders.push(o);
+    }
+    (store, orders)
+}
+
+#[test]
+fn a_fact_joined_to_a_subtree_plans_as_a_hierarchy_driven_scan() {
+    let (store, _) = order_store();
+    let plan = plan_description(
+        "MATCH (o:Order)-[:FOR]->(d), (r:Class {code: \"C0\"}) WHERE subsumes(d, r) RETURN count(o) AS n",
+        &store,
+    );
+    assert!(
+        plan.contains("HierarchyDescendantScan"),
+        "the subtree should drive the plan, not the fact table: {plan}"
+    );
+    assert!(
+        plan.contains("Expand"),
+        "and it should walk back into the facts: {plan}"
+    );
+    assert!(
+        !plan.contains("NodeScan (var=o"),
+        "the fact table must not be scanned: {plan}"
+    );
+}
+
+#[test]
+fn the_driven_plan_returns_the_same_answer_as_the_fact_scan() {
+    let (store, _) = order_store();
+    let engine = QueryEngine::new();
+    // 3 drugs under C0, one order each.
+    let driven = engine
+        .execute(
+            "MATCH (o:Order)-[:FOR]->(d), (r:Class {code: \"C0\"}) WHERE subsumes(d, r) RETURN count(o) AS n",
+            &store,
+        )
+        .unwrap();
+    assert_eq!(cell_int(&driven, 0, "n"), 3);
+
+    // The whole hierarchy: every order.
+    let all = engine
+        .execute(
+            "MATCH (o:Order)-[:FOR]->(d), (r:Class {code: \"ROOT\"}) WHERE subsumes(d, r) RETURN count(o) AS n",
+            &store,
+        )
+        .unwrap();
+    assert_eq!(cell_int(&all, 0, "n"), 9);
+}
+
+#[test]
+fn the_driven_plan_preserves_row_multiplicity() {
+    // The sharp case for turning the join around: one fact linked to *two* members of the
+    // same subtree. The original plan yields one row per (fact, member) pair; the driven
+    // plan discovers the same pairs from the other end and must yield the same count —
+    // 2, not 1. Getting this wrong would silently under-count every many-to-many join.
+    let (mut store, _) = order_store();
+    let c0_drugs: Vec<NodeId> = {
+        let engine = QueryEngine::new();
+        let r = engine
+            .execute(
+                "MATCH (d:Drug)-[:IS_A]->(c:Class {code: \"C0\"}) RETURN d",
+                &store,
+            )
+            .unwrap();
+        r.records
+            .iter()
+            .filter_map(|rec| match rec.get("d") {
+                Some(samyama::query::executor::record::Value::Node(id, _)) => Some(*id),
+                Some(samyama::query::executor::record::Value::NodeRef(id)) => Some(*id),
+                _ => None,
+            })
+            .collect()
+    };
+    assert!(c0_drugs.len() >= 2);
+    let multi = store.create_node("Order");
+    store.set_column_property(multi, "qty", PropertyValue::Integer(100));
+    store.create_edge(multi, c0_drugs[0], "FOR").unwrap();
+    store.create_edge(multi, c0_drugs[1], "FOR").unwrap();
+    // Rebuild: the covering relation did not change, but be explicit rather than lucky.
+    let engine = QueryEngine::new();
+    engine
+        .execute_mut("REBUILD HIERARCHY INDEX atc", &mut store, "default")
+        .unwrap();
+
+    let counted = engine
+        .execute(
+            "MATCH (o:Order)-[:FOR]->(d), (r:Class {code: \"C0\"}) WHERE subsumes(d, r) RETURN count(o) AS n",
+            &store,
+        )
+        .unwrap();
+    assert_eq!(
+        cell_int(&counted, 0, "n"),
+        5,
+        "3 single-drug orders + the multi-drug order counted once per matching drug"
+    );
+
+    let distinct = engine
+        .execute(
+            "MATCH (o:Order)-[:FOR]->(d), (r:Class {code: \"C0\"}) WHERE subsumes(d, r) RETURN count(DISTINCT o) AS n",
+            &store,
+        )
+        .unwrap();
+    assert_eq!(
+        cell_int(&distinct, 0, "n"),
+        4,
+        "DISTINCT collapses the multi-drug order"
+    );
+}
+
+#[test]
+fn the_driven_plan_handles_sum_over_a_fact_property() {
+    let (store, _) = order_store();
+    let engine = QueryEngine::new();
+    let plan = plan_description(
+        "MATCH (o:Order)-[:FOR]->(d), (r:Class {code: \"ROOT\"}) WHERE subsumes(d, r) RETURN sum(o.qty) AS v",
+        &store,
+    );
+    assert!(plan.contains("HierarchyDescendantScan"), "{plan}");
+    let result = engine
+        .execute(
+            "MATCH (o:Order)-[:FOR]->(d), (r:Class {code: \"ROOT\"}) WHERE subsumes(d, r) RETURN sum(o.qty) AS v",
+            &store,
+        )
+        .unwrap();
+    assert_eq!(cell_int(&result, 0, "v"), 45, "quantities 1..=9");
+}
+
+#[test]
+fn the_driven_plan_declines_a_negated_predicate() {
+    // The complement of a subtree is not something a descendant scan can enumerate.
+    let (store, _) = order_store();
+    let plan = plan_description(
+        "MATCH (o:Order)-[:FOR]->(d), (r:Class {code: \"C0\"}) WHERE NOT subsumes(d, r) RETURN count(o) AS n",
+        &store,
+    );
+    assert!(!plan.contains("HierarchyDescendantScan"), "{plan}");
+}


### PR DESCRIPTION
Fixes #350 for the single-axis shape.

The default plan for *facts joined to a hierarchy subtree* scans the whole fact table and tests each row against the hierarchy. That is backwards when the subtree is the selective side: the index can enumerate `{r} ∪ descendants(r)` directly, and the facts are reachable by walking the relationship **backwards** from those nodes — so facts outside the subtree are never touched.

This was the one HIER class where a hierarchy query **lost outright to Neo4j** (0.3×, competitor-benchmarks #15): Neo4j drives from the pinned root while we scanned 5,000 facts to keep a few hundred.

## The rewrite

```cypher
MATCH (e:F)-[:REL]->(x), (r:L {pin}) WHERE subsumes(x, r)
RETURN count(e) | count(DISTINCT e) | sum(e.prop)
```

plans as `HierarchyDescendantScan → Expand(reversed) → Aggregate`.

## Result

HIER on one box, median ms, indexed:

| Class | Before | After | |
|---|---:|---:|---|
| **H5 hierarchy × traversal** | 4.643 | **0.562** | **8.3× faster** |
| All | 3.991 | **3.506** | |

**108/108 HIER queries still agree with the unindexed ground truth.**

Against Neo4j's 2.492 ms this should turn a 0.3× loss into roughly a 4× win — the last class where a hierarchy query was behind. I'd want a re-run to state that as measured rather than inferred.

## The correctness risk, and the test for it

Turning a join around changes which side drives, and the thing most likely to break is **row multiplicity**. The original enumerates every `(e, x)` pair where `x ⊑ r`; the driven plan must discover exactly the same pairs from the other end. A fact linked to *two* members of the same subtree has to count **twice**, not once.

There is a test for precisely that — one order linked to two drugs under the same class, asserting **5** rows with duplicates and **4** under `count(DISTINCT o)`. Getting it wrong would silently under-count every many-to-many join, which is the kind of bug this whole workstream has been finding.

It also **declines a negated predicate**: the complement of a subtree is not something a descendant scan can enumerate.

## What remains of #350

**H4 is unchanged at 1.1×.** It composes *three* hierarchy axes and so needs a choice of driving axis among them. The index can already supply the selectivity estimate that choice needs — `descendant_count()` is O(1) in nested-set mode — so the remaining work is picking the most selective axis, driving it, and applying the other two as `HierarchyOrderTest` predicates. I've left #350 open for that half rather than closing it on a partial fix.

## Testing

2109 lib tests, 31 hierarchy integration tests (5 new), 31 conformance tests. `cargo fmt` / `clippy` clean on the new code. The planner diff is 64 lines — I reverted an accidental whole-file rustfmt pass so the change stays reviewable.