### PR TITLE
feat(hierarchy): apply measure writes in place instead of invalidating

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -1040,8 +1040,8 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
     /// Set a property directly in the columnar store, bypassing the Node's row HashMap.
     pub fn set_column_property(&mut self, node_id: NodeId, key: &str, value: PropertyValue) {
         let idx = node_id.as_u64() as usize;
-        self.node_columns.set_property(idx, key, value);
-        self.invalidate_hierarchies_for_property(key);
+        self.node_columns.set_property(idx, key, value.clone());
+        self.update_hierarchies_for_property(node_id, key, &value);
     }
 
     /// Intern an edge type string → u16 index. Returns existing index if already interned.
@@ -1087,7 +1087,7 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
 
         // Update columnar storage (always latest)
         self.node_columns.set_property(idx, &key_str, val.clone());
-        self.invalidate_hierarchies_for_property(&key_str);
+        self.update_hierarchies_for_property(node_id, &key_str, &val);
 
         // Get access to versions
         let versions = self.nodes.get_mut(idx).ok_or(GraphError::NodeNotFound(node_id))?;
@@ -2022,6 +2022,23 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
     pub fn invalidate_hierarchies_for_property(&self, property: &str) {
         if !self.hierarchy_index.is_empty() {
             self.hierarchy_index.mark_stale_for_property(property);
+        }
+    }
+
+    /// Apply a measure write to any hierarchy that declares `property`, in place.
+    ///
+    /// Only the value changes, not the shape of the poset, so the index absorbs it in
+    /// O(log n) rather than being invalidated (ADR-035 §6, #351). Falls back to marking
+    /// stale for any hierarchy that cannot take the update.
+    #[inline]
+    pub fn update_hierarchies_for_property(
+        &self,
+        node_id: NodeId,
+        property: &str,
+        value: &PropertyValue,
+    ) {
+        if !self.hierarchy_index.is_empty() {
+            self.hierarchy_index.update_measure(node_id, property, value);
         }
     }
 

--- a/src/index/hierarchy/manager.rs
+++ b/src/index/hierarchy/manager.rs
@@ -361,6 +361,43 @@ impl HierarchyIndexManager {
         }
     }
 
