### PR TITLE
fix(query): keys(), properties() and node RETURN read columnar storage

### DIFF
--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -34,6 +34,33 @@ pub struct QueryResponse {
 }
 
 /// Handler for Cypher queries
+/// Merge row-storage and columnar properties for every node in `batch`.
+///
+/// A snapshot import populates only the columnar store, so serializing `node.properties`
+/// directly reported imported nodes as having no properties -- `"properties": {}` -- even
+/// while `n.name` returned a value (#333). Resolving only the nodes in one result keeps
+/// late materialization intact; materializing on every scan would not.
+///
+/// Synchronous, and called while the store guard is already held: a `RecordBatch` is not
+/// `Send`, so awaiting anything after the query has run would make the handler's future
+/// non-`Send`.
+fn merged_node_properties(
+    batch: &crate::query::RecordBatch,
+    store: &crate::graph::GraphStore,
+) -> HashMap<u64, HashMap<String, PropertyValue>> {
+    batch
+        .records
+        .iter()
+        .flat_map(|r| r.bindings().values())
+        .filter_map(|v| match v {
+            Value::Node(id, _) => Some(*id),
+            Value::NodeRef(id) => Some(*id),
+            _ => None,
+        })
+        .map(|id| (id.as_u64(), store.node_properties_full(id)))
+        .collect()
+}
+
 pub async fn query_handler(
     State(state): State<AppState>,
     Json(payload): Json<QueryRequest>,
@@ -74,12 +101,22 @@ pub async fn query_handler(
                      query_upper.ends_with(" CREATE") || query_upper.ends_with(" SET") ||
                      query_upper.ends_with(" DELETE") || query_upper.ends_with(" MERGE")));
 
