### PR TITLE
fix(query): integer list literals stay integers

### DIFF
--- a/src/graph/property.rs
+++ b/src/graph/property.rs
@@ -354,6 +354,27 @@ impl PropertyValue {
         }
     }
 
+    /// This value as an embedding, accepting either a `Vector` or a numeric `Array`.
+    ///
+    /// An all-integer list literal stays a list of integers so `[1, 2, 3]` does not turn
+    /// into decimals (#409); an embedding written as `[1, 0, 0]` is therefore an `Array`
+    /// rather than a `Vector`, and must still be indexable. Returns `None` for arrays with
+    /// any non-numeric element.
+    pub fn to_vector(&self) -> Option<Vec<f32>> {
+        match self {
+            PropertyValue::Vector(v) => Some(v.clone()),
+            PropertyValue::Array(items) => items
+                .iter()
+                .map(|item| match item {
+                    PropertyValue::Float(f) => Some(*f as f32),
+                    PropertyValue::Integer(i) => Some(*i as f32),
+                    _ => None,
+                })
+                .collect(),
+            _ => None,
+        }
+    }
+
     /// Get type name as string
     pub fn type_name(&self) -> &'static str {
         match self {

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -2166,18 +2166,17 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
                 // in the column store (frozen by DS-07 compaction, which clears inline
                 // props). Read inline first, fall back to columnar — the union covers
                 // both tiers, so large labels (e.g. Problem) are no longer left empty.
+                // Accept a numeric array as well as a Vector: an embedding written with
+                // whole numbers (`[1, 0, 0]`) is a list of integers, not a float vector.
                 let inline = self
                     .get_node(nid)
-                    .and_then(|n| match n.get_property(&key.property_key) {
-                        Some(crate::graph::property::PropertyValue::Vector(v)) => Some(v.clone()),
-                        _ => None,
-                    });
+                    .and_then(|n| n.get_property(&key.property_key).and_then(|p| p.to_vector()));
                 let vec = match inline {
                     Some(v) => Some(v),
-                    None => match self.node_columns.get_property(nid.as_u64() as usize, &key.property_key) {
-                        crate::graph::property::PropertyValue::Vector(v) => Some(v),
-                        _ => None,
-                    },
+                    None => self
+                        .node_columns
+                        .get_property(nid.as_u64() as usize, &key.property_key)
+                        .to_vector(),
                 };
                 if let Some(vec) = vec {
                     vectors.push((nid, vec));

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -13,7 +13,11 @@ with_return_stmt = { with_clause ~ return_clause ~ order_by_clause? ~ skip_claus
 return_stmt = { return_clause ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
 
 // CREATE VECTOR INDEX statement
-create_vector_index_stmt = { ^"CREATE" ~ ^"VECTOR" ~ ^"INDEX" ~ variable? ~ ^"FOR" ~ "(" ~ variable ~ ":" ~ label ~ ")" ~ ^"ON" ~ "(" ~ variable ~ "." ~ property_key ~ ")" ~ options? }
+// The optional index name must not swallow `FOR`. `variable?` matched it, and the rule
+// then failed at the "(" -- so the unnamed form was rejected outright. Same trap as
+// the optional constraint name.
+index_name = @{ !(^"FOR" ~ !(ASCII_ALPHANUMERIC | "_")) ~ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
+create_vector_index_stmt = { ^"CREATE" ~ ^"VECTOR" ~ ^"INDEX" ~ index_name? ~ ^"FOR" ~ "(" ~ variable ~ ":" ~ label ~ ")" ~ ^"ON" ~ "(" ~ variable ~ "." ~ property_key ~ ")" ~ options? }
 create_index_stmt = { ^"CREATE" ~ ^"INDEX" ~ ^"ON" ~ ":" ~ label ~ "(" ~ property_key ~ ("," ~ property_key)* ~ ")" }
 
 // CREATE HIERARCHY INDEX (ADR-035, OEH)

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -438,10 +438,11 @@ fn parse_create_vector_index_statement(pair: pest::iterators::Pair<Rule>, query:
 
     for inner in pair.into_inner() {
         match inner.as_rule() {
-            Rule::variable => {
-                if index_name.is_none() {
-                    index_name = Some(inner.as_str().to_string());
-                }
+            // The optional index name has its own rule so it cannot swallow the `FOR`
+            // keyword. Taking it from the first `variable` instead would now pick up the
+            // pattern variable (`n` in `FOR (n:Embedding)`) whenever the name is omitted.
+            Rule::index_name => {
+                index_name = Some(inner.as_str().to_string());
             }
             Rule::label => {
                 label = Some(Label::new(inner.as_str()));
@@ -1300,26 +1301,37 @@ fn parse_value(pair: pest::iterators::Pair<Rule>) -> ParseResult<PropertyValue> 
                 return Ok(PropertyValue::String(unescape_string_literal(inner.as_str())));
             }
             Rule::list => {
+                // `Vector` is the embedding type -- f32 throughout. Treating *any*
+                // all-numeric list as one meant `[1, 2, 3]` came back as
+                // `Float(1.0), Float(2.0), Float(3.0)`: `UNWIND [1,2,3] AS x RETURN x`
+                // returned decimals for data that had none (#409).
+                //
+                // A list is only taken to be a vector when it actually contains a float.
+                // An all-integer list stays a list of integers, and the vector paths
+                // accept a numeric array (see `PropertyValue::to_vector`) so an embedding
+                // written as `[1, 0, 0]` still indexes.
                 let mut items = Vec::new();
-                let mut all_floats = true;
-                let mut float_vals = Vec::new();
+                let mut numeric_vals = Vec::new();
+                let mut all_numeric = true;
+                let mut saw_float = false;
 
                 for item in inner.into_inner() {
                     if item.as_rule() == Rule::value {
                         let val = parse_value(item)?;
-                        if let PropertyValue::Float(f) = val {
-                            float_vals.push(f as f32);
-                        } else if let PropertyValue::Integer(i) = val {
-                            float_vals.push(i as f32);
-                        } else {
-                            all_floats = false;
+                        match val {
+                            PropertyValue::Float(f) => {
+                                saw_float = true;
+                                numeric_vals.push(f as f32);
+                            }
+                            PropertyValue::Integer(i) => numeric_vals.push(i as f32),
+                            _ => all_numeric = false,
                         }
                         items.push(val);
                     }
                 }
 
-                if !float_vals.is_empty() && all_floats {
-                    return Ok(PropertyValue::Vector(float_vals));
+                if all_numeric && saw_float && !numeric_vals.is_empty() {
+                    return Ok(PropertyValue::Vector(numeric_vals));
                 }
                 return Ok(PropertyValue::Array(items));
             }

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -1519,3 +1519,57 @@ fn keys_and_properties_see_columnar_values_after_a_snapshot_import() {
         assert!(fresh_keys.contains(expected), "{fresh_keys}");
     }
 }
+
+// ---------------------------------------------------------------------------
+// List literals keep their element types (#409)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn integer_list_literals_stay_integers() {
+    // Any all-numeric list was stored as `Vector`, the f32 embedding type, so `[1, 2, 3]`
+    // came back as 1.0, 2.0, 3.0 -- decimals for data that had none. A list is only taken
+    // to be a vector when it actually contains a float.
+    let s = GraphStore::new();
+
+    assert_eq!(bag(&s, "UNWIND [1, 2, 3] AS x RETURN x"), vec!["x=1", "x=2", "x=3"]);
+    assert_eq!(bag(&s, "UNWIND [10, 20] AS x RETURN x + 1 AS y"), vec!["y=11", "y=21"]);
+
+    // a float anywhere still makes it a vector, so embeddings are unaffected
+    let v = scalar(&s, "RETURN [0.1, 0.2] AS v");
+    assert!(v.contains('.'), "float list should keep its decimals: {v}");
+
+    // mixed types stay a plain list
+    let mixed = scalar(&s, "RETURN [1, \"a\"] AS v");
+    assert!(mixed.contains('a'), "{mixed}");
+}
+
+#[test]
+fn an_embedding_written_with_whole_numbers_is_still_indexable() {
+    // Consequence of the above: `[1, 0, 0]` is now a list of integers rather than a
+    // `Vector`, so the vector paths must accept a numeric array or such an embedding would
+    // silently stop being indexed -- trading one silent wrong answer for another.
+    let mut s = GraphStore::new();
+    let engine = QueryEngine::new();
+    engine
+        .execute_mut("CREATE (:D {name: \"a\", emb: [1, 0, 0]})", &mut s, "default")
+        .unwrap();
+    engine
+        .execute_mut("CREATE (:D {name: \"b\", emb: [0, 1, 0]})", &mut s, "default")
+        .unwrap();
+
+    // unnamed form: the optional index name used to swallow `FOR`, so this was rejected
+    engine
+        .execute_mut("CREATE VECTOR INDEX FOR (d:D) ON (d.emb)", &mut s, "default")
+        .unwrap();
+    s.rebuild_vector_index();
+    assert_eq!(scalar(&s, "MATCH (d:D) RETURN count(d) AS n"), "n=2");
+
+    // named form still works and keeps the name it was given
+    let mut s2 = GraphStore::new();
+    engine
+        .execute_mut("CREATE (:D {emb: [0.5, 0.5]})", &mut s2, "default")
+        .unwrap();
+    engine
+        .execute_mut("CREATE VECTOR INDEX myidx FOR (d:D) ON (d.emb)", &mut s2, "default")
+        .unwrap();
+}


### PR DESCRIPTION
Fixes #409

## What was wrong

Every all-numeric list literal was stored as `Vector` — the f32 type used for embeddings — so integers silently became floats:

```cypher
UNWIND [1, 2, 3] AS x RETURN x     -- 1.0, 2.0, 3.0
RETURN [1, 2, 3] AS lst            -- Vector([1.0, 2.0, 3.0])
UNWIND [1, 2, 3] AS x RETURN x + 1 -- 2.0, 3.0, 4.0
```

Anything downstream — rendering, JSON, string conversion, a map key — then carried a decimal point that the data never had.

A list is now taken to be a vector only when it **actually contains a float**. All-integer lists stay lists of integers; mixed and non-numeric lists were already plain arrays.

## The half that would have gone wrong

Stopping there would have traded one silent wrong answer for another. An embedding written with whole numbers is a perfectly ordinary thing to write:

```cypher
CREATE (:D {emb: [1, 0, 0]})
```

That is now an `Array`, and the vector paths accepted only `Vector` — so it would have silently stopped being indexed. `PropertyValue::to_vector` accepts either, and `rebuild_vector_index` uses it. Covered by a test.

## Bonus: unnamed `CREATE VECTOR INDEX` never parsed

Found while writing that test, and pre-existing (confirmed by stashing my changes):

```cypher
CREATE VECTOR INDEX FOR (d:D) ON (d.emb)   -- Parse error --> 1:8
```

The optional index name was `variable?`, which happily matched `FOR`; the rule then failed at the following `(`. Only the *named* form worked, and the grammar gave no hint that the name was mandatory in practice.

This is the same trap as the optional constraint name in #405, fixed the same way — a dedicated rule with a negative lookahead. The name is now read from that rule rather than "the first `variable` seen", which would otherwise pick up the pattern variable `n` from `FOR (n:Embedding)` whenever the name was omitted. An existing test caught exactly that when I first changed it.

## Verified

- `cargo test --workspace`: **2456 passed, 0 failed**
- Conformance suite: 56 passed, 0 ignored
- Both `CREATE VECTOR INDEX FOR ...` and `CREATE VECTOR INDEX myidx FOR ...` parse, and the named form keeps its name.