### PR TITLE
fix(embed): auto-embed indexes under the target property, not the source

### DIFF
--- a/src/embed/client.rs
+++ b/src/embed/client.rs
@@ -231,6 +231,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 64,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         }
     }
 
@@ -266,6 +267,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 1536,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         let client = EmbeddingClient::new(&config);
         assert!(client.is_ok());
@@ -282,6 +284,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 768,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         let client = EmbeddingClient::new(&config);
         assert!(client.is_ok());
@@ -308,6 +311,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 768,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         let client = EmbeddingClient::new(&config);
         assert!(client.is_ok());
@@ -324,6 +328,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 768,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         let client = EmbeddingClient::new(&config);
         assert!(client.is_ok());
@@ -340,6 +345,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 1536,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         let client = EmbeddingClient::new(&config);
         // AzureOpenAI without api_base_url should fail
@@ -357,6 +363,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 1536,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         let client = EmbeddingClient::new(&config);
         assert!(client.is_ok());
@@ -373,6 +380,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 768,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         let client = EmbeddingClient::new(&config);
         assert!(client.is_ok());
@@ -421,6 +429,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 768,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         let client = EmbeddingClient::new(&config).unwrap();
         let result = client.generate_embeddings(&["test".to_string()]).await;
@@ -448,6 +457,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 1536,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         let client = EmbeddingClient::new(&config);
         assert!(client.is_ok());
@@ -526,6 +536,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 768,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         let client = EmbeddingClient::new(&config).unwrap();
         assert_eq!(client.api_base_url, "https://api.openai.com/v1");
@@ -540,6 +551,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 768,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         let client_ollama = EmbeddingClient::new(&config_ollama).unwrap();
         assert_eq!(client_ollama.api_base_url, "http://localhost:11434");
@@ -554,6 +566,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 768,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         let client_gemini = EmbeddingClient::new(&config_gemini).unwrap();
         assert_eq!(client_gemini.api_base_url, "https://generativelanguage.googleapis.com/v1beta");
@@ -568,6 +581,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 768,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         let client_anthropic = EmbeddingClient::new(&config_anthropic).unwrap();
         assert_eq!(client_anthropic.api_base_url, "https://api.anthropic.com/v1");
@@ -582,6 +596,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 768,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         let client_cc = EmbeddingClient::new(&config_cc).unwrap();
         assert_eq!(client_cc.api_base_url, "");
@@ -602,6 +617,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 768,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         let client = EmbeddingClient::new(&config).unwrap();
         assert_eq!(client.api_base_url, "https://proxy.example.com/v1");
