### PR TITLE
fix(graph): clear the columnar row when a node is deleted

### DIFF
--- a/src/graph/storage/columnar.rs
+++ b/src/graph/storage/columnar.rs
@@ -36,6 +36,16 @@ impl Column {
         }
     }
 
+    /// Remove this row's value from the column, if present.
+    pub fn remove(&mut self, idx: usize) {
+        match self {
+            Column::Int(m) => { m.remove(&idx); }
+            Column::Float(m) => { m.remove(&idx); }
+            Column::String(m) => { m.remove(&idx); }
+            Column::Bool(m) => { m.remove(&idx); }
+        }
+    }
+
     pub fn get(&self, idx: usize) -> PropertyValue {
         match self {
             Column::Int(m) => m.get(&idx).map(|&v| PropertyValue::Integer(v)).unwrap_or(PropertyValue::Null),
@@ -92,6 +102,18 @@ impl ColumnStore {
             };
             col.set(idx, value);
             self.columns.insert(key.to_string(), col);
+        }
+    }
+
+    /// Drop every property stored for one row.
+    ///
+    /// Node ids are recycled through a free list, so a deleted node's slot is handed to the
+    /// next `create_node`. Without this the new node inherits whatever the previous
+    /// occupant left in each column — values from deleted data reappearing on new data
+    /// (#364). Deletion has to clear the columns as well as the sparse map.
+    pub fn clear_row(&mut self, idx: usize) {
+        for col in self.columns.values_mut() {
+            col.remove(idx);
         }
     }
 

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -1214,6 +1214,11 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             self.handle_index_event(event, None);
         }
 
+        // Clear the columnar row. The id goes on the free list just above and will be
+        // handed to the next create_node, which would otherwise inherit whatever this node
+        // left in each column — deleted values reappearing on new nodes (#364).
+        self.node_columns.clear_row(idx);
+
         // Remove from the versions (breaking historical reads for now, full MVCC is complex)
         // TODO: Implement proper tombstone versions
         let node = self.nodes[idx].pop().unwrap();

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -730,3 +730,45 @@ fn a_second_match_joins_on_every_shared_variable() {
         "a variant must pair only with its own model's other variant: {r:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Deletion hygiene (#364)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_deleted_nodes_property_does_not_reappear_on_its_successor() {
+    // Node ids are recycled through a free list, so the next CREATE gets the deleted
+    // node's slot. If deletion leaves the columnar row behind, the new node inherits the
+    // old value for any property it does not itself set — deleted data reappearing on new
+    // data, with nothing in the query to hint at it.
+    let mut s = GraphStore::new();
+    let engine = QueryEngine::new();
+    engine
+        .execute_mut(
+            "CREATE (:Ghost {id: \"a\", secret: \"LEAKED\"})",
+            &mut s,
+            "default",
+        )
+        .unwrap();
+    engine
+        .execute_mut("MATCH (n:Ghost) DETACH DELETE n", &mut s, "default")
+        .unwrap();
+    assert_eq!(scalar(&s, "MATCH (n:Ghost) RETURN count(n) AS n"), "n=0");
+
+    // the successor sets `id` but never `secret`
+    engine
+        .execute_mut("CREATE (:Ghost {id: \"b\"})", &mut s, "default")
+        .unwrap();
+    let r = bag(&s, "MATCH (n:Ghost) RETURN n.id AS id, n.secret AS secret");
+    assert_eq!(r, vec!["id=b secret=NULL"], "{r:?}");
+
+    // and again after a global wipe
+    engine
+        .execute_mut("MATCH (n) DETACH DELETE n", &mut s, "default")
+        .unwrap();
+    engine
+        .execute_mut("CREATE (:Ghost {id: \"c\"})", &mut s, "default")
+        .unwrap();
+    let r = bag(&s, "MATCH (n:Ghost) RETURN n.id AS id, n.secret AS secret");
+    assert_eq!(r, vec!["id=c secret=NULL"], "{r:?}");
+}


### PR DESCRIPTION
Fixes #364.

Node ids are recycled through a free list, so a deleted node's slot goes to the next `create_node`. Deletion cleared the **sparse property map** but never the **columnar store**, so the new node inherited whatever the previous occupant left in each column:

```cypher
CREATE (:Ghost {id:"a", ghost:"LEAKED"})
MATCH (n:Ghost) DETACH DELETE n           -- count is now 0
CREATE (:Ghost {id:"b"})                  -- sets no `ghost`
MATCH (n:Ghost) RETURN n.id, n.ghost      -- "b", "LEAKED"
```

**Deleted data reappearing on new data**, with nothing in the query to hint at it. A global `MATCH (n) DETACH DELETE n` did not help either, because the leak is per-slot rather than per-statement.

## Fix

Adds `ColumnStore::clear_row` and calls it from `delete_node`, immediately next to the free-list push that creates the hazard — so the two are read together by anyone touching that path. `delete_node` is also where `DETACH DELETE` and edge cleanup funnel, so one call covers all of them.

## Testing

Regression test covers **both** the single-label delete and the global wipe, since the reporter found the second still leaked after the first looked fixed.

2126 lib tests; snapshot, MVCC and hierarchy suites pass — the ones that lean on node-id reuse and columnar reads.
