### PR TITLE
fix(http): answer Chrome's Private Network Access preflight

### DIFF
--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -44,6 +44,35 @@ async fn static_handler() -> impl IntoResponse {
     }
 }
 
+/// Answer Chrome's Private Network Access preflight.
+///
+/// A public HTTPS origin (the hosted Studio) may not call a loopback address unless the
+/// local server opts in. Chrome sends `Access-Control-Request-Private-Network: true` on the
+/// preflight and requires `Access-Control-Allow-Private-Network: true` back; without it the
+/// browser blocks the request before it ever reaches the container, which is the first
+/// thing a new user following the documented Docker setup hits (#342).
+///
+/// `CorsLayer` cannot do this -- tower-http has no PNA support -- so the header is added
+/// outside it, on the response it produces. Only echoed when the request actually asks for
+/// it, so ordinary same-origin traffic is unaffected.
+async fn allow_private_network(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let asked = req
+        .headers()
+        .get("access-control-request-private-network")
+        .is_some_and(|v| v.as_bytes().eq_ignore_ascii_case(b"true"));
+    let mut res = next.run(req).await;
+    if asked {
+        res.headers_mut().insert(
+            "access-control-allow-private-network",
+            axum::http::HeaderValue::from_static("true"),
+        );
+    }
+    res
+}
+
 /// Shared application state for HTTP routes
 #[derive(Clone)]
 pub struct AppState {
@@ -94,8 +123,31 @@ impl HttpServer {
         self
     }
 
+    /// Build the router this server serves, layers and all.
+    ///
+    /// Separate from `start` so tests can exercise the *shipped* stack. The existing HTTP
+    /// tests each assemble their own miniature router, which means anything that lives in a
+    /// layer -- CORS, the Private Network Access opt-in (#342) -- was untestable and
+    /// therefore untested.
+    pub fn router(&self) -> Router {
+        self.build_router()
+    }
+
     /// Start the HTTP server
     pub async fn start(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let app = self.build_router();
+
+        let addr = format!("0.0.0.0:{}", self.port);
+        let listener = tokio::net::TcpListener::bind(&addr).await?;
+
+        info!("Visualizer available at http://localhost:{}", self.port);
+
+        axum::serve(listener, app).await?;
+
+        Ok(())
+    }
+
+    fn build_router(&self) -> Router {
         let embed_cache: Arc<RwLock<HashMap<String, Arc<EmbedPipeline>>>> =
             Arc::new(RwLock::new(HashMap::new()));
 
@@ -137,16 +189,8 @@ impl HttpServer {
             app = app.merge(super::tenants::router(Arc::clone(tm), Arc::clone(&embed_cache)));
         }
 
-        let app = app.layer(CorsLayer::permissive());
-
-        let addr = format!("0.0.0.0:{}", self.port);
-        let listener = tokio::net::TcpListener::bind(&addr).await?;
-
-        info!("Visualizer available at http://localhost:{}", self.port);
-
-        axum::serve(listener, app).await?;
-
-        Ok(())
+        app.layer(CorsLayer::permissive())
+            .layer(axum::middleware::from_fn(allow_private_network))
     }
 }
 

--- a/tests/cors_private_network.rs
+++ b/tests/cors_private_network.rs
@@ -1,0 +1,84 @@
+//! Chrome Private Network Access preflight (#342).
+//!
+//! A public HTTPS origin — the hosted Studio — may not call a loopback address unless the
+//! local server opts in. Chrome sends `Access-Control-Request-Private-Network: true` on the
+//! preflight and requires `Access-Control-Allow-Private-Network: true` in reply; without it
+//! the request is blocked in the browser and never reaches the engine at all.
+//!
+//! `CorsLayer::permissive()` does not cover this — tower-http has no PNA support — so the
+//! header has to be added alongside it, and this test is what keeps it there.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use samyama::graph::GraphStore;
+use samyama::http::server::HttpServer;
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+
+fn app() -> axum::Router {
+    let store = Arc::new(RwLock::new(GraphStore::new()));
+    HttpServer::new(store, 0).router()
+}
+
+#[tokio::test]
+async fn preflight_from_a_public_origin_opts_into_the_loopback_address_space() {
+    let response = app()
+        .oneshot(
+            Request::builder()
+                .method("OPTIONS")
+                .uri("/api/status")
+                .header("Origin", "https://graph.samyama.cloud")
+                .header("Access-Control-Request-Method", "GET")
+                .header("Access-Control-Request-Private-Network", "true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.headers().get("access-control-allow-private-network"),
+        Some(&axum::http::HeaderValue::from_static("true")),
+        "preflight must opt in, or Chrome blocks the request before it reaches the engine"
+    );
+}
+
+#[tokio::test]
+async fn the_header_is_not_sent_when_it_was_not_asked_for() {
+    // Only echoed for requests that actually carry the PNA request header, so ordinary
+    // same-origin traffic is unaffected.
+    let response = app()
+        .oneshot(
+            Request::builder()
+                .method("OPTIONS")
+                .uri("/api/status")
+                .header("Origin", "https://graph.samyama.cloud")
+                .header("Access-Control-Request-Method", "GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(response
+        .headers()
+        .get("access-control-allow-private-network")
+        .is_none());
+}
+
+#[tokio::test]
+async fn a_normal_request_still_works() {
+    let response = app()
+        .oneshot(
+            Request::builder()
+                .uri("/api/status")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}


### PR DESCRIPTION
Fixes #342

## What was wrong

Chrome enforces Private Network Access: a public HTTPS origin may not call a loopback address unless the local server opts in. The preflight carries `Access-Control-Request-Private-Network: true` and needs `Access-Control-Allow-Private-Network: true` in reply.

We never sent it, so the browser blocked the request **before it reached the container** — the documented "run the engine in Docker, connect the hosted Studio to `localhost:8080`" flow failed at the very first request, for every user.

`CorsLayer::permissive()` can't help here; tower-http has no PNA support.

## The fix

A middleware layered *outside* CORS, so the header lands on the preflight response CORS itself generates. It's only echoed when the request actually carries the PNA request header, so ordinary same-origin traffic is unaffected.

## Why the suite couldn't have caught this

Every existing HTTP test builds its own miniature router:

```rust
fn test_app() -> (Router, AppState) {
    let app = Router::new()
        .route("/api/query", post(query_handler))
        .route("/api/status", get(status_handler))
        .with_state(state.clone());
    ...
}
```

No layers. So anything living in a layer — CORS, this header, body limits — was untestable and untested. Router construction now lives in `HttpServer::build_router`, exposed as `router()`, and the new tests drive **the stack that actually ships**.

Verified by deleting just the middleware line: `preflight must opt in, or Chrome blocks the request before it reaches the engine` — 1 failed. Restored: 3 passed.

## Tests

- preflight from a public origin gets the opt-in header
- the header is **not** sent when it wasn't asked for
- a normal request still returns 200

## Verified

- `cargo test --workspace`: **2466 passed, 0 failed**