+    /// Apply a measure write in place where possible, falling back to invalidation.
+    ///
+    /// A write to the declared measure changes a value, not the shape of the poset, so the
+    /// order embedding stays valid and the range structures can absorb the change in
+    /// O(log n). Marking the index stale for this — as the first implementation did — meant
+    /// a full rebuild to reflect one number, which on a 2.9M-node taxonomy is nine seconds
+    /// (#351).
+    ///
+    /// Returns the number of indexes updated in place. Any hierarchy that cannot take the
+    /// update — no measure attached yet, or the node is outside its poset — is marked stale
+    /// instead, so correctness never depends on the fast path succeeding.
+    pub fn update_measure(&self, node: NodeId, property: &str, value: &PropertyValue) -> usize {
+        let entries = self.entries.read().unwrap();
+        let mut updated = 0usize;
+        for e in entries.values() {
+            let mut g = e.write().unwrap();
+            if g.spec
+                .measure
+                .as_ref()
+                .is_none_or(|m| m.property != property)
+            {
+                continue;
+            }
+            let rollup = to_rollup_value(value);
+            let applied = match g.index.as_mut() {
+                Some(idx) => idx.update_measure(node, rollup),
+                None => false,
+            };
+            if applied {
+                updated += 1;
+            } else {
+                g.stale = true;
+            }
+        }
+        updated
+    }
+
     /// Mark every hierarchy whose declared measure is `property` stale. Called from node
     /// property writes.
     pub fn mark_stale_for_property(&self, property: &str) {
@@ -768,20 +805,62 @@ mod tests {
     }
 
     #[test]
-    fn store_property_write_invalidates_through_graph_store() {
+    fn a_measure_write_updates_the_index_in_place_instead_of_invalidating_it() {
+        // Only the value changed, not the shape of the poset, so the index absorbs it and
+        // stays usable — and the roll-up must reflect the new number immediately (#351).
         let (mut store, ids) = drug_store();
         let mgr = Arc::clone(&store.hierarchy_index);
         mgr.create(&store, spec_with_measure()).unwrap();
         let et = EdgeType::new("IS_A");
-        store.set_column_property(ids[2], "colour", PropertyValue::Integer(1));
+        let root = ids[0];
+
+        let before = {
+            let e = mgr.get("atc").unwrap();
+            let g = e.read().unwrap();
+            g.index
+                .as_ref()
+                .unwrap()
+                .rollup_id(root, RollupOp::Sum)
+                .unwrap()
+        };
+        assert_eq!(before, RollupValue::Int(45), "units 1..=9");
+
+        // one leaf goes from 9 to 109: the total should rise by exactly 100
+        store.set_column_property(ids[12], "units", PropertyValue::Integer(109));
+
         assert!(
-            store.hierarchy_index.usable_for_edge_type(&et).is_some(),
-            "an unrelated property write must not invalidate"
+            mgr.usable_for_edge_type(&et).is_some(),
+            "a measure write must not take the index out of service"
         );
-        store.set_column_property(ids[2], "units", PropertyValue::Integer(99));
-        assert!(
-            store.hierarchy_index.usable_for_edge_type(&et).is_none(),
-            "writing the declared measure must mark the hierarchy stale"
+        let after = {
+            let e = mgr.get("atc").unwrap();
+            let g = e.read().unwrap();
+            assert!(!g.stale, "the index is still fresh");
+            g.index
+                .as_ref()
+                .unwrap()
+                .rollup_id(root, RollupOp::Sum)
+                .unwrap()
+        };
+        assert_eq!(
+            after,
+            RollupValue::Int(145),
+            "roll-up reflects the write without a rebuild"
+        );
+    }
+
+    #[test]
+    fn an_unrelated_property_write_touches_nothing() {
+        let (mut store, ids) = drug_store();
+        let mgr = Arc::clone(&store.hierarchy_index);
+        mgr.create(&store, spec_with_measure()).unwrap();
+        store.set_column_property(ids[2], "colour", PropertyValue::Integer(1));
+        let e = mgr.get("atc").unwrap();
+        let g = e.read().unwrap();
+        assert!(!g.stale);
+        assert_eq!(
+            g.index.as_ref().unwrap().rollup_id(ids[0], RollupOp::Sum),
+            Some(RollupValue::Int(45))
         );
     }
 

--- a/src/index/hierarchy/monoid.rs
+++ b/src/index/hierarchy/monoid.rs
@@ -188,6 +188,38 @@ impl Fenwick {
         }
     }
 
+    /// Add `delta` at `pos`, in O(log n).
+    ///
+    /// A Fenwick tree updates in place because SUM has an inverse — the caller supplies the
+    /// difference and every covering node absorbs it. This is what lets a measure write
+    /// avoid invalidating the whole index (#351).
+    pub fn add(&mut self, pos: usize, delta: RollupValue) {
+        match self {
+            Fenwick::Int(t) => {
+                let d = match delta {
+                    RollupValue::Int(v) => v,
+                    RollupValue::Float(f) => f as i128,
+                    RollupValue::Null => return,
+                };
+                let n = t.len() - 1;
+                let mut j = pos + 1;
+                while j <= n {
+                    t[j] += d;
+                    j += j & j.wrapping_neg();
+                }
+            }
+            Fenwick::Float(t) => {
+                let d = delta.as_f64().unwrap_or(0.0);
+                let n = t.len() - 1;
+                let mut j = pos + 1;
+                while j <= n {
+                    t[j] += d;
+                    j += j & j.wrapping_neg();
+                }
+            }
+        }
+    }
+
     /// Sum of positions `[0, i)`.
     fn prefix(&self, i: usize) -> RollupValue {
         let mut i = i.min(self.len());

--- a/src/index/hierarchy/oeh.rs
+++ b/src/index/hierarchy/oeh.rs
@@ -632,6 +632,76 @@ impl OehIndex {
         self.measure = Some(measure);
     }
 
+    /// Point-update the measure at one node, without rebuilding.
+    ///
+    /// The topology has not changed — only a value — so the order embedding stays valid and
+    /// each range structure absorbs the difference in O(log n). Before this, a write to the
+    /// declared measure marked the whole index stale and forced a full rebuild, which on a
+    /// 2.9M-node taxonomy is nine seconds of work to reflect one number (#351).
+    ///
+    /// Returns `false` if the node is not in this hierarchy, so the caller can fall back to
+    /// invalidation rather than silently ignoring the write.
+    pub fn update_measure(&mut self, node: crate::graph::types::NodeId, value: Option<RollupValue>) -> bool {
+        let Some(idx) = self.poset.idx(node) else {
+            return false;
+        };
+        let Some(measure) = self.measure.as_mut() else {
+            return false;
+        };
+        let old = measure[idx as usize];
+        measure[idx as usize] = value;
+
+        let rank = match &self.data {
+            EncodingData::NestedSet { tin, .. } | EncodingData::NearTree { tin, .. } => {
+                Some(tin[idx as usize] as usize)
+            }
+            EncodingData::Chain { .. } => None,
+        };
+
+        for (op, data) in self.rollups.iter_mut() {
+            match data {
+                RollupData::Fenwick(f) => {
+                    // SUM is invertible, so the difference is enough.
+                    let (Some(rank), true) = (rank, op.is_invertible()) else { continue };
+                    let delta = match (value, old) {
+                        (Some(RollupValue::Int(n)), Some(RollupValue::Int(o))) => {
+                            RollupValue::Int(n - o)
+                        }
+                        (Some(RollupValue::Int(n)), None) => RollupValue::Int(n),
+                        (None, Some(RollupValue::Int(o))) => RollupValue::Int(-o),
+                        (a, b) => {
+                            let an = a.and_then(|v| v.as_f64()).unwrap_or(0.0);
+                            let bn = b.and_then(|v| v.as_f64()).unwrap_or(0.0);
+                            RollupValue::Float(an - bn)
+                        }
+                    };
+                    f.add(rank, delta);
+                }
+                RollupData::Sparse(seg) => {
+                    let Some(rank) = rank else { continue };
+                    seg.set(rank, value.unwrap_or(op.identity()));
+                }
+                RollupData::ChainSuffix(suffixes) => {
+                    // Per-chain suffix folds have no inverse: refold this chain's suffix
+                    // from the updated position. O(chain length), still far below a rebuild.
+                    if let EncodingData::Chain { chain_of, chains, .. } = &self.data {
+                        let (cid, pos) = chain_of[idx as usize];
+                        let chain = &chains[cid as usize];
+                        let suf = &mut suffixes[cid as usize];
+                        for i in (0..=pos as usize).rev() {
+                            let v = measure[chain[i] as usize].unwrap_or(op.identity());
+                            suf[i] = op.combine(v, suf[i + 1]);
+                        }
+                    }
+                }
+                // Near-tree folds the descendant set at query time from `measure`, which is
+                // already updated above.
+                RollupData::FoldSet => {}
+            }
+        }
+        true
+    }
+
     /// Whether a roll-up for `op` can be answered from the index right now.
     pub fn has_rollup(&self, op: RollupOp) -> bool {
         op == RollupOp::Count || self.rollups.contains_key(&op)
@@ -1297,6 +1367,65 @@ mod tests {
         let (a, b) = (p.idx(nid(1)).unwrap(), p.idx(nid(3)).unwrap());
         let idx = OehIndex::build(p).unwrap();
         assert!(idx.lowest_common_ancestors(a, b).is_empty());
+    }
+
+    #[test]
+    fn a_measure_update_matches_a_full_rebuild() {
+        // The property that makes #351 safe: point-updating must land in exactly the state
+        // a rebuild would have produced, for every node and every monoid.
+        for p in [balanced_tree(4, 3), layered_dag(5, 4)] {
+            let n = p.n();
+            let oracle_poset = p.clone();
+            let ops = [RollupOp::Sum, RollupOp::Min, RollupOp::Max];
+            let mut measure = ramp_measure(n);
+
+            let mut updated = OehIndex::build(p).unwrap();
+            updated.set_measure(measure.clone(), &ops);
+
+            // change a handful of nodes, including a clear and a set-from-absent
+            let changes: Vec<(u32, Option<RollupValue>)> = vec![
+                (0, Some(RollupValue::Int(1000))),
+                ((n / 3) as u32, None),
+                ((n / 2) as u32, Some(RollupValue::Int(-5))),
+                ((n - 1) as u32, Some(RollupValue::Int(7))),
+            ];
+            for (i, v) in &changes {
+                assert!(updated.update_measure(oracle_poset.node_at(*i), *v));
+                measure[*i as usize] = *v;
+            }
+
+            let mut rebuilt = OehIndex::build(oracle_poset.clone()).unwrap();
+            rebuilt.set_measure(measure.clone(), &ops);
+
+            for op in ops {
+                for y in 0..n as u32 {
+                    assert_eq!(
+                        updated.rollup(y, op),
+                        rebuilt.rollup(y, op),
+                        "{op:?} at {y} after point updates in {:?} mode",
+                        updated.encoding()
+                    );
+                    // and both still match the brute-force oracle
+                    assert_eq!(
+                        updated.rollup(y, op),
+                        Some(oracle::rollup(&oracle_poset, y, &measure, op)),
+                        "{op:?} at {y} vs oracle"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_measure_update_for_an_unknown_node_reports_failure() {
+        let p = balanced_tree(2, 2);
+        let n = p.n();
+        let mut idx = OehIndex::build(p).unwrap();
+        idx.set_measure(unit_measure(n), &[RollupOp::Sum]);
+        assert!(
+            !idx.update_measure(nid(9999), Some(RollupValue::Int(1))),
+            "a node outside the hierarchy must report failure so the caller can invalidate"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #351 for measure-only writes — stage 1 of the four staged there.

A write to the declared measure changes a **value**, not the shape of the poset, so the order embedding stays valid. Marking the whole index stale for it meant a full rebuild to reflect one number — nine seconds on a 2.9M-node taxonomy.

Each range structure now absorbs the change directly:

| Structure | Update | Cost |
|---|---|---|
| Fenwick (SUM/COUNT) | add the difference | O(log n) — SUM has an inverse |
| segment tree (MIN/MAX) | set the leaf, refold the path | O(log n) |
| chain suffix folds | refold that chain's suffix | O(chain length) |
| near-tree | nothing — it folds the measure at query time | — |

**The segment tree from #352 is what makes the MIN/MAX half possible at all.** A sparse table cannot be point-updated, which is why that change was worth making before this one.

## The property this rests on

After a series of point updates the index must be in **exactly the state a full rebuild would have produced**. That is tested directly — for every node and every monoid, in both nested-set and chain mode, including clearing a value and setting one that was previously absent — and both are cross-checked against the brute-force oracle.

Through the store:

```
before: sum under root = 45      (units 1..=9)
        set one leaf 9 -> 109
after:  sum under root = 145     index still fresh, no rebuild
```

## What is unchanged

The fallback is preserved: any hierarchy that cannot take the update — no measure attached, or the node outside its poset — is marked stale exactly as before, so **correctness never depends on the fast path succeeding**.

Topology writes still invalidate. Inserts and deletes are stages 2 and 3 of #351 and are the harder half, because nested-set intervals shift.

2125 lib tests, 31 hierarchy integration tests, 31 conformance tests.
