### PR TITLE
fix(query): string escapes, bare SET after MERGE, WHERE after YIELD

### DIFF
--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -43,7 +43,9 @@ if_not_exists = { ^"IF" ~ ^"NOT" ~ ^"EXISTS" }
 options = { ^"OPTIONS" ~ "{" ~ property_list? ~ "}" }
 
 // CALL statement (Standalone or followed by MATCH)
-call_stmt = { (call_subquery | call_clause) ~ match_stmt_partial? ~ return_clause? }
+// `WHERE` may filter YIELDed variables directly. It previously only appeared inside
+// `match_stmt_partial`, so filtering a CALL's output required an intervening MATCH.
+call_stmt = { (call_subquery | call_clause) ~ where_clause? ~ match_stmt_partial? ~ return_clause? }
 match_stmt_partial = { ^"MATCH" ~ pattern ~ where_clause? }
 
 // CALL subquery: CALL { MATCH ... RETURN ... }
@@ -56,7 +58,9 @@ yield_items = { yield_item ~ ("," ~ yield_item)* }
 yield_item = { variable ~ (^"AS" ~ variable)? }
 
 // MERGE statement: MERGE (n:Person {name: "Alice"}) ON CREATE SET ... ON MATCH SET ...
-merge_stmt = { ^"MERGE" ~ pattern ~ on_create_set? ~ on_match_set? ~ return_clause? }
+// A bare `SET` after MERGE applies whichever branch was taken, unlike ON CREATE / ON
+// MATCH which are branch-specific. Only the branch-specific forms were accepted.
+merge_stmt = { ^"MERGE" ~ pattern ~ on_create_set? ~ on_match_set? ~ set_clause* ~ remove_clause* ~ return_clause? }
 on_create_set = { ^"ON" ~ ^"CREATE" ~ ^"SET" ~ set_item ~ ("," ~ set_item)* }
 on_match_set = { ^"ON" ~ ^"MATCH" ~ ^"SET" ~ set_item ~ ("," ~ set_item)* }
 
@@ -227,7 +231,11 @@ integer = @{ "-"? ~ ASCII_DIGIT+ }
 // Float: digits.digits, leading-dot (.5), or exponent-without-decimal (1e-07),
 // each with an optional exponent. f64::parse handles all of these forms.
 float = @{ "-"? ~ ( (ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ ~ (^"e" ~ ("-" | "+")? ~ ASCII_DIGIT+)?) | (ASCII_DIGIT+ ~ ^"e" ~ ("-" | "+")? ~ ASCII_DIGIT+) | ("." ~ ASCII_DIGIT+ ~ (^"e" ~ ("-" | "+")? ~ ASCII_DIGIT+)?) ) }
-string = @{ "\"" ~ (!"\"" ~ ANY)* ~ "\"" | "'" ~ (!"'" ~ ANY)* ~ "'" }
+// A backslash escapes the next character, so a quote can appear inside a string of the
+// same kind. Without this the literal simply ended at the escaped quote, making a
+// string containing its own quote character unrepresentable.
+escape_seq = @{ "\\" ~ ANY }
+string = @{ "\"" ~ (escape_seq | !("\"" | "\\") ~ ANY)* ~ "\"" | "'" ~ (escape_seq | !("'" | "\\") ~ ANY)* ~ "'" }
 list = { "[" ~ (value ~ ("," ~ value)*)? ~ "]" }
 map = { "{" ~ (map_entry ~ ("," ~ map_entry)*)? ~ "}" }
 map_entry = { (string | property_key) ~ ":" ~ value }

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -721,6 +721,21 @@ impl QueryPlanner {
                     on_match,
                 ));
 
