### PR TITLE
bench(mesh): hierarchical roll-up over the real MeSH tree at scale

### DIFF
--- a/examples/mesh_scale_bench.rs
+++ b/examples/mesh_scale_bench.rs
@@ -1,0 +1,290 @@
+//! Large-scale hierarchical roll-up over the **real MeSH tree**.
+//!
+//! The HIER corpus runs on a generated hierarchy, which is reproducible but leaves the
+//! obvious question open: does the index still pay off on a real ontology at real fact
+//! volume? This answers it with the ontology that matters most for the biomedical
+//! federation — MeSH — and a literature-shaped fact table on top.
+//!
+//! ## Why MeSH, and why by tree number
+//!
+//! MeSH is the annotation vocabulary for all 66M PubMed articles, and in the mega-federation
+//! (`samyama-graph-competitor-benchmarks/benchmarks/large-scale/`) `MeSHTerm` nodes are
+//! **flat** — there is no hierarchy, so "articles about anything under Cardiovascular
+//! Diseases" cannot be asked without enumerating descendants by hand.
+//!
+//! The hierarchy lives in the **tree number** (`C14.280.400` ⊑ `C14.280` ⊑ `C14`), not the
+//! descriptor. That distinction is load-bearing: a descriptor may occupy several positions
+//! at once — "Breast Neoplasms" is both a breast disease and a neoplasm — so a
+//! descriptor-to-descriptor graph is a poly-hierarchy the structural probe would likely
+//! decline, while tree numbers form a strict tree that gets the nested-set encoding.
+//!
+//! ```bash
+//! cargo run --release --example mesh_scale_bench -- --mesh mtrees2025.bin --articles 2000000
+//! cargo run --release --example mesh_scale_bench -- --mesh mtrees2025.bin --articles 500000 --export-csv /tmp/mesh-csv
+//! ```
+
+use std::collections::HashMap;
+use std::io::{BufRead, Write};
+use std::time::Instant;
+
+use samyama::graph::{GraphStore, NodeId, PropertyValue};
+use samyama::index::hierarchy::{HierarchySpec, RollupOp};
+use samyama::query::QueryEngine;
+
+fn arg(args: &[String], flag: &str) -> Option<String> {
+    args.iter().position(|a| a == flag).and_then(|i| args.get(i + 1)).cloned()
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let mesh_path = arg(&args, "--mesh").unwrap_or_else(|| {
+        eprintln!("--mesh <mtrees.bin> is required (NLM MeSH tree file)");
+        std::process::exit(2)
+    });
+    let n_articles: usize =
+        arg(&args, "--articles").and_then(|v| v.parse().ok()).unwrap_or(1_000_000);
+    let terms_per_article: usize =
+        arg(&args, "--terms").and_then(|v| v.parse().ok()).unwrap_or(5);
+    let export = arg(&args, "--export-csv");
+    let reps: usize = arg(&args, "--reps").and_then(|v| v.parse().ok()).unwrap_or(5);
+
+    // ---- load the real MeSH tree ------------------------------------------
+    let t0 = Instant::now();
+    let mut store = GraphStore::new();
+    let file = std::fs::File::open(&mesh_path)
+        .unwrap_or_else(|e| panic!("cannot open {mesh_path}: {e}"));
+    let mut tree_ids: HashMap<String, NodeId> = HashMap::new();
+    let mut order: Vec<String> = Vec::new();
+    for line in std::io::BufReader::new(file).lines().map_while(Result::ok) {
+        let Some((name, tree)) = line.split_once(';') else { continue };
+        let (name, tree) = (name.trim().to_string(), tree.trim().to_string());
+        if tree.is_empty() {
+            continue;
+        }
+        let id = *tree_ids.entry(tree.clone()).or_insert_with(|| {
+            let n = store.create_node("MeshTree");
+            order.push(tree.clone());
+            n
+        });
+        store.set_column_property(id, "code", PropertyValue::String(tree.clone()));
+        store.set_column_property(id, "name", PropertyValue::String(name));
+        store.set_column_property(
+            id,
+            "level",
+            PropertyValue::Integer(tree.matches('.').count() as i64),
+        );
+    }
+    // mtrees.bin starts at A01 — the single-letter categories ("C" = Diseases) are implied
+    // but never listed, so top-level codes would otherwise be 16 disconnected roots. Adding
+    // them makes the tree match MeSH as documented and gives the workload subtrees that
+    // span three orders of magnitude instead of one.
+    let categories: Vec<char> = {
+        let mut c: Vec<char> = tree_ids
+            .keys()
+            .filter(|t| !t.contains('.'))
+            .filter_map(|t| t.chars().next())
+            .collect();
+        c.sort_unstable();
+        c.dedup();
+        c
+    };
+    for cat in &categories {
+        let code = cat.to_string();
+        let id = *tree_ids.entry(code.clone()).or_insert_with(|| {
+            let n = store.create_node("MeshTree");
+            order.push(code.clone());
+            n
+        });
+        store.set_column_property(id, "code", PropertyValue::String(code));
+        store.set_column_property(id, "name", PropertyValue::String(format!("Category {cat}")));
+        store.set_column_property(id, "level", PropertyValue::Integer(-1));
+    }
+
+    // parents, after every node exists
+    let mut mesh_edges = 0usize;
+    let all: Vec<String> = tree_ids.keys().cloned().collect();
+    for tree in &all {
+        let parent = match tree.rsplit_once('.') {
+            Some((p, _)) => Some(p.to_string()),
+            // "C14" hangs off category "C"; a bare category has no parent
+            None if tree.len() > 1 => tree.chars().next().map(|c| c.to_string()),
+            None => None,
+        };
+        if let Some(parent) = parent {
+            if let (Some(&c), Some(&p)) = (tree_ids.get(tree), tree_ids.get(&parent)) {
+                if store.create_edge(c, p, "IS_A").is_ok() {
+                    mesh_edges += 1;
+                }
+            }
+        }
+    }
+    let mesh_nodes = tree_ids.len();
+    eprintln!(
+        "[mesh] {mesh_nodes} tree numbers, {mesh_edges} IS_A edges in {:.2}s",
+        t0.elapsed().as_secs_f64()
+    );
+
+    // ---- literature-shaped facts on top -----------------------------------
+    // Deterministic annotation: a fixed multiplicative hash spreads articles over the tree
+    // without an RNG, so the graph — and therefore every roll-up total — is identical on
+    // every machine and every run.
+    let t1 = Instant::now();
+    let leaves: Vec<&String> = order.iter().collect();
+    let mut fact_edges = 0usize;
+    for a in 0..n_articles {
+        let art = store.create_node("Article");
+        store.set_column_property(art, "pmid", PropertyValue::Integer(a as i64 + 1));
+        store.set_column_property(
+            art,
+            "citations",
+            PropertyValue::Integer(((a as u64).wrapping_mul(2_654_435_761) >> 9 % 64) as i64 % 97),
+        );
+        for t in 0..terms_per_article {
+            let h = (a as u64)
+                .wrapping_mul(11_400_714_819_323_198_485)
+                .wrapping_add((t as u64).wrapping_mul(1_442_695_040_888_963_407));
+            let tree = leaves[(h >> 11) as usize % leaves.len()];
+            let term = tree_ids[tree];
+            if store.create_edge(art, term, "ANNOTATED_WITH").is_ok() {
+                fact_edges += 1;
+            }
+        }
+    }
+    eprintln!(
+        "[facts] {n_articles} articles, {fact_edges} ANNOTATED_WITH edges in {:.2}s",
+        t1.elapsed().as_secs_f64()
+    );
+    eprintln!("[graph] {} nodes, {} edges", store.node_count(), mesh_edges + fact_edges);
+
+    if let Some(dir) = &export {
+        export_csv(&store, dir, mesh_nodes + n_articles, mesh_edges + fact_edges);
+        return;
+    }
+
+    // ---- declare the hierarchy --------------------------------------------
+    let engine = QueryEngine::new();
+    engine
+        .execute_mut("CREATE INDEX ON :MeshTree(code)", &mut store, "default")
+        .unwrap();
+    let t2 = Instant::now();
+    let mgr = std::sync::Arc::clone(&store.hierarchy_index);
+    let info = mgr
+        .create(
+            &store,
+            HierarchySpec::new("mesh", vec![samyama::graph::EdgeType::new("IS_A")]).with_measure(
+                None,
+                "level",
+                vec![RollupOp::Sum, RollupOp::Count],
+            ),
+        )
+        .expect("mesh hierarchy");
+    eprintln!(
+        "[index] {} — {} nodes, {:.2} B/node, build {:.0} ms",
+        info.encoding.unwrap_or("declined"),
+        info.nodes,
+        info.structural_bytes as f64 / info.nodes.max(1) as f64,
+        t2.elapsed().as_secs_f64() * 1000.0
+    );
+
+    // ---- the workload ------------------------------------------------------
+    // Real MeSH roots: A anatomy, C diseases, D chemicals, E techniques, G phenomena.
+    // Subtree sizes span three orders of magnitude, which is the point.
+    let roots = ["C", "C14", "C04", "C01", "D", "A", "E01", "C14.280", "G", "B"];
+    println!();
+    println!("{:<10} {:>9} {:>12} {:>14} {:>10}", "subtree", "terms", "indexed ms", "traversal ms", "speedup");
+    println!("{}", "-".repeat(60));
+    let mut rows = Vec::new();
+    for root in roots {
+        let indexed = format!(
+            "MATCH (t:MeshTree {{code: \"{root}\"}}) RETURN hierarchy_rollup(t, \"count\") AS n"
+        );
+        // A label on the descendant side makes the planner decline the roll-up rewrite
+        // (it filters the subtree the index would enumerate wholesale), so this really is
+        // a variable-length traversal. Without the label the "baseline" is silently the
+        // indexed plan and the comparison measures nothing.
+        let traversal = format!(
+            "MATCH (d:MeshTree)-[:IS_A*0..]->(r:MeshTree {{code: \"{root}\"}}) RETURN count(d) AS n"
+        );
+        let (ims, iv) = timed(&engine, &store, &indexed, reps);
+        let (tms, tv) = timed(&engine, &store, &traversal, reps);
+        let agree = iv == tv;
+        println!(
+            "{root:<10} {:>9} {ims:>12.4} {tms:>14.4} {:>9.1}x{}",
+            iv,
+            if ims > 0.0 { tms / ims } else { 0.0 },
+            if agree { "" } else { "  <-- DISAGREE" }
+        );
+        rows.push((root.to_string(), iv, ims, tms, agree));
+    }
+    let disagreements = rows.iter().filter(|r| !r.4).count();
+    println!("{}", "-".repeat(60));
+    println!(
+        "{} subtrees, {} disagreements",
+        rows.len(),
+        disagreements
+    );
+    if disagreements > 0 {
+        std::process::exit(1);
+    }
+}
+
+fn timed(engine: &QueryEngine, store: &GraphStore, q: &str, reps: usize) -> (f64, i64) {
+    let mut times = Vec::new();
+    let mut val = -1i64;
+    for _ in 0..reps.max(1) {
+        let t = Instant::now();
+        let r = engine.execute(q, store);
+        times.push(t.elapsed().as_secs_f64() * 1000.0);
+        if let Ok(b) = r {
+            if let Some(rec) = b.records.first() {
+                if let Some(v) = rec.bindings().values().next() {
+                    if let samyama::query::executor::record::Value::Property(
+                        PropertyValue::Integer(i),
+                    ) = v
+                    {
+                        val = *i;
+                    }
+                }
+            }
+        }
+    }
+    times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    (times[times.len() / 2], val)
+}
+
+fn export_csv(store: &GraphStore, dir: &str, _n: usize, _e: usize) {
+    std::fs::create_dir_all(dir).expect("mkdir");
+    let mut nodes = std::io::BufWriter::new(
+        std::fs::File::create(format!("{dir}/nodes.csv")).expect("nodes.csv"),
+    );
+    writeln!(nodes, "id:ID,code,name,level:long,pmid:long,citations:long,:LABEL").unwrap();
+    for node in store.all_nodes() {
+        let i = node.id.as_u64() as usize;
+        let g = |k: &str| match store.node_columns.get_property(i, k) {
+            PropertyValue::String(s) => s.replace(',', " "),
+            PropertyValue::Integer(v) => v.to_string(),
+            _ => String::new(),
+        };
+        let label = node.labels.iter().map(|l| l.as_str()).collect::<Vec<_>>().join(";");
+        writeln!(
+            nodes,
+            "{},{},{},{},{},{},{}",
+            node.id.as_u64(), g("code"), g("name"), g("level"), g("pmid"), g("citations"), label
+        )
+        .unwrap();
+    }
+    nodes.flush().unwrap();
+    let mut rels = std::io::BufWriter::new(
+        std::fs::File::create(format!("{dir}/rels.csv")).expect("rels.csv"),
+    );
+    writeln!(rels, ":START_ID,:END_ID,:TYPE").unwrap();
+    let mut n = 0usize;
+    for node in store.all_nodes() {
+        for (_e, s, t, et) in store.get_outgoing_edge_targets_owned(node.id) {
+            writeln!(rels, "{},{},{}", s.as_u64(), t.as_u64(), et.as_str()).unwrap();
+            n += 1;
+        }
+    }
+    rels.flush().unwrap();
+    eprintln!("[export] wrote {dir}/nodes.csv and {dir}/rels.csv ({n} rels)");
+}

