### PR TITLE
feat(query): CREATE property values may be expressions

### DIFF
--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -276,6 +276,14 @@ pub struct NodePattern {
     pub labels: Vec<Label>,
     /// Property constraints
     pub properties: Option<HashMap<String, PropertyValue>>,
+    /// Property values that are not literals, e.g. `{n: p.n}` or `{id: row.id}`.
+    ///
+    /// Kept separate from `properties` so the literal case -- the overwhelming majority,
+    /// and the only one usable for an index lookup -- keeps its concrete `PropertyValue`
+    /// and every existing consumer is unaffected. Only CREATE and MERGE evaluate these,
+    /// once per row; a MATCH pattern carrying one is rejected in planning rather than
+    /// silently ignoring the constraint.
+    pub property_exprs: Option<HashMap<String, Expression>>,
 }
 
 /// Edge pattern: -[:KNOWS|FOLLOWS*1..5]->
@@ -291,6 +299,14 @@ pub struct EdgePattern {
     pub length: Option<LengthPattern>,
     /// Property constraints
     pub properties: Option<HashMap<String, PropertyValue>>,
+    /// Property values that are not literals, e.g. `{n: p.n}` or `{id: row.id}`.
+    ///
+    /// Kept separate from `properties` so the literal case -- the overwhelming majority,
+    /// and the only one usable for an index lookup -- keeps its concrete `PropertyValue`
+    /// and every existing consumer is unaffected. Only CREATE and MERGE evaluate these,
+    /// once per row; a MATCH pattern carrying one is rejected in planning rather than
+    /// silently ignoring the constraint.
+    pub property_exprs: Option<HashMap<String, Expression>>,
 }
 
 /// Edge direction
@@ -690,6 +706,7 @@ mod tests {
             variable: Some("n".to_string()),
             labels: vec![Label::new("Person")],
             properties: None,
+            property_exprs: None,
         };
         assert_eq!(pattern.variable, Some("n".to_string()));
         assert_eq!(pattern.labels.len(), 1);

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -128,7 +128,14 @@ range_pattern = { integer? ~ ".." ~ integer? }
 // Properties: {name: "Alice", age: 30}
 properties = { "{" ~ property_list? ~ "}" }
 property_list = { property ~ ("," ~ property)* }
-property = { property_key ~ ":" ~ value }
+// A property value may be any expression, not only a literal: `CREATE (:Q {n: p.n})`
+// and `UNWIND $rows AS row CREATE (:N {id: row.id})` both need to read a bound
+// variable. `value` is tried first so literals -- the overwhelming majority, and the
+// ones usable for index lookup -- keep parsing to a literal exactly as before.
+property = { property_key ~ ":" ~ (value ~ !expression_continues | expression) }
+// A literal followed by an operator is really the start of an expression
+// (`{n: 1 + 2}`), so `value` must not win in that case.
+expression_continues = { "+" | "-" | "*" | "/" | "%" | "." | "[" | "=" | "<" | ">" | "!" }
 property_key = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 // RETURN items

--- a/src/query/executor/logical_plan.rs
+++ b/src/query/executor/logical_plan.rs
@@ -448,6 +448,7 @@ mod tests {
                 variable: Some(start_var.to_string()),
                 labels: start_labels,
                 properties: None,
+                property_exprs: None,
             },
             segments,
         }