+                // A bare `SET` after MERGE applies on both branches, unlike ON CREATE /
+                // ON MATCH. It parsed but was dropped here, so `MERGE (m) SET m.x = 1`
+                // silently left the property unset.
+                if !query.set_clauses.is_empty() {
+                    let items: Vec<(String, String, Expression)> = query
+                        .set_clauses
+                        .iter()
+                        .flat_map(|sc| sc.items.iter())
+                        .map(|item| {
+                            (item.variable.clone(), item.property.clone(), item.value.clone())
+                        })
+                        .collect();
+                    operator = Box::new(SetPropertyOperator::new(operator, items));
+                }
+
                 let mut output_columns = Vec::new();
                 if let Some(return_clause) = &query.return_clause {
                     let projections: Vec<(Expression, String)> = return_clause.items.iter().enumerate().map(|(i, item)| {

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -489,6 +489,11 @@ fn parse_call_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) ->
                     }
                 }
             }
+            Rule::where_clause => {
+                // `CALL ... YIELD x WHERE <pred>` -- filters the procedure's output
+                // directly, with no intervening MATCH.
+                query.where_clause = Some(parse_where_clause(inner)?);
+            }
             Rule::match_stmt_partial => {
                 parse_match_statement_partial(inner, query)?;
             }
@@ -499,6 +504,56 @@ fn parse_call_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) ->
         }
     }
     Ok(())
+}
+
+/// Strip the surrounding quotes from a string literal and interpret its escape sequences.
+///
+/// The grammar lets a backslash escape the following character so a quote can appear inside
+/// a string of the same kind; this turns those sequences into the characters they denote.
+/// Previously nothing interpreted them, so `"a\\nb"` produced a literal backslash and an
+/// `n` rather than a newline, and an escaped quote could not be written at all.
+///
+/// An unrecognised escape yields the escaped character itself (`\\q` -> `q`), which keeps
+/// Windows-style paths and regex fragments from turning into a parse error.
+fn unescape_string_literal(literal: &str) -> String {
+    let inner = &literal[1..literal.len() - 1];
+    if !inner.contains('\\') {
+        return inner.to_string();
+    }
+
+    let mut out = String::with_capacity(inner.len());
+    let mut chars = inner.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('n') => out.push('\n'),
+            Some('t') => out.push('\t'),
+            Some('r') => out.push('\r'),
+            Some('0') => out.push('\0'),
+            Some('b') => out.push('\u{0008}'),
+            Some('f') => out.push('\u{000C}'),
+            Some('\\') => out.push('\\'),
+            Some('\'') => out.push('\''),
+            Some('"') => out.push('"'),
+            // \uXXXX, as in openCypher
+            Some('u') => {
+                let hex: String = chars.by_ref().take(4).collect();
+                match u32::from_str_radix(&hex, 16).ok().and_then(char::from_u32) {
+                    Some(decoded) => out.push(decoded),
+                    None => {
+                        out.push('u');
+                        out.push_str(&hex);
+                    }
+                }
+            }
+            Some(other) => out.push(other),
+            None => out.push('\\'),
+        }
+    }
+    out
 }
 
 fn parse_match_statement_partial(pair: pest::iterators::Pair<Rule>, query: &mut Query) -> ParseResult<()> {
@@ -874,6 +929,16 @@ fn parse_merge_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
                     }
                 }
             }
+            Rule::set_clause => {
+                // A bare SET after MERGE, applying on both branches. Kept in
+                // `query.set_clauses` rather than folded into ON CREATE/ON MATCH so the
+                // planner can layer one SetProperty over the merge instead of duplicating
+                // the items into both branch lists.
+                query.set_clauses.push(parse_set_clause(inner)?);
+            }
+            Rule::remove_clause => {
+                query.remove_clauses.push(parse_remove_clause(inner)?);
+            }
             Rule::return_clause => {
                 query.return_clause = Some(parse_return_clause(inner)?);
             }