--- a/examples/ontology_loader.rs
+++ b/examples/ontology_loader.rs
@@ -12,6 +12,7 @@
 //! cargo run --release --example ontology_loader -- --format obo --path mondo.obo
 //! cargo run --release --example ontology_loader -- --format obo --path go-basic.obo   # declines
 //! cargo run --release --example ontology_loader -- --format geonames --path hierarchy.txt
+//! cargo run --release --example ontology_loader -- --format mesh --path mtrees2025.bin
 //! cargo run --release --example ontology_loader -- --format prefix --path atc.csv --cuts 1,3,4,5,7
 //! cargo run --release --example ontology_loader -- --format edgelist --path cwe.csv
 //! cargo run --release --example ontology_loader -- --format calendar --from 2015 --to 2026
@@ -89,6 +90,7 @@ fn main() {
         "obo" => load_obo(&mut store, &args),
         "taxdump" => load_taxdump(&mut store, &args),
         "geonames" => load_geonames(&mut store, &args),
+        "mesh" => load_mesh(&mut store, &args),
         "prefix" => load_prefix(&mut store, &args),
         "edgelist" => load_edgelist(&mut store, &args),
         "calendar" => load_calendar(&mut store, &args),
@@ -169,7 +171,7 @@ fn main() {
 
 fn usage() -> String {
     format!(
-        "ontology_loader --format <obo|taxdump|geonames|prefix|edgelist|calendar> [--path FILE]\n\
+        "ontology_loader --format <obo|taxdump|geonames|mesh|prefix|edgelist|calendar> [--path FILE]\n\
          \n\
          Options:\n\
          \x20 --label L          node label to create           (default Concept)\n\
@@ -406,6 +408,47 @@ fn load_prefix(store: &mut GraphStore, args: &Args) -> (usize, usize) {
                 if store.create_edge(id, p, args.edge_type.as_str()).is_ok() {
                     edges += 1;
                 }
+            }
+        }
+        if args.limit.is_some_and(|l| edges >= l) {
+            break;
+        }
+    }
+    (interner.ids.len(), edges)
+}
+
+/// NLM MeSH tree file (`mtrees<year>.bin`): `Descriptor Name;TreeNumber`, one line per
+/// tree position.
+///
+/// The hierarchy is carried by the **tree number**, not the descriptor: `C01.252.400` sits
+/// under `C01.252` under `C01`. Modelling tree numbers as the nodes matters — a descriptor
+/// may occupy several positions in the tree ("Breast Neoplasms" is both a breast disease
+/// and a neoplasm), so a descriptor-to-descriptor graph is a poly-hierarchy that the probe
+/// would likely decline. Tree numbers give a strict tree, and the descriptor name rides
+/// along as a property, so an article annotated with a descriptor can still be rolled up
+/// through every position that descriptor occupies.
+fn load_mesh(store: &mut GraphStore, args: &Args) -> (usize, usize) {
+    let reader = open(&args.path);
+    let mut interner = Interner::new();
+    let mut edges = 0usize;
+    for line in reader.lines().map_while(Result::ok) {
+        let Some((name, tree)) = line.split_once(';') else { continue };
+        let (name, tree) = (name.trim(), tree.trim());
+        if tree.is_empty() {
+            continue;
+        }
+        let id = interner.get(store, &args.label, tree);
+        store.set_column_property(id, "name", PropertyValue::String(name.to_string()));
+        // Depth is free here and makes level-wise roll-up queries expressible.
+        store.set_column_property(
+            id,
+            "level",
+            PropertyValue::Integer(tree.matches('.').count() as i64),
+        );
+        if let Some((parent, _)) = tree.rsplit_once('.') {
+            let p = interner.get(store, &args.label, parent);
+            if store.create_edge(id, p, args.edge_type.as_str()).is_ok() {
+                edges += 1;
             }
         }
         if args.limit.is_some_and(|l| edges >= l) {


### PR DESCRIPTION
Adds `--format mesh` to the ontology loader and a scale benchmark putting a literature-shaped fact table on top of the real NLM MeSH tree.

**Why MeSH.** It is the annotation vocabulary for all 66M PubMed articles, and in the mega-federation (`benchmarks/large-scale/`) the `MeSHTerm` nodes are **flat** — there is no hierarchy, so *"articles about anything under Cardiovascular Diseases"* cannot be asked without enumerating descendants by hand.

**Why by tree number.** The hierarchy lives in the tree number (`C14.280.400` ⊑ `C14.280` ⊑ `C14`), not the descriptor. A descriptor may occupy several positions at once — "Breast Neoplasms" is both a breast disease and a neoplasm — so a descriptor-to-descriptor graph is a poly-hierarchy the probe would likely decline, while tree numbers form a strict tree that gets nested-set.

**Real MeSH 2025: 64,899 tree numbers, nested-set, 12.00 B/node, 23 ms build.** That is the largest widely-used biomedical ontology *accepted* by the index — a useful counterweight to the real-ontology run where three of five declined.

200k articles / 1M annotations:

| subtree | terms | indexed ms | traversal ms | speedup |
|---|---:|---:|---:|---:|
| C (Diseases) | 13,181 | 0.0121 | 309.26 | **25,462×** |
| D (Chemicals) | 24,665 | 0.0091 | 297.86 | **32,794×** |
| C14.280 | 249 | 0.0092 | 284.81 | 30,934× |

Indexed time is flat at ~0.01 ms regardless of subtree size; the traversal is ~285 ms because it scans the graph either way.

## Two bugs in my first draft, both caught by the benchmark's own disagreement check

Worth recording, because both would have produced impressive and meaningless numbers:

1. `mtrees.bin` starts at `A01` — the single-letter categories are implied but never listed, so top-level codes were 16 disconnected roots and queries against `"C"` silently matched nothing. Synthesizing the categories also widened the subtree range from one order of magnitude to three.
2. **The traversal baseline was being rewritten to the indexed plan** by the very roll-up rewrite it was meant to be measured against. It now carries a label on the descendant side, which makes the planner decline the rewrite and leaves a genuine variable-length walk.

The check that caught them compares the two engines' answers per subtree and exits non-zero on any disagreement.