-    let result = if is_write {
+    let (result, full_props) = if is_write {
         let mut store_guard = state.store.write().await;
-        state.engine.execute_mut(&payload.query, &mut *store_guard, &payload.graph)
+        let result = state.engine.execute_mut(&payload.query, &mut *store_guard, &payload.graph);
+        let props = result
+            .as_ref()
+            .map(|b| merged_node_properties(b, &store_guard))
+            .unwrap_or_default();
+        (result, props)
     } else {
         let store_guard = state.store.read().await;
-        state.engine.execute(&payload.query, &*store_guard)
+        let result = state.engine.execute(&payload.query, &*store_guard);
+        let props = result
+            .as_ref()
+            .map(|b| merged_node_properties(b, &store_guard))
+            .unwrap_or_default();
+        (result, props)
     };
 
     match result {
@@ -87,6 +124,13 @@ pub async fn query_handler(
             let mut nodes = HashMap::new();
             let mut edges = HashMap::new();
             let mut records = Vec::new();
+
+            // Properties live in row storage and in the columnar store; a snapshot import
+            // populates only the latter, so serializing `node.properties` alone reported
+            // imported nodes as having none -- `"properties": {}` -- while `n.name`
+            // returned a value (#333). Resolve the merged view for the nodes actually in
+            // this result, rather than materializing it on every scan, which would defeat
+            // late materialization.
 
             for record in &batch.records {
                 let mut row = Vec::new();
@@ -97,8 +141,17 @@ pub async fn query_handler(
                     match val {
                         Value::Node(id, node) => {
                             let mut properties = serde_json::Map::new();
-                            for (k, v) in &node.properties {
-                                properties.insert(k.clone(), v.to_json());
+                            if let Some(merged) = full_props.get(&id.as_u64()) {
+                                for (k, v) in merged {
+                                    properties.insert(k.clone(), v.to_json());
+                                }
+                            }
+                            // fall back to whatever the value itself carries if the node is
+                            // no longer in the store (e.g. one returned by a DELETE)
+                            if properties.is_empty() {
+                                for (k, v) in &node.properties {
+                                    properties.insert(k.clone(), v.to_json());
+                                }
                             }
                             let node_json = json!({
                                 "id": id.as_u64().to_string(),

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1272,16 +1272,33 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
         }
         "keys" => {
             match &args[0] {
-                Value::Node(_, node) => {
-                    let keys: Vec<PropertyValue> = node.properties.keys()
-                        .map(|k| PropertyValue::String(k.clone()))
-                        .collect();
+                Value::Node(id, node) => {
+                    // Properties live in row storage *and* in the columnar store, and a
+                    // snapshot import populates only the latter -- so reading
+                    // `node.properties` alone reported an imported node as having no
+                    // properties at all, even while `n.name` returned a value (#333).
+                    let keys: Vec<PropertyValue> = match store {
+                        Some(s) => s
+                            .node_properties_full(*id)
+                            .keys()
+                            .map(|k| PropertyValue::String(k.clone()))
+                            .collect(),
+                        None => node
+                            .properties
+                            .keys()
+                            .map(|k| PropertyValue::String(k.clone()))
+                            .collect(),
+                    };
                     Ok(Value::Property(PropertyValue::Array(keys)))
                 }
                 Value::NodeRef(id) => {
                     let s = store.ok_or_else(|| ExecutionError::RuntimeError("keys() on NodeRef requires store".to_string()))?;
-                    let node = s.get_node(*id).ok_or_else(|| ExecutionError::RuntimeError(format!("Node {} not found", id.as_u64())))?;
-                    let keys: Vec<PropertyValue> = node.properties.keys()
+                    if s.get_node(*id).is_none() {
+                        return Err(ExecutionError::RuntimeError(format!("Node {} not found", id.as_u64())));
+                    }
+                    let keys: Vec<PropertyValue> = s
+                        .node_properties_full(*id)
+                        .keys()
                         .map(|k| PropertyValue::String(k.clone()))
                         .collect();
                     Ok(Value::Property(PropertyValue::Array(keys)))
@@ -1561,13 +1578,20 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
         // CY-20: properties() — return all properties as a map
         "properties" => {
             match &args[0] {
-                Value::Node(_, node) => {
-                    Ok(Value::Property(PropertyValue::Map(node.properties.clone())))
+                Value::Node(id, node) => {
+                    // See keys(): row storage alone is incomplete after a snapshot import.
+                    let props = match store {
+                        Some(s) => s.node_properties_full(*id),
+                        None => node.properties.clone(),
+                    };
+                    Ok(Value::Property(PropertyValue::Map(props)))
                 }
                 Value::NodeRef(id) => {
                     let s = store.ok_or_else(|| ExecutionError::RuntimeError("properties() on NodeRef requires store".to_string()))?;
-                    let node = s.get_node(*id).ok_or_else(|| ExecutionError::RuntimeError(format!("Node {} not found", id.as_u64())))?;
-                    Ok(Value::Property(PropertyValue::Map(node.properties.clone())))
+                    if s.get_node(*id).is_none() {
+                        return Err(ExecutionError::RuntimeError(format!("Node {} not found", id.as_u64())));
+                    }
+                    Ok(Value::Property(PropertyValue::Map(s.node_properties_full(*id))))
                 }
                 Value::Edge(_, edge) => {
                     Ok(Value::Property(PropertyValue::Map(edge.properties.clone())))

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -1459,3 +1459,63 @@ fn projecting_several_properties_across_a_relationship_keeps_them_on_one_node() 
         assert!(row.contains(&format!("aemail=e{ai}@x")), "{row:?}");
     }
 }
+
+// ---------------------------------------------------------------------------
+// Properties survive a snapshot round-trip (#333)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn keys_and_properties_see_columnar_values_after_a_snapshot_import() {
+    // Properties live in row storage *and* in the columnar store, and a snapshot import
+    // populates only the latter. `keys()`, `properties()` and whole-node RETURN read the
+    // row map directly, so an imported node reported having no properties at all — while
+    // `n.name` returned a value, because scalar access goes through the columnar store.
+    //
+    // Reported (#333) as specific to nodes carrying embeddings, but it is not: the
+    // embedding merely happened to be the one property that survived in row storage, which
+    // made embedded nodes look singled out. A node with no embedding is equally affected.
+    let mut s = GraphStore::new();
+    let engine = QueryEngine::new();
+    engine
+        .execute_mut(
+            "CREATE (:Player {name: \"Alice\", player_id: \"P-1\", age: 30})",
+            &mut s, "default",
+        )
+        .unwrap();
+    engine
+        .execute_mut("CREATE (:Team {name: \"Reds\", city: \"X\"})", &mut s, "default")
+        .unwrap();
+    engine
+        .execute_mut("MATCH (p:Player) SET p.embedding = [0.1, 0.2, 0.3]", &mut s, "default")
+        .unwrap();
+
+    let mut buf: Vec<u8> = Vec::new();
+    samyama::snapshot::export_tenant(&s, &mut buf).expect("export");
+    let mut imported = GraphStore::new();
+    samyama::snapshot::import_tenant(&mut imported, &buf[..]).expect("import");
+
+    // scalar access always worked; it is the aggregate views that did not
+    assert_eq!(scalar(&imported, "MATCH (p:Player) RETURN p.name AS v"), "v=Alice");
+
+    let keys = scalar(&imported, "MATCH (p:Player) RETURN keys(p) AS v");
+    for expected in ["name", "player_id", "age", "embedding"] {
+        assert!(keys.contains(expected), "keys() lost {expected}: {keys}");
+    }
+
+    let props = scalar(&imported, "MATCH (p:Player) RETURN properties(p) AS v");
+    for expected in ["name", "player_id", "age"] {
+        assert!(props.contains(expected), "properties() lost {expected}: {props}");
+    }
+
+    // the node without an embedding must be just as complete
+    let team_keys = scalar(&imported, "MATCH (t:Team) RETURN keys(t) AS v");
+    for expected in ["name", "city"] {
+        assert!(team_keys.contains(expected), "keys() lost {expected}: {team_keys}");
+    }
+
+    // and nothing regressed for a graph that was never exported
+    let fresh_keys = scalar(&s, "MATCH (t:Team) RETURN keys(t) AS v");
+    for expected in ["name", "city"] {
+        assert!(fresh_keys.contains(expected), "{fresh_keys}");
+    }
+}


### PR DESCRIPTION
Fixes #333

## What was wrong

After a snapshot import, a node reported having no properties — while its scalar properties returned fine:

```cypher
MATCH (p:Player) RETURN p.name        -- "Alice"        ✅
MATCH (p:Player) RETURN keys(p)       -- ["embedding"]  ❌ name, player_id, age all missing
MATCH (p:Player) RETURN properties(p) -- {embedding:…}  ❌
MATCH (p:Player) RETURN p             -- "properties":{} ❌
```

Properties live in **two** places — row storage and the columnar store — and a snapshot import populates only the columnar one. Scalar access already reads columnar; `keys()`, `properties()` and node serialization read the row map directly. So the same session answers "what is its name?" correctly and "what do you know about this node?" with nothing.

`GraphStore::node_properties_full` already merged the two views. Nothing called it from these paths.

## The report was narrower than the bug

#333 describes this as specific to nodes carrying vector embeddings, and says non-embedded nodes are fine. They are not:

```cypher
-- Team has no embedding at all
MATCH (t:Team) RETURN keys(t)   -- []   before this PR
```

The embedding was just the one property that happened to survive in row storage, which made embedded nodes look singled out and sent the diagnosis toward the vector index. The test asserts the non-embedded case explicitly so the real scope is recorded.

## Performance

The merge resolves only the nodes actually present in a result — not every node on every scan, which would defeat the late materialization the columnar store exists for.

In the HTTP handler it runs **inside the existing store guard**. `RecordBatch` is not `Send`, so acquiring a second lock after the query makes the handler's future non-`Send` and the route stops compiling. Worth knowing before anyone tries to await anything else there.

## Verified

- Snapshot round-trip: `keys()` returns all four properties, `properties()` returns them with values, the non-embedded node returns both of its own, and an unexported graph is unchanged.
- Test confirmed failing without the fix (`keys() lost name: v=[embedding]`).
- `cargo test --workspace`: **2455 passed, 0 failed**
- Conformance suite: 54 passed, 0 ignored