### PR TITLE
fix(query): comparisons with null are unknown, not true

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -127,6 +127,19 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
         Value::Null => PropertyValue::Null,
         _ => return Err(ExecutionError::TypeError("Binary op requires property values".to_string())),
     };
+    // Cypher's three-valued logic: any comparison with a null operand is *unknown*, not
+    // true or false, and a WHERE treats unknown as "exclude". Evaluating `null <> 1` as
+    // true kept every row whose property was simply absent — the opposite of what the
+    // predicate asks. `IS NULL` / `IS NOT NULL` are postfix operators and unaffected;
+    // they remain the way to test for absence.
+    if matches!(
+        op,
+        BinaryOp::Eq | BinaryOp::Ne | BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge
+    ) && (matches!(left_prop, PropertyValue::Null) || matches!(right_prop, PropertyValue::Null))
+    {
+        return Ok(Value::Property(PropertyValue::Null));
+    }
+
     let result = match op {
         BinaryOp::Eq => PropertyValue::Boolean(left_prop == right_prop),
         BinaryOp::Ne => PropertyValue::Boolean(left_prop != right_prop),
@@ -2590,6 +2603,19 @@ impl FilterOperator {
             Value::Null => PropertyValue::Null,
             _ => return Err(ExecutionError::TypeError("Binary op requires property values".to_string())),
         };
+
+        // Three-valued logic, same rule as `eval_binary_op`: a comparison with a null
+        // operand is unknown, and a WHERE excludes unknown. `null <> 1` evaluating to true
+        // kept every row whose property was merely absent. Note this is a *second*
+        // comparison implementation — the two must agree, and did not.
+        if matches!(
+            op,
+            BinaryOp::Eq | BinaryOp::Ne | BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge
+        ) && (matches!(left_prop, PropertyValue::Null)
+            || matches!(right_prop, PropertyValue::Null))
+        {
+            return Ok(Value::Property(PropertyValue::Null));
+        }
 
         let result = match op {
             BinaryOp::Eq => PropertyValue::Boolean(self.coerced_eq(&left_prop, &right_prop)),
@@ -10097,7 +10123,9 @@ mod tests {
             Value::Property(PropertyValue::Null),
             Value::Property(PropertyValue::Null),
         ).unwrap();
-        assert_eq!(result, Value::Property(PropertyValue::Boolean(true)));
+        // Cypher: null = null is *unknown*, not true. This is why `IS NULL` exists as a
+        // separate operator -- equality can never confirm nullness.
+        assert_eq!(result, Value::Property(PropertyValue::Null));
     }
 
     #[test]
@@ -10106,7 +10134,8 @@ mod tests {
             Value::Property(PropertyValue::Null),
             Value::Property(PropertyValue::Integer(1)),
         ).unwrap();
-        assert_eq!(result, Value::Property(PropertyValue::Boolean(true)));
+        // Unknown, not true -- a WHERE must exclude the row rather than keep it.
+        assert_eq!(result, Value::Property(PropertyValue::Null));
     }
 
     // -- And/Or type errors --
@@ -10235,8 +10264,9 @@ mod tests {
             Value::Null,
             Value::Property(PropertyValue::Integer(1)),
         ).unwrap();
-        // Null != Integer
-        assert_eq!(result, Value::Property(PropertyValue::Boolean(false)));
+        // Unknown. Filters coerce this to "exclude", so the observable WHERE behaviour is
+        // unchanged from the old `false`, but NOT(unknown) is unknown -- not true.
+        assert_eq!(result, Value::Property(PropertyValue::Null));
     }
 
     // -- Comparison operators --

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -772,3 +772,71 @@ fn a_deleted_nodes_property_does_not_reappear_on_its_successor() {
     let r = bag(&s, "MATCH (n:Ghost) RETURN n.id AS id, n.secret AS secret");
     assert_eq!(r, vec!["id=c secret=NULL"], "{r:?}");
 }
