### PR TITLE
fix(vector): backfill existing embeddings when a vector index is created

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -5539,6 +5539,13 @@ impl PhysicalOperator for CreateVectorIndexOperator {
         store.create_vector_index(self.label.as_str(), &self.property_key, self.dimensions, metric)
             .map_err(|e| ExecutionError::GraphError(e.to_string()))?;
 
+        // Backfill nodes that already carry the embedding. Registering the index without
+        // populating it leaves every search returning nothing on a graph that was loaded
+        // before the index was declared — which is the normal order for a bulk import
+        // followed by DDL. `rebuild_vector_index` reads both the inline map and the
+        // columnar store, so it covers whichever tier the vectors landed in.
+        store.rebuild_vector_index();
+
         self.executed = true;
         
         // Return an empty record or a success record

--- a/tests/index_test.rs
+++ b/tests/index_test.rs
@@ -75,3 +75,43 @@ fn test_create_index_ddl() {
     let (_, node) = result.records[0].get("n").unwrap().as_node().unwrap();
     assert_eq!(node.get_property("id").unwrap().as_integer(), Some(5));
 }
+
+#[test]
+fn create_vector_index_backfills_existing_embeddings() {
+    // The normal order for a bulk load is data first, DDL second. Registering the index
+    // without populating it left every search returning nothing on a graph that already
+    // held the embeddings — a permanently empty index with no error to say so.
+    use samyama::graph::PropertyValue;
+
+    let mut store = GraphStore::new();
+    for i in 0..4 {
+        let id = store.create_node("Doc");
+        let f = i as f32 / 10.0;
+        if let Some(n) = store.get_node_mut(id) {
+            n.set_property("title", PropertyValue::String(format!("doc{i}")));
+            n.set_property("emb", PropertyValue::Vector(vec![f, f, f, f]));
+        }
+    }
+    let engine = QueryEngine::new();
+    engine
+        .execute_mut(
+            "CREATE VECTOR INDEX docvec FOR (d:Doc) ON (d.emb) OPTIONS {dimensions: 4}",
+            &mut store,
+            "default",
+        )
+        .unwrap();
+
+    let result = engine
+        .execute(
+            "CALL db.index.vector.queryNodes(\"Doc\", \"emb\", [0.1, 0.1, 0.1, 0.1], 4) \
+             YIELD node, score RETURN node, score",
+            &store,
+        )
+        .unwrap();
+    assert_eq!(
+        result.records.len(),
+        4,
+        "every indexed document must be reachable; an empty result here means the index \
+         was registered but never populated"
+    );
+}


### PR DESCRIPTION
`CREATE VECTOR INDEX` registered the index and **never populated it**, so on a graph that already held embeddings every search returned nothing — a permanently empty index, with no error to say so. Data first, DDL second is the normal order for a bulk load, which makes this the common case rather than an edge one.

```cypher
CREATE VECTOR INDEX docvec FOR (d:Doc) ON (d.emb) OPTIONS {dimensions: 4}
CALL db.index.vector.queryNodes("Doc","emb",[0.1,0.1,0.1,0.1],4) YIELD node, score
-- before: 0 rows        after: 4 rows
```

`rebuild_vector_index()` already reads **both** the inline property map and the columnar store, so calling it after registration covers whichever tier the vectors landed in.

## How it was found

While investigating #348, whose report noted the ANN call returning no rows and flagged it as *possibly a separate problem*. It was. **#348's actual defect is narrower and still open**: `YIELD`-bound variables are not in scope for a `WHERE` attached to a following `MATCH` — though after this fix they do survive into the `MATCH` itself and into `RETURN`, so the remaining gap is smaller than the issue describes.

## One more thing worth recording

`set_column_property` **silently discards `Vector` values** — the column store only handles scalars and returns early on anything else. Embeddings written that way vanish with no error. That is what made this hard to see from the outside, and it caught my own first fixture. Relevant to #310 and #333, which both describe embeddings that never reach the index.

2126 lib tests, index and snapshot suites pass.
