### PR TITLE
fix(query-engine): count(expr) counts values, collect() drops nulls

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3741,12 +3741,16 @@ impl AggregatorState {
                 }
             }
             AggregatorState::Collect(items) => {
+                // collect() drops nulls, like every other aggregate (#358) — otherwise the
+                // list carries holes that every consumer has to filter again.
                 if let Some(prop) = value.as_property() {
-                    items.push(prop.clone());
+                    if !matches!(prop, PropertyValue::Null) {
+                        items.push(prop.clone());
+                    }
                 }
             }
             AggregatorState::CollectDistinct(set) => {
-                if let Some(prop) = value.as_property() {
+                if let Some(prop) = value.as_property().filter(|p| !matches!(p, PropertyValue::Null)) {
                     if !prop.is_null() {
                         set.insert(prop.clone());
                     }
@@ -4022,7 +4026,15 @@ impl AggregateOperator {
         let group_expr = &self.group_by[0].0;
 
         // Check if all aggregates are simple count (non-distinct) — can skip aggregate expression evaluation
-        let all_simple_count = self.aggregates.iter().all(|a| matches!(a.func, AggregateType::Count) && !a.distinct);
+        // Fast path: count rows without evaluating the argument. Valid only when the
+        // argument cannot be null per row — `count(*)` (a literal) or `count(var)` for a
+        // bound node or edge. `count(x.prop)` counts *non-null values*, so skipping the
+        // evaluation there counted rows instead and reported every row as a value (#358).
+        let all_simple_count = self.aggregates.iter().all(|a| {
+            matches!(a.func, AggregateType::Count)
+                && !a.distinct
+                && matches!(a.expr, Expression::Literal(_) | Expression::Variable(_))
+        });
 
         let batch_size = 65536;
         let mut batch_count = 0u64;
@@ -4074,7 +4086,15 @@ impl AggregateOperator {
             .map(|agg| AggregatorState::new(&agg.func, agg.distinct))
             .collect();
 
-        let all_simple_count = self.aggregates.iter().all(|a| matches!(a.func, AggregateType::Count) && !a.distinct);
+        // Fast path: count rows without evaluating the argument. Valid only when the
+        // argument cannot be null per row — `count(*)` (a literal) or `count(var)` for a
+        // bound node or edge. `count(x.prop)` counts *non-null values*, so skipping the
+        // evaluation there counted rows instead and reported every row as a value (#358).
+        let all_simple_count = self.aggregates.iter().all(|a| {
+            matches!(a.func, AggregateType::Count)
+                && !a.distinct
+                && matches!(a.expr, Expression::Literal(_) | Expression::Variable(_))
+        });
 
         let batch_size = 65536;
         let mut batch_count = 0u64;

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1413,6 +1413,13 @@ impl QueryPlanner {
                 && group_by.is_empty()
                 && matches!(aggregates[0].func, AggregateType::Count)
                 && !aggregates[0].distinct
+                // O(1) label count answers "how many rows", which is `count(*)` or
+                // `count(var)`. `count(x.prop)` counts non-null *values*, and returning the
+                // label count for it reported every node as having the property (#358).
+                && matches!(
+                    aggregates[0].expr,
+                    Expression::Literal(_) | Expression::Variable(_)
+                )
                 && query.where_clause.is_none()
                 && query.with_clause.is_none()
                 && query.match_clauses.len() == 1

--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -205,8 +205,15 @@ impl Value {
     }
 
     /// Check if this is null
+    /// Is this value null?
+    ///
+    /// Null has two representations here — the `Value::Null` variant, and a
+    /// `Value::Property(PropertyValue::Null)` produced when a node simply does not carry
+    /// the property being read. They mean the same thing, and treating only the first as
+    /// null is what made `count(x.prop)` count rows rather than non-null values (#358):
+    /// a missing property arrives as the second form and slipped through the check.
     pub fn is_null(&self) -> bool {
-        matches!(self, Value::Null)
+        matches!(self, Value::Null | Value::Property(PropertyValue::Null))
     }
 
     /// Extract NodeId from any node variant (Node or NodeRef)

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -406,7 +406,6 @@ fn count_of_a_node_counts_rows() {
 }
 
 #[test]
-#[ignore = "blocked on #358: count(expr) counts rows instead of non-null values"]
 fn count_of_a_property_skips_nulls() {
     let s = fixture();
     assert_eq!(


### PR DESCRIPTION
Fixes #358.

openCypher distinguishes `count(*)` and `count(var)`, which count **rows**, from `count(expr)`, which counts **non-null values**. All three counted rows. `collect()` had the matching problem, emitting a `NULL` element rather than skipping it.

## Three places had to agree

Each was individually enough to keep the bug alive, which is why the first two fixes did not move the test:

1. **`Value::is_null()` matched only the `Value::Null` variant.** A property a node does not carry arrives as `Value::Property(PropertyValue::Null)`, so it slipped the check. Null has two representations that mean the same thing; treating only one as null is the root defect — and fixing it there is why the accumulator itself needed no change.

2. **The aggregate fast path skipped evaluating the argument** and just incremented. Sound for `count(*)` and `count(var)`, where the argument cannot be null per row; not for `count(x.prop)`. Now gated on the expression being a literal or a variable.

3. **The planner's O(1) `LabelCountOperator` shortcut** answers "how many nodes carry this label" — right for `count(*)` and `count(var)`, wrong for `count(x.prop)`, where it reported every node as having the property. Gated the same way.

Both fast paths are kept for the shapes where they are sound; only their applicability narrowed.

## Result

```cypher
MATCH (p:Person) RETURN count(p.salary)   -- 6 -> 5   (one person has no salary)
MATCH (p:Person) RETURN count(p)          -- 6        (unchanged)
MATCH (p:Person) RETURN collect(p.salary) -- [100,150,200,250,300,NULL] -> without NULL
```

2126 lib tests; 34 conformance tests, with the one parked against #358 now live. Only #346 and #347 remain parked.