@@ -618,6 +634,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 768,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         let client = EmbeddingClient::new(&config).unwrap();
         let result = client.generate_embeddings(&["test".to_string()]).await;

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -118,6 +118,7 @@ mod tests {
             chunk_overlap: 20,
             vector_dimension: 64,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         }
     }
 

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -675,17 +675,44 @@ impl GraphStore {
                                                 // Trigger Auto-Embed
                                                 let vector_index_clone = Arc::clone(&vector_index);
                                                 let label_str = label.as_str().to_string();
-                                                let key_clone = key.clone();
+                                                // The vector is indexed under the
+                                                // *target* property, not the source text
+                                                // property it was generated from: an index
+                                                // is created on `Person.embedding`, never
+                                                // on `Person.headline`, so indexing under
+                                                // the source key put every vector in an
+                                                // index nobody queried (#310).
+                                                let target_key = config.embedding_property.clone();
                                                 let text_clone = text.clone();
                                                 let config_clone = config.clone();
-                                                
+
                                                 tokio::spawn(async move {
-                                                    if let Ok(pipeline) = crate::embed::EmbedPipeline::new(config_clone) {
-                                                        if let Ok(chunks) = pipeline.process_text(&text_clone).await {
-                                                            for chunk in chunks {
-                                                                let _ = vector_index_clone.add_vector(&label_str, &key_clone, id, &chunk.embedding);
+                                                    match crate::embed::EmbedPipeline::new(config_clone) {
+                                                        Ok(pipeline) => match pipeline.process_text(&text_clone).await {
+                                                            Ok(chunks) => {
+                                                                for chunk in chunks {
+                                                                    if let Err(e) = vector_index_clone.add_vector(
+                                                                        &label_str,
+                                                                        &target_key,
+                                                                        id,
+                                                                        &chunk.embedding,
+                                                                    ) {
+                                                                        tracing::warn!(
+                                                                            "auto-embed: could not index {}.{} for node {}: {}",
+                                                                            label_str, target_key, id.as_u64(), e
+                                                                        );
+                                                                    }
+                                                                }
                                                             }
-                                                        }
+                                                            Err(e) => tracing::warn!(
+                                                                "auto-embed: embedding failed for {}.{}: {}",
+                                                                label_str, target_key, e
+                                                            ),
+                                                        },
+                                                        Err(e) => tracing::warn!(
+                                                            "auto-embed: pipeline unavailable for {}.{}: {}",
+                                                            label_str, target_key, e
+                                                        ),
                                                     }
                                                 });
                                             }
@@ -759,17 +786,36 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
                                         if keys.contains(&key) {
                                             let vector_index_clone = Arc::clone(&vector_index);
                                             let label_str = label.as_str().to_string();
-                                            let key_clone = key.clone();
+                                            // Index under the target property, not the
+                                            // source text property -- see NodeCreated.
+                                            let target_key = config.embedding_property.clone();
                                             let text_clone = text.clone();
                                             let config_clone = config.clone();
-                                            
+
                                             tokio::spawn(async move {
-                                                if let Ok(pipeline) = crate::embed::EmbedPipeline::new(config_clone) {
-                                                    if let Ok(chunks) = pipeline.process_text(&text_clone).await {
-                                                        if let Some(first) = chunks.first() {
-                                                            let _ = vector_index_clone.add_vector(&label_str, &key_clone, id, &first.embedding);
+                                                match crate::embed::EmbedPipeline::new(config_clone) {
+                                                    Ok(pipeline) => match pipeline.process_text(&text_clone).await {
+                                                        Ok(chunks) => {
+                                                            if let Some(first) = chunks.first() {
+                                                                if let Err(e) = vector_index_clone.add_vector(
+                                                                    &label_str, &target_key, id, &first.embedding,
+                                                                ) {
+                                                                    tracing::warn!(
+                                                                        "auto-embed: could not index {}.{} for node {}: {}",
+                                                                        label_str, target_key, id.as_u64(), e
+                                                                    );
+                                                                }
+                                                            }
                                                         }
-                                                    }
+                                                        Err(e) => tracing::warn!(
+                                                            "auto-embed: embedding failed for {}.{}: {}",
+                                                            label_str, target_key, e
+                                                        ),
+                                                    },
+                                                    Err(e) => tracing::warn!(
+                                                        "auto-embed: pipeline unavailable for {}.{}: {}",
+                                                        label_str, target_key, e
+                                                    ),
                                                 }
                                             });
                                         }
@@ -822,17 +868,36 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
                                         if keys.contains(&key) {
                                             let vector_index_clone = Arc::clone(&vector_index);
                                             let label_str = label.as_str().to_string();
-                                            let key_clone = key.clone();
+                                            // Index under the target property, not the
+                                            // source text property -- see NodeCreated.
+                                            let target_key = config.embedding_property.clone();
                                             let text_clone = text.clone();
                                             let config_clone = config.clone();
-                                            
+
                                             tokio::spawn(async move {
-                                                if let Ok(pipeline) = crate::embed::EmbedPipeline::new(config_clone) {
-                                                    if let Ok(chunks) = pipeline.process_text(&text_clone).await {
-                                                        if let Some(first) = chunks.first() {
-                                                            let _ = vector_index_clone.add_vector(&label_str, &key_clone, id, &first.embedding);
+                                                match crate::embed::EmbedPipeline::new(config_clone) {
+                                                    Ok(pipeline) => match pipeline.process_text(&text_clone).await {
+                                                        Ok(chunks) => {
+                                                            if let Some(first) = chunks.first() {
+                                                                if let Err(e) = vector_index_clone.add_vector(
+                                                                    &label_str, &target_key, id, &first.embedding,
+                                                                ) {
+                                                                    tracing::warn!(
+                                                                        "auto-embed: could not index {}.{} for node {}: {}",
+                                                                        label_str, target_key, id.as_u64(), e
+                                                                    );
+                                                                }
+                                                            }
                                                         }
-                                                    }
+                                                        Err(e) => tracing::warn!(
+                                                            "auto-embed: embedding failed for {}.{}: {}",
+                                                            label_str, target_key, e
+                                                        ),
+                                                    },
+                                                    Err(e) => tracing::warn!(
+                                                        "auto-embed: pipeline unavailable for {}.{}: {}",
+                                                        label_str, target_key, e
+                                                    ),
                                                 }
                                             });
                                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -585,6 +585,7 @@ async fn start_server() {
                 chunk_overlap,
                 vector_dimension: dimension,
                 embedding_policies: HashMap::new(),
+                embedding_property: "embedding".to_string(),
             };
 
             match EmbedPipeline::new(embed_config) {

--- a/src/persistence/tenant.rs
+++ b/src/persistence/tenant.rs
@@ -269,8 +269,20 @@ pub struct AutoEmbedConfig {
     pub chunk_overlap: usize,
     /// Vector dimension size
     pub vector_dimension: usize,
-    /// Embedding policies: Label -> `Vec<PropertyKey>`
+    /// Embedding policies: Label -> `Vec<PropertyKey>` (the *source* text properties)
     pub embedding_policies: HashMap<String, Vec<String>>,
+    /// Property the generated embedding is indexed under. Defaults to `embedding`.
+    ///
+    /// Auto-embed used to index the vector under the *source* property (`headline`), while
+    /// users naturally create their vector index on the property the embedding is called
+    /// (`embedding`) -- so the vectors landed in an index nobody queried, and search
+    /// returned nothing (#310). Naming the target explicitly removes the guess.
+    #[serde(default = "default_embedding_property")]
+    pub embedding_property: String,
+}
+
+fn default_embedding_property() -> String {
+    "embedding".to_string()
 }
 
 /// Tenant manager - manages all tenants and their resources
@@ -646,6 +658,7 @@ mod tests {
             chunk_overlap: 64,
             vector_dimension: 1536,
             embedding_policies: HashMap::from([("Document".to_string(), vec!["content".to_string()])]),
+            embedding_property: "embedding".to_string(),
         };
 
         manager.update_embed_config("tenant1", Some(embed_config)).unwrap();
@@ -1037,6 +1050,7 @@ mod tests {
             chunk_overlap: 32,
             vector_dimension: 1536,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         let result = manager.update_embed_config("ghost", Some(config));
         assert!(result.is_err());
@@ -1063,6 +1077,7 @@ mod tests {
             chunk_overlap: 32,
             vector_dimension: 768,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         };
         manager.update_embed_config("t1", Some(config)).unwrap();
         assert!(manager.get_tenant("t1").unwrap().embed_config.is_some());
@@ -1185,6 +1200,7 @@ mod tests {
             embedding_policies: HashMap::from([
                 ("Document".to_string(), vec!["content".to_string(), "title".to_string()]),
             ]),
+            embedding_property: "embedding".to_string(),
         };
         let json = serde_json::to_string(&config).unwrap();
         let deserialized: AutoEmbedConfig = serde_json::from_str(&json).unwrap();
@@ -1331,6 +1347,7 @@ mod tests {
             chunk_overlap: 128,
             vector_dimension: 768,
             embedding_policies: policies,
+            embedding_property: "embedding".to_string(),
         };
 
         assert_eq!(config.provider, LLMProvider::Ollama);
@@ -1462,6 +1479,7 @@ mod tests {
             chunk_overlap: 32,
             vector_dimension: 1536,
             embedding_policies: HashMap::new(),
+            embedding_property: "embedding".to_string(),
         });
         tenant.nlq_config = Some(NLQConfig {
             enabled: true,

--- a/src/vector/manager.rs
+++ b/src/vector/manager.rs
@@ -67,9 +67,22 @@ impl VectorIndexManager {
         node_id: NodeId,
         vector: &Vec<f32>,
     ) -> VectorResult<()> {
-        if let Some(index_lock) = self.get_index(label, property_key) {
-            let mut index = index_lock.write().unwrap();
-            index.add(node_id, vector)?;
+        match self.get_index(label, property_key) {
+            Some(index_lock) => {
+                let mut index = index_lock.write().unwrap();
+                index.add(node_id, vector)?;
+            }
+            // Returning Ok here made a vector added to a non-existent index indistinguishable
+            // from one that was stored, which is how auto-embed could generate thousands of
+            // embeddings that went nowhere without a single error (#310). Callers that treat
+            // a missing index as acceptable can still ignore the result; they can no longer
+            // do so unknowingly.
+            None => {
+                tracing::warn!(
+                    "no vector index for {}.{}; vector for node {} was not stored",
+                    label, property_key, node_id.as_u64()
+                );
+            }
         }
         Ok(())
     }

--- a/tests/auto_embed_indexing.rs
+++ b/tests/auto_embed_indexing.rs
@@ -1,0 +1,129 @@
+//! Auto-embed must put its vectors in the index a user actually queries (#310).
+//!
+//! The pipeline generated embeddings correctly — the reporter's Ollama received thousands
+//! of requests — but indexed each one under the *source* text property (`Person.headline`).
+//! Users create their vector index on the property the embedding is called
+//! (`Person.embedding`), so every vector went into an index nobody queried, and
+//! `add_vector` returned `Ok(())` for a missing index, so nothing ever said so.
+//!
+//! Uses the `Mock` provider, so no network and no model are involved.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::index::manager::IndexManager;
+use samyama::persistence::tenant::{AutoEmbedConfig, LLMProvider};
+use samyama::persistence::TenantManager;
+use samyama::vector::{DistanceMetric, VectorIndexManager};
+
+/// The Mock provider emits 64-dimensional vectors.
+const MOCK_DIM: usize = 64;
+
+fn embed_config(source_property: &str) -> AutoEmbedConfig {
+    AutoEmbedConfig {
+        provider: LLMProvider::Mock,
+        embedding_model: "mock".to_string(),
+        api_key: None,
+        api_base_url: None,
+        chunk_size: 512,
+        chunk_overlap: 0,
+        vector_dimension: MOCK_DIM,
+        embedding_policies: HashMap::from([(
+            "Person".to_string(),
+            vec![source_property.to_string()],
+        )]),
+        embedding_property: "embedding".to_string(),
+    }
+}
+
+#[tokio::test]
+async fn auto_embed_indexes_under_the_target_property() {
+    let tenants = Arc::new(TenantManager::new());
+    tenants
+        .update_embed_config("default", Some(embed_config("headline")))
+        .expect("set embed config");
+
+    let vector_index = Arc::new(VectorIndexManager::new());
+    let property_index = Arc::new(IndexManager::new());
+    // the index a user would create: on the embedding property, not the text it came from
+    vector_index
+        .create_index("Person", "embedding", MOCK_DIM, DistanceMetric::Cosine)
+        .expect("create index");
+
+    let (mut store, rx) = GraphStore::with_async_indexing();
+    let (vi, pi, tm) = (
+        Arc::clone(&vector_index),
+        Arc::clone(&property_index),
+        Arc::clone(&tenants),
+    );
+    tokio::spawn(async move { GraphStore::start_background_indexer(rx, vi, pi, tm).await });
+
+    let id = store.create_node("Person");
+    store
+        .set_node_property(
+            "default",
+            id,
+            "headline".to_string(),
+            PropertyValue::String("a graph database engineer".to_string()),
+        )
+        .expect("set property");
+
+    // auto-embed runs on a spawned task
+    tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+
+    let hits = vector_index
+        .search("Person", "embedding", &vec![0.1f32; MOCK_DIM], 5)
+        .expect("search");
+    assert_eq!(
+        hits.len(),
+        1,
+        "the generated embedding should be findable in the index that was created for it"
+    );
+
+    // and it must not have gone into an index keyed by the source text property
+    let source_hits = vector_index
+        .search("Person", "headline", &vec![0.1f32; MOCK_DIM], 5)
+        .expect("search");
+    assert!(source_hits.is_empty(), "nothing should be indexed under the source property");
+}
+
+#[tokio::test]
+async fn a_property_outside_the_policy_is_not_embedded() {
+    // The policy names which properties are embedding sources; anything else must be left
+    // alone, or every string write would hit the provider.
+    let tenants = Arc::new(TenantManager::new());
+    tenants
+        .update_embed_config("default", Some(embed_config("headline")))
+        .expect("set embed config");
+
+    let vector_index = Arc::new(VectorIndexManager::new());
+    vector_index
+        .create_index("Person", "embedding", MOCK_DIM, DistanceMetric::Cosine)
+        .expect("create index");
+
+    let (mut store, rx) = GraphStore::with_async_indexing();
+    let (vi, pi, tm) = (
+        Arc::clone(&vector_index),
+        Arc::new(IndexManager::new()),
+        Arc::clone(&tenants),
+    );
+    tokio::spawn(async move { GraphStore::start_background_indexer(rx, vi, pi, tm).await });
+
+    let id = store.create_node("Person");
+    store
+        .set_node_property(
+            "default",
+            id,
+            "nickname".to_string(), // not in the policy
+            PropertyValue::String("nobody".to_string()),
+        )
+        .expect("set property");
+
+    tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+
+    let hits = vector_index
+        .search("Person", "embedding", &vec![0.1f32; MOCK_DIM], 5)
+        .expect("search");
+    assert!(hits.is_empty(), "only policy properties should be embedded");
+}


### PR DESCRIPTION
Refs #310 — fixes vector search; see "what's left" below for the part I deliberately didn't do.

## Root cause

The pipeline was working. The reporter saw ~3,394 Ollama requests, and that was accurate — embeddings were being generated. They were then indexed under the **source text property**:

```rust
let _ = vector_index_clone.add_vector(&label_str, &key_clone, id, &chunk.embedding);
//                                                 ^^^^^^^^^^ "headline", not "embedding"
```

Nobody creates a vector index on `Person.headline`; you create it on `Person.embedding`. So every vector went into an index that didn't exist.

And nothing said so, because:

```rust
pub fn add_vector(...) -> VectorResult<()> {
    if let Some(index_lock) = self.get_index(label, property_key) { ... }
    Ok(())          // <-- missing index is indistinguishable from success
}
```

`Ok(())` for a missing index, and every caller writing `let _ =`. Thousands of embeddings could go nowhere without one error.

## Changes

- `AutoEmbedConfig` gains `embedding_property` (serde default `"embedding"`) — the target is now named rather than implied.
- All three auto-embed sites (`NodeCreated` and both `PropertySet` paths) index under it, and log at `warn` when the pipeline, the embedding call, or the insert fails.
- `add_vector` warns when the index doesn't exist.

That last change earned its keep immediately: the first run of the new test printed

```
WARN auto-embed: could not index Person.embedding for node 1: Dimension mismatch: expected 8, got 64
```

— a config error that had been silently swallowed until the log existed. That is very likely a second way real deployments lose embeddings.

## Verification

Tested with the `Mock` provider, so no network or model needed:

| | before | after |
|---|---|---|
| `search Person.embedding` | 0 neighbours | **1 neighbour** |
| `search Person.headline` | 0 | 0 |

Second test asserts a property outside the policy is *not* embedded, so the fix can't degrade into embedding every string write.

## What's left, and why

The embedding is still **not written to the node as a property**, so `MATCH (p:Person) WHERE p.embedding IS NOT NULL RETURN count(p)` remains 0, and embeddings don't survive a restart. The background indexer has no handle to a mutable store; giving it one means passing `Arc<RwLock<GraphStore>>` into a task the store itself feeds, which is a lifetime and deadlock question I'd rather not answer blind in the same change. Noted on the issue so it stays open for that.

## One correction to the report

The suspicion that `MERGE ... ON CREATE SET` was the trigger isn't it — a plain `CREATE` reproduces identically, which the reporter's own "quick check" had already hinted at.

## Verified

- `cargo test --workspace`: **2463 passed, 0 failed**
- New test confirmed failing without the fix