### PR TITLE
fix(query): MERGE matches or creates the whole relationship pattern

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -7654,6 +7654,186 @@ impl MergeOperator {
     ) -> Self {
         Self { pattern, on_create_set, on_match_set, executed: false }
     }
+
+    /// Does a node satisfy the pattern's labels and inline properties?
+    fn node_matches(node: &crate::graph::Node, labels: &[Label], props: Option<&HashMap<String, PropertyValue>>) -> bool {
+        if !labels.iter().all(|l| node.labels.contains(l)) {
+            return false;
+        }
+        match props {
+            Some(required) => required
+                .iter()
+                .all(|(k, v)| node.properties.get(k).map_or(false, |pv| pv == v)),
+            None => true,
+        }
+    }
+
+    /// MERGE over a pattern that contains relationships: find the whole pattern or create
+    /// the whole pattern.
+    ///
+    /// Note this creates *fresh* nodes when the pattern as a whole is absent, even where
+    /// nodes with the same labels and properties already exist -- openCypher's documented
+    /// behaviour, and the reason the idiomatic way to add an edge between existing nodes is
+    /// to bind them first (`MATCH (a),(b) MERGE (a)-[:R]->(b)`), which reuses them.
+    fn merge_path(
+        &self,
+        path: &crate::query::ast::PathPattern,
+        store: &mut GraphStore,
+        tenant_id: &str,
+    ) -> ExecutionResult<Option<Record>> {
+        // Flatten the path into nodes and the relationships between them.
+        let mut pattern_nodes: Vec<&crate::query::ast::NodePattern> = vec![&path.start];
+        // (from_index, to_index, type, properties, variable)
+        let mut pattern_rels: Vec<(usize, usize, EdgeType, HashMap<String, PropertyValue>, Option<String>)> = Vec::new();
+        for segment in &path.segments {
+            pattern_nodes.push(&segment.node);
+            let to = pattern_nodes.len() - 1;
+            let from = to - 1;
+            let edge_type = segment
+                .edge
+                .types
+                .first()
+                .cloned()
+                .unwrap_or_else(|| EdgeType::new("RELATED_TO"));
+            let props = segment.edge.properties.clone().unwrap_or_default();
+            let (a, b) = match segment.edge.direction {
+                Direction::Incoming => (to, from),
+                Direction::Outgoing | Direction::Both => (from, to),
+            };
+            pattern_rels.push((a, b, edge_type, props, segment.edge.variable.clone()));
+        }
+
+        // Candidate node ids per pattern position. A pattern node with no label has no
+        // cheap candidate set, so it cannot participate in a match and the pattern is
+        // treated as absent (i.e. created).
+        let mut candidates: Vec<Vec<NodeId>> = Vec::with_capacity(pattern_nodes.len());
+        for np in &pattern_nodes {
+            let mut ids = Vec::new();
+            if let Some(first_label) = np.labels.first() {
+                for node in store.get_nodes_by_label(first_label) {
+                    if Self::node_matches(node, &np.labels, np.properties.as_ref()) {
+                        ids.push(node.id);
+                    }
+                }
+            }
+            candidates.push(ids);
+        }
+
+        // Backtracking search for an assignment satisfying every relationship. Patterns are
+        // a handful of nodes, so this stays trivial.
+        let found = if candidates.iter().any(|c| c.is_empty()) {
+            None
+        } else {
+            let mut assignment: Vec<NodeId> = Vec::with_capacity(pattern_nodes.len());
+            Self::search(&candidates, &pattern_rels, store, &mut assignment)
+        };
+
+        let mut record = Record::new();
+
+        if let Some(assignment) = found {
+            for (i, np) in pattern_nodes.iter().enumerate() {
+                if let Some(var) = &np.variable {
+                    record.bind(var.clone(), Value::NodeRef(assignment[i]));
+                }
+            }
+            let sets = self.on_match_set.clone();
+            self.apply_sets(&sets, &record, store, tenant_id)?;
+            return Ok(Some(record));
+        }
+
+        // Create the entire pattern.
+        let mut created: Vec<NodeId> = Vec::with_capacity(pattern_nodes.len());
+        for np in &pattern_nodes {
+            let label_str = np.labels.first().map(|l| l.as_str()).unwrap_or("Node");
+            let node_id = store.create_node(label_str);
+            for label in np.labels.iter().skip(1) {
+                if let Some(node) = store.get_node_mut(node_id) {
+                    node.labels.insert(label.clone());
+                }
+            }
+            if let Some(required) = np.properties.as_ref() {
+                for (k, v) in required {
+                    let _ = store.set_node_property(tenant_id, node_id, k.clone(), v.clone());
+                }
+            }
+            if let Some(var) = &np.variable {
+                record.bind(var.clone(), Value::NodeRef(node_id));
+            }
+            created.push(node_id);
+        }
+        for (from, to, edge_type, props, _var) in &pattern_rels {
+            let edge_id = store
+                .create_edge(created[*from], created[*to], edge_type.clone())
+                .map_err(|e| ExecutionError::GraphError(e.to_string()))?;
+            for (k, v) in props {
+                store.set_edge_property_sparse(edge_id, k.clone(), v.clone());
+            }
+        }
+
+        let sets = self.on_create_set.clone();
+        self.apply_sets(&sets, &record, store, tenant_id)?;
+        Ok(Some(record))
+    }
+
+    /// Assign candidate nodes position by position, keeping only assignments whose
+    /// relationships all exist in the store.
+    fn search(
+        candidates: &[Vec<NodeId>],
+        rels: &[(usize, usize, EdgeType, HashMap<String, PropertyValue>, Option<String>)],
+        store: &GraphStore,
+        assignment: &mut Vec<NodeId>,
+    ) -> Option<Vec<NodeId>> {
+        let i = assignment.len();
+        if i == candidates.len() {
+            return Some(assignment.clone());
+        }
+        for &cand in &candidates[i] {
+            // A pattern node cannot bind to a node already used at another position.
+            if assignment.contains(&cand) {
+                continue;
+            }
+            assignment.push(cand);
+            // Check every relationship whose endpoints are now both assigned.
+            let ok = rels.iter().all(|(from, to, ty, _p, _v)| {
+                if *from > i || *to > i {
+                    return true;
+                }
+                let src = assignment[*from];
+                let dst = assignment[*to];
+                store
+                    .get_outgoing_edge_targets(src)
+                    .iter()
+                    .any(|(_eid, _s, t, et)| *t == dst && et == ty)
+            });
+            if ok {
+                if let Some(found) = Self::search(candidates, rels, store, assignment) {
+                    return Some(found);
+                }
+            }
+            assignment.pop();
+        }
+        None
+    }
+
+    /// Apply ON CREATE / ON MATCH SET items for any variable bound by the pattern.
+    fn apply_sets(
+        &self,
+        sets: &[(String, String, Expression)],
+        record: &Record,
+        store: &mut GraphStore,
+        tenant_id: &str,
+    ) -> ExecutionResult<()> {
+        for (var, prop, expr) in sets {
+            let Some(node_id) = record.get(var).and_then(|v| v.node_id()) else {
+                continue;
+            };
+            let val = eval_expression(expr, record, store)?;
+            if let Value::Property(pv) = val {
+                let _ = store.set_node_property(tenant_id, node_id, prop.clone(), pv);
+            }
+        }
+        Ok(())
+    }
 }
 
 impl PhysicalOperator for MergeOperator {
@@ -7671,6 +7851,15 @@ impl PhysicalOperator for MergeOperator {
 
         let path = self.pattern.paths.first()
             .ok_or_else(|| ExecutionError::PlanningError("MERGE pattern has no paths".to_string()))?;
+
+        // A MERGE pattern containing relationships is match-or-create over the *whole*
+        // pattern, per openCypher: if the entire pattern does not already exist, the
+        // entire pattern is created. Previously only `path.start` was considered and the
+        // segments were ignored outright, so `MERGE (a:X {..})-[:R]->(b:X {..})` matched
+        // the first node, created no relationship, and reported success.
+        if !path.segments.is_empty() {
+            return self.merge_path(path, store, tenant_id);
+        }
 
         let start = &path.start;
         let start_var = start.variable.clone().unwrap_or_else(|| "n".to_string());

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -1030,3 +1030,102 @@ fn match_where_groups_chain_beyond_two() {
         "n=0"
     );
 }
+
+// ---------------------------------------------------------------------------
+// MERGE over a relationship pattern (#306)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn merge_on_a_relationship_pattern_creates_and_then_matches_the_whole_pattern() {
+    // MERGE only ever inspected the first node of its pattern and ignored the segments, so
+    // a relationship MERGE created no edge and reported success. openCypher treats a MERGE
+    // pattern as all-or-nothing: match the whole pattern, else create the whole pattern.
+    let engine = QueryEngine::new();
+
+    let mut s = GraphStore::new();
+    for run in 1..=3 {
+        engine
+            .execute_mut(
+                "MERGE (a:X {k: 1})-[:R]->(b:Y {k: 2}) RETURN a.k AS k",
+                &mut s,
+                "default",
+            )
+            .unwrap();
+        // idempotent: the second and third runs must match, not create again
+        assert_eq!(scalar(&s, "MATCH (n) RETURN count(n) AS n"), "n=2", "run {run}");
+        assert_eq!(edge_count(&s), "n=1", "run {run}");
+    }
+
+    // direction comes from the pattern
+    let mut s = GraphStore::new();
+    engine
+        .execute_mut("MERGE (a:X {k: 1})<-[:R]-(b:Y {k: 2}) RETURN a.k AS k", &mut s, "default")
+        .unwrap();
+    assert_eq!(scalar(&s, "MATCH (:Y)-[:R]->(:X) RETURN count(*) AS n"), "n=1");
+    assert_eq!(scalar(&s, "MATCH (:X)-[:R]->(:Y) RETURN count(*) AS n"), "n=0");
+
+    // multi-segment paths, also idempotent
+    let mut s = GraphStore::new();
+    for _ in 0..2 {
+        engine
+            .execute_mut(
+                "MERGE (a:X {k: 1})-[:R]->(b:Y {k: 2})-[:R2]->(c:Z {k: 3}) RETURN a.k AS k",
+                &mut s, "default",
+            )
+            .unwrap();
+    }
+    assert_eq!(scalar(&s, "MATCH (n) RETURN count(n) AS n"), "n=3");
+    assert_eq!(edge_count(&s), "n=2");
+
+    // a pattern differing only in edge type is a *different* pattern, so it is created
+    let mut s = GraphStore::new();
+    engine.execute_mut("MERGE (a:X {k: 1})-[:R]->(b:Y {k: 2}) RETURN a.k AS k", &mut s, "default").unwrap();
+    engine.execute_mut("MERGE (a:X {k: 1})-[:OTHER]->(b:Y {k: 2}) RETURN a.k AS k", &mut s, "default").unwrap();
+    assert_eq!(edge_count(&s), "n=2");
+}
+
+#[test]
+fn merge_between_already_bound_nodes_reuses_them() {
+    // The idiomatic way to add an edge between *existing* nodes is to bind them first.
+    // This form reuses the matched nodes rather than creating fresh ones, and is the
+    // reason a standalone MERGE creating new nodes is not a bug but the documented
+    // openCypher behaviour.
+    let mut s = GraphStore::new();
+    let engine = QueryEngine::new();
+    engine.execute_mut("CREATE (:Repro {k: 10})", &mut s, "default").unwrap();
+    engine.execute_mut("CREATE (:Repro {k: 11})", &mut s, "default").unwrap();
+
+    for _ in 0..2 {
+        engine
+            .execute_mut(
+                "MATCH (a:Repro {k: 10}), (b:Repro {k: 11}) MERGE (a)-[:R]->(b) RETURN a.k AS k",
+                &mut s, "default",
+            )
+            .unwrap();
+        assert_eq!(scalar(&s, "MATCH (n) RETURN count(n) AS n"), "n=2", "must not duplicate nodes");
+        assert_eq!(edge_count(&s), "n=1", "must not duplicate the edge");
+    }
+}
+
+#[test]
+fn merge_on_create_and_on_match_fire_on_the_right_branch() {
+    let mut s = GraphStore::new();
+    let engine = QueryEngine::new();
+
+    engine
+        .execute_mut(
+            "MERGE (a:X {k: 1})-[:R]->(b:Y {k: 2}) ON CREATE SET a.tag = \"created\" RETURN a.k AS k",
+            &mut s, "default",
+        )
+        .unwrap();
+    assert_eq!(scalar(&s, "MATCH (a:X) RETURN a.tag AS tag"), "tag=created");
+
+    engine
+        .execute_mut(
+            "MERGE (a:X {k: 1})-[:R]->(b:Y {k: 2}) ON MATCH SET a.tag = \"matched\" RETURN a.k AS k",
+            &mut s, "default",
+        )
+        .unwrap();
+    assert_eq!(scalar(&s, "MATCH (a:X) RETURN a.tag AS tag"), "tag=matched");
+    assert_eq!(scalar(&s, "MATCH (n) RETURN count(n) AS n"), "n=2", "the second MERGE matched");
+}


