### PR TITLE
fix(snapshot): entity dedup indexes and looks up every label

### DIFF
--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -302,7 +302,18 @@ pub fn import_tenant_with_dedup(
     // Pre-populate dedup index from existing store nodes (only if dedup requested)
     if !dedup_keys.is_empty() {
     for node in store.all_nodes() {
-        let label = node.labels.iter().next().map(|l| l.as_str().to_string()).unwrap_or_default();
+        // Index under *every* label, not just whichever one iterated first. `labels` is a
+        // set, so "first" is not a stable contract: a dual-labelled node such as
+        // :ChemblTarget + :Protein could be indexed under either, and if the two snapshots
+        // happened to iterate differently the keys never matched and the merge silently did
+        // not happen (#317). Indexing under all labels makes the merge depend on label
+        // *intersection*, which is order-independent.
+        let labels: Vec<String> = if node.labels.is_empty() {
+            vec![String::new()]
+        } else {
+            node.labels.iter().map(|l| l.as_str().to_string()).collect()
+        };
+        for label in &labels {
         for &key in dedup_keys {
             // Check node HashMap properties
             if let Some(val) = node.get_property(key) {
@@ -325,6 +336,7 @@ pub fn import_tenant_with_dedup(
                 _ => {}
             }
         }
+        }
     }
     } // end if !dedup_keys.is_empty()
 
@@ -346,18 +358,27 @@ pub fn import_tenant_with_dedup(
                 .unwrap_or_else(|| "".to_string());
 
             // --- Entity dedup: check if this node already exists (only if dedup requested) ---
+            // Try every label the incoming node carries, for the same reason the index
+            // holds every label: a match on any shared label is a match.
+            let snap_labels: Vec<String> = if snap_node.labels.is_empty() {
+                vec![String::new()]
+            } else {
+                snap_node.labels.clone()
+            };
             let mut existing_id: Option<NodeId> = None;
-            for &key in dedup_keys.iter() {
+            'dedup: for &key in dedup_keys.iter() {
                 if let Some(json_val) = snap_node.props.get(key) {
                     let val_str = match json_val {
                         serde_json::Value::String(s) => normalize_dedup(s),
                         serde_json::Value::Number(n) => n.to_string(),
                         _ => continue,
                     };
-                    let lookup = (first_label.clone(), key.to_string(), val_str);
-                    if let Some(&eid) = dedup_index.get(&lookup) {
-                        existing_id = Some(eid);
-                        break;
+                    for label in &snap_labels {
+                        let lookup = (label.clone(), key.to_string(), val_str.clone());
+                        if let Some(&eid) = dedup_index.get(&lookup) {
+                            existing_id = Some(eid);
+                            break 'dedup;
+                        }
                     }
                 }
             }
@@ -440,7 +461,12 @@ pub fn import_tenant_with_dedup(
                             serde_json::Value::Number(n) => n.to_string(),
                             _ => continue,
                         };
-                        dedup_index.insert((first_label.clone(), key.to_string(), val_str), new_id);
+                        for label in &snap_labels {
+                            dedup_index.insert(
+                                (label.clone(), key.to_string(), val_str.clone()),
+                                new_id,
+                            );
+                        }
                     }
                 }
                 id_remap.insert(snap_node.id, new_id);
@@ -463,7 +489,12 @@ pub fn import_tenant_with_dedup(
                             PropertyValue::Integer(i) => i.to_string(),
                             _ => continue,
                         };
-                        dedup_index.insert((first_label.clone(), key.to_string(), val_str), new_id);
+                        for label in &snap_labels {
+                            dedup_index.insert(
+                                (label.clone(), key.to_string(), val_str.clone()),
+                                new_id,
+                            );
+                        }
                     }
                 }
                 id_remap.insert(snap_node.id, new_id);

