### PR TITLE
fix(planner): join a second MATCH on every shared variable, not one

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -5032,8 +5032,15 @@ impl PhysicalOperator for CartesianProductOperator {
 pub struct JoinOperator {
     left: OperatorBox,
     right: OperatorBox,
-    join_var: String,
-    left_records: HashMap<Value, Vec<Record>>,
+    /// **Every** variable shared between the two sides, not just one.
+    ///
+    /// Joining on a single shared variable silently drops the correlation carried by the
+    /// others and returns a cartesian product across them. The planner used to pass the
+    /// first element of a `HashSet` intersection, so which correlation was enforced — and
+    /// therefore whether the answer was right — varied between runs of the same query on
+    /// the same data (#360).
+    join_vars: Vec<String>,
+    left_records: HashMap<Vec<Value>, Vec<Record>>,
     right_records: Vec<Record>,
     current_right_index: usize,
     current_left_list_index: usize,
@@ -5041,11 +5048,17 @@ pub struct JoinOperator {
 }
 
 impl JoinOperator {
-    pub fn new(left: OperatorBox, right: OperatorBox, join_var: String) -> Self {
+    /// The composite key: every join variable's value, in a fixed order. `None` when the
+    /// record does not bind them all, in which case it cannot match anything.
+    fn key_of(record: &Record, vars: &[String]) -> Option<Vec<Value>> {
+        vars.iter().map(|v| record.get(v).cloned()).collect()
+    }
+
+    pub fn new(left: OperatorBox, right: OperatorBox, join_vars: Vec<String>) -> Self {
         Self {
             left,
             right,
-            join_var,
+            join_vars,
             left_records: HashMap::new(),
             right_records: Vec::new(),
             current_right_index: 0,
@@ -5062,8 +5075,8 @@ impl JoinOperator {
         // Materialize left into a hash map (with periodic timeout check)
         let mut count = 0u64;
         while let Some(record) = self.left.next(store)? {
-            if let Some(val) = record.get(&self.join_var) {
-                self.left_records.entry(val.clone()).or_default().push(record);
+            if let Some(key) = Self::key_of(&record, &self.join_vars) {
+                self.left_records.entry(key).or_default().push(record);
             }
             count += 1;
             if count % 10000 == 0 { check_deadline()?; }
@@ -5088,8 +5101,8 @@ impl PhysicalOperator for JoinOperator {
 
         while self.current_right_index < self.right_records.len() {
             let right_record = &self.right_records[self.current_right_index];
-            if let Some(join_val) = right_record.get(&self.join_var) {
-                if let Some(left_list) = self.left_records.get(join_val) {
+            if let Some(join_key) = Self::key_of(right_record, &self.join_vars) {
+                if let Some(left_list) = self.left_records.get(&join_key) {
                     if self.current_left_list_index < left_list.len() {
                         let left_record = &left_list[self.current_left_list_index];
                         self.current_left_list_index += 1;
@@ -5118,8 +5131,8 @@ impl PhysicalOperator for JoinOperator {
 
         while results.len() < batch_size && self.current_right_index < self.right_records.len() {
             let right_record = &self.right_records[self.current_right_index];
-            if let Some(join_val) = right_record.get(&self.join_var) {
-                if let Some(left_list) = self.left_records.get(join_val) {
+            if let Some(join_key) = Self::key_of(right_record, &self.join_vars) {
+                if let Some(left_list) = self.left_records.get(&join_key) {
                     let take = (batch_size - results.len()).min(left_list.len() - self.current_left_list_index);
                     
                     for i in 0..take {
@@ -5166,7 +5179,7 @@ impl PhysicalOperator for JoinOperator {
     fn describe(&self) -> OperatorDescription {
         OperatorDescription {
             name: "HashJoin".to_string(),
-            details: format!("on={}", self.join_var),
+            details: format!("on={}", self.join_vars.join(",")),
             children: vec![self.left.describe(), self.right.describe()],
         }
     }
@@ -5178,11 +5191,12 @@ impl PhysicalOperator for JoinOperator {
 pub struct LeftOuterJoinOperator {
     left: OperatorBox,
     right: OperatorBox,
-    join_var: String,
+    /// Every shared variable — see [`JoinOperator::join_vars`] (#360).
+    join_vars: Vec<String>,
     right_only_vars: Vec<String>,
     // Materialized data
     left_records: Vec<Record>,
-    right_hash: HashMap<Value, Vec<Record>>,
+    right_hash: HashMap<Vec<Value>, Vec<Record>>,
     // Iteration state
     current_left_idx: usize,
     current_right_match_idx: usize,
@@ -5194,13 +5208,13 @@ impl LeftOuterJoinOperator {
     pub fn new(
         left: OperatorBox,
         right: OperatorBox,
-        join_var: String,
+        join_vars: Vec<String>,
         right_only_vars: Vec<String>,
     ) -> Self {
         Self {
             left,
             right,
-            join_var,
+            join_vars,
             right_only_vars,
             left_records: Vec::new(),
             right_hash: HashMap::new(),
@@ -5227,7 +5241,7 @@ impl LeftOuterJoinOperator {
         // Materialize right into a hash map by join variable
         count = 0;
         while let Some(record) = self.right.next(store)? {
-            if let Some(val) = record.get(&self.join_var) {
+            if let Some(val) = JoinOperator::key_of(&record, &self.join_vars) {
                 self.right_hash.entry(val.clone()).or_default().push(record);
             }
             count += 1;
@@ -5246,8 +5260,8 @@ impl PhysicalOperator for LeftOuterJoinOperator {
         while self.current_left_idx < self.left_records.len() {
             let left_record = &self.left_records[self.current_left_idx];
 
-            if let Some(join_val) = left_record.get(&self.join_var) {
-                if let Some(right_list) = self.right_hash.get(join_val) {
+            if let Some(join_val) = JoinOperator::key_of(left_record, &self.join_vars) {
+                if let Some(right_list) = self.right_hash.get(&join_val) {
                     // Has right matches — emit merged records
                     if self.current_right_match_idx < right_list.len() {
                         let right_record = &right_list[self.current_right_match_idx];
@@ -5317,7 +5331,7 @@ impl PhysicalOperator for LeftOuterJoinOperator {
     fn describe(&self) -> OperatorDescription {
         OperatorDescription {
             name: "LeftOuterJoin".to_string(),
-            details: format!("on={}", self.join_var),
+            details: format!("on={}", self.join_vars.join(",")),
             children: vec![self.left.describe(), self.right.describe()],
         }
     }

--- a/src/query/executor/physical_planner.rs
+++ b/src/query/executor/physical_planner.rs
@@ -114,7 +114,7 @@ pub fn logical_to_physical(plan: &LogicalPlanNode) -> OperatorBox {
             let physical_right = logical_to_physical(right);
             // JoinOperator takes a single join variable
             let join_var = join_keys.first().cloned().unwrap_or_default();
-            Box::new(JoinOperator::new(physical_left, physical_right, join_var))
+            Box::new(JoinOperator::new(physical_left, physical_right, vec![join_var]))
         }
 
         LogicalPlanNode::CartesianProduct { left, right } => {

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -903,13 +903,18 @@ impl QueryPlanner {
 
             operator = Some(match operator {
                 Some(existing) => {
-                    let shared: Vec<String> = known_vars.intersection(&clause_vars).cloned().collect();
+                    // ALL shared variables form the join key. Taking one of them left the
+                    // rest uncorrelated — a silent cartesian product — and since this comes
+                    // from a HashSet intersection, which one varied between runs (#360).
+                    let mut shared: Vec<String> =
+                        known_vars.intersection(&clause_vars).cloned().collect();
+                    shared.sort();
                     if !shared.is_empty() {
                         if match_clause.optional {
                             let right_only: Vec<String> = clause_vars.difference(&known_vars).cloned().collect();
-                            Box::new(LeftOuterJoinOperator::new(existing, match_op, shared[0].clone(), right_only)) as OperatorBox
+                            Box::new(LeftOuterJoinOperator::new(existing, match_op, shared.clone(), right_only)) as OperatorBox
                         } else {
-                            Box::new(JoinOperator::new(existing, match_op, shared[0].clone())) as OperatorBox
+                            Box::new(JoinOperator::new(existing, match_op, shared.clone())) as OperatorBox
                         }
                     } else {
                         Box::new(CartesianProductOperator::new(existing, match_op)) as OperatorBox
@@ -1093,13 +1098,18 @@ impl QueryPlanner {
 
                     operator = Some(match operator {
                         Some(existing) => {
-                            let shared: Vec<String> = known_vars.intersection(&clause_vars).cloned().collect();
+                            // ALL shared variables form the join key. Taking one of them left the
+                    // rest uncorrelated — a silent cartesian product — and since this comes
+                    // from a HashSet intersection, which one varied between runs (#360).
+                    let mut shared: Vec<String> =
+                        known_vars.intersection(&clause_vars).cloned().collect();
+                    shared.sort();
                             if !shared.is_empty() {
                                 if match_clause.optional {
                                     let right_only: Vec<String> = clause_vars.difference(&known_vars).cloned().collect();
-                                    Box::new(LeftOuterJoinOperator::new(existing, match_op, shared[0].clone(), right_only)) as OperatorBox
+                                    Box::new(LeftOuterJoinOperator::new(existing, match_op, shared.clone(), right_only)) as OperatorBox
                                 } else {
-                                    Box::new(JoinOperator::new(existing, match_op, shared[0].clone())) as OperatorBox
+                                    Box::new(JoinOperator::new(existing, match_op, shared.clone())) as OperatorBox
                                 }
                             } else {
                                 Box::new(CartesianProductOperator::new(existing, match_op)) as OperatorBox
@@ -1156,8 +1166,9 @@ impl QueryPlanner {
                 }
 
                 if !shared_vars.is_empty() {
-                    // Use JoinOperator on the first shared variable
-                    operator = Some(Box::new(JoinOperator::new(existing_op, call_op, shared_vars[0].clone())));
+                    // Join on every shared variable, not just the first — see #360.
+                    shared_vars.sort();
+                    operator = Some(Box::new(JoinOperator::new(existing_op, call_op, shared_vars.clone())));
                 } else {
                     // Fallback to Cartesian Product
                     operator = Some(Box::new(CartesianProductOperator::new(existing_op, call_op)));
@@ -2001,7 +2012,7 @@ impl QueryPlanner {
         for (op, vars) in operators.into_iter().zip(path_vars.into_iter()) {
             let shared: Vec<String> = combined_vars.intersection(&vars).cloned().collect();
             if !shared.is_empty() {
-                result = Box::new(JoinOperator::new(result, op, shared[0].clone()));
+                result = Box::new(JoinOperator::new(result, op, shared.clone()));
             } else {
                 result = Box::new(CartesianProductOperator::new(result, op));
             }

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -678,3 +678,55 @@ fn null_ordering_follows_opencypher() {
     );
     assert_eq!(desc[0], "n=Frank v=NULL", "nulls first on DESC: {desc:?}");
 }
+
+// ---------------------------------------------------------------------------
+// Multi-clause joins (#360)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_second_match_joins_on_every_shared_variable() {
+    // Two MATCH clauses sharing *two* variables. Joining on only one of them leaves the
+    // other uncorrelated and yields a cartesian product across it — and because the join
+    // key came from a HashSet intersection, which one was enforced varied between runs of
+    // the same query on the same data.
+    let mut s = GraphStore::new();
+    let mut mk = |s: &mut GraphStore, label: &str, id: &str| {
+        let n = s.create_node(label);
+        s.set_column_property(n, "id", PropertyValue::String(id.into()));
+        n
+    };
+    let board = mk(&mut s, "Board", "B1");
+    let ma = mk(&mut s, "Model", "MA");
+    let mb = mk(&mut s, "Model", "MB");
+    for (vid, precision, model) in [
+        ("MA32", "fp32", ma),
+        ("MA8", "int8", ma),
+        ("MB32", "fp32", mb),
+        ("MB8", "int8", mb),
+    ] {
+        let v = mk(&mut s, "Variant", vid);
+        s.set_column_property(v, "precision", PropertyValue::String(precision.into()));
+        s.create_edge(v, model, "VARIANT_OF").unwrap();
+        let d = s.create_node("Deploy");
+        s.create_edge(d, v, "OF").unwrap();
+        s.create_edge(d, board, "ON").unwrap();
+    }
+
+    // Each model's fp32 variant paired with *its own* int8 variant: 2 rows, not 4.
+    let r = bag(
+        &s,
+        "MATCH (b:Board)<-[:ON]-(d1:Deploy)-[:OF]->(v1:Variant)-[:VARIANT_OF]->(m:Model) \
+         WHERE v1.precision = \"fp32\" \
+         MATCH (b)<-[:ON]-(d2:Deploy)-[:OF]->(v2:Variant)-[:VARIANT_OF]->(m) \
+         WHERE v2.precision = \"int8\" \
+         RETURN m.id AS model, v1.id AS fp32, v2.id AS int8",
+    );
+    assert_eq!(
+        r,
+        vec![
+            "fp32=MA32 int8=MA8 model=MA",
+            "fp32=MB32 int8=MB8 model=MB",
+        ],
+        "a variant must pair only with its own model's other variant: {r:?}"
+    );
+}


### PR DESCRIPTION
Fixes #360.

When a second `MATCH` shares more than one variable with what is already bound, the planner joined on **a single one of them** and left the rest uncorrelated — a cartesian product across those variables, returned silently.

## The reported symptom understates it

The join key was `shared[0]` of a `HashSet` intersection, so *which* correlation got enforced depended on hash iteration order. The same query, on the same data, in the same binary, alternated between right and wrong across runs:

```
HashJoin (on=m)  ->  2 rows   correct
HashJoin (on=b)  ->  4 rows   cartesian across models
```

Ten runs of the reporter's fixture: `2, 4, 2, 2, 4, 4, 2, 2, …`

That is worse than a deterministic bug. A query can be written, validated against known-good output, shipped — and then start returning wrong rows with nothing having changed. It also explains why this was hard to pin down from the outside.

## The fix

`JoinOperator` and `LeftOuterJoinOperator` now key on a `Vec<Value>` built from **every** shared variable, and the planner passes the full **sorted** set at all four sites that construct a join. Sorting also makes the plan reproducible in `EXPLAIN` — which is how I found the non-determinism: diffing plans between a correct and an incorrect run showed only `on=m` versus `on=b`.

## Verification

10 runs × both property-storage paths: **20/20 correct**, where roughly half were wrong before. A regression test is in the conformance suite rather than left as a scratch example.

2126 lib tests and every query-related integration suite pass.
