### PR TITLE
fix(query): pattern predicates, modern CONSTRAINT syntax, and unique-constraint enforcement

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -142,6 +142,9 @@ pub enum GraphError {
 
     #[error("Write conflict: {0}")]
     WriteConflict(String),
+
+    #[error("Constraint violation: {0}")]
+    ConstraintViolation(String),
 }
 
 pub type GraphResult<T> = Result<T, GraphError>;
@@ -1085,6 +1088,45 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         let val = value.into();
         let idx = node_id.as_u64() as usize;
 
+        // Enforce unique constraints on the write path. The constraint registry, the
+        // per-constraint index and `check_unique_constraint` all existed but nothing ever
+        // called them, so `CREATE CONSTRAINT ... IS UNIQUE` was accepted, listed by
+        // SHOW CONSTRAINTS, and enforced nothing -- a double load silently produced
+        // duplicates. The `has_any_unique_constraints` guard keeps graphs without
+        // constraints (every bulk load) off the per-label path entirely.
+        let constrained_labels: Vec<Label> = if self.property_index.has_any_unique_constraints()
+            && !val.is_null()
+        {
+            let labels: Vec<Label> = match self.get_node(node_id) {
+                Some(node) => node.labels.iter().cloned().collect(),
+                None => Vec::new(),
+            };
+            labels
+                .into_iter()
+                .filter(|l| self.property_index.has_unique_constraint(l, &key_str))
+                .collect()
+        } else {
+            Vec::new()
+        };
+        for label in &constrained_labels {
+            // Re-setting a property to the value this same node already holds is not a
+            // violation; only another node holding it is.
+            if let Some(holder) =
+                self.property_index
+                    .unique_constraint_holder(label, &key_str, &val)
+            {
+                if holder != node_id {
+                    return Err(GraphError::ConstraintViolation(format!(
+                        ":{}({}) already has value {:?} on node {}",
+                        label.as_str(),
+                        key_str,
+                        val,
+                        holder
+                    )));
+                }
+            }
+        }
+
         // Update columnar storage (always latest)
         self.node_columns.set_property(idx, &key_str, val.clone());
         self.update_hierarchies_for_property(node_id, &key_str, &val);
@@ -1106,6 +1148,14 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             // Update in place (same transaction/version)
             let node = versions.last_mut().unwrap();
             old_val = node.set_property(key_str.clone(), val.clone());