+
+// ---------------------------------------------------------------------------
+// Three-valued logic in WHERE (#398)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn comparisons_against_a_missing_property_are_unknown_not_true() {
+    // Cypher has three truth values. A comparison where either side is null is *unknown*,
+    // and WHERE keeps only rows that are definitely true. The dangerous case is `<>`:
+    // read as two-valued boolean logic, "the property is not 1" looks true for a row that
+    // has no such property at all, so the filter kept every row instead of none — a
+    // silently inverted predicate, the worst kind of wrong answer because it looks like a
+    // successful query returning data.
+    let mut s = GraphStore::new();
+    let engine = QueryEngine::new();
+    for id in ["a", "b", "c"] {
+        engine
+            .execute_mut(&format!("CREATE (:Blank {{id: \"{id}\"}})"), &mut s, "default")
+            .unwrap();
+    }
+
+    for pred in [
+        "n.missing <> 1",
+        "n.missing = 1",
+        "n.missing > 0",
+        "n.missing < 0",
+        "n.missing >= 0",
+        "n.missing <= 0",
+        "n.missing = null",
+        "n.missing <> null",
+    ] {
+        assert_eq!(
+            scalar(
+                &s,
+                &format!("MATCH (n:Blank) WHERE {pred} RETURN count(n) AS n")
+            ),
+            "n=0",
+            "`WHERE {pred}` must match nothing: unknown is not true"
+        );
+    }
+
+    // IS NULL / IS NOT NULL are the operators that *can* see nullness, and still do.
+    assert_eq!(
+        scalar(
+            &s,
+            "MATCH (n:Blank) WHERE n.missing IS NULL RETURN count(n) AS n"
+        ),
+        "n=3"
+    );
+    assert_eq!(
+        scalar(
+            &s,
+            "MATCH (n:Blank) WHERE n.missing IS NOT NULL RETURN count(n) AS n"
+        ),
+        "n=0"
+    );
+
+    // A present property still compares normally — the null rule must not swallow real
+    // predicates.
+    assert_eq!(
+        scalar(&s, "MATCH (n:Blank) WHERE n.id <> \"a\" RETURN count(n) AS n"),
+        "n=2"
+    );
+    assert_eq!(
+        scalar(&s, "MATCH (n:Blank) WHERE n.id = \"a\" RETURN count(n) AS n"),
+        "n=1"
+    );
+}


### PR DESCRIPTION
Fixes #398

## What was wrong

`MATCH (n:Blank) WHERE n.missing <> 1` returned **every** row instead of none — an inverted predicate presented as a successful query with a full result set.

Cypher is three-valued: a comparison with a null operand is *unknown*, and `WHERE` keeps only rows that are definitely true. Read as two-valued boolean logic, "the property is not 1" looks true for a row that has no such property at all.

## The fix

`Eq/Ne/Lt/Le/Gt/Ge` now return `Null` when either operand is null. Filters already coerce null to "exclude", so no filter change was needed. `IS NULL` / `IS NOT NULL` are postfix operators and keep working as the way to test absence.

## The part worth reviewing

This had to be fixed in **two** places. The engine has two independent comparison implementations — the free function `eval_binary_op` and `FilterOperator`'s own arm — and they had drifted. Only the latter is on the query path, so my first patch (to `eval_binary_op`) left the bug **100% reproducible**; the repro output was byte-identical before and after. That is how the duplication surfaced at all.

The new test therefore asserts at the **query level**, not against either helper, so it cannot be satisfied by fixing only one path. Collapsing the two implementations is noted as follow-up in #398 — this PR makes them agree but does not remove the trap.

## Test changes, stated plainly

Three existing unit tests asserted the *old* behaviour and are **corrected, not relaxed**:

| test | asserted | now |
|---|---|---|
| `test_binary_op_eq_null` | `null = null` → `true` | → `Null` |
| `test_binary_op_ne_null_vs_int` | `null <> 1` → `true` | → `Null` |
| `test_binary_op_null_value_left` | `null = 1` → `false` | → `Null` |

`null = null → true` is precisely the assumption behind the bug — it is why `IS NULL` exists as a separate operator. These tests were pinning the defect in place.

New conformance test `comparisons_against_a_missing_property_are_unknown_not_true` covers all six operators, `= null` / `<> null`, that `IS NULL`/`IS NOT NULL` still see nullness, and that **present** properties still compare normally (so the null rule cannot swallow real predicates).

## Verification

- `cargo test --workspace`: **2439 passed, 0 failed**
- Conformance suite: 39 passed, 0 ignored