@@ -461,11 +462,13 @@ mod tests {
                 direction: dir,
                 length: None,
                 properties: None,
+                property_exprs: None,
             },
             node: NodePattern {
                 variable: Some(node_var.to_string()),
                 labels: node_labels,
                 properties: None,
+                property_exprs: None,
             },
         }
     }

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -5390,7 +5390,7 @@ impl PhysicalOperator for LeftOuterJoinOperator {
 /// Create node operator: CREATE (n:Person {name: "Alice"})
 pub struct CreateNodeOperator {
     /// Nodes to create (label, properties, variable)
-    nodes_to_create: Vec<(Vec<Label>, HashMap<String, PropertyValue>, Option<String>)>,
+    nodes_to_create: Vec<(Vec<Label>, HashMap<String, PropertyValue>, Option<String>, Option<HashMap<String, Expression>>)>,
     /// Created node IDs (for returning)
     created_nodes: Vec<(NodeId, Option<String>)>,
     /// Current index for iteration
@@ -5401,7 +5401,14 @@ pub struct CreateNodeOperator {
 
 impl CreateNodeOperator {
     /// Create a new CreateNodeOperator
-    pub fn new(nodes: Vec<(Vec<Label>, HashMap<String, PropertyValue>, Option<String>)>) -> Self {
+    pub fn new(
+        nodes: Vec<(
+            Vec<Label>,
+            HashMap<String, PropertyValue>,
+            Option<String>,
+            Option<HashMap<String, Expression>>,
+        )>,
+    ) -> Self {
         Self {
             nodes_to_create: nodes,
             created_nodes: Vec::new(),
@@ -5422,7 +5429,7 @@ impl PhysicalOperator for CreateNodeOperator {
     fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
         // First call: create all nodes
         if !self.executed {
-            for (labels, properties, variable) in &self.nodes_to_create {
+            for (labels, properties, variable, property_exprs) in &self.nodes_to_create {
                 // Use first label as primary, or empty string if none
                 let primary_label = labels.first()
                     .map(|l| l.clone())
@@ -5435,8 +5442,30 @@ impl PhysicalOperator for CreateNodeOperator {
                     let _ = store.add_label_to_node(tenant_id, node_id, label.clone());
                 }
 
+                // A CREATE with no input row has nothing bound, so a non-literal value can
+                // only be a constant (`{n: 1 + 2}`). Anything referring to a variable is an
+                // error rather than a silent null -- quietly storing nothing for a property
+                // is the failure this change exists to remove.
+                let mut evaluated: HashMap<String, PropertyValue> = HashMap::new();
+                if let Some(exprs) = property_exprs {
+                    let empty = Record::new();
+                    for (key, expr) in exprs {
+                        match eval_expression(expr, &empty, store) {
+                            Ok(Value::Property(p)) => {
+                                evaluated.insert(key.clone(), p);
+                            }
+                            _ => {
+                                let _ = store.delete_node(tenant_id, node_id);
+                                return Err(ExecutionError::RuntimeError(format!(
+                                    "CREATE property `{key}` refers to a variable that is not bound here; bind it first with MATCH, WITH or UNWIND"
+                                )));
+                            }
+                        }
+                    }
+                }
+
                 // Set properties using store.set_node_property to trigger indexing
-                for (key, value) in properties {
+                for (key, value) in properties.iter().chain(evaluated.iter()) {
                     if let Err(e) = store.set_node_property(tenant_id, node_id, key.clone(), value.clone())
                     {
                         // A rejected property must not leave a half-built node behind.
@@ -6396,7 +6425,7 @@ pub struct MatchCreateEdgeOperator {
     /// created fresh for every matched row: (handle, labels, properties). Previously these
     /// were ignored entirely, so `MATCH (p) CREATE (p)-[:R]->(c:C {..})` created neither
     /// the node nor the edge and reported success.
-    nodes_to_create: Vec<(String, Vec<Label>, HashMap<String, PropertyValue>)>,
+    nodes_to_create: Vec<(String, Vec<Label>, HashMap<String, PropertyValue>, Option<HashMap<String, Expression>>)>,
     /// Edges to create: (source_var, target_var, edge_type, properties, edge_var)
     edges_to_create: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>)>,
     /// Whether edges have been created for current batch
@@ -6421,7 +6450,7 @@ impl MatchCreateEdgeOperator {
     /// reference them exactly like a matched variable.
     pub fn with_nodes(
         input: OperatorBox,
-        nodes_to_create: Vec<(String, Vec<Label>, HashMap<String, PropertyValue>)>,
+        nodes_to_create: Vec<(String, Vec<Label>, HashMap<String, PropertyValue>, Option<HashMap<String, Expression>>)>,
         edges_to_create: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>)>,
     ) -> Self {
         Self {
@@ -6450,7 +6479,7 @@ impl PhysicalOperator for MatchCreateEdgeOperator {
                 // bind is a *new* node for this row. Bind it under its handle first; the
                 // edge wiring below then treats it exactly like a matched variable.
                 let mut record = record;
-                for (handle, labels, properties) in &self.nodes_to_create {
+                for (handle, labels, properties, property_exprs) in &self.nodes_to_create {
                     let primary_label = labels
                         .first()
                         .cloned()
@@ -6459,7 +6488,26 @@ impl PhysicalOperator for MatchCreateEdgeOperator {
                     for label in labels.iter().skip(1) {
                         let _ = store.add_label_to_node(tenant_id, node_id, label.clone());
                     }
-                    for (key, value) in properties {
+                    // Non-literal property values (`{id: row.id}`) are evaluated against
+                    // this row, so each created node gets the value belonging to its own
+                    // match rather than a constant.
+                    let mut evaluated: HashMap<String, PropertyValue> = HashMap::new();
+                    if let Some(exprs) = property_exprs {
+                        for (key, expr) in exprs {
+                            let value = eval_expression(expr, &record, store)?;
+                            let pv = match value {
+                                Value::Property(p) => p,
+                                Value::Null => PropertyValue::Null,
+                                other => {
+                                    return Err(ExecutionError::TypeError(format!(
+                                        "property `{key}` must be a scalar, got {other:?}"
+                                    )))
+                                }
+                            };
+                            evaluated.insert(key.clone(), pv);
+                        }
+                    }
+                    for (key, value) in properties.iter().chain(evaluated.iter()) {
                         if let Err(e) = store.set_node_property(tenant_id, node_id, key.clone(), value.clone())
                         {
                             // A rejected property must not leave a half-built node behind.

--- a/src/query/executor/plan_enumerator.rs
+++ b/src/query/executor/plan_enumerator.rs
@@ -376,6 +376,7 @@ mod tests {
                 variable: Some(start_var.to_string()),
                 labels: start_labels,
                 properties: None,
+                property_exprs: None,
             },
             segments,
         }
@@ -389,11 +390,13 @@ mod tests {
                 direction: dir,
                 length: None,
                 properties: None,
+                property_exprs: None,
             },
             node: NodePattern {
                 variable: Some(node_var.to_string()),
                 labels: node_labels,
                 properties: None,
+                property_exprs: None,
             },
         }
     }

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -510,7 +510,53 @@ impl QueryPlanner {
     /// each individually capable of dropping the flag on the floor — which is how
     /// `RETURN DISTINCT` came to be a complete no-op (#311). One choke point cannot
     /// forget.
+    /// Reject non-literal property values where they are not yet evaluated.
+    ///
+    /// CREATE evaluates them per row; MATCH and MERGE patterns do not. Until they do, a
+    /// pattern carrying one has to be an error: silently dropping the constraint means
+    /// `MATCH (p:P {n: x})` returns every `:P` rather than the matching one, which looks
+    /// like a working query returning too much.
+    fn reject_unevaluated_property_exprs(query: &Query) -> ExecutionResult<()> {
+        let complain = |clause: &str, key: &str| {
+            ExecutionError::PlanningError(format!(
+                "{clause} does not yet support a non-literal property value (`{key}`); use a WHERE comparison instead"
+            ))
+        };
+
+        for mc in &query.match_clauses {
+            for path in &mc.pattern.paths {
+                if let Some(key) = path.start.property_exprs.as_ref().and_then(|e| e.keys().next()) {
+                    return Err(complain("MATCH", key));
+                }
+                for seg in &path.segments {
+                    if let Some(key) = seg.node.property_exprs.as_ref().and_then(|e| e.keys().next()) {
+                        return Err(complain("MATCH", key));
+                    }
+                    if let Some(key) = seg.edge.property_exprs.as_ref().and_then(|e| e.keys().next()) {
+                        return Err(complain("MATCH", key));
+                    }
+                }
+            }
+        }
+
+        if let Some(merge) = &query.merge_clause {
+            for path in &merge.pattern.paths {
+                if let Some(key) = path.start.property_exprs.as_ref().and_then(|e| e.keys().next()) {
+                    return Err(complain("MERGE", key));
+                }
+                for seg in &path.segments {
+                    if let Some(key) = seg.node.property_exprs.as_ref().and_then(|e| e.keys().next()) {
+                        return Err(complain("MERGE", key));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn plan(&self, query: &Query, store: &GraphStore) -> ExecutionResult<ExecutionPlan> {
+        Self::reject_unevaluated_property_exprs(query)?;
         let mut plan = self.plan_inner(query, store)?;
         if query.return_clause.as_ref().is_some_and(|r| r.distinct) {
             plan.root = Box::new(DistinctOperator::new(plan.root));
@@ -758,8 +804,16 @@ impl QueryPlanner {
             }
         }
 
-        // Handle CREATE-only queries (no MATCH/CALL required)
-        if query.match_clauses.is_empty() && query.call_clause.is_none() {
+        // Handle CREATE-only queries (no MATCH/CALL required).
+        //
+        // A leading UNWIND is excluded: `UNWIND $rows AS row CREATE (:N {id: row.id})` has
+        // no MATCH but is still row-driven, and planning it as a CREATE-only statement runs
+        // it once with nothing bound. It falls through to the general pipeline, where the
+        // Unwind feeds the create.
+        if query.match_clauses.is_empty()
+            && query.call_clause.is_none()
+            && query.unwind_clause.is_none()
+        {
             if let Some(create_clause) = &query.create_clause {
                 let mut plan = self.plan_create_only(create_clause)?;
                 // CY-12: Wrap with ProjectOperator if RETURN clause is present
@@ -1316,15 +1370,24 @@ impl QueryPlanner {
             }
 
             // Nodes to create per matched row: (handle, labels, properties)
-            let mut nodes_to_create: Vec<(String, Vec<Label>, HashMap<String, PropertyValue>)> =
-                Vec::new();
+            let mut nodes_to_create: Vec<(
+                String,
+                Vec<Label>,
+                HashMap<String, PropertyValue>,
+                Option<HashMap<String, Expression>>,
+            )> = Vec::new();
             let mut anon_seq = 0usize;
 
             // Assign a handle to a CREATE-pattern node, registering it for creation when
             // the MATCH did not bind it. Anonymous nodes get a synthetic handle so an edge
             // can still be wired to them.
             let mut handle_for = |node: &crate::query::ast::NodePattern,
-                                  nodes_to_create: &mut Vec<(String, Vec<Label>, HashMap<String, PropertyValue>)>,
+                                  nodes_to_create: &mut Vec<(
+                String,
+                Vec<Label>,
+                HashMap<String, PropertyValue>,
+                Option<HashMap<String, Expression>>,
+            )>,
                                   anon_seq: &mut usize|
              -> String {
                 match &node.variable {
@@ -1334,6 +1397,7 @@ impl QueryPlanner {
                             v.clone(),
                             node.labels.clone(),
                             node.properties.clone().unwrap_or_default(),
+                            node.property_exprs.clone(),
                         ));
                         v.clone()
                     }
@@ -1344,6 +1408,7 @@ impl QueryPlanner {
                             h.clone(),
                             node.labels.clone(),
                             node.properties.clone().unwrap_or_default(),
+                            node.property_exprs.clone(),
                         ));
                         h
                     }
@@ -2855,7 +2920,12 @@ impl QueryPlanner {
 
         // Collect all nodes to create from the pattern
         // Each node has: (labels, properties, variable_name)
-        let mut nodes_to_create: Vec<(Vec<Label>, HashMap<String, PropertyValue>, Option<String>)> = Vec::new();
+        let mut nodes_to_create: Vec<(
+            Vec<Label>,
+            HashMap<String, PropertyValue>,
+            Option<String>,
+            Option<HashMap<String, Expression>>,
+        )> = Vec::new();
         let mut output_columns: Vec<String> = Vec::new();
 
         // Collect edges to create: (source_var, target_var, edge_type, properties, edge_var)
@@ -2906,7 +2976,12 @@ impl QueryPlanner {
                 Some(v) => v.clone(),
                 None => next_anon(&declared),
             };
-            nodes_to_create.push((labels, properties, Some(start_handle.clone())));
+            nodes_to_create.push((
+                labels,
+                properties,
+                Some(start_handle.clone()),
+                start.property_exprs.clone(),
+            ));
 
             // Track current source variable for edge creation
             let mut current_source_var = Some(start_handle);
@@ -2927,7 +3002,12 @@ impl QueryPlanner {
                     Some(v) => v.clone(),
                     None => next_anon(&declared),
                 };
-                nodes_to_create.push((node_labels, node_properties, Some(node_handle.clone())));
+                nodes_to_create.push((
+                    node_labels,
+                    node_properties,
+                    Some(node_handle.clone()),
+                    node.property_exprs.clone(),
+                ));
 
                 // Extract edge information
                 let edge = &segment.edge;

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1138,6 +1138,7 @@ fn parse_node(pair: pest::iterators::Pair<Rule>) -> ParseResult<NodePattern> {
     let mut variable = None;
     let mut labels = Vec::new();
     let mut properties = None;
+    let mut property_exprs = None;
 
     for inner in pair.into_inner() {
         match inner.as_rule() {
@@ -1152,7 +1153,9 @@ fn parse_node(pair: pest::iterators::Pair<Rule>) -> ParseResult<NodePattern> {
                 }
             }
             Rule::properties => {
-                properties = Some(parse_properties(inner)?);
+                let (literals, exprs) = parse_properties_split(inner)?;
+                properties = Some(literals);
+                property_exprs = exprs;
             }
             _ => {}
         }
@@ -1162,6 +1165,7 @@ fn parse_node(pair: pest::iterators::Pair<Rule>) -> ParseResult<NodePattern> {
         variable,
         labels,
         properties,
+        property_exprs,
     })
 }
 
@@ -1179,6 +1183,7 @@ fn parse_edge(pair: pest::iterators::Pair<Rule>) -> ParseResult<EdgePattern> {
     let mut types = Vec::new();
     let mut length = None;
     let mut properties = None;
+    let mut property_exprs = None;
 
     for inner in pair.into_inner() {
         if inner.as_rule() == Rule::edge_detail {
@@ -1198,7 +1203,9 @@ fn parse_edge(pair: pest::iterators::Pair<Rule>) -> ParseResult<EdgePattern> {
                         length = Some(parse_length_pattern(detail)?);
                     }
                     Rule::properties => {
-                        properties = Some(parse_properties(detail)?);
+                        let (literals, exprs) = parse_properties_split(detail)?;
+                        properties = Some(literals);
+                        property_exprs = exprs;
                     }
                     _ => {}
                 }
@@ -1212,6 +1219,7 @@ fn parse_edge(pair: pest::iterators::Pair<Rule>) -> ParseResult<EdgePattern> {
         direction,
         length,
         properties,
+        property_exprs,
     })
 }
 
@@ -1250,6 +1258,45 @@ fn parse_length_pattern(pair: pest::iterators::Pair<Rule>) -> ParseResult<Length
     })
 }
 
+/// Split a property map into literal values and expression values.
+///
+/// Literals keep their concrete `PropertyValue` -- they are the majority and the only form
+/// usable for an index lookup -- while anything referring to a bound variable
+/// (`{n: p.n}`, `{id: row.id}`) is returned separately for CREATE/MERGE to evaluate per
+/// row. Returning `(literals, exprs)` rather than converting everything to expressions
+/// keeps all existing consumers of `properties` working unchanged.
+type SplitProperties = (HashMap<String, PropertyValue>, Option<HashMap<String, Expression>>);
+
+fn parse_properties_split(pair: pest::iterators::Pair<Rule>) -> ParseResult<SplitProperties> {
+    let mut literals = HashMap::new();
+    let mut exprs: HashMap<String, Expression> = HashMap::new();
+
+    for inner in pair.into_inner() {
+        if inner.as_rule() == Rule::property_list {
+            for prop in inner.into_inner() {
+                if prop.as_rule() == Rule::property {
+                    let mut key = String::new();
+                    for part in prop.into_inner() {
+                        match part.as_rule() {
+                            Rule::property_key => key = part.as_str().to_string(),
+                            Rule::value => {
+                                literals.insert(key.clone(), parse_value(part)?);
+                            }
+                            Rule::expression => {
+                                exprs.insert(key.clone(), parse_expression(part)?);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok((literals, if exprs.is_empty() { None } else { Some(exprs) }))
+}
+
+#[allow(dead_code)]
 fn parse_properties(pair: pest::iterators::Pair<Rule>) -> ParseResult<HashMap<String, PropertyValue>> {
     let mut props = HashMap::new();
 

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -1573,3 +1573,101 @@ fn an_embedding_written_with_whole_numbers_is_still_indexable() {
         .execute_mut("CREATE VECTOR INDEX myidx FOR (d:D) ON (d.emb)", &mut s2, "default")
         .unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// CREATE property values may be expressions (#408)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn create_can_derive_property_values_from_bound_variables() {
+    // Pattern property values had to be literals, so a node could only ever be created with
+    // constants: `CREATE (:Q {n: p.n})` was a parse error while `SET p.m = p.n` was fine.
+    // That ruled out copy/derive writes and, with UNWIND, batch writes entirely.
+    let mut s = GraphStore::new();
+    let engine = QueryEngine::new();
+    engine
+        .execute_mut("CREATE (:P {n: 1, name: \"a\"})", &mut s, "default")
+        .unwrap();
+
+    engine.execute_mut("MATCH (p:P) CREATE (:Q {n: p.n})", &mut s, "default").unwrap();
+    assert_eq!(scalar(&s, "MATCH (q:Q) RETURN q.n AS v"), "v=1");
+
+    engine.execute_mut("MATCH (p:P) CREATE (:R {n: p.n + 10})", &mut s, "default").unwrap();
+    assert_eq!(scalar(&s, "MATCH (r:R) RETURN r.n AS v"), "v=11");
+
+    engine.execute_mut("MATCH (p:P) CREATE (:S {label: p.name})", &mut s, "default").unwrap();
+    assert_eq!(scalar(&s, "MATCH (x:S) RETURN x.label AS v"), "v=a");
+
+    // literals are unaffected
+    engine.execute_mut("MATCH (p:P) CREATE (:T {n: 5})", &mut s, "default").unwrap();
+    assert_eq!(scalar(&s, "MATCH (t:T) RETURN t.n AS v"), "v=5");
+}
+
+#[test]
+fn unwind_drives_a_batch_create() {
+    // The batch-write idiom from #307. It needs both a leading UNWIND *and* a non-literal
+    // property value; with either missing it runs once with nothing bound.
+    let mut s = GraphStore::new();
+    let engine = QueryEngine::new();
+
+    engine
+        .execute_mut("UNWIND [1, 2, 3] AS x CREATE (:N {id: x})", &mut s, "default")
+        .unwrap();
+
+    assert_eq!(scalar(&s, "MATCH (n:N) RETURN count(n) AS n"), "n=3");
+    let mut ids = bag(&s, "MATCH (n:N) RETURN n.id AS id");
+    ids.sort();
+    assert_eq!(ids, vec!["id=1", "id=2", "id=3"]);
+
+    // one row per unwound value, each carrying its own value — not three copies of one
+    engine
+        .execute_mut("UNWIND [7, 8] AS x CREATE (:M {id: x, doubled: x * 2})", &mut s, "default")
+        .unwrap();
+    let mut rows = bag(&s, "MATCH (m:M) RETURN m.id AS id, m.doubled AS doubled");
+    rows.sort();
+    assert_eq!(rows, vec!["doubled=14 id=7", "doubled=16 id=8"]);
+}
+
+#[test]
+fn a_constant_expression_is_allowed_but_an_unbound_variable_is_refused() {
+    let mut s = GraphStore::new();
+    let engine = QueryEngine::new();
+
+    // nothing bound, but a constant needs nothing bound
+    engine.execute_mut("CREATE (:C {n: 1 + 2})", &mut s, "default").unwrap();
+    assert_eq!(scalar(&s, "MATCH (c:C) RETURN c.n AS v"), "v=3");
+
+    // a variable that is not bound must be an error, not a silent null — storing nothing
+    // for a property without saying so is the failure this whole change removes
+    let err = engine
+        .execute_mut("CREATE (:D {n: nosuch.x})", &mut s, "default")
+        .expect_err("should not silently store null");
+    assert!(format!("{err}").contains("not bound"), "{err}");
+    assert_eq!(scalar(&s, "MATCH (d:D) RETURN count(d) AS n"), "n=0");
+}
+
+#[test]
+fn match_and_merge_refuse_non_literal_property_values_rather_than_ignoring_them() {
+    // These are not evaluated yet. Accepting and dropping the constraint would make
+    // `MATCH (p:P {n: x})` return *every* :P — a working-looking query returning too much.
+    let mut s = GraphStore::new();
+    let engine = QueryEngine::new();
+    engine.execute_mut("CREATE (:P {n: 1})", &mut s, "default").unwrap();
+    engine.execute_mut("CREATE (:P {n: 2})", &mut s, "default").unwrap();
+
+    let err = engine
+        .execute("UNWIND [1] AS x MATCH (p:P {n: x}) RETURN p.n AS v", &s)
+        .expect_err("must not silently match everything");
+    assert!(format!("{err}").contains("WHERE"), "should name the workaround: {err}");
+
+    let err = engine
+        .execute_mut("MATCH (p:P) MERGE (:M {n: p.n})", &mut s, "default")
+        .expect_err("must not silently store null");
+    assert!(format!("{err}").contains("WHERE"), "{err}");
+
+    // the WHERE form it points at does work
+    assert_eq!(
+        bag(&s, "UNWIND [1] AS x MATCH (p:P) WHERE p.n = x RETURN p.n AS v"),
+        vec!["v=1"]
+    );
+}


### PR DESCRIPTION
Fixes #408. Closes the remaining half of #307.

## What was wrong

Pattern property values had to be literals:

```cypher
MATCH (p:P) CREATE (:Q {n: p.n})   -- Parse error --> 1:28
MATCH (p:P) SET p.m = p.n          -- fine
```

So a node could only ever be created with constants. That rules out copy/derive writes, and with UNWIND it rules out batch writes — the half of #307 that #407 didn't reach.

## Design: a second field, not a type change

The obvious fix is `properties: HashMap<String, Expression>`. That's **53 call sites**, most of which only care about literals and several of which use them for index lookup — a change that touches the planner, the hierarchy detector, the semi-join detector and the plan enumerator, for a feature that only CREATE needs.

Instead, non-literal values go into a new `property_exprs` alongside `properties`. Literals keep their concrete `PropertyValue`, every existing consumer is untouched, and the index-lookup path still sees exactly what it saw before. The grammar tries `value` first so literals — the overwhelming majority — parse as they always did.

## What works now

```cypher
MATCH (p:P) CREATE (:Q {n: p.n})            -- 1
MATCH (p:P) CREATE (:R {n: p.n + 10})       -- 11
MATCH (p:P) CREATE (:S {label: p.name})     -- "a"
UNWIND [1,2,3] AS x CREATE (:N {id: x})     -- 3 nodes, ids 1, 2, 3
UNWIND [7,8] AS x CREATE (:M {id: x, doubled: x * 2})
CREATE (:C {n: 1 + 2})                      -- 3
```

Each row gets **its own** value — the test asserts `{id: 7, doubled: 14}` and `{id: 8, doubled: 16}`, not three copies of one row, which a count-based test would have missed.

A leading UNWIND with a CREATE is no longer planned as a CREATE-only statement; doing so ran it once with nothing bound (one node, `id` null).

## Two cases refused rather than half-supported

Both would otherwise be silent wrong answers, which is the failure mode this whole change exists to remove:

- **Bare CREATE with an unbound variable.** Constants fold; a name resolving to nothing is an error, and the half-built node is deleted. `CREATE (:D {n: nosuch.x})` → error, and `count(d) = 0` afterwards.
- **MATCH and MERGE patterns.** They don't evaluate these yet. Accepting and dropping the constraint would make `MATCH (p:P {n: x})` return **every** `:P`. The error names the WHERE form that does work, and a test asserts that form still returns the right single row.

Supporting `{n: x}` in MATCH means desugaring it to a filter (and synthesising a variable for anonymous nodes); worth doing, but as its own change rather than smuggled in here.

## Verified

- `cargo test --workspace`: **2470 passed, 0 failed**
- Conformance suite: 60 passed, 0 ignored