+        }
+
+        // Record the new value so subsequent writes can see it. Without this the
+        // constraint index only ever holds what the backfill put there at CREATE
+        // CONSTRAINT time, and nodes added afterwards would not conflict with each other.
+        for label in &constrained_labels {
+            self.property_index
+                .constraint_insert(label, &key_str, val.clone(), node_id);
         }
 
         let event = crate::graph::event::IndexEvent::PropertySet {

--- a/src/index/manager.rs
+++ b/src/index/manager.rs
@@ -134,6 +134,36 @@ impl IndexManager {
         Ok(())
     }
 
+    /// Are there any unique constraints at all?
+    ///
+    /// The write path checks this first so that graphs without constraints -- the common
+    /// case, and every bulk load -- pay only one lock-free-ish map read per property set
+    /// rather than a per-label lookup.
+    pub fn has_any_unique_constraints(&self) -> bool {
+        !self.unique_constraints.read().unwrap().is_empty()
+    }
+
+    /// The node currently holding `value` for a constrained `label`.`property`, if any.
+    ///
+    /// Distinct from `check_unique_constraint`, which cannot tell "another node holds this"
+    /// from "this same node already holds this" -- the latter must stay legal so that
+    /// re-setting a property to its current value is not a violation.
+    pub fn unique_constraint_holder(
+        &self,
+        label: &Label,
+        property: &str,
+        value: &PropertyValue,
+    ) -> Option<NodeId> {
+        let key = PropertyIndexKey {
+            label: label.clone(),
+            property: property.to_string(),
+        };
+        let constraints = self.unique_constraints.read().unwrap();
+        let index = constraints.get(&key)?;
+        let holders = index.read().unwrap().get(value);
+        holders.first().copied()
+    }
+
     /// Insert into unique constraint index
     pub fn constraint_insert(&self, label: &Label, property: &str, value: PropertyValue, node_id: NodeId) {
         let key = PropertyIndexKey {

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -33,7 +33,13 @@ hier_aggregates = { ^"AGGREGATE" ~ property_key ~ ("," ~ property_key)* }
 drop_index_stmt = { ^"DROP" ~ ^"INDEX" ~ ^"ON" ~ ":" ~ label ~ "(" ~ property_key ~ ")" }
 show_indexes_stmt = { ^"SHOW" ~ (^"INDEXES" | ^"INDEX") }
 show_constraints_stmt = { ^"SHOW" ~ ^"CONSTRAINTS" }
-create_constraint_stmt = { ^"CREATE" ~ ^"CONSTRAINT" ~ ^"ON" ~ "(" ~ variable ~ ":" ~ label ~ ")" ~ ^"ASSERT" ~ property_access ~ ^"IS" ~ ^"UNIQUE" }
+create_constraint_stmt = { ^"CREATE" ~ ^"CONSTRAINT" ~ (constraint_modern | constraint_legacy) }
+// Neo4j 4+/5 form. The optional name must not swallow the `IF` or `FOR` keyword, and is
+// kept in its own rule so it is not mistaken for the pattern variable.
+constraint_modern = { constraint_name? ~ if_not_exists? ~ ^"FOR" ~ "(" ~ variable ~ ":" ~ label ~ ")" ~ ^"REQUIRE" ~ property_access ~ ^"IS" ~ ^"UNIQUE" }
+constraint_legacy = { ^"ON" ~ "(" ~ variable ~ ":" ~ label ~ ")" ~ ^"ASSERT" ~ property_access ~ ^"IS" ~ ^"UNIQUE" }
+constraint_name = @{ !(^"IF" ~ !(ASCII_ALPHANUMERIC | "_")) ~ !(^"FOR" ~ !(ASCII_ALPHANUMERIC | "_")) ~ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
+if_not_exists = { ^"IF" ~ ^"NOT" ~ ^"EXISTS" }
 options = { ^"OPTIONS" ~ "{" ~ property_list? ~ "}" }
 
 // CALL statement (Standalone or followed by MATCH)
@@ -146,8 +152,13 @@ primary = {
     parameter |
     value |
     variable |
+    pattern_predicate |
     "(" ~ expression ~ ")"
 }
+
+// A relationship pattern used as a boolean predicate: `WHERE (:Acc)-[:SUPPORTS]->(o)`.
+// Requires at least one segment, so a parenthesised expression `(a + b)` cannot match it.
+pattern_predicate = { node ~ (edge_pattern ~ node)+ }
 
 // COUNT(*) — special rule since * is not a valid expression
 count_star = { ^"COUNT" ~ "(" ~ distinct? ~ "*" ~ ")" }

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -5413,7 +5413,12 @@ impl PhysicalOperator for CreateNodeOperator {
 
                 // Set properties using store.set_node_property to trigger indexing
                 for (key, value) in properties {
-                    let _ = store.set_node_property(tenant_id, node_id, key.clone(), value.clone());
+                    if let Err(e) = store.set_node_property(tenant_id, node_id, key.clone(), value.clone())
+                    {
+                        // A rejected property must not leave a half-built node behind.
+                        let _ = store.delete_node(tenant_id, node_id);
+                        return Err(ExecutionError::GraphError(e.to_string()));
+                    }
                 }
 
                 self.created_nodes.push((node_id, variable.clone()));
@@ -6431,7 +6436,12 @@ impl PhysicalOperator for MatchCreateEdgeOperator {
                         let _ = store.add_label_to_node(tenant_id, node_id, label.clone());
                     }
                     for (key, value) in properties {
-                        let _ = store.set_node_property(tenant_id, node_id, key.clone(), value.clone());
+                        if let Err(e) = store.set_node_property(tenant_id, node_id, key.clone(), value.clone())
+                        {
+                            // A rejected property must not leave a half-built node behind.
+                            let _ = store.delete_node(tenant_id, node_id);
+                            return Err(ExecutionError::GraphError(e.to_string()));
+                        }
                     }
                     if let Some(node) = store.get_node(node_id) {
                         record.bind(handle.clone(), Value::Node(node_id, node.clone()));
@@ -7466,7 +7476,8 @@ impl PhysicalOperator for SetPropertyOperator {
                 if let Some(node_val) = record.get(var) {
                     match node_val {
                         Value::NodeRef(id) | Value::Node(id, _) => {
-                            let _ = store.set_node_property(tenant_id, *id, prop.clone(), val.clone());
+                            store.set_node_property(tenant_id, *id, prop.clone(), val.clone())
+                                .map_err(|e| ExecutionError::GraphError(e.to_string()))?;
                         }
                         Value::EdgeRef(id, ..) | Value::Edge(id, _) => {
                             let _ = store.set_edge_property(*id, prop.clone(), val.clone());
@@ -7753,7 +7764,12 @@ impl MergeOperator {
             }
             if let Some(required) = np.properties.as_ref() {
                 for (k, v) in required {
-                    let _ = store.set_node_property(tenant_id, node_id, k.clone(), v.clone());
+                    if let Err(e) = store.set_node_property(tenant_id, node_id, k.clone(), v.clone())
+                    {
+                        // A rejected property must not leave a half-built node behind.
+                        let _ = store.delete_node(tenant_id, node_id);
+                        return Err(ExecutionError::GraphError(e.to_string()));
+                    }
                 }
             }
             if let Some(var) = &np.variable {
@@ -7913,7 +7929,12 @@ impl PhysicalOperator for MergeOperator {
 
             if let Some(required_props) = props {
                 for (k, v) in required_props {
-                    let _ = store.set_node_property(tenant_id, node_id, k.clone(), v.clone());
+                    if let Err(e) = store.set_node_property(tenant_id, node_id, k.clone(), v.clone())
+                    {
+                        // A rejected property must not leave a half-built node behind.
+                        let _ = store.delete_node(tenant_id, node_id);
+                        return Err(ExecutionError::GraphError(e.to_string()));
+                    }
                 }
             }
 

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -382,7 +382,21 @@ fn parse_create_constraint_statement(pair: pest::iterators::Pair<Rule>, query: &
     let mut label = None;
     let mut property = None;
 
-    for inner in pair.into_inner() {
+    // Both the legacy `ON ... ASSERT` and modern `FOR ... REQUIRE` forms wrap their parts
+    // in a sub-rule; unwrap it so the field extraction below is shared. `constraint_name`
+    // and `if_not_exists` are deliberately separate rules so the optional constraint name
+    // is not picked up as the pattern variable.
+    let inner_pairs: Vec<_> = pair
+        .into_inner()
+        .flat_map(|p| match p.as_rule() {
+            Rule::constraint_modern | Rule::constraint_legacy => {
+                p.into_inner().collect::<Vec<_>>()
+            }
+            _ => vec![p],
+        })
+        .collect();
+
+    for inner in inner_pairs {
         match inner.as_rule() {
             Rule::variable => {
                 if variable.is_none() {
@@ -1528,6 +1542,15 @@ fn parse_primary(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
             }
             Rule::exists_subquery => {
                 return parse_exists_subquery(inner);
+            }
+            Rule::pattern_predicate => {
+                // `WHERE (:Acc)-[:SUPPORTS]->(o)` means "such a path exists", which is
+                // exactly `EXISTS { MATCH ... }` -- so it desugars to the same node and
+                // inherits its (already correct) evaluation, including under NOT.
+                return Ok(Expression::ExistsSubquery {
+                    pattern: Pattern { paths: vec![parse_path(inner)?] },
+                    where_clause: None,
+                });
             }
             Rule::reduce_expression => {
                 return parse_reduce_expression(inner);

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -1129,3 +1129,104 @@ fn merge_on_create_and_on_match_fire_on_the_right_branch() {
     assert_eq!(scalar(&s, "MATCH (a:X) RETURN a.tag AS tag"), "tag=matched");
     assert_eq!(scalar(&s, "MATCH (n) RETURN count(n) AS n"), "n=2", "the second MERGE matched");
 }
+
+// ---------------------------------------------------------------------------
+// Pattern predicates, modern constraint syntax, and unique enforcement (#367)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_relationship_pattern_can_be_used_as_a_predicate() {
+    // `WHERE (:Acc)-[:SUPPORTS]->(o)` is the natural way to write "has a ...", and its
+    // negation is the natural way to write "has no ..." — the whole point of coverage and
+    // gap analysis. Both were parse errors, forcing the OPTIONAL MATCH + count = 0 idiom.
+    let mut s = GraphStore::new();
+    let engine = QueryEngine::new();
+    engine.execute_mut("CREATE (:Op {name: \"op1\"})", &mut s, "default").unwrap();
+    engine.execute_mut("CREATE (:Op {name: \"op2\"})", &mut s, "default").unwrap();
+    engine
+        .execute_mut(
+            "MATCH (o:Op {name: \"op1\"}) CREATE (:Acc {name: \"a1\"})-[:SUPPORTS]->(o)",
+            &mut s, "default",
+        )
+        .unwrap();
+
+    assert_eq!(
+        bag(&s, "MATCH (o:Op) WHERE (:Acc)-[:SUPPORTS]->(o) RETURN o.name AS name"),
+        vec!["name=op1"]
+    );
+    assert_eq!(
+        bag(&s, "MATCH (o:Op) WHERE NOT (:Acc)-[:SUPPORTS]->(o) RETURN o.name AS name"),
+        vec!["name=op2"]
+    );
+    // must agree with the EXISTS { } form it desugars to
+    assert_eq!(
+        bag(&s, "MATCH (o:Op) WHERE EXISTS { MATCH (:Acc)-[:SUPPORTS]->(o) } RETURN o.name AS name"),
+        vec!["name=op1"]
+    );
+
+    // Parenthesised expressions must not be mistaken for patterns.
+    let mut s2 = GraphStore::new();
+    engine.execute_mut("CREATE (:N {a: 1, b: 2})", &mut s2, "default").unwrap();
+    assert_eq!(scalar(&s2, "MATCH (n:N) WHERE (n.a + n.b) = 3 RETURN count(n) AS n"), "n=1");
+    assert_eq!(scalar(&s2, "MATCH (n:N) RETURN (n.a * (n.b + 1)) AS v"), "v=3");
+}
+
+#[test]
+fn unique_constraints_accept_modern_syntax_and_are_actually_enforced() {
+    // The registry, the per-constraint index and `check_unique_constraint` all existed but
+    // nothing on the write path called them, so a constraint was accepted, listed by
+    // SHOW CONSTRAINTS, and enforced nothing — a double load silently produced duplicates
+    // while appearing to be protected against exactly that.
+    let engine = QueryEngine::new();
+
+    // all three spellings register the same constraint
+    for stmt in [
+        "CREATE CONSTRAINT ON (n:Kernel) ASSERT n.id IS UNIQUE",
+        "CREATE CONSTRAINT kid IF NOT EXISTS FOR (n:Kernel) REQUIRE n.id IS UNIQUE",
+        "CREATE CONSTRAINT FOR (n:Kernel) REQUIRE n.id IS UNIQUE",
+    ] {
+        let mut s = GraphStore::new();
+        engine.execute_mut(stmt, &mut s, "default").unwrap();
+        let shown = bag(&s, "SHOW CONSTRAINTS");
+        assert_eq!(shown.len(), 1, "{stmt}");
+        assert!(shown[0].contains("Kernel"), "{stmt}: {shown:?}");
+        assert!(shown[0].contains("id"), "{stmt}: {shown:?}");
+    }
+
+    let mut s = GraphStore::new();
+    engine
+        .execute_mut("CREATE CONSTRAINT FOR (n:Kernel) REQUIRE n.id IS UNIQUE", &mut s, "default")
+        .unwrap();
+    engine.execute_mut("CREATE (:Kernel {id: 1})", &mut s, "default").unwrap();
+
+    // the duplicate is rejected ...
+    assert!(engine.execute_mut("CREATE (:Kernel {id: 1})", &mut s, "default").is_err());
+    // ... and leaves nothing behind: a rejected statement must not half-apply
+    assert_eq!(scalar(&s, "MATCH (k:Kernel) RETURN count(k) AS n"), "n=1");
+
+    // a distinct value is fine
+    engine.execute_mut("CREATE (:Kernel {id: 2})", &mut s, "default").unwrap();
+    assert_eq!(scalar(&s, "MATCH (k:Kernel) RETURN count(k) AS n"), "n=2");
+
+    // re-setting a node's own value is not a violation; taking another's is
+    engine
+        .execute_mut("MATCH (k:Kernel {id: 2}) SET k.id = 2 RETURN k.id AS i", &mut s, "default")
+        .unwrap();
+    assert!(engine
+        .execute_mut("MATCH (k:Kernel {id: 2}) SET k.id = 1 RETURN k.id AS i", &mut s, "default")
+        .is_err());
+
+    // graphs with no constraints are unaffected
+    let mut s2 = GraphStore::new();
+    engine.execute_mut("CREATE (:Free {id: 1})", &mut s2, "default").unwrap();
+    engine.execute_mut("CREATE (:Free {id: 1})", &mut s2, "default").unwrap();
+    assert_eq!(scalar(&s2, "MATCH (f:Free) RETURN count(f) AS n"), "n=2");
+
+    // creating a constraint over pre-existing duplicates still fails
+    let mut s3 = GraphStore::new();
+    engine.execute_mut("CREATE (:K {id: 1})", &mut s3, "default").unwrap();
+    engine.execute_mut("CREATE (:K {id: 1})", &mut s3, "default").unwrap();
+    assert!(engine
+        .execute_mut("CREATE CONSTRAINT FOR (n:K) REQUIRE n.id IS UNIQUE", &mut s3, "default")
+        .is_err());
+}


### PR DESCRIPTION
Fixes #367

Two parse gaps — and a third, more serious defect they were hiding.

## 1. Relationship patterns as predicates

```cypher
MATCH (o:Op) WHERE NOT (:Acc)-[:SUPPORTS]->(o) RETURN o.name
```

Now parses. The grammar rule requires **at least one segment**, so it cannot swallow a parenthesised expression — `(n.a + n.b) = 3` and `(n.a * (n.b + 1))` are covered by tests to prove it.

It desugars to the same `ExistsSubquery` AST node that `EXISTS { MATCH ... }` already produced, so it inherits evaluation that was already correct rather than introducing a second implementation that could drift (cf. #398, where exactly that drift cost a full debugging cycle). A test asserts the two spellings return the same rows.

## 2. Modern `CREATE CONSTRAINT` syntax

```cypher
CREATE CONSTRAINT kid IF NOT EXISTS FOR (n:Kernel) REQUIRE n.id IS UNIQUE
```

Accepted alongside the legacy `ON ... ASSERT` form. The optional constraint name gets its own grammar rule — sharing `variable` would have made `kid` the pattern variable, silently constraining the wrong thing. A test asserts all three spellings register identical (label, property) pairs.

## 3. ⚠️ The constraint was never enforced

This is the part worth the review. Everything needed was already there — the constraint registry, a per-constraint index, a backfill at creation time, and a written-and-unused `check_unique_constraint`. **Nothing on the write path ever called any of it.**

```cypher
CREATE CONSTRAINT FOR (n:Kernel) REQUIRE n.id IS UNIQUE;
CREATE (:Kernel {id: 1});
CREATE (:Kernel {id: 1});   -- accepted; SHOW CONSTRAINTS still lists the constraint
```

That is worse than not supporting constraints: the double load the feature exists to prevent proceeds silently, while the schema claims protection. It also matches the theme in #368 — the failure is a wrong state, not an error.

`set_node_property` now checks and records constrained values. The hot path is guarded by `has_any_unique_constraints()`, so a graph with no constraints — every bulk load — pays one map read and skips the per-label work entirely. Re-setting a property to the value the same node already holds stays legal; only *another* node holding it is a violation.

### Enforcement exposed a partial-write bug

The first working version rejected the duplicate **and still left the node behind** (`Kernel nodes = 2` after a rejection), because the creation paths discarded the result of `set_node_property` with `let _ =`. A rejected statement must not half-apply. The CREATE, MATCH..CREATE and MERGE paths now unwind what they created before surfacing the error, and a test asserts the count is unchanged after a rejection.

## Verified

| case | result |
|---|---|
| duplicate insert | rejected, **and no node left behind** |
| distinct value | accepted |
| `SET` to a node's own current value | accepted |
| `SET` to a value another node holds | rejected |
| graph with no constraints | unaffected, duplicates allowed |
| `CREATE CONSTRAINT` over existing duplicates | still rejected |

- `cargo test --workspace`: **2446 passed, 0 failed**
- Conformance suite: 48 passed, 0 ignored