### PR TITLE
fix(cypher): NOT binds looser than comparison, as openCypher specifies

### DIFF
--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -122,7 +122,11 @@ order_item = { expression ~ order_direction? }
 order_direction = { ^"ASC" | ^"DESC" }
 
 // Expressions
-expression = { term ~ (binary_op ~ term)* }
+// `NOT` is an expression-level prefix, not part of `term`. Inside `term` it bound to a
+// single primary, so `NOT a STARTS WITH b` parsed as `(NOT a) STARTS WITH b` — tighter than
+// any comparison, which is the opposite of openCypher. Emitting it here lets the Pratt
+// parser give it a precedence between AND and the comparison operators.
+expression = { not_op* ~ term ~ (binary_op ~ not_op* ~ term)* }
 term = { unary_op* ~ primary ~ postfix_op? ~ index_op? }
 postfix_op = { ^"IS" ~ ^"NOT" ~ ^"NULL" | ^"IS" ~ ^"NULL" }
 index_op = { "[" ~ (slice_op | expression) ~ "]" }
@@ -187,7 +191,8 @@ or_op = @{ ^"OR" ~ !(ASCII_ALPHANUMERIC | "_") }
 
 binary_op = _{ mul_div_mod_op | add_sub_op | comparison_op | in_op | and_op | or_op }
 
-unary_op = { ^"NOT" | "-" }
+unary_op = { "-" }
+not_op = @{ ^"NOT" ~ !(ASCII_ALPHANUMERIC | "_") }
 
 // Values
 value = {

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -74,6 +74,9 @@ static PRATT_PARSER: LazyLock<PrattParser<Rule>> = LazyLock::new(|| {
     PrattParser::new()
         .op(Op::infix(Rule::or_op, Assoc::Left))
         .op(Op::infix(Rule::and_op, Assoc::Left))
+        // NOT sits between AND and the comparisons: `NOT a STARTS WITH b` negates the
+        // comparison, while `NOT a AND b` still groups as `(NOT a) AND b`.
+        .op(Op::prefix(Rule::not_op))
         .op(Op::infix(Rule::in_op, Assoc::Left) | Op::infix(Rule::comparison_op, Assoc::Left))
         .op(Op::infix(Rule::add_sub_op, Assoc::Left))
         .op(Op::infix(Rule::mul_div_mod_op, Assoc::Left))
@@ -1367,6 +1370,15 @@ fn parse_order_item(pair: pest::iterators::Pair<Rule>) -> ParseResult<OrderByIte
 fn parse_expression(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
     PRATT_PARSER
         .map_primary(|primary| parse_term(primary))
+        .map_prefix(|op, rhs| match op.as_rule() {
+            Rule::not_op => Ok(Expression::Unary {
+                op: UnaryOp::Not,
+                expr: Box::new(rhs?),
+            }),
+            other => Err(ParseError::SemanticError(format!(
+                "Unexpected prefix operator: {other:?}"
+            ))),
+        })
         .map_infix(|left, op, right| {
             let left = left?;
             let right = right?;

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -557,7 +557,6 @@ fn exists_subquery_applies_inline_property_constraints() {
 }
 
 #[test]
-#[ignore = "blocked on #347: NOT binds tighter than STARTS WITH"]
 fn not_binds_looser_than_string_comparison() {
     let s = fixture();
     assert_eq!(


### PR DESCRIPTION
Fixes #347.

`NOT` was consumed inside the `term` rule, so it attached to a single primary and bound **tighter than every operator**: `NOT a STARTS WITH b` parsed as `(NOT a) STARTS WITH b`, which raised *"NOT requires boolean"* in one shape and silently returned nothing in another.

The parser already has a Pratt table with correct infix precedence. The fix is to stop swallowing `NOT` in `term` and emit it as an **expression-level prefix operator** the Pratt parser can place — between `AND` and the comparisons.

## That position is the point, and both sides are tested

```cypher
WHERE NOT p.name STARTS WITH "A"        -- negates the comparison  (looser than comparison)
WHERE NOT p.city = "NYC" AND p.dept = "Eng"
                                        -- groups as (NOT city=NYC) AND dept=Eng
                                        -- (still tighter than AND)
```

A fix that only moved `NOT` looser would have broken the second form. There are also tests that the parenthesised spelling agrees with the bare one, and that double negation works.

`ENDS WITH`, `CONTAINS`, `IN` and the arithmetic comparisons all sit at or below the same precedence level, so they are fixed by the same change.

## Testing

2126 lib tests, plus every query-related integration suite — this touches expression parsing centrally, so `exists_subquery`, `target_node_filter`, `advanced_cypher`, `advanced_aggregations`, `index_test`, `age_plan_executor` and the hierarchy suites were all run explicitly. Only #346 now remains parked in the conformance suite.
