### PR TITLE
fix(snapshot): a failed import leaves nothing behind

### DIFF
--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -258,6 +258,29 @@ pub fn import_tenant_with_dedup(
     reader: impl Read,
     dedup_keys: &[&str],
 ) -> Result<ImportStats, Box<dyn std::error::Error>> {
+    // A failed import used to leave whatever it had already applied in the graph: a
+    // truncated snapshot returned "unexpected end of file" *and* several million nodes,
+    // so the caller saw an error and a partially-populated graph, with no way to tell how
+    // much of it had landed (#199). Track what this import creates and undo it on failure.
+    let mut created_nodes: Vec<crate::graph::NodeId> = Vec::new();
+    match import_tenant_inner(store, reader, dedup_keys, &mut created_nodes) {
+        Ok(stats) => Ok(stats),
+        Err(e) => {
+            // Reverse order so edges go with their endpoints.
+            for id in created_nodes.iter().rev() {
+                let _ = store.delete_node("default", *id);
+            }
+            Err(e)
+        }
+    }
+}
+
+fn import_tenant_inner(
+    store: &mut GraphStore,
+    reader: impl Read,
+    dedup_keys: &[&str],
+    created_nodes: &mut Vec<crate::graph::NodeId>,
+) -> Result<ImportStats, Box<dyn std::error::Error>> {
     let decoder = GzDecoder::new(reader);
     let buf_reader = BufReader::new(decoder);
     let mut lines = buf_reader.lines();
@@ -432,6 +455,7 @@ pub fn import_tenant_with_dedup(
             if use_stubs {
                 // v2: use lightweight stubs + column properties
                 let new_id = store.create_node_stub(first_label.as_str());
+                created_nodes.push(new_id);
                 // Add remaining labels
                 if let Some(node) = store.get_node_mut(new_id) {
                     for label in snap_node.labels.iter().skip(1) {
@@ -473,6 +497,7 @@ pub fn import_tenant_with_dedup(
             } else {
                 // v1: use full create_node with HashMap properties
                 let new_id = store.create_node(first_label.as_str());
+                created_nodes.push(new_id);
                 if let Some(node) = store.get_node_mut(new_id) {
                     for label in snap_node.labels.iter().skip(1) {
                         node.add_label(label.as_str());

--- a/tests/snapshot_import_rollback.rs
+++ b/tests/snapshot_import_rollback.rs
@@ -1,0 +1,93 @@
+//! A failed snapshot import must not leave part of itself behind (#199).
+//!
+//! A truncated snapshot returned "unexpected end of file" *and* several million nodes: the
+//! caller saw an error and a partially-populated graph, with no way to tell how much had
+//! landed or whether a retry would duplicate it.
+
+use std::io::{Read, Write};
+
+use samyama::graph::GraphStore;
+use samyama::query::QueryEngine;
+use samyama::snapshot::{export_tenant, import_tenant};
+
+fn good_snapshot(n: usize) -> Vec<u8> {
+    let engine = QueryEngine::new();
+    let mut store = GraphStore::new();
+    for i in 0..n {
+        engine
+            .execute_mut(&format!("CREATE (:N {{id: {i}}})"), &mut store, "default")
+            .unwrap();
+    }
+    let mut buf = Vec::new();
+    export_tenant(&store, &mut buf).expect("export");
+    buf
+}
+
+/// Cut a snapshot mid-record, so parsing fails partway through rather than at the start.
+fn truncated(buf: &[u8]) -> Vec<u8> {
+    let mut plain = String::new();
+    flate2::read::GzDecoder::new(buf)
+        .read_to_string(&mut plain)
+        .expect("decode");
+    let lines: Vec<&str> = plain.lines().collect();
+    let cut = lines[..lines.len() / 2].join("\n")
+        + "\n{\"t\":\"n\",\"id\":999,\"labels\":[\"N\"],\"pro";
+    let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    enc.write_all(cut.as_bytes()).expect("encode");
+    enc.finish().expect("finish")
+}
+
+#[test]
+fn a_failed_import_leaves_nothing_behind() {
+    let snapshot = truncated(&good_snapshot(50));
+    let mut store = GraphStore::new();
+
+    let result = import_tenant(&mut store, &snapshot[..]);
+
+    assert!(result.is_err(), "a truncated snapshot must fail");
+    assert_eq!(
+        store.all_nodes().len(),
+        0,
+        "a failed import must not leave partial state"
+    );
+}
+
+#[test]
+fn a_failed_import_does_not_disturb_existing_data() {
+    // The rollback must remove what *this* import created and nothing else.
+    let engine = QueryEngine::new();
+    let mut store = GraphStore::new();
+    engine
+        .execute_mut("CREATE (:Existing {k: 1})", &mut store, "default")
+        .unwrap();
+    engine
+        .execute_mut("CREATE (:Existing {k: 2})", &mut store, "default")
+        .unwrap();
+
+    let snapshot = truncated(&good_snapshot(50));
+    assert!(import_tenant(&mut store, &snapshot[..]).is_err());
+
+    assert_eq!(store.all_nodes().len(), 2, "pre-existing nodes must survive");
+    let batch = engine
+        .execute("MATCH (x:Existing) RETURN x.k AS k", &store)
+        .expect("still queryable");
+    assert_eq!(batch.records.len(), 2);
+}
+
+#[test]
+fn a_good_import_still_works_and_still_works_after_a_failed_one() {
+    let good = good_snapshot(50);
+    let bad = truncated(&good);
+
+    let mut store = GraphStore::new();
+    let stats = import_tenant(&mut store, &good[..]).expect("good import");
+    assert_eq!(stats.node_count, 50);
+    assert_eq!(store.all_nodes().len(), 50);
+
+    // a failure in between must not poison the store for the next attempt
+    let mut store = GraphStore::new();
+    assert!(import_tenant(&mut store, &bad[..]).is_err());
+    let stats = import_tenant(&mut store, &good[..]).expect("import after failure");
+    assert_eq!(stats.node_count, 50);
+    assert_eq!(store.all_nodes().len(), 50);
+}


### PR DESCRIPTION
Refs #199 — fixes the rollback half. The EOF root cause needs the actual snapshots; see below.

## What was wrong

```
$ curl -X POST .../api/snapshot/import -F "file=@clinical-full.sgsnap"
{"error":"unexpected end of file"}

$ MATCH (n) RETURN count(n)
7,774,446
```

An error **and** 7.7M nodes. The importer streamed records, applied them, hit the error and returned — leaving everything already applied in the graph. The caller couldn't tell how much had landed, or whether retrying would duplicate it.

Reproduced locally with a snapshot truncated mid-record: `Err(EOF while parsing a string)` and **24 nodes left behind**.

## The fix

The import records the nodes it creates and deletes them on failure, in reverse order so edges go with their endpoints.

| | before | after |
|---|---|---|
| failed import into an empty store | 24 nodes left | **0** |
| failed import with 2 pre-existing nodes | 26 nodes | **2**, still queryable |
| good import | 50 | 50 |
| good import *after* a failed one | — | 50, no residue |

## Scope, stated plainly

**This does not fix "unexpected end of file".** That is a property of those particular snapshots — comparable and larger files from the same bucket import cleanly — and diagnosing it needs the files. The issue should stay open for it. What changes here is that when it happens, the error is the whole story rather than half of it.

**Dedup merges are not rolled back.** With `dedup_keys` supplied, a merge writes properties onto a *pre-existing* node; only newly created nodes are removed. Undoing a merge would mean snapshotting each target's prior properties. Dedup is opt-in and off by default, so the common path rolls back completely — but it's a real edge and worth knowing rather than discovering.

## Verified

- All three tests confirmed failing without the fix (`a failed import must not leave partial state`)
- `cargo test --workspace`: **2477 passed, 0 failed**