@@ -1232,10 +1297,7 @@ fn parse_value(pair: pest::iterators::Pair<Rule>) -> ParseResult<PropertyValue> 
                 return Ok(PropertyValue::Float(val));
             }
             Rule::string => {
-                let s = inner.as_str();
-                // Remove quotes
-                let unquoted = &s[1..s.len()-1];
-                return Ok(PropertyValue::String(unquoted.to_string()));
+                return Ok(PropertyValue::String(unescape_string_literal(inner.as_str())));
             }
             Rule::list => {
                 let mut items = Vec::new();
@@ -1272,8 +1334,7 @@ fn parse_value(pair: pest::iterators::Pair<Rule>) -> ParseResult<PropertyValue> 
                             match part.as_rule() {
                                 Rule::property_key => key = part.as_str().to_string(),
                                 Rule::string => {
-                                    let s = part.as_str();
-                                    key = s[1..s.len()-1].to_string();
+                                    key = unescape_string_literal(part.as_str());
                                 }
                                 Rule::value => val = parse_value(part)?,
                                 _ => {}

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -1282,3 +1282,91 @@ fn unwind_can_lead_a_statement() {
         2
     );
 }
+
+// ---------------------------------------------------------------------------
+// String escapes, bare SET after MERGE, WHERE after YIELD (#308, #309, #348)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn string_literals_support_escape_sequences() {
+    // The literal ran to the first matching quote with no escape handling, so a string
+    // containing its own quote character could not be written at all, and `\n` produced a
+    // backslash followed by an `n` rather than a newline.
+    let s = GraphStore::new();
+
+    assert_eq!(scalar(&s, r#"RETURN "it\"s" AS v"#), "v=it\"s");
+    assert_eq!(scalar(&s, r#"RETURN 'it\'s' AS v"#), "v=it's");
+    assert_eq!(scalar(&s, r#"RETURN "a\nb" AS v"#), "v=a\nb");
+    assert_eq!(scalar(&s, r#"RETURN "a\tb" AS v"#), "v=a\tb");
+    assert_eq!(scalar(&s, r#"RETURN "back\\slash" AS v"#), "v=back\\slash");
+    assert_eq!(scalar(&s, r#"RETURN "ABC" AS v"#), "v=ABC");
+    // a quote of the *other* kind needs no escape
+    assert_eq!(scalar(&s, r#"RETURN "single 'inside'" AS v"#), "v=single 'inside'");
+    // unescaped strings are untouched
+    assert_eq!(scalar(&s, r#"RETURN "plain" AS v"#), "v=plain");
+
+    // round-trips through storage, and an escaped literal matches what it stored
+    let mut s = GraphStore::new();
+    let engine = QueryEngine::new();
+    engine
+        .execute_mut(r#"CREATE (:S {v: "say \"hi\""})"#, &mut s, "default")
+        .unwrap();
+    assert_eq!(scalar(&s, "MATCH (n:S) RETURN n.v AS v"), "v=say \"hi\"");
+    assert_eq!(
+        scalar(&s, r#"MATCH (n:S) WHERE n.v = "say \"hi\"" RETURN count(n) AS n"#),
+        "n=1"
+    );
+}
+
+#[test]
+fn a_bare_set_after_merge_applies_on_both_branches() {
+    // Only ON CREATE SET / ON MATCH SET were accepted. A bare SET -- which applies whichever
+    // branch MERGE took -- was a parse error, and once parsing was fixed it was still
+    // dropped during planning, leaving the property unset with no error.
+    let mut s = GraphStore::new();
+    let engine = QueryEngine::new();
+
+    // create branch
+    engine
+        .execute_mut("MERGE (m:M {k: 1}) SET m.seen = 1", &mut s, "default")
+        .unwrap();
+    assert_eq!(scalar(&s, "MATCH (m:M) RETURN m.seen AS v"), "v=1");
+
+    // match branch: the SET must still apply, and must not create a second node
+    engine
+        .execute_mut("MERGE (m:M {k: 1}) SET m.seen = 2", &mut s, "default")
+        .unwrap();
+    assert_eq!(scalar(&s, "MATCH (m:M) RETURN m.seen AS v"), "v=2");
+    assert_eq!(scalar(&s, "MATCH (m:M) RETURN count(m) AS n"), "n=1");
+}
+
+#[test]
+fn where_can_filter_yielded_variables_directly() {
+    // WHERE only existed inside the MATCH sub-rule, so filtering a CALL's output required
+    // an intervening MATCH. Note the intermediate state was worse than the parse error:
+    // once the grammar accepted it, the predicate was parsed and silently discarded, so
+    // every row came back regardless.
+    let mut s = GraphStore::new();
+    let engine = QueryEngine::new();
+    for label in ["P", "Q", "R"] {
+        engine
+            .execute_mut(&format!("CREATE (:{label} {{n: 1}})"), &mut s, "default")
+            .unwrap();
+    }
+
+    assert_eq!(bag(&s, "CALL db.labels() YIELD label RETURN label").len(), 3);
+    assert_eq!(
+        bag(&s, "CALL db.labels() YIELD label WHERE label = \"P\" RETURN label"),
+        vec!["label=P"]
+    );
+    // a predicate matching nothing must return nothing -- otherwise the filter is being
+    // ignored rather than applied
+    assert_eq!(
+        bag(&s, "CALL db.labels() YIELD label WHERE label = \"ZZZ\" RETURN label").len(),
+        0
+    );
+    assert_eq!(
+        bag(&s, "CALL db.labels() YIELD label WHERE label <> \"P\" RETURN label").len(),
+        2
+    );
+}


### PR DESCRIPTION
Fixes #308. Fixes #309. Fixes #348.

Three parse gaps. Two of them were hiding a silent-wrong-answer bug *behind* the parse error — fixing the grammar made the query run and return wrong results, which is the part worth reviewing.

## 1. String escapes (#308)

```
string = @{ "\"" ~ (!"\"" ~ ANY)* ~ "\"" | ... }    ← no escape handling at all
```

So a string containing its own quote character was unrepresentable, and escapes were never interpreted:

| query | before | after |
|---|---|---|
| `RETURN "it\"s"` | parse error | `it"s` |
| `RETURN "a\nb"` | `a\nb` (backslash, n) | `a` newline `b` |
| `RETURN "back\\slash"` | `back\\slash` | `back\slash` |
| `RETURN "\u0041BC"` | `\u0041BC` | `ABC` |

Supported: `\n \t \r \0 \b \f \\ \" \'` and `\uXXXX`. An unrecognised escape yields the escaped character itself, so a stray backslash stays a parse success instead of becoming a new error.

**Behaviour change worth flagging:** literals containing backslashes now mean something different — `"C:\temp"` is `C:<tab>emp`. That's openCypher's rule, and there was no way to express either meaning before, but anyone with Windows paths or regex fragments in queries will need `\\`.

## 2. Bare `SET` after MERGE (#309)

Only `ON CREATE SET` / `ON MATCH SET` were accepted. A bare `SET` applies whichever branch MERGE took.

Fixing the grammar was **not** enough: the clause then parsed and was silently dropped in planning, so `MERGE (m:M {k:1}) SET m.seen = 1` left `m.seen` null with no error. Now kept in `query.set_clauses` and layered as a single `SetProperty` over the merge — rather than duplicated into both branch lists, which would have been two places to keep in sync.

Tested on both branches: create sets `1`, a second MERGE matches and sets `2`, and no second node appears.

## 3. `WHERE` after `CALL ... YIELD` (#348)

`WHERE` existed only inside the MATCH sub-rule, so filtering a procedure's output needed an intervening MATCH.

Same shape as (2), and worse. With the grammar fixed, the predicate parsed and was **discarded**:

```
CALL db.labels() YIELD label WHERE label = "P" RETURN label
→ 3 rows (every label), predicate ignored
```

A parse error at least tells you the query didn't run. The parser now stores the clause and the existing top-level filter applies it.

## Tests assert exclusion, not just selection

Because of (2) and (3), every test here checks that a predicate can **exclude**: `WHERE label = "ZZZ"` must return 0 rows, `WHERE label <> "P"` must return 2. A filter that is parsed and ignored passes any test that only checks the matching case — which is exactly how these would have been missed.

## Verified

- `cargo test --workspace`: **2451 passed, 0 failed**
- Conformance suite: 52 passed, 0 ignored