### PR TITLE
fix(query): MATCH..CREATE builds new nodes; MATCH/WHERE groups chain past two

### DIFF
--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -55,7 +55,7 @@ on_create_set = { ^"ON" ~ ^"CREATE" ~ ^"SET" ~ set_item ~ ("," ~ set_item)* }
 on_match_set = { ^"ON" ~ ^"MATCH" ~ ^"SET" ~ set_item ~ ("," ~ set_item)* }
 
 // MATCH statement: sequence of reading clauses, optional write, finishing with RETURN
-match_stmt = { (optional_match_clause | match_clause)+ ~ where_clause? ~ call_clause? ~ unwind_clause? ~ ((optional_match_clause | match_clause)+ ~ where_clause?)? ~ (with_clause ~ unwind_clause? ~ ((optional_match_clause | match_clause)+ ~ where_clause?)?)* ~ create_clause? ~ merge_inline? ~ delete_clause? ~ foreach_clause? ~ set_clause* ~ remove_clause* ~ return_clause? ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
+match_stmt = { (optional_match_clause | match_clause)+ ~ where_clause? ~ call_clause? ~ unwind_clause? ~ ((optional_match_clause | match_clause)+ ~ where_clause?)* ~ (with_clause ~ unwind_clause? ~ ((optional_match_clause | match_clause)+ ~ where_clause?)*)* ~ create_clause? ~ merge_inline? ~ delete_clause? ~ foreach_clause? ~ set_clause* ~ remove_clause* ~ return_clause? ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
 foreach_clause = { ^"FOREACH" ~ "(" ~ variable ~ in_op ~ expression ~ "|" ~ foreach_body+ ~ ")" }
 foreach_body = _{ set_clause | remove_clause | delete_clause | create_clause }
 unwind_clause = { ^"UNWIND" ~ expression ~ ^"AS" ~ variable }

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -6363,6 +6363,11 @@ impl PhysicalOperator for CreateNodesAndEdgesOperator {
 pub struct MatchCreateEdgeOperator {
     /// Input operator (MATCH results)
     input: OperatorBox,
+    /// Nodes in the CREATE pattern that the MATCH did not bind, and must therefore be
+    /// created fresh for every matched row: (handle, labels, properties). Previously these
+    /// were ignored entirely, so `MATCH (p) CREATE (p)-[:R]->(c:C {..})` created neither
+    /// the node nor the edge and reported success.
+    nodes_to_create: Vec<(String, Vec<Label>, HashMap<String, PropertyValue>)>,
     /// Edges to create: (source_var, target_var, edge_type, properties, edge_var)
     edges_to_create: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>)>,
     /// Whether edges have been created for current batch
@@ -6379,8 +6384,20 @@ impl MatchCreateEdgeOperator {
         input: OperatorBox,
         edges_to_create: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>)>,
     ) -> Self {
+        Self::with_nodes(input, Vec::new(), edges_to_create)
+    }
+
+    /// As `new`, plus the CREATE-pattern nodes the MATCH did not bind. Those are created
+    /// once per matched row, then bound under their handle so the edge wiring below can
+    /// reference them exactly like a matched variable.
+    pub fn with_nodes(
+        input: OperatorBox,
+        nodes_to_create: Vec<(String, Vec<Label>, HashMap<String, PropertyValue>)>,
+        edges_to_create: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>)>,
+    ) -> Self {
         Self {
             input,
+            nodes_to_create,
             edges_to_create,
             done: false,
             results: Vec::new(),
@@ -6400,6 +6417,27 @@ impl PhysicalOperator for MatchCreateEdgeOperator {
         // First pass: process all matched records and create edges
         if !self.done {
             while let Some(record) = self.input.next_mut(store, tenant_id)? {
+                // CREATE runs once per matched row, so any pattern node the MATCH did not
+                // bind is a *new* node for this row. Bind it under its handle first; the
+                // edge wiring below then treats it exactly like a matched variable.
+                let mut record = record;
+                for (handle, labels, properties) in &self.nodes_to_create {
+                    let primary_label = labels
+                        .first()
+                        .cloned()
+                        .unwrap_or_else(|| Label::new(""));
+                    let node_id = store.create_node(primary_label);
+                    for label in labels.iter().skip(1) {
+                        let _ = store.add_label_to_node(tenant_id, node_id, label.clone());
+                    }
+                    for (key, value) in properties {
+                        let _ = store.set_node_property(tenant_id, node_id, key.clone(), value.clone());
+                    }
+                    if let Some(node) = store.get_node(node_id) {
+                        record.bind(handle.clone(), Value::Node(node_id, node.clone()));
+                    }
+                }
+
                 // For each matched record, create the specified edges
                 for (source_var, target_var, edge_type, properties, _edge_var) in &self.edges_to_create {
                     // Get source node ID from record bindings
@@ -6429,6 +6467,13 @@ impl PhysicalOperator for MatchCreateEdgeOperator {
                         result_record.bind("_edge".to_string(), Value::Edge(edge_id, edge));
                     }
                     self.results.push(result_record);
+                }
+
+                // A CREATE that only adds nodes (no relationship segment) still produced a
+                // row for this match; without this the row -- and any RETURN over it --
+                // would vanish.
+                if self.edges_to_create.is_empty() {
+                    self.results.push(record);
                 }
             }
             self.done = true;

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1215,11 +1215,67 @@ impl QueryPlanner {
             // Collect edges to create from the CREATE pattern
             let mut edges_to_create: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>)> = Vec::new();
 
+            // Variables the MATCH already bound. Anything else in the CREATE pattern is a
+            // *new* node: previously such nodes were dropped on the floor, so
+            // `MATCH (p) CREATE (p)-[:R]->(c:C {..})` created neither node nor edge and
+            // still reported success.
+            let mut matched_vars: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+            for mc in &query.match_clauses {
+                for path in &mc.pattern.paths {
+                    if let Some(v) = &path.start.variable {
+                        matched_vars.insert(v.clone());
+                    }
+                    for seg in &path.segments {
+                        if let Some(v) = &seg.node.variable {
+                            matched_vars.insert(v.clone());
+                        }
+                    }
+                }
+            }
+
+            // Nodes to create per matched row: (handle, labels, properties)
+            let mut nodes_to_create: Vec<(String, Vec<Label>, HashMap<String, PropertyValue>)> =
+                Vec::new();
+            let mut anon_seq = 0usize;
+
+            // Assign a handle to a CREATE-pattern node, registering it for creation when
+            // the MATCH did not bind it. Anonymous nodes get a synthetic handle so an edge
+            // can still be wired to them.
+            let mut handle_for = |node: &crate::query::ast::NodePattern,
+                                  nodes_to_create: &mut Vec<(String, Vec<Label>, HashMap<String, PropertyValue>)>,
+                                  anon_seq: &mut usize|
+             -> String {
+                match &node.variable {
+                    Some(v) if matched_vars.contains(v) => v.clone(),
+                    Some(v) => {
+                        nodes_to_create.push((
+                            v.clone(),
+                            node.labels.clone(),
+                            node.properties.clone().unwrap_or_default(),
+                        ));
+                        v.clone()
+                    }
+                    None => {
+                        let h = format!("__anon_mcreate_{anon_seq}");
+                        *anon_seq += 1;
+                        nodes_to_create.push((
+                            h.clone(),
+                            node.labels.clone(),
+                            node.properties.clone().unwrap_or_default(),
+                        ));
+                        h
+                    }
+                }
+            };
+
             for path in &create_pattern.paths {
-                let mut current_var = path.start.variable.clone();
+                let mut current_var =
+                    handle_for(&path.start, &mut nodes_to_create, &mut anon_seq);
 
                 for segment in &path.segments {
-                    let target_var = segment.node.variable.clone();
+                    let target_var =
+                        handle_for(&segment.node, &mut nodes_to_create, &mut anon_seq);
                     let edge = &segment.edge;
                     let edge_type = edge.types.first()
                         .cloned()
@@ -1227,24 +1283,33 @@ impl QueryPlanner {
                     let edge_properties = edge.properties.clone().unwrap_or_default();
                     let edge_variable = edge.variable.clone();
 
-                    if let (Some(src), Some(tgt)) = (&current_var, &target_var) {
-                        edges_to_create.push((
-                            src.clone(),
-                            tgt.clone(),
-                            edge_type,
-                            edge_properties,
-                            edge_variable,
-                        ));
-                    }
+                    // Direction comes from the pattern, not from write order.
+                    let (from, to) = match segment.edge.direction {
+                        Direction::Incoming => (target_var.clone(), current_var.clone()),
+                        Direction::Outgoing | Direction::Both => {
+                            (current_var.clone(), target_var.clone())
+                        }
+                    };
+                    edges_to_create.push((
+                        from,
+                        to,
+                        edge_type,
+                        edge_properties,
+                        edge_variable,
+                    ));
 
                     current_var = target_var;
                 }
             }
 
-            // Wrap the match operator with edge creation
-            if !edges_to_create.is_empty() {
+            // Wrap the match operator with node+edge creation
+            if !edges_to_create.is_empty() || !nodes_to_create.is_empty() {
                 use crate::query::executor::operator::MatchCreateEdgeOperator;
-                operator = Box::new(MatchCreateEdgeOperator::new(operator, edges_to_create));
+                operator = Box::new(MatchCreateEdgeOperator::with_nodes(
+                    operator,
+                    nodes_to_create,
+                    edges_to_create,
+                ));
             }
 
             true // This is a write query

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -925,3 +925,108 @@ fn create_honours_the_direction_the_pattern_was_written_in() {
         "n=1"
     );
 }
+
+// ---------------------------------------------------------------------------
+// MATCH ... CREATE builds new nodes, and MATCH/WHERE groups chain (#305, #402)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn match_create_creates_the_unbound_nodes_in_its_pattern() {
+    // `MATCH (p) CREATE (p)-[:R]->(c:C {..})` wired edges only between variables the MATCH
+    // had already bound; a node appearing for the first time in the CREATE pattern was
+    // dropped, taking its edge with it. The statement reported success and changed nothing,
+    // which is how the fixture in this very file's sibling tests came to be silently empty.
+    let engine = QueryEngine::new();
+
+    for (pattern, want_dir) in [
+        ("MATCH (p:P) CREATE (p)-[:R]->(c:C {id: 1})", "forward"),
+        ("MATCH (p:P) CREATE (p)-[:R]->(:C {id: 1})", "forward"), // anonymous new node
+        ("MATCH (p:P) CREATE (p)<-[:R]-(c:C {id: 1})", "reverse"),
+    ] {
+        let mut s = GraphStore::new();
+        engine
+            .execute_mut("CREATE (:P {id: 0})", &mut s, "default")
+            .unwrap();
+        engine.execute_mut(pattern, &mut s, "default").unwrap();
+
+        assert_eq!(scalar(&s, "MATCH (n) RETURN count(n) AS n"), "n=2", "{pattern}");
+        assert_eq!(edge_count(&s), "n=1", "{pattern}");
+        let fwd = scalar(&s, "MATCH (:P)-[:R]->(:C) RETURN count(*) AS n");
+        let rev = scalar(&s, "MATCH (:C)-[:R]->(:P) RETURN count(*) AS n");
+        match want_dir {
+            "forward" => assert_eq!((fwd.as_str(), rev.as_str()), ("n=1", "n=0"), "{pattern}"),
+            _ => assert_eq!((fwd.as_str(), rev.as_str()), ("n=0", "n=1"), "{pattern}"),
+        }
+    }
+
+    // CREATE runs once per matched row.
+    let mut s = GraphStore::new();
+    for id in 0..3 {
+        engine
+            .execute_mut(&format!("CREATE (:P {{id: {id}}})"), &mut s, "default")
+            .unwrap();
+    }
+    engine
+        .execute_mut("MATCH (p:P) CREATE (p)-[:R]->(:C {tag: 1})", &mut s, "default")
+        .unwrap();
+    assert_eq!(scalar(&s, "MATCH (c:C) RETURN count(c) AS n"), "n=3");
+    assert_eq!(edge_count(&s), "n=3");
+}
+
+#[test]
+fn match_where_groups_chain_beyond_two() {
+    // The grammar hand-unrolled exactly two `MATCH+ WHERE?` groups before the first WITH,
+    // so a third MATCH after a second WHERE was a *parse error* — the multi-hop cohort
+    // shape that analytic queries are written in. Asserting semantics, not just parsing:
+    // each added clause must actually narrow the result.
+    let mut s = GraphStore::new();
+    let engine = QueryEngine::new();
+    // p1 has all three attachments, p2 two, p3 one.
+    for (p, drug, lab) in [("p1", true, true), ("p2", true, false), ("p3", false, false)] {
+        engine
+            .execute_mut(&format!("CREATE (:P {{n: \"{p}\"}})"), &mut s, "default")
+            .unwrap();
+        engine
+            .execute_mut(
+                &format!("MATCH (p:P {{n: \"{p}\"}}) CREATE (p)-[:HAS_CONDITION]->(:C {{x: \"Diabetes\"}})"),
+                &mut s, "default",
+            )
+            .unwrap();
+        if drug {
+            engine.execute_mut(
+                &format!("MATCH (p:P {{n: \"{p}\"}}) CREATE (p)-[:PRESCRIBED]->(:D {{y: \"Metformin\"}})"),
+                &mut s, "default").unwrap();
+        }
+        if lab {
+            engine.execute_mut(
+                &format!("MATCH (p:P {{n: \"{p}\"}}) CREATE (p)-[:MEASURED]->(:M {{z: \"HbA1c\"}})"),
+                &mut s, "default").unwrap();
+        }
+    }
+
+    let base = "MATCH (p:P)-[:HAS_CONDITION]->(c:C) WHERE c.x CONTAINS \"Diabetes\" \
+                MATCH (p)-[:PRESCRIBED]->(d:D) WHERE d.y CONTAINS \"Metformin\"";
+    assert_eq!(scalar(&s, &format!("{base} RETURN count(p) AS n")), "n=2");
+    // third group: parses *and* narrows
+    assert_eq!(
+        scalar(&s, &format!("{base} MATCH (p)-[:MEASURED]->(m:M) RETURN count(p) AS n")),
+        "n=1"
+    );
+    assert_eq!(
+        scalar(&s, &format!("{base} MATCH (p)-[:MEASURED]->(m:M) WHERE m.z = \"HbA1c\" RETURN count(p) AS n")),
+        "n=1"
+    );
+    // a predicate in the third group must be able to exclude everything — proving it is
+    // applied rather than parsed and discarded
+    assert_eq!(
+        scalar(&s, &format!("{base} MATCH (p)-[:MEASURED]->(m:M) WHERE m.z = \"NOPE\" RETURN count(p) AS n")),
+        "n=0"
+    );
+    // and an earlier group's predicate is still ANDed in, not overwritten
+    assert_eq!(
+        scalar(&s, &"MATCH (p:P)-[:HAS_CONDITION]->(c:C) WHERE c.x CONTAINS \"Diabetes\" \
+                     MATCH (p)-[:PRESCRIBED]->(d:D) WHERE d.y = \"NOPE\" \
+                     MATCH (p)-[:MEASURED]->(m:M) RETURN count(p) AS n".to_string()),
+        "n=0"
+    );
+}


### PR DESCRIPTION
Fixes #402. Fixes #305.

Two independent defects, found because the first was hiding inside the test fixture for the second.

## 1. `MATCH ... CREATE` silently created nothing (#402)

```cypher
CREATE (:P {id: 0});
MATCH (p:P) CREATE (p)-[:R]->(c:C {id: 1});
MATCH (n) RETURN count(n);        -- 1, expected 2
MATCH ()-[r]->() RETURN count(r); -- 0, expected 1
```

Succeeds, changes nothing, discards the new node's labels and properties.

**This is a different path from #400.** Bare `CREATE` and `MATCH ... CREATE` are planned separately, so fixing #400 left this fully intact. Only the both-endpoints-already-matched case ever worked:

```cypher
MATCH (a:P), (b:D) CREATE (a)-[:R]->(b);   -- fine, and all this path was built for
```

The planner kept edges only where both variables resolved, and the operator skipped unbound endpoints:

```rust
None => continue, // Skip if target not found
```

Nothing created the unbound node, so the `continue` fired on every row.

Now: the planner computes the MATCH-bound variable set, treats every other CREATE-pattern node (named or anonymous) as a node-to-create carrying its labels/properties, and the operator materialises it **once per matched row** — Cypher's per-row CREATE semantics, covered by a test that matches 3 rows and expects 3 new nodes and 3 edges. Direction is honoured here too, and a node-only CREATE still emits its row.

## 2. `MATCH..WHERE..MATCH..WHERE..MATCH` was a parse error (#305)

The grammar hand-unrolled exactly **two** `MATCH+ WHERE?` groups before the first WITH:

```
match_stmt = { (…match_clause)+ ~ where_clause? ~ call_clause? ~ unwind_clause?
             ~ ((…match_clause)+ ~ where_clause?)?     ← one extra group, then nothing
```

So the boundary was oddly specific — `M W M` fine, `M M W M` fine, `M W M W M` **parse error**. That is the shape multi-hop cohort queries are written in. The group is now repeated instead of duplicated, pre- and post-WITH.

The AST builder already ANDs repeated WHEREs together (done earlier for OM27), so it needed no change.

**The tests assert semantics, not parsing** — a parse fix that quietly dropped the third clause would be worse than the error it replaced. Over a 3-patient fixture each added clause must actually narrow the cohort (3 → 2 → 1), a predicate in the *third* group must be able to exclude every row, and an earlier group's predicate must still be ANDed in rather than overwritten.

## How #402 surfaced

The fixture for #305 used `MATCH (p:P {..}) CREATE (p)-[:HAS_CONDITION]->(:C {..})`. Every query against it returned 0 rows, which read exactly like a query-engine bug. The queries were correct — the fixture had never created a single node or edge.

## Verification

- `cargo test --workspace`: **2441 passed, 0 failed**
- Conformance suite: 43 passed, 0 ignored
- Both new tests confirmed failing against the unpatched tree (`git stash` on planner/operator/grammar → 2 failed)