### PR TITLE
fix(query): CREATE wires edges for anonymous endpoints and honours direction

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2705,6 +2705,33 @@ impl QueryPlanner {
         // Collect edges to create: (source_var, target_var, edge_type, properties, edge_var)
         let mut edges_to_create: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>)> = Vec::new();
 
+        // Anonymous nodes still need a handle for edge wiring. Edges are wired by variable
+        // name, so an endpoint written as `(:Label)` used to have nothing to wire to and
+        // the edge was dropped -- silently, since the nodes were still created. Give every
+        // anonymous node a synthetic name that cannot collide with a user variable, and
+        // keep it out of `output_columns` so it stays invisible to RETURN.
+        let mut declared: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for path in &pattern.paths {
+            if let Some(v) = &path.start.variable {
+                declared.insert(v.clone());
+            }
+            for seg in &path.segments {
+                if let Some(v) = &seg.node.variable {
+                    declared.insert(v.clone());
+                }
+            }
+        }
+        let mut anon_seq = 0usize;
+        let mut next_anon = move |declared: &std::collections::HashSet<String>| -> String {
+            loop {
+                let name = format!("__anon_create_{anon_seq}");
+                anon_seq += 1;
+                if !declared.contains(&name) {
+                    return name;
+                }
+            }
+        };
+
         for path in &pattern.paths {
             // Add start node
             let start = &path.start;
@@ -2717,10 +2744,16 @@ impl QueryPlanner {
                 output_columns.push(var.clone());
             }
 
-            nodes_to_create.push((labels, properties, variable.clone()));
+            // Only the *named* variable reaches output_columns above; the synthetic one is
+            // purely for edge wiring.
+            let start_handle = match &variable {
+                Some(v) => v.clone(),
+                None => next_anon(&declared),
+            };
+            nodes_to_create.push((labels, properties, Some(start_handle.clone())));
 
             // Track current source variable for edge creation
-            let mut current_source_var = variable;
+            let mut current_source_var = Some(start_handle);
 
             // Add nodes and edges from path segments (if any)
             // Example: CREATE (a:Person)-[:KNOWS]->(b:Person)
@@ -2734,7 +2767,11 @@ impl QueryPlanner {
                     output_columns.push(var.clone());
                 }
 
-                nodes_to_create.push((node_labels, node_properties, node_variable.clone()));
+                let node_handle = match &node_variable {
+                    Some(v) => v.clone(),
+                    None => next_anon(&declared),
+                };
+                nodes_to_create.push((node_labels, node_properties, Some(node_handle.clone())));
 
                 // Extract edge information
                 let edge = &segment.edge;
@@ -2744,12 +2781,25 @@ impl QueryPlanner {
                 let edge_properties: HashMap<String, PropertyValue> = edge.properties.clone().unwrap_or_default();
                 let edge_variable = edge.variable.clone();
 
-                // Create edge between source and target nodes
-                // For CREATE, we need both variables to be defined
-                if let (Some(source_var), Some(target_var)) = (&current_source_var, &node_variable) {
+                // Both endpoints now always have a handle (real or synthetic), so an edge
+                // is created for every segment regardless of how the pattern was written.
+                //
+                // Direction is taken from the pattern rather than from write order: an
+                // `<-` segment points at the *earlier* node. This was previously ignored
+                // entirely, so `CREATE (a)<-[:R]-(b)` stored a->b -- an edge pointing the
+                // opposite way to what was written, with nothing to indicate it.
+                if let Some(source_var) = &current_source_var {
+                    let (from, to) = match segment.edge.direction {
+                        Direction::Incoming => (node_handle.clone(), source_var.clone()),
+                        // `-[:R]-` is undirected; CREATE has to pick one, and written
+                        // order is the least surprising choice.
+                        Direction::Outgoing | Direction::Both => {
+                            (source_var.clone(), node_handle.clone())
+                        }
+                    };
                     edges_to_create.push((
-                        source_var.clone(),
-                        target_var.clone(),
+                        from,
+                        to,
                         edge_type,
                         edge_properties,
                         edge_variable,
@@ -2757,7 +2807,7 @@ impl QueryPlanner {
                 }
 
                 // Update source variable for next segment
-                current_source_var = node_variable;
+                current_source_var = Some(node_handle);
             }
         }
 

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -840,3 +840,88 @@ fn comparisons_against_a_missing_property_are_unknown_not_true() {
         "n=1"
     );
 }
+
+// ---------------------------------------------------------------------------
+// CREATE builds the pattern it was given (#400)
+// ---------------------------------------------------------------------------
+
+fn edge_count(s: &GraphStore) -> String {
+    scalar(s, "MATCH ()-[r]->() RETURN count(r) AS n")
+}
+
+#[test]
+fn create_wires_edges_even_when_endpoints_are_anonymous() {
+    // Edges were wired by variable name, so an endpoint written as `(:Label)` had no name
+    // to wire to and the relationship was dropped. The nodes were still created and no
+    // error was raised, so a bulk load of `CREATE (:A {..})-[:R]->(:B {..})` produced a
+    // graph with every node and not one edge -- the shape most load scripts are written in.
+    let engine = QueryEngine::new();
+
+    for pattern in [
+        "CREATE (a:A {id: 1})-[:R]->(b:B {id: 2})", // both named (always worked)
+        "CREATE (a:A {id: 1})-[:R]->(:B {id: 2})",  // tail anonymous
+        "CREATE (:A {id: 1})-[:R]->(b:B {id: 2})",  // head anonymous
+        "CREATE (:A {id: 1})-[:R]->(:B {id: 2})",   // both anonymous
+        "CREATE (:A {id: 1})-[r:R]->(:B {id: 2})",  // named rel, anonymous endpoints
+    ] {
+        let mut s = GraphStore::new();
+        engine.execute_mut(pattern, &mut s, "default").unwrap();
+        assert_eq!(edge_count(&s), "n=1", "no edge created by: {pattern}");
+        assert_eq!(scalar(&s, "MATCH (n) RETURN count(n) AS n"), "n=2", "{pattern}");
+    }
+
+    // Multi-segment paths wire every segment, named or not.
+    for pattern in [
+        "CREATE (a:A)-[:R]->(b:B)-[:R2]->(c:C)",
+        "CREATE (:A)-[:R]->(:B)-[:R2]->(:C)",
+        "CREATE (a:A)-[:R]->(:B)-[:R2]->(c:C)",
+    ] {
+        let mut s = GraphStore::new();
+        engine.execute_mut(pattern, &mut s, "default").unwrap();
+        assert_eq!(edge_count(&s), "n=2", "wrong edge count for: {pattern}");
+    }
+}
+
+#[test]
+fn create_honours_the_direction_the_pattern_was_written_in() {
+    // `plan_create_only` wired source -> target in written order and never consulted the
+    // segment's direction, so a `<-` pattern stored an edge pointing the *opposite* way.
+    // Every query against it then silently returns nothing, or the wrong endpoint.
+    let engine = QueryEngine::new();
+
+    let mut s = GraphStore::new();
+    engine
+        .execute_mut("CREATE (a:A {id: 1})<-[:R]-(b:B {id: 2})", &mut s, "default")
+        .unwrap();
+    assert_eq!(edge_count(&s), "n=1");
+    assert_eq!(
+        scalar(&s, "MATCH (b:B)-[:R]->(a:A) RETURN count(*) AS n"),
+        "n=1",
+        "`(a)<-[:R]-(b)` must store b -> a"
+    );
+    assert_eq!(
+        scalar(&s, "MATCH (a:A)-[:R]->(b:B) RETURN count(*) AS n"),
+        "n=0",
+        "the edge must not also point a -> b"
+    );
+
+    // Same, with anonymous endpoints.
+    let mut s = GraphStore::new();
+    engine
+        .execute_mut("CREATE (:A {id: 1})<-[:R]-(:B {id: 2})", &mut s, "default")
+        .unwrap();
+    assert_eq!(
+        scalar(&s, "MATCH (b:B)-[:R]->(a:A) RETURN count(*) AS n"),
+        "n=1"
+    );
+
+    // And the forward form is unchanged.
+    let mut s = GraphStore::new();
+    engine
+        .execute_mut("CREATE (a:A {id: 1})-[:R]->(b:B {id: 2})", &mut s, "default")
+        .unwrap();
+    assert_eq!(
+        scalar(&s, "MATCH (a:A)-[:R]->(b:B) RETURN count(*) AS n"),
+        "n=1"
+    );
+}


### PR DESCRIPTION
Fixes #400

Found while re-verifying #305 — my own test fixture used `CREATE (:P {..})-[:HAS_CONDITION]->(:C {..})` and the multi-MATCH queries kept returning 0 rows. The queries were fine; **the fixture had never created any edges.**

## 1. Anonymous endpoint ⇒ edge silently dropped

Edges are wired by variable name, and the planner was explicit about the consequence:

```rust
// For CREATE, we need both variables to be defined
if let (Some(source_var), Some(target_var)) = (&current_source_var, &node_variable) {
```

An anonymous node has no name, the `if let` fails, the segment is skipped — no error, nodes still created.

| pattern | before | after |
|---|---|---|
| `CREATE (a:A)-[:R]->(b:B)` | 1 | 1 |
| `CREATE (a:A)-[:R]->(:B)` | **0** | 1 |
| `CREATE (:A)-[:R]->(b:B)` | **0** | 1 |
| `CREATE (:A)-[:R]->(:B)` | **0** | 1 |
| `CREATE (:A)-[:R]->(:B)-[:R2]->(:C)` | **0** | 2 |

`CREATE (:Label {..})-[:REL]->(:Label {..})` is *the* load-script shape, so this produced graphs with all nodes and no edges.

Anonymous nodes now get a synthetic handle, collision-checked against declared variables and kept out of `output_columns` so it never reaches RETURN.

## 2. `<-` direction ignored (pre-existing, independent)

The tuple was always `(source, target)` in written order; `segment.edge.direction` was never read. `CREATE (a)<-[:R]-(b)` stored `a->b`.

This is **not** caused by fix (1) — the named-endpoint form `CREATE (a:A)<-[:R]-(b:B)` reverses identically and always has. But fix (1) would have started emitting wrong-direction edges where it previously emitted none, so shipping it alone would have traded a missing-edge bug for a wrong-edge bug. Fixed together.

`-[:R]-` keeps written order. Neo4j rejects undirected CREATE outright, which is arguably more correct — flagged in #400 rather than changed silently here.

## Why both survived until now

`cargo test --workspace` is **2439 passed / 0 failed both before and after the direction fix**. No existing test asserted an edge count following an anonymous-endpoint CREATE, or the direction of a `<-` CREATE. That absence is the actual finding; the two new conformance tests were confirmed to fail against the unpatched planner (`git stash` on planner.rs → 2 failed) so they are real regression cover, not tests written to match current output.

## Verification

- `cargo test --workspace`: **2439 passed, 0 failed**
- Conformance suite: 41 passed, 0 ignored