### PR TITLE
fix(query-engine): read columnar properties inside EXISTS { }

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -453,7 +453,19 @@ fn exists_node_matches(
         return false;
     }
     if let Some(props) = &pat.properties {
-        if !props.iter().all(|(k, v)| node.properties.get(k).map_or(false, |pv| pv == v)) {
+        // Columnar store first, sparse map as fallback. Reading only `node.properties`
+        // made every inline constraint inside EXISTS { } fail on a columnar graph — and
+        // after a snapshot import that map is *always* empty (ADR-021), so EXISTS matched
+        // nothing at all on imported data while the equivalent WHERE inside the subquery
+        // worked (#346).
+        let idx = id.as_u64() as usize;
+        let matches_all = props.iter().all(|(k, v)| {
+            match store.node_columns.get_property(idx, k) {
+                PropertyValue::Null => node.properties.get(k).is_some_and(|pv| pv == v),
+                col => &col == v,
+            }
+        });
+        if !matches_all {
             return false;
         }
     }

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -543,7 +543,6 @@ fn order_by_a_repeated_aggregate_expression_sorts_like_its_alias() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "blocked on #346: inline property maps inside EXISTS { } never match"]
 fn exists_subquery_applies_inline_property_constraints() {
     let s = fixture();
     assert_eq!(


### PR DESCRIPTION
Fixes #346.

An inline property constraint in an `EXISTS` subquery pattern matched nothing:

```cypher
EXISTS { MATCH (d)-[:IS_A]->(r:T {code: "AB"}) }          -- always false
EXISTS { MATCH (d)-[:IS_A]->(r:T) WHERE r.code = "AB" }   -- correct
```

`exists_node_matches` read `node.properties` — the **sparse map** — and never the columnar store. So the constraint failed for any node whose properties were set through `set_column_property`, and **after a snapshot import that map is always empty** (ADR-021), meaning `EXISTS` matched nothing at all on imported data. `NOT EXISTS` correspondingly returned *every* row, which is the dangerous direction: the query looks like it worked and the row count looks plausible.

This is the same shape as the rule ADR-035 records for the hierarchy measure — columnar first, sparse map as fallback. **Three places in this codebase now follow that pattern**; it is the kind of thing that wants a shared accessor, which I've noted as follow-up rather than folded in here to keep the fix reviewable.

Also worth recording: it is **not** variable-length-specific. A plain single hop reproduces it, which is what made the original report's diagnosis ("EXISTS with a variable-length pattern") wrong about the cause — and why I re-derived it from a minimal repro rather than taking the issue at its word.

## Testing

2126 lib tests, 11 exists-subquery tests, and the conformance suite is now at **36 passing with nothing ignored** — every test parked against #345, #346, #347, #356, #357, #358 and #369 during this session is live.