### PR DESCRIPTION
Fixes #306

## What was wrong

```cypher
MERGE (a:X {k: 1})-[:R]->(b:Y {k: 2});   -- created no relationship, reported success
```

`MergeOperator::next_mut` read `path.start` and never looked at `path.segments`, so **any** MERGE pattern containing a relationship silently degraded to a single-node merge.

## What it does now

A MERGE pattern is all-or-nothing in openCypher: match the whole pattern, else create the whole pattern. Implemented as a backtracking search over label+property candidates per position, verifying each relationship exists with the right type and direction, then creating the entire pattern if nothing satisfies it.

Also fixed along the way: direction (`<-`), multi-segment paths, and `ON CREATE` / `ON MATCH SET` for **any** variable the pattern binds — previously applied only to the start variable, so `ON CREATE SET b.x = …` was silently dropped.

## ⚠️ This diverges from the expectation stated in #306 — please sanity-check

The issue expects the existing nodes to be reused, giving 2 nodes + 1 edge. **This PR gives 4 nodes + 1 edge**, and I believe the issue's premise is wrong.

openCypher/Neo4j treat the MERGE pattern as a unit: the pattern `(a:Repro {k:10})-[:R]->(b:Repro {k:11})` does not exist (there is no such edge), so the *whole* pattern is created — new nodes included. This is the well-documented "MERGE creates duplicate nodes" surprise, not an implementation shortcut.

