### PR TITLE
fix(query): UNWIND can lead a statement

### DIFF
--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -121,6 +121,13 @@ pub struct Query {
     pub foreach_clause: Option<ForeachClause>,
     /// UNWIND clause (optional)
     pub unwind_clause: Option<UnwindClause>,
+    /// Whether the UNWIND *led* the statement (`UNWIND ... MATCH ...`) rather than
+    /// following the match. The AST keeps a single `unwind_clause` with no position, but
+    /// the two orders plan differently: a leading UNWIND must bind its variable before the
+    /// WHERE runs, or a predicate referencing it fails with "Variable not found". A
+    /// trailing UNWIND deliberately stays after the filter so the cross product is built
+    /// from the already-narrowed rows.
+    pub unwind_leading: bool,
     /// MERGE clause (optional)
     pub merge_clause: Option<MergeClause>,
     /// UNION queries (chained via UNION/UNION ALL)
@@ -651,6 +658,7 @@ impl Query {
             params: HashMap::new(),
             foreach_clause: None,
             unwind_clause: None,
+            unwind_leading: false,
             merge_clause: None,
             union_queries: Vec::new(),
             explain: false,

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -8,7 +8,7 @@ COMMENT = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ("//" ~ (!"\n" ~ ANY)*) }
 query = { SOI ~ explain_clause? ~ statement ~ (union_clause ~ statement)* ~ ";"? ~ EOI }
 explain_clause = { ^"PROFILE" | ^"EXPLAIN" }
 union_clause = { ^"UNION" ~ ^"ALL"? }
-statement = { show_hierarchy_indexes_stmt | show_indexes_stmt | show_constraints_stmt | drop_hierarchy_index_stmt | drop_index_stmt | create_constraint_stmt | create_vector_index_stmt | create_hierarchy_index_stmt | create_index_stmt | rebuild_hierarchy_index_stmt | call_stmt | merge_stmt | match_stmt | create_stmt | with_return_stmt | return_stmt }
+statement = { show_hierarchy_indexes_stmt | show_indexes_stmt | show_constraints_stmt | drop_hierarchy_index_stmt | drop_index_stmt | create_constraint_stmt | create_vector_index_stmt | create_hierarchy_index_stmt | create_index_stmt | rebuild_hierarchy_index_stmt | call_stmt | merge_stmt | unwind_stmt | match_stmt | create_stmt | with_return_stmt | return_stmt }
 with_return_stmt = { with_clause ~ return_clause ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
 return_stmt = { return_clause ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
 
@@ -66,6 +66,11 @@ foreach_clause = { ^"FOREACH" ~ "(" ~ variable ~ in_op ~ expression ~ "|" ~ fore
 foreach_body = _{ set_clause | remove_clause | delete_clause | create_clause }
 unwind_clause = { ^"UNWIND" ~ expression ~ ^"AS" ~ variable }
 merge_inline = { ^"MERGE" ~ pattern ~ on_create_set? ~ on_match_set? }
+// A statement that *begins* with UNWIND. UNWIND was already allowed after a MATCH or a
+// WITH, but a leading one had no rule to match, so the batch-write idiom
+// `UNWIND $rows AS row CREATE (...)` was a parse error at column 1. Same tail as
+// `match_stmt`, with the leading MATCH group optional rather than required.
+unwind_stmt = { unwind_clause ~ ((optional_match_clause | match_clause)+ ~ where_clause?)* ~ (with_clause ~ unwind_clause? ~ ((optional_match_clause | match_clause)+ ~ where_clause?)*)* ~ create_clause? ~ merge_inline? ~ delete_clause? ~ foreach_clause? ~ set_clause* ~ remove_clause* ~ return_clause? ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
 match_clause = { ^"MATCH" ~ pattern }
 optional_match_clause = { ^"OPTIONAL" ~ ^"MATCH" ~ pattern }
 where_clause = { ^"WHERE" ~ expression }

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -800,7 +800,11 @@ impl QueryPlanner {
                 });
             }
 
-            // CY-30: Standalone RETURN without MATCH/CREATE (e.g., RETURN 1+2, RETURN sin(0.5))
+            // CY-30: Standalone RETURN without MATCH/CREATE (e.g., RETURN 1+2, RETURN sin(0.5)).
+            // A leading UNWIND also has no MATCH, but it is *not* a single-row projection --
+            // it must fall through to the general pipeline so the Unwind, and any
+            // aggregation over it, get planned.
+            if query.unwind_clause.is_none() {
             if let Some(return_clause) = &query.return_clause {
                 // Single-row operator that emits one empty record for projection
                 use crate::query::executor::operator::SingleRowOperator;
@@ -826,10 +830,13 @@ impl QueryPlanner {
                     is_write: false, candidates_evaluated: 0, chosen_plan_cost: 0.0, candidate_costs: Vec::new(),
                 });
             }
+            }
 
-            return Err(ExecutionError::PlanningError(
-                "Query must have at least one MATCH, CALL, CREATE, or RETURN clause".to_string()
-            ));
+            if query.unwind_clause.is_none() {
+                return Err(ExecutionError::PlanningError(
+                    "Query must have at least one MATCH, CALL, CREATE, or RETURN clause".to_string()
+                ));
+            }
         }
 
         let mut operator: Option<OperatorBox> = None;
@@ -870,9 +877,25 @@ impl QueryPlanner {
         let mut per_match_where: Vec<Option<WhereClause>> = vec![None; pre_with_clauses.len()];
         let mut cross_match_predicates: Vec<Expression> = Vec::new();
 
+        // See the matching guard in the WITH-stage decomposition below: a predicate that
+        // references a leading UNWIND's variable cannot run during match planning, because
+        // the Unwind operator that binds it sits above the matches. The top-level WHERE
+        // filter re-applies the full predicate after the Unwind, so dropping it here loses
+        // nothing.
+        let deferred_unwind_var_pre: Option<String> = if query.unwind_leading {
+            query.unwind_clause.as_ref().map(|u| u.variable.clone())
+        } else {
+            None
+        };
+
         for pred in pre_where_preds {
             let mut pred_vars = HashSet::new();
             Self::collect_expression_variables(&pred, &mut pred_vars);
+            if let Some(uv) = &deferred_unwind_var_pre {
+                if pred_vars.contains(uv) {
+                    continue;
+                }
+            }
 
             let target = pre_match_var_sets.iter().position(|match_vars| {
                 pred_vars.is_empty() || pred_vars.iter().all(|v| match_vars.contains(v))
@@ -998,9 +1021,26 @@ impl QueryPlanner {
             let mut per_match_where: Vec<Option<WhereClause>> = vec![None; stage_matches.len()];
             let mut cross_match_preds: Vec<Expression> = Vec::new();
 
+            // A predicate referring to a leading UNWIND's variable cannot be evaluated
+            // during match planning -- the variable is not bound until the Unwind operator
+            // runs, which sits above the matches. Leaving it here produced a filter under
+            // the Unwind and the query died with "Variable not found". Dropping it from the
+            // decomposition is safe because the top-level WHERE filter, applied after the
+            // Unwind, evaluates the full predicate anyway.
+            let deferred_unwind_var: Option<String> = if query.unwind_leading {
+                query.unwind_clause.as_ref().map(|u| u.variable.clone())
+            } else {
+                None
+            };
+
             for pred in where_preds {
                 let mut pred_vars = HashSet::new();
                 Self::collect_expression_variables(&pred, &mut pred_vars);
+                if let Some(uv) = &deferred_unwind_var {
+                    if pred_vars.contains(uv) {
+                        continue;
+                    }
+                }
                 let target = match_var_sets.iter().position(|match_vars| {
                     pred_vars.is_empty() || pred_vars.iter().all(|v| match_vars.contains(v))
                 });
@@ -1178,7 +1218,31 @@ impl QueryPlanner {
             }
         }
 
+        // A statement that begins with UNWIND has no MATCH to build a pipeline on, so seed
+        // it with a single empty row and let the rest of the planner -- filters,
+        // aggregation, ORDER BY, SKIP/LIMIT -- apply unchanged. Hand-building a plan here
+        // instead would have to re-implement all of that; the first attempt did, and
+        // promptly failed on `UNWIND [...] AS x RETURN count(x)`.
+        if operator.is_none() && query.unwind_clause.is_some() {
+            use crate::query::executor::operator::SingleRowOperator;
+            operator = Some(Box::new(SingleRowOperator::new()));
+        }
+
         let mut operator = operator.unwrap();
+
+        // A *leading* UNWIND binds its variable before the WHERE, because the predicate may
+        // reference it (`UNWIND [1,2] AS x MATCH (p) WHERE p.n = x`). Applied after the
+        // filter, as a trailing UNWIND is, that query fails with "Variable not found".
+        let leading_unwind = query.unwind_leading && query.with_clause.is_none();
+        if leading_unwind {
+            if let Some(unwind_clause) = &query.unwind_clause {
+                operator = Box::new(UnwindOperator::new(
+                    operator,
+                    unwind_clause.expression.clone(),
+                    unwind_clause.variable.clone(),
+                ));
+            }
+        }
 
         // Add WHERE clause if present.
         // When a WITH clause exists, WHERE predicates were already decomposed and
@@ -1192,8 +1256,10 @@ impl QueryPlanner {
 
         // Extra WITH stages and UNWIND are now handled in the unified loop above.
 
-        // Add standalone UNWIND clause (only when no WITH clause handles it)
-        if query.with_clause.is_none() {
+        // Add standalone UNWIND clause (only when no WITH clause handles it, and not
+        // already applied above as a leading UNWIND). A trailing UNWIND stays here, after
+        // the filter, so the cross product is built from the already-narrowed rows.
+        if query.with_clause.is_none() && !leading_unwind {
             if let Some(unwind_clause) = &query.unwind_clause {
                 operator = Box::new(UnwindOperator::new(
                     operator,
@@ -3969,6 +4035,7 @@ mod tests {
             params: std::collections::HashMap::new(),
             foreach_clause: None,
             unwind_clause: None,
+            unwind_leading: false,
             merge_clause: None,
             union_queries: vec![],
             explain: false,

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -195,7 +195,12 @@ fn parse_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -> Pars
             Rule::merge_stmt => {
                 parse_merge_statement(inner, query)?;
             }
-            Rule::match_stmt => {
+            Rule::match_stmt | Rule::unwind_stmt => {
+                // Same clause set, so the same builder applies -- it already dispatches on
+                // each inner rule rather than assuming a fixed clause order. The rule
+                // itself is what records the UNWIND's position: in `unwind_stmt` it is by
+                // construction the first clause.
+                query.unwind_leading = inner.as_rule() == Rule::unwind_stmt;
                 parse_match_statement(inner, query)?;
             }
             Rule::create_stmt => {

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -1230,3 +1230,55 @@ fn unique_constraints_accept_modern_syntax_and_are_actually_enforced() {
         .execute_mut("CREATE CONSTRAINT FOR (n:K) REQUIRE n.id IS UNIQUE", &mut s3, "default")
         .is_err());
 }
+
+// ---------------------------------------------------------------------------
+// UNWIND as a leading clause (#307)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unwind_can_lead_a_statement() {
+    // UNWIND was already allowed after a MATCH or WITH, but a *leading* one had no rule to
+    // match, so `UNWIND [...] AS x ...` failed at column 1 — the shape batch and
+    // parameterized writes are written in.
+    let mut s = GraphStore::new();
+    let engine = QueryEngine::new();
+    engine.execute_mut("CREATE (:P {name: \"a\", n: 1})", &mut s, "default").unwrap();
+    engine.execute_mut("CREATE (:P {name: \"b\", n: 2})", &mut s, "default").unwrap();
+
+    assert_eq!(bag(&s, "UNWIND [1, 2, 3] AS x RETURN x").len(), 3);
+    assert_eq!(bag(&s, "UNWIND [] AS x RETURN x").len(), 0);
+    assert_eq!(bag(&s, "UNWIND [1, 2, 3] AS x RETURN x LIMIT 2").len(), 2);
+    assert_eq!(
+        bag(&s, "UNWIND [\"a\", \"b\"] AS s RETURN s"),
+        vec!["s=a", "s=b"]
+    );
+    assert_eq!(scalar(&s, "UNWIND [1, 2, 3] AS x RETURN count(x) AS n"), "n=3");
+
+    // A leading UNWIND feeding a MATCH: the predicate references the unwound variable, so
+    // the Unwind must be planned *below* the filter. It was previously pushed above it,
+    // and the query died with "Variable not found: x".
+    assert_eq!(
+        bag(&s, "UNWIND [1, 2] AS x MATCH (p:P) WHERE p.n = x RETURN p.name AS name").len(),
+        2
+    );
+    assert_eq!(
+        bag(&s, "UNWIND [1] AS x MATCH (p:P) WHERE p.n = x RETURN p.name AS name"),
+        vec!["name=a"]
+    );
+    // ... and a value matching nothing yields nothing, so the predicate is really applied
+    assert_eq!(
+        bag(&s, "UNWIND [99] AS x MATCH (p:P) WHERE p.n = x RETURN p.name AS name").len(),
+        0
+    );
+
+    // A trailing UNWIND still cross-products, unchanged.
+    assert_eq!(
+        bag(&s, "MATCH (p:P) UNWIND [1, 2] AS x RETURN p.name AS name, x").len(),
+        4
+    );
+    // and one fed from an aggregate still works
+    assert_eq!(
+        bag(&s, "MATCH (p:P) WITH collect(p.n) AS ns UNWIND ns AS x RETURN x").len(),
+        2
+    );
+}


### PR DESCRIPTION
Refs #307 — closes the read half; see the note at the bottom on what still blocks batch writes.

## What was wrong

`UNWIND` worked *after* a MATCH or WITH, but a leading one had no rule, so this failed at column 1:

```cypher
UNWIND [1, 2, 3] AS x RETURN x
```

## Three fixes, and the order matters

**1. Grammar.** New `unwind_stmt` rule with the same clause tail as `match_stmt`, leading MATCH group optional rather than required. The parser reuses `parse_match_statement` — it already dispatches per inner rule instead of assuming a clause order, so no new builder was needed.

**2. Planning.** With no MATCH there's no pipeline to build on. My first attempt hand-built a plan, which meant re-implementing projection, filtering, aggregation, ORDER BY and LIMIT — and it fell over immediately on `UNWIND [1,2,3] AS x RETURN count(x)` (`Unknown function: count`). Replaced with a one-line change in spirit: **seed the general pipeline with a single empty row** and let every existing stage apply unchanged. The standalone-RETURN early return is guarded so it stops intercepting these queries.

**3. Ordering.** A leading UNWIND must bind its variable *before* the WHERE:

```cypher
UNWIND [1, 2] AS x MATCH (p:P) WHERE p.n = x RETURN p.name
```

Predicate decomposition was assigning `p.n = x` down next to the MATCH — below the Unwind — so this still died with `Variable not found: x` after it parsed. The plan showed the filter applied twice, once on each side of the Unwind:

```
Project → Filter (p.n = x) → Unwind → Filter (p.n = x) → NodeScan   ← the lower one is unrunnable
```

Predicates referencing the unwound variable are now left to the top-level filter, which runs after the Unwind. A **trailing** UNWIND deliberately stays after the filter, so its cross product is still built from already-narrowed rows — moving it unconditionally would have turned a 10-row filtered result into a cross product over the full match.

Since the AST holds one `unwind_clause` with no position, `unwind_leading` records which order was written.

## Tests assert semantics

A predicate in the unwound value must be able to select and to exclude: `UNWIND [1]` returns just `a`, `UNWIND [99]` returns nothing. Otherwise a plan that dropped the filter would pass.

## Verified

- `cargo test --workspace`: **2451 passed, 0 failed**
- Conformance suite: 49 passed, 0 ignored

## What still blocks #307's batch writes

`UNWIND $rows AS row CREATE (:N {id: row.id})` still does not work, for a reason unrelated to UNWIND: **CREATE property values must be literals**. `MATCH (p:P) CREATE (:Q {n: p.n})` is a parse error today, while `SET p.m = p.n` is fine. Filing that separately; #307 should stay open until it lands.