### PR TITLE
fix(server): reject the graph argument instead of silently ignoring it

### DIFF
--- a/sdk/python/src/lib.rs
+++ b/sdk/python/src/lib.rs
@@ -189,7 +189,12 @@ impl SamyamaClient {
         })
     }
 
-    /// Execute a Cypher query
+    /// Execute a Cypher query.
+    ///
+    /// `graph` selects the target graph. This build serves a single graph, `"default"`,
+    /// and the server rejects any other name. It previously accepted and ignored the
+    /// argument, so datasets written under different graph names silently merged into one
+    /// (#366). To keep datasets apart here, run a separate instance per dataset.
     #[pyo3(signature = (cypher, graph="default"))]
     fn query(&self, cypher: &str, graph: &str) -> PyResult<QueryResult> {
         let rt = get_runtime();
@@ -203,7 +208,9 @@ impl SamyamaClient {
         }
     }
 
-    /// Execute a read-only Cypher query
+    /// Execute a read-only Cypher query.
+    ///
+    /// See `query` for what `graph` does -- and does not -- select.
     #[pyo3(signature = (cypher, graph="default"))]
     fn query_readonly(&self, cypher: &str, graph: &str) -> PyResult<QueryResult> {
         let rt = get_runtime();

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -1,5 +1,6 @@
 //! HTTP handlers for the Visualizer API
 
+use axum::http::StatusCode;
 use axum::{
     extract::{Query, State, Json, Multipart},
     response::IntoResponse,
@@ -37,6 +38,29 @@ pub async fn query_handler(
     State(state): State<AppState>,
     Json(payload): Json<QueryRequest>,
 ) -> impl IntoResponse {
+    // OSS serves exactly one graph. The `graph` argument used to be accepted and then
+    // ignored: every read and write landed in the same store, so two datasets loaded into
+    // what looked like separate graphs silently merged, and the merge was only discoverable
+    // by noticing the row counts were wrong. Rejecting the argument turns that into a loud,
+    // actionable failure at the first query rather than silent corruption of a loaded
+    // dataset. See #366.
+    if payload.graph != default_graph() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!(
+                    "This build serves a single graph ('{}'); the requested graph '{}' does not \
+                     exist and the argument cannot be honoured. Previously it was ignored and \
+                     the query silently ran against '{}', merging datasets. Omit the argument, \
+                     or use a separate data directory per dataset.",
+                    default_graph(), payload.graph, default_graph()
+                ),
+                "graph": payload.graph,
+            })),
+        )
+            .into_response();
+    }
+
     // Check if query is write or read
     let query_upper = payload.query.trim().to_uppercase();
     let is_write = query_upper.starts_with("CREATE") ||
