### PR TITLE
fix(query): graph algorithms are callable under the names people type

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -7257,21 +7257,57 @@ impl AlgorithmOperator {
     }
 }
 
+impl AlgorithmOperator {
+    /// Canonical form of a procedure name for algorithm dispatch.
+    ///
+    /// Dispatch matched `"algo.pageRank"` exactly, so `algo.pagerank` -- the spelling
+    /// anyone would try first -- reported "Unknown algorithm" while the algorithm was
+    /// there all along (#198). The namespace is optional and the name is matched
+    /// case-insensitively, so `pagerank`, `algo.pagerank`, `algo.pageRank` and
+    /// `samyama.pageRank` all reach the same implementation.
+    pub fn canonical_name(name: &str) -> String {
+        let bare = name
+            .strip_prefix("algo.")
+            .or_else(|| name.strip_prefix("samyama."))
+            .or_else(|| name.strip_prefix("gds."))
+            .unwrap_or(name);
+        bare.to_ascii_lowercase()
+    }
+
+    /// Is this a name the algorithm operator can run?
+    pub fn is_algorithm(name: &str) -> bool {
+        matches!(
+            Self::canonical_name(name).as_str(),
+            "pagerank"
+                | "shortestpath"
+                | "wcc"
+                | "scc"
+                | "weightedpath"
+                | "maxflow"
+                | "mst"
+                | "trianglecount"
+                | "cdlp"
+                | "lcc"
+                | "or.solve"
+        )
+    }
+}
+
 impl PhysicalOperator for AlgorithmOperator {
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         if !self.executed {
-            match self.name.as_str() {
-                "algo.pageRank" => self.execute_pagerank(store)?,
-                "algo.shortestPath" => self.execute_shortest_path(store)?,
-                "algo.wcc" => self.execute_wcc(store)?,
-                "algo.scc" => self.execute_scc(store)?,
-                "algo.weightedPath" => self.execute_weighted_path(store)?,
-                "algo.maxFlow" => self.execute_max_flow(store)?,
-                "algo.mst" => self.execute_mst(store)?,
-                "algo.triangleCount" => self.execute_triangle_count(store)?,
-                "algo.cdlp" => self.execute_cdlp(store)?,
-                "algo.lcc" => self.execute_lcc(store)?,
-                "algo.or.solve" => return Err(ExecutionError::RuntimeError("algo.or.solve requires write access (MutQueryExecutor)".to_string())),
+            match Self::canonical_name(&self.name).as_str() {
+                "pagerank" => self.execute_pagerank(store)?,
+                "shortestpath" => self.execute_shortest_path(store)?,
+                "wcc" => self.execute_wcc(store)?,
+                "scc" => self.execute_scc(store)?,
+                "weightedpath" => self.execute_weighted_path(store)?,
+                "maxflow" => self.execute_max_flow(store)?,
+                "mst" => self.execute_mst(store)?,
+                "trianglecount" => self.execute_triangle_count(store)?,
+                "cdlp" => self.execute_cdlp(store)?,
+                "lcc" => self.execute_lcc(store)?,
+                "or.solve" => return Err(ExecutionError::RuntimeError("algo.or.solve requires write access (MutQueryExecutor)".to_string())),
                 _ => return Err(ExecutionError::RuntimeError(format!("Unknown algorithm: {}", self.name))),
             }
             self.executed = true;
@@ -7288,21 +7324,21 @@ impl PhysicalOperator for AlgorithmOperator {
 
     fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
          if !self.executed {
-            match self.name.as_str() {
-                "algo.or.solve" => self.execute_or_solve(store, tenant_id)?,
+            match Self::canonical_name(&self.name).as_str() {
+                "or.solve" => self.execute_or_solve(store, tenant_id)?,
                 // For read-only algos, we can just call the immutable implementations
                 // But we need to borrow store immutably.
                 // Since we have &mut store, we can reborrow as &store
-                "algo.pageRank" => self.execute_pagerank(store)?,
-                "algo.shortestPath" => self.execute_shortest_path(store)?,
-                "algo.wcc" => self.execute_wcc(store)?,
-                "algo.scc" => self.execute_scc(store)?,
-                "algo.weightedPath" => self.execute_weighted_path(store)?,
-                "algo.maxFlow" => self.execute_max_flow(store)?,
-                "algo.mst" => self.execute_mst(store)?,
-                "algo.triangleCount" => self.execute_triangle_count(store)?,
-                "algo.cdlp" => self.execute_cdlp(store)?,
-                "algo.lcc" => self.execute_lcc(store)?,
+                "pagerank" => self.execute_pagerank(store)?,
+                "shortestpath" => self.execute_shortest_path(store)?,
+                "wcc" => self.execute_wcc(store)?,
+                "scc" => self.execute_scc(store)?,
+                "weightedpath" => self.execute_weighted_path(store)?,
+                "maxflow" => self.execute_max_flow(store)?,
+                "mst" => self.execute_mst(store)?,
+                "trianglecount" => self.execute_triangle_count(store)?,
+                "cdlp" => self.execute_cdlp(store)?,
+                "lcc" => self.execute_lcc(store)?,
                 _ => return Err(ExecutionError::RuntimeError(format!("Unknown algorithm: {}", self.name))),
             }
             self.executed = true;

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -62,7 +62,7 @@ use std::sync::Mutex;
 use crate::query::executor::{
     ExecutionError, ExecutionResult, OperatorBox,
     // Added CreateNodeOperator and CreateNodesAndEdgesOperator for CREATE statement support
-    operator::{NodeScanOperator, FilterOperator, ExpandOperator, ProjectOperator, LimitOperator, SkipOperator, CreateNodeOperator, CreateNodesAndEdgesOperator, CartesianProductOperator, VectorSearchOperator, JoinOperator, LeftOuterJoinOperator, CreateVectorIndexOperator, CreateIndexOperator, CompositeCreateIndexOperator, CreateConstraintOperator, DropIndexOperator, ShowIndexesOperator, ShowConstraintsOperator, DistinctOperator, ShowLabelsOperator, ShowRelationshipTypesOperator, ShowPropertyKeysOperator, SchemaVisualizationOperator, AlgorithmOperator, IndexScanOperator, AggregateOperator, AggregateType, AggregateFunction, SortOperator, DeleteOperator, SetPropertyOperator, RemovePropertyOperator, UnwindOperator, MergeOperator, ForeachOperator, ShortestPathOperator, VarLengthExpandOperator, WithBarrierOperator, LabelCountOperator, EdgeTypeCountOperator},
+    operator::{NodeScanOperator, FilterOperator, ExpandOperator, ProjectOperator, LimitOperator, SkipOperator, CreateNodeOperator, CreateNodesAndEdgesOperator, CartesianProductOperator, VectorSearchOperator, JoinOperator, LeftOuterJoinOperator, CreateVectorIndexOperator, CreateIndexOperator, CompositeCreateIndexOperator, CreateConstraintOperator, DropIndexOperator, ShowIndexesOperator, ShowConstraintsOperator, DistinctOperator, ShowLabelsOperator, ShowRelationshipTypesOperator, ShowPropertyKeysOperator, SchemaVisualizationOperator, AlgorithmOperator, IndexScanOperator, AggregateOperator, AggregateType, AggregateFunction, AlgorithmOperator as _AlgoOp, SortOperator, DeleteOperator, SetPropertyOperator, RemovePropertyOperator, UnwindOperator, MergeOperator, ForeachOperator, ShortestPathOperator, VarLengthExpandOperator, WithBarrierOperator, LabelCountOperator, EdgeTypeCountOperator},
 };
 use crate::graph::EdgeType;  // Added for CREATE edge support
 use std::collections::{HashMap, HashSet};  // Added for CREATE properties and JOIN logic
@@ -1769,7 +1769,17 @@ impl QueryPlanner {
             Ok(Box::new(ShowPropertyKeysOperator::new()))
         } else if call_clause.procedure_name == "db.schema.visualization" {
             Ok(Box::new(SchemaVisualizationOperator::new()))
-        } else if call_clause.procedure_name.starts_with("algo.") {
+        } else if call_clause.procedure_name.starts_with("algo.")
+            || AlgorithmOperator::is_algorithm(&call_clause.procedure_name)
+        {
+            // Namespace optional and case-insensitive: `pagerank`, `algo.pagerank`,
+            // `algo.pageRank` and `samyama.pageRank` all route here. Routing on the
+            // `algo.` prefix alone meant `CALL pagerank()` never reached the operator and
+            // came back as "Unknown procedure" (#198).
+            //
+            // The prefix check is kept alongside so an unrecognised `algo.*` name still
+            // reaches the operator and gets the specific "Unknown algorithm" error rather
+            // than the generic "Unknown procedure".
             Ok(Box::new(AlgorithmOperator::new(
                 call_clause.procedure_name.clone(),
                 call_clause.arguments.clone(),

--- a/tests/algorithm_procedures.rs
+++ b/tests/algorithm_procedures.rs
@@ -1,0 +1,120 @@
+//! Graph algorithms are reachable from Cypher under the names people actually type (#198).
+//!
+//! Dispatch matched `"algo.pageRank"` *exactly*, so `algo.pagerank` — the first spelling
+//! anyone tries — returned "Unknown algorithm" while the implementation sat right there,
+//! and the bare `CALL pagerank()` never even reached the operator ("Unknown procedure").
+//! The algorithm crate's own 38 unit tests all passed throughout; nothing exercised the
+//! path from Cypher to them.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::record::Value;
+use samyama::query::QueryEngine;
+
+/// 5 nodes, edges 0→1, 1→2, 3→1, leaving node 4 isolated.
+fn fixture() -> GraphStore {
+    let engine = QueryEngine::new();
+    let mut store = GraphStore::new();
+    for i in 0..5 {
+        engine
+            .execute_mut(&format!("CREATE (:N {{id: {i}}})"), &mut store, "default")
+            .unwrap();
+    }
+    for (a, b) in [(0, 1), (1, 2), (3, 1)] {
+        engine
+            .execute_mut(
+                &format!("MATCH (a:N {{id: {a}}}), (b:N {{id: {b}}}) CREATE (a)-[:R]->(b)"),
+                &mut store, "default",
+            )
+            .unwrap();
+    }
+    store
+}
+
+#[test]
+fn pagerank_is_callable_under_every_reasonable_spelling() {
+    let store = fixture();
+    let engine = QueryEngine::new();
+
+    for spelling in [
+        "CALL pagerank() YIELD node, score RETURN node, score",
+        "CALL algo.pagerank() YIELD node, score RETURN node, score",
+        "CALL algo.pageRank() YIELD node, score RETURN node, score",
+        "CALL samyama.pagerank() YIELD node, score RETURN node, score",
+        "CALL PAGERANK() YIELD node, score RETURN node, score",
+    ] {
+        let batch = engine
+            .execute(spelling, &store)
+            .unwrap_or_else(|e| panic!("{spelling}\n  {e}"));
+        assert_eq!(batch.records.len(), 5, "one row per node: {spelling}");
+    }
+}
+
+#[test]
+fn pagerank_actually_ranks() {
+    // A count of rows would pass even if every score were identical, or zero. Node 1 has
+    // two in-edges and must outrank the isolated node 4.
+    let store = fixture();
+    let engine = QueryEngine::new();
+
+    let batch = engine
+        .execute("CALL pagerank() YIELD node, score RETURN node, score", &store)
+        .unwrap();
+
+    let scores: Vec<f64> = batch
+        .records
+        .iter()
+        .filter_map(|r| match r.get("score") {
+            Some(Value::Property(PropertyValue::Float(f))) => Some(*f),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(scores.len(), 5);
+
+    let mut distinct: Vec<String> = scores.iter().map(|s| format!("{s:.6}")).collect();
+    distinct.sort();
+    distinct.dedup();
+    assert!(distinct.len() > 1, "all scores identical — did it run? {scores:?}");
+
+    let max = scores.iter().cloned().fold(f64::MIN, f64::max);
+    let min = scores.iter().cloned().fold(f64::MAX, f64::min);
+    assert!(max > min, "no ranking at all: {scores:?}");
+}
+
+#[test]
+fn other_algorithms_are_reachable_too() {
+    let store = fixture();
+    let engine = QueryEngine::new();
+
+    let wcc = engine
+        .execute("CALL algo.wcc() YIELD node, componentId RETURN node, componentId", &store)
+        .expect("wcc");
+    assert_eq!(wcc.records.len(), 5);
+
+    // case-insensitive here as well
+    let wcc_upper = engine
+        .execute("CALL algo.WCC() YIELD node, componentId RETURN node, componentId", &store)
+        .expect("WCC");
+    assert_eq!(wcc_upper.records.len(), 5);
+}
+
+#[test]
+fn an_unknown_algorithm_still_errors() {
+    // Leniency about spelling must not turn into running the wrong thing, and an
+    // unrecognised name under `algo.` keeps the specific error rather than the generic
+    // "Unknown procedure".
+    let store = fixture();
+    let engine = QueryEngine::new();
+
+    let err = engine
+        .execute("CALL algo.nonExistent() YIELD x RETURN x", &store)
+        .expect_err("should not resolve");
+    assert!(
+        format!("{err}").contains("Unknown algorithm"),
+        "expected an algorithm-specific error, got: {err}"
+    );
+
+    let err = engine
+        .execute("CALL notAProcedure() YIELD x RETURN x", &store)
+        .expect_err("should not resolve");
+    assert!(format!("{err}").contains("Unknown"), "got: {err}");
+}


### PR DESCRIPTION
Fixes #198

## What was wrong

Dispatch matched exact string literals:

```rust
match self.name.as_str() {
    "algo.pageRank" => self.execute_pagerank(store)?,
    ...
```

So:

| call | before | after |
|---|---|---|
| `CALL pagerank()` | `Unknown procedure` | ✅ 5 rows |
| `CALL algo.pagerank()` | `Unknown algorithm` | ✅ 5 rows |
| `CALL algo.pageRank()` | ✅ | ✅ |
| `CALL samyama.pagerank()` | `Unknown procedure` | ✅ 5 rows |
| `CALL PAGERANK()` | `Unknown procedure` | ✅ 5 rows |

The reporter's observation that the error message *changed* between `pagerank` and `algo.pagerank` was exactly right, and it identified the shape of the bug: the namespace was recognised, the name wasn't.

## The fix

Names are canonicalised before dispatch — optional `algo.` / `samyama.` / `gds.` namespace, matched case-insensitively. The planner routes on "is this a known algorithm" **as well as** the `algo.` prefix, so an unrecognised `algo.*` name still produces the specific `Unknown algorithm` error instead of falling through to the generic `Unknown procedure`. An existing test asserts that distinction, and caught me when my first version dropped it.

## Why it survived

The algorithm crate ships 38 unit tests and they all passed the whole time — `cargo test --workspace` was green. Nothing exercised the path *from Cypher* to them, so a table of exact string literals could drift from the documented spelling without a single failure.

The new tests go through Cypher, and one of them asserts PageRank genuinely **ranks**:

```rust
assert!(distinct.len() > 1, "all scores identical — did it run?");
assert!(max > min, "no ranking at all");
```

A row count would pass even if every score came back identical or zero — which is precisely the failure mode a "did the procedure resolve?" test would miss.

## Verified

- `cargo test --workspace`: **2466 passed, 0 failed**
- PageRank on a 5-node fixture (0→1, 1→2, 3→1, node 4 isolated): 5 rows, 3 distinct scores, top 0.3663
- `algo.wcc()` and `algo.WCC()` both return 5 rows