--- a/tests/entity_dedup_labels.rs
+++ b/tests/entity_dedup_labels.rs
@@ -1,0 +1,124 @@
+//! Entity dedup must not depend on which label happens to iterate first (#317).
+//!
+//! The dedup index was keyed on `(first_label, key, value)`, where "first" came from
+//! iterating a *set* of labels. For a dual-labelled node — the concrete case being ChEMBL
+//! targets carrying both `:ChemblTarget` and `:Protein`, merged against UniProt `:Protein`
+//! nodes on `accession` — the key could be either label. When the two sides disagreed the
+//! lookup missed and the merge silently did not happen, leaving an unmerged duplicate with
+//! no error.
+//!
+//! Label order in a snapshot is a plain JSON array, so these tests set it explicitly:
+//! the *same* data must merge either way round.
+
+use std::io::{Read, Write};
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::snapshot::{export_tenant, import_tenant_with_dedup};
+
+/// Export a dual-labelled node, then force the label array into a given order.
+fn snapshot_with_label_order(order: &str) -> Vec<u8> {
+    let mut src = GraphStore::new();
+    let id = src.create_node("ChemblTarget");
+    let node = src.get_node_mut(id).unwrap();
+    node.add_label("Protein");
+    node.set_property(
+        "accession".to_string(),
+        PropertyValue::String("P12345".to_string()),
+    );
+
+    let mut buf = Vec::new();
+    export_tenant(&src, &mut buf).expect("export");
+
+    let mut plain = String::new();
+    flate2::read::GzDecoder::new(&buf[..])
+        .read_to_string(&mut plain)
+        .expect("decode");
+    let rewritten = plain
+        .replace("[\"Protein\",\"ChemblTarget\"]", order)
+        .replace("[\"ChemblTarget\",\"Protein\"]", order);
+    assert!(rewritten.contains(order), "label order not applied");
+
+    let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    enc.write_all(rewritten.as_bytes()).expect("encode");
+    enc.finish().expect("finish")
+}
+
+/// A store holding the UniProt side: a single-labelled `:Protein` with the bridge key.
+fn uniprot_side() -> GraphStore {
+    let mut store = GraphStore::new();
+    let id = store.create_node("Protein");
+    let node = store.get_node_mut(id).unwrap();
+    node.set_property(
+        "accession".to_string(),
+        PropertyValue::String("P12345".to_string()),
+    );
+    node.set_property(
+        "src".to_string(),
+        PropertyValue::String("uniprot".to_string()),
+    );
+    store
+}
+
+#[test]
+fn a_dual_labelled_node_merges_whichever_label_comes_first() {
+    for order in [
+        "[\"ChemblTarget\",\"Protein\"]", // the shared label second — this is what failed
+        "[\"Protein\",\"ChemblTarget\"]", // the shared label first — this happened to work
+    ] {
+        let snapshot = snapshot_with_label_order(order);
+        let mut store = uniprot_side();
+
+        let stats = import_tenant_with_dedup(&mut store, &snapshot[..], &["accession"])
+            .expect("import");
+
+        assert_eq!(
+            stats.merged_count, 1,
+            "labels {order}: should merge on the shared :Protein label"
+        );
+        assert_eq!(
+            store.all_nodes().len(),
+            1,
+            "labels {order}: merged node should not be duplicated"
+        );
+
+        // the merged node keeps both labels
+        let labels: Vec<String> = store.all_nodes()[0]
+            .labels
+            .iter()
+            .map(|l| l.as_str().to_string())
+            .collect();
+        for expected in ["Protein", "ChemblTarget"] {
+            assert!(labels.contains(&expected.to_string()), "labels {order}: {labels:?}");
+        }
+    }
+}
+
+#[test]
+fn nodes_sharing_no_label_are_not_merged() {
+    // Matching on *any* shared label must not become matching on the key alone: a :Gene and
+    // a :Protein that happen to carry the same accession are different entities.
+    let snapshot = snapshot_with_label_order("[\"ChemblTarget\",\"Protein\"]");
+    let mut store = GraphStore::new();
+    let id = store.create_node("Gene");
+    store.get_node_mut(id).unwrap().set_property(
+        "accession".to_string(),
+        PropertyValue::String("P12345".to_string()),
+    );
+
+    let stats = import_tenant_with_dedup(&mut store, &snapshot[..], &["accession"]).expect("import");
+
+    assert_eq!(stats.merged_count, 0, "no shared label, so no merge");
+    assert_eq!(store.all_nodes().len(), 2);
+}
+
+#[test]
+fn dedup_is_still_off_by_default() {
+    // Importing without dedup keys must not merge anything, regardless of labels.
+    let snapshot = snapshot_with_label_order("[\"ChemblTarget\",\"Protein\"]");
+    let mut store = uniprot_side();
+
+    let stats = import_tenant_with_dedup(&mut store, &snapshot[..], &[]).expect("import");
+
+    assert_eq!(stats.merged_count, 0);
+    assert_eq!(store.all_nodes().len(), 2);
+}


### PR DESCRIPTION
Fixes #317

## What was wrong

The dedup index was keyed `(first_label, key, value)` — and "first" came from iterating a **set**:

```rust
let label = node.labels.iter().next().map(...)      // pre-populate side
let first_label = snap_node.labels.first().cloned() // lookup side
```

Set order isn't a stable contract, so a dual-labelled node could be indexed under either label. When the two sides disagreed, the lookup missed and the merge **silently did not happen** — an unmerged duplicate, no error.

The concrete case from the biomedical federation: ChEMBL targets carry both `:ChemblTarget` and `:Protein` and merge against UniProt `:Protein` on `accession`. Whether that worked came down to iteration order on each side.

## The fix

Both sides use every label — the index holds an entry per label, and an incoming node is looked up under each of its own. A merge now depends on label **intersection**, which is order-independent.

Matching on *any* shared label is deliberately not the same as matching on the key alone: a `:Gene` and a `:Protein` that happen to share an accession are different entities and still don't merge. There's a test for that, plus one asserting dedup stays off when no keys are passed.

## The fixture matters here

My first reproduction proved nothing. Base `:Protein`, incoming `:ChemblTarget`+`:Protein`, exported normally — and it **merged fine without the fix**, because the snapshot's first label happened to come out as `Protein` that run. Left to chance it passes roughly half the time, which would have been a flaky test asserting a bug was fixed.

Label order in a snapshot is a plain JSON array, so the tests set it explicitly. That makes the failure deterministic:

| incoming label order | before | after |
|---|---|---|
| `["ChemblTarget","Protein"]` (shared label second) | **merged=0**, 2 nodes | merged=1, 1 node |
| `["Protein","ChemblTarget"]` (shared label first) | merged=1, 1 node | merged=1, 1 node |

The same data, the same keys — merging or not purely on label order. That table is the bug.

## Verified

- Test confirmed failing without the fix (`should merge on the shared :Protein label`)
- `cargo test --workspace`: **2461 passed, 0 failed**