@@ -1242,13 +1266,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_query_handler_explicit_graph_param() {
-        // When graph field is sent, should use that graph
+    async fn test_query_handler_rejects_non_default_graph() {
+        // This previously asserted OK, on the belief that the graph argument selected a
+        // graph. It never did -- the query ran against the single default store, so two
+        // datasets loaded into different graph names merged with no error (#366). A build
+        // that serves one graph must refuse the argument rather than quietly ignore it.
+        let (app, _state) = test_app();
+
+        let (status, json) = post_query(
+            app,
+            r#"{"query": "MATCH (n) RETURN n", "graph": "test_graph"}"#,
+        ).await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(json["graph"], "test_graph");
+        assert!(
+            json["error"].as_str().unwrap_or_default().contains("single graph"),
+            "error should explain why: {json:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_query_handler_accepts_default_graph_explicitly() {
         let (app, _state) = test_app();
 
         let (status, _json) = post_query(
             app,
-            r#"{"query": "MATCH (n) RETURN n", "graph": "test_graph"}"#,
+            r#"{"query": "MATCH (n) RETURN n", "graph": "default"}"#,
         ).await;
 
         assert_eq!(status, StatusCode::OK);

--- a/src/protocol/command.rs
+++ b/src/protocol/command.rs
@@ -112,12 +112,23 @@ impl CommandHandler {
             return RespValue::Error("ERR wrong number of arguments for 'GRAPH.QUERY' command".to_string());
         }
 
-        // Extract graph name (for future multi-tenancy)
+        // Extract graph name. This build serves a single graph: the name used to be
+        // accepted and ignored, so two datasets written under different names landed in the
+        // same store and silently merged (#366). Refuse the name instead -- a loud error on
+        // the first query beats corrupting a loaded dataset.
         let graph_name = match args[1].as_string() {
             Ok(Some(s)) => s,
             Ok(None) => return RespValue::Error("ERR null graph name".to_string()),
             Err(e) => return RespValue::Error(format!("ERR {}", e)),
         };
+        if graph_name != "default" {
+            return RespValue::Error(format!(
+                "ERR this build serves a single graph ('default'); graph '{}' does not exist. \
+                 The name was previously ignored and the query ran against 'default', \
+                 merging datasets. Use 'default', or run a separate instance per dataset.",
+                graph_name
+            ));
+        }
 
         // Extract query string
         let query_str = match args[2].as_string() {
@@ -423,7 +434,7 @@ mod tests {
 
         let cmd = RespValue::Array(vec![
             RespValue::BulkString(Some(b"GRAPH.QUERY".to_vec())),
-            RespValue::BulkString(Some(b"mygraph".to_vec())),
+            RespValue::BulkString(Some(b"default".to_vec())),
             RespValue::BulkString(Some(b"MATCH (n:Person) RETURN n".to_vec())),
         ]);
 
@@ -458,7 +469,7 @@ mod tests {
 
         let cmd = RespValue::Array(vec![
             RespValue::BulkString(Some(b"GRAPH.RO_QUERY".to_vec())),
-            RespValue::BulkString(Some(b"mygraph".to_vec())),
+            RespValue::BulkString(Some(b"default".to_vec())),
             RespValue::BulkString(Some(b"MATCH (n:Person) RETURN n.name".to_vec())),
         ]);
         let response = handler.handle_command(&cmd, &store).await;
@@ -472,7 +483,7 @@ mod tests {
 
         let cmd = RespValue::Array(vec![
             RespValue::BulkString(Some(b"GRAPH.DELETE".to_vec())),
-            RespValue::BulkString(Some(b"mygraph".to_vec())),
+            RespValue::BulkString(Some(b"default".to_vec())),
         ]);
         let response = handler.handle_command(&cmd, &store).await;
         // Should return OK or similar
@@ -534,11 +545,48 @@ mod tests {
 
         let cmd = RespValue::Array(vec![
             RespValue::BulkString(Some(b"GRAPH.QUERY".to_vec())),
-            RespValue::BulkString(Some(b"mygraph".to_vec())),
+            RespValue::BulkString(Some(b"default".to_vec())),
             RespValue::BulkString(Some(b"CREATE (n:Person {name: 'Alice'})".to_vec())),
         ]);
         let response = handler.handle_command(&cmd, &store).await;
         assert!(matches!(response, RespValue::Array(_)));
+    }
+
+    #[tokio::test]
+    async fn test_graph_query_rejects_non_default_graph_name() {
+        // The name used to be parsed and thrown away, so `GRAPH.QUERY analytics ...` and
+        // `GRAPH.QUERY staging ...` both ran against the one store and silently merged
+        // their data (#366). A single-graph build must refuse the name, not ignore it.
+        let handler = CommandHandler::new(None);
+        let store = Arc::new(RwLock::new(GraphStore::new()));
+
+        let cmd = RespValue::Array(vec![
+            RespValue::BulkString(Some(b"GRAPH.QUERY".to_vec())),
+            RespValue::BulkString(Some(b"analytics".to_vec())),
+            RespValue::BulkString(Some(b"MATCH (n) RETURN n".to_vec())),
+        ]);
+        let response = handler.handle_command(&cmd, &store).await;
+
+        match response {
+            RespValue::Error(msg) => {
+                assert!(msg.contains("analytics"), "should name the rejected graph: {msg}");
+                assert!(msg.contains("single graph"), "should explain why: {msg}");
+            }
+            other => panic!("expected an error, got {other:?}"),
+        }
+
+        // and writes under a rejected name must not have landed anywhere
+        let cmd = RespValue::Array(vec![
+            RespValue::BulkString(Some(b"GRAPH.QUERY".to_vec())),
+            RespValue::BulkString(Some(b"analytics".to_vec())),
+            RespValue::BulkString(Some(b"CREATE (:Leak {id: 1})".to_vec())),
+        ]);
+        let _ = handler.handle_command(&cmd, &store).await;
+        assert_eq!(
+            store.read().await.get_nodes_by_label(&crate::graph::Label::new("Leak")).len(),
+            0,
+            "a rejected query must not write to the default graph"
+        );
     }
 
     // ========== Coverage expansion tests ==========
@@ -551,7 +599,7 @@ mod tests {
         // Only 2 args (command + graph name, missing query)
         let cmd = RespValue::Array(vec![
             RespValue::BulkString(Some(b"GRAPH.QUERY".to_vec())),
-            RespValue::BulkString(Some(b"mygraph".to_vec())),
+            RespValue::BulkString(Some(b"default".to_vec())),
         ]);
         let response = handler.handle_command(&cmd, &store).await;
         assert_eq!(
@@ -594,7 +642,7 @@ mod tests {
 
         let cmd = RespValue::Array(vec![
             RespValue::BulkString(Some(b"GRAPH.QUERY".to_vec())),
-            RespValue::BulkString(Some(b"mygraph".to_vec())),
+            RespValue::BulkString(Some(b"default".to_vec())),
             RespValue::BulkString(None), // null query
         ]);
         let response = handler.handle_command(&cmd, &store).await;
@@ -1045,7 +1093,7 @@ mod tests {
         // Test a query that has write keywords in the middle (e.g., MATCH ... SET ...)
         let cmd = RespValue::Array(vec![
             RespValue::BulkString(Some(b"GRAPH.QUERY".to_vec())),
-            RespValue::BulkString(Some(b"mygraph".to_vec())),
+            RespValue::BulkString(Some(b"default".to_vec())),
             RespValue::BulkString(Some(b"MATCH (n:Person {name: 'Alice'}) SET n.age = 30 RETURN n".to_vec())),
         ]);
         // Should detect " SET " and treat as write query


### PR DESCRIPTION
Fixes #366

## What was wrong

Both the HTTP and RESP paths accepted a graph/tenant name and threw it away:

```rust
// Extract graph name (for future multi-tenancy)
let graph_name = match args[1].as_string() { ... };
// ...never used to select anything
```

There is exactly one `Arc<RwLock<GraphStore>>`, and the read path doesn't take a tenant at all. So two datasets loaded under different graph names merged into one, with nothing to indicate it. The reporter lost a loaded dataset this way — experiments written to `bench` and `bugrepro` overwrote it.

`TenantManager` doesn't change this: it holds tenant metadata and quotas, not per-tenant stores.

## The fix

Take option 1 from the issue — refuse the argument:

- `POST /api/query` → **400**, naming the rejected graph and stating that the query would otherwise have run against `default`.
- `GRAPH.QUERY <name> ...` → `ERR` with the same explanation.
- Python SDK docstrings for `query` / `query_readonly` now say what the parameter does and does not select. They previously read as though it were functional, which is how the issue's reproduction got written in the first place.

Multi-tenancy being Enterprise-only is fine. Accepting the argument and ignoring it is not, because the failure mode is silent data corruption rather than a refusal.

## Tests that asserted the bug

Worth flagging, since they're the reason this survived:

```rust
async fn test_query_handler_explicit_graph_param() {
    // When graph field is sent, should use that graph
    ...
    assert_eq!(status, StatusCode::OK);
}
```

The comment states a selection that never happened, and the assertion passed precisely *because* the argument was ignored. It is rewritten to assert the rejection. The RESP tests passed `mygraph` incidentally while testing query execution; they now pass `default`, which is what they were always actually running against.

New coverage asserts the rejection names the graph, explains why, and — importantly — that **a rejected write does not land in `default`**.

## Verified

- `cargo test --workspace`: **2450 passed, 0 failed**

## Note on scope

This makes the single-graph limit explicit; it does not implement multi-graph isolation. The issue's closing point stands and is worth documenting separately: with `DETACH DELETE` also not being a full reset, "isolate this experiment" has no OSS mechanism short of a separate data directory per dataset, which the new error message now tells the user directly.