The form that reuses existing nodes is the one where they are already bound:

```cypher
MATCH (a:Repro {k:10}), (b:Repro {k:11}) MERGE (a)-[:R]->(b);   -- 2 nodes, 1 edge
```

The issue calls this a "workaround that doubles write traffic". It is actually the correct idiom for attaching an edge to existing nodes, **and it already worked correctly and idempotently before this PR** — I verified that first. I've added a test pinning it so the two forms can't quietly converge.

If you'd rather we deliberately diverge from openCypher here and have standalone MERGE reuse matching nodes, that's a one-line change in the create branch — say the word and I'll switch it.

## Verified

| case | result |
|---|---|
| repeat standalone MERGE ×3 | 2 nodes, 1 edge — stable (idempotent) |
| `<-` direction | edge stored `Y -> X` |
| multi-segment `(a)-[:R]->(b)-[:R2]->(c)` ×2 | 3 nodes, 2 edges — idempotent |
| same endpoints, different edge type | correctly a distinct pattern → created |
| `ON CREATE` then `ON MATCH` | fires on the right branch; no duplication |
| bound-nodes idiom ×2 | 2 nodes, 1 edge — unchanged |

- `cargo test --workspace`: **2443 passed, 0 failed**
- Conformance suite: 46 passed, 0 ignored
- The two behaviour-change tests confirmed failing against the unpatched tree; `merge_between_already_bound_nodes_reuses_them` passes both before and after **by design**, since it documents behaviour this PR must not change.