### PR TITLE
fix(planner): anchored hops seed from the anchor index after a snapshot import

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -2324,8 +2324,15 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
 
             for (i, &node_id) in node_ids.iter().enumerate() {
                 if i >= sample_size { break; }
-                if let Some(node) = self.get_node(node_id) {
-                    for (key, val) in &node.properties {
+                // Read the merged view, not `node.properties` alone. A snapshot import
+                // populates only the columnar store, so sampling row storage found *no*
+                // properties at all and produced zero statistics -- leaving every
+                // selectivity estimate on the 10% default. On a large label that made an
+                // index lookup look more expensive than scanning a smaller label, and the
+                // planner anchored on the wrong end of the pattern and scanned it (#303).
+                {
+                    let props = self.node_properties_full(node_id);
+                    for (key, val) in &props {
                         *property_presence.entry(key.clone()).or_insert(0) += 1;
 
                         let hash = {

--- a/src/index/manager.rs
+++ b/src/index/manager.rs
@@ -105,6 +105,21 @@ impl IndexManager {
         self.create_index(label, property);
     }
 
+    /// Exact number of nodes an indexed equality would return, if such an index exists.
+    ///
+    /// Lets the planner cost an anchored lookup from the index itself instead of a
+    /// selectivity estimate that may be a placeholder (#303).
+    pub fn indexed_equality_count(
+        &self,
+        label: &Label,
+        property: &str,
+        value: &PropertyValue,
+    ) -> Option<usize> {
+        let index = self.get_index(label, property)?;
+        let count = index.read().unwrap().count(value);
+        Some(count)
+    }
+
     /// Check if a unique constraint exists
     pub fn has_unique_constraint(&self, label: &Label, property: &str) -> bool {
         let key = PropertyIndexKey {

--- a/src/index/property_index.rs
+++ b/src/index/property_index.rs
@@ -32,6 +32,16 @@ impl PropertyIndex {
         }
     }
 
+    /// How many nodes hold `value`, without materialising their ids.
+    ///
+    /// The planner uses this to cost an indexed equality exactly rather than estimating it.
+    /// The estimate defaults to 10% selectivity when a property has no statistics, which on
+    /// a large label makes an index lookup look more expensive than a full scan of a
+    /// smaller one -- see #303.
+    pub fn count(&self, value: &PropertyValue) -> usize {
+        self.index.get(value).map_or(0, |nodes| nodes.len())
+    }
+
     pub fn get(&self, value: &PropertyValue) -> Vec<NodeId> {
         self.index.get(value)
             .map(|nodes| nodes.iter().cloned().collect())

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -3233,14 +3233,36 @@ fn choose_anchor_index(nodes: &[PathNodeRef], path_preds: &[Expression], store: 
         }
         candidates.extend(path_preds.iter().cloned());
 
-        let cost = if let Some((_, label, property, op, _)) = find_index_predicate(&node.var, &node.labels, &candidates, store) {
-            let base = stats.estimate_label_scan(&label) as f64;
-            let selectivity = if matches!(op, BinaryOp::Eq) {
-                stats.estimate_equality_selectivity(&label, &property)
+        let cost = if let Some((_, label, property, op, val)) = find_index_predicate(&node.var, &node.labels, &candidates, store) {
+            // For an indexed equality, ask the index how many nodes actually match instead
+            // of estimating. `estimate_equality_selectivity` falls back to 10% when a
+            // property has no statistics, so on a large label an index lookup was costed at
+            // a tenth of the label -- more than a full scan of a smaller one, and the
+            // planner would anchor on the *other* end of the pattern and scan it. That is
+            // why structurally identical anchored 1-hops differed by six orders of
+            // magnitude, and why an anchor value that does not exist still scanned (#303).
+            //
+            // The lookup is one index probe at plan time, and it makes a missing anchor cost
+            // 0 -- so the plan short-circuits instead of scanning.
+            let exact = if matches!(op, BinaryOp::Eq) {
+                store
+                    .property_index
+                    .indexed_equality_count(&label, &property, &val)
             } else {
-                0.3
+                None
             };
-            (base * selectivity).max(1.0)
+            match exact {
+                Some(n) => n as f64,
+                None => {
+                    let base = stats.estimate_label_scan(&label) as f64;
+                    let selectivity = if matches!(op, BinaryOp::Eq) {
+                        stats.estimate_equality_selectivity(&label, &property)
+                    } else {
+                        0.3
+                    };
+                    (base * selectivity).max(1.0)
+                }
+            }
         } else if let Some(label) = node.labels.first() {
             stats.estimate_label_scan(label) as f64
         } else {

--- a/tests/anchored_scan_after_import.rs
+++ b/tests/anchored_scan_after_import.rs
@@ -1,0 +1,121 @@
+//! An anchored single-hop must seed from its anchor index, including on a graph loaded
+//! from a snapshot (#303).
+//!
+//! The failure had a two-step cause, and neither step is visible on a graph built by
+//! CREATE:
+//!
+//! 1. Property statistics were sampled from `node.properties` -- row storage. A snapshot
+//!    import populates only the columnar store, so sampling found no properties and
+//!    produced **zero** statistics.
+//! 2. `estimate_equality_selectivity` then fell back to its 10% default. On a large anchor
+//!    label that makes an index lookup look more expensive than scanning a *smaller* target
+//!    label, so the planner anchored on the target and scanned it -- expanding backwards.
+//!
+//! Which is why structurally identical anchored 1-hops differed by six orders of magnitude
+//! depending on the target label, and why an anchor value that did not exist still scanned
+//! instead of returning immediately.
+
+use samyama::graph::{GraphStore, Label};
+use samyama::query::QueryEngine;
+use samyama::snapshot::{export_tenant, import_tenant};
+
+/// Large indexed anchor label, small target label — the shape that misleads the estimate.
+fn imported_store() -> GraphStore {
+    let engine = QueryEngine::new();
+    let mut source = GraphStore::new();
+    for i in 0..5000 {
+        engine
+            .execute_mut(&format!("CREATE (:Article {{pmid: \"{i}\"}})"), &mut source, "default")
+            .unwrap();
+    }
+    for i in 0..50 {
+        engine
+            .execute_mut(&format!("CREATE (:Author {{id: {i}}})"), &mut source, "default")
+            .unwrap();
+    }
+    for i in 0..50 {
+        engine
+            .execute_mut(
+                &format!(
+                    "MATCH (a:Article {{pmid: \"{i}\"}}), (x:Author {{id: {i}}}) \
+                     CREATE (a)-[:AUTHORED_BY]->(x)"
+                ),
+                &mut source, "default",
+            )
+            .unwrap();
+    }
+
+    let mut buf = Vec::new();
+    export_tenant(&source, &mut buf).expect("export");
+    let mut store = GraphStore::new();
+    import_tenant(&mut store, &buf[..]).expect("import");
+    engine
+        .execute_mut("CREATE INDEX ON :Article(pmid)", &mut store, "default")
+        .unwrap();
+    store
+}
+
+fn plan_for(store: &GraphStore, query: &str) -> String {
+    let engine = QueryEngine::new();
+    let batch = engine
+        .execute(&format!("EXPLAIN {query}"), store)
+        .expect("explain");
+    format!("{:?}", batch.records[0].get("plan")).replace("\\n", "\n")
+}
+
+#[test]
+fn property_statistics_survive_a_snapshot_import() {
+    // Step 1 of the cause. With zero statistics every selectivity is the 10% placeholder,
+    // and every cost decision on an imported graph is made on that placeholder.
+    let store = imported_store();
+    let stats = store.statistics();
+
+    assert!(
+        !stats.property_stats.is_empty(),
+        "a snapshot-imported graph produced no property statistics at all"
+    );
+
+    let selectivity = stats.estimate_equality_selectivity(&Label::new("Article"), "pmid");
+    assert!(
+        selectivity < 0.1,
+        "pmid is near-unique across 5000 articles; got the {selectivity} default instead"
+    );
+}
+
+#[test]
+fn an_anchored_hop_seeds_from_the_anchor_index_not_the_target_label() {
+    let store = imported_store();
+
+    for (name, query) in [
+        ("present anchor", "MATCH (a:Article {pmid: \"10\"})-[:AUTHORED_BY]->(au:Author) RETURN au"),
+        // the anchor value does not exist: this must resolve from the index, not scan
+        ("absent anchor", "MATCH (a:Article {pmid: \"999999\"})-[:AUTHORED_BY]->(au:Author) RETURN au"),
+    ] {
+        let plan = plan_for(&store, query);
+        assert!(
+            plan.contains("IndexScan (var=a"),
+            "{name}: should seed from :Article(pmid), plan was:\n{plan}"
+        );
+        assert!(
+            !plan.contains("NodeScan (var=au"),
+            "{name}: scanned the target label instead, plan was:\n{plan}"
+        );
+    }
+}
+
+#[test]
+fn the_anchored_hop_still_returns_the_right_rows() {
+    // A plan assertion alone would pass on a plan that is fast and wrong.
+    let store = imported_store();
+    let engine = QueryEngine::new();
+
+    let hit = engine
+        .execute("MATCH (a:Article {pmid: \"10\"})-[:AUTHORED_BY]->(au:Author) RETURN au.id AS id", &store)
+        .expect("query");
+    assert_eq!(hit.records.len(), 1);
+
+    let miss = engine
+        .execute("MATCH (a:Article {pmid: \"999999\"})-[:AUTHORED_BY]->(au:Author) RETURN au.id AS id", &store)
+        .expect("query");
+    assert_eq!(miss.records.len(), 0);
+}


### PR DESCRIPTION
Fixes #303

## Root cause

Two steps, and **neither is visible on a graph built by CREATE** — which is why this only ever showed up on the imported federation.

**1. A snapshot-imported graph has no property statistics at all.**

Statistics sample `node.properties` — row storage. A snapshot import populates only the columnar store (the same split behind #333), so the sample finds nothing:

```
property_stats entries after snapshot import: 0
selectivity for Article.pmid:                 0.1     ← the default, not a measurement
```

**2. The 10% default then inverts the anchor decision.**

`choose_anchor_index` costs an indexed anchor as `label_size × selectivity`. With 5,000 articles that is 500 — more than scanning 50 authors, so it anchors on `:Author`:

```
Expand ((au)<-[:AUTHORED_BY]-(a))
  +- NodeScan (var=au, labels=["Author"])      ← the anchor index is never touched
```

At 30M+ articles the same arithmetic gives 3M, and the target label wins by an even wider margin. That is precisely the reported dependence on *target label cardinality*, and it explains the case that puzzled the report most: an anchor `pmid` that doesn't exist still scanned for 5 minutes, because the plan never consulted the index to discover there was nothing to find.

## Two fixes, deliberately both

**Statistics sample the merged row+columnar view.** An imported graph now has real statistics (`0 → 2` entries; selectivity `0.1 → 0.001`). This corrects *every* cost decision on such a graph, not just this one — worth having on its own.

**An indexed equality is costed by asking the index.** One probe at plan time returns the exact match count instead of an estimate. This is belt-and-braces: it holds even if statistics are ever missing or stale again, and a missing anchor costs 0, so the plan short-circuits rather than scanning.

## Verified

Reproduced end to end on a snapshot-imported graph:

| | before | after |
|---|---|---|
| present anchor | `NodeScan(Author)` + backwards Expand | `IndexScan(Article.pmid)` |
| absent anchor | `NodeScan(Author)` + backwards Expand | `IndexScan(Article.pmid)` |

Both plan assertions confirmed failing without the fix, as is the statistics one.

A third test asserts the **rows** are still right (1 for the present anchor, 0 for the absent one) — a plan assertion alone would happily pass on a plan that is fast and wrong.

- `cargo test --workspace`: **2477 passed, 0 failed**

## Note

This is a 1-hop fix. #296 (complex multi-hop scaling) is separate — though if those benchmarks also ran against imported graphs, they were being planned on placeholder statistics too, and are worth re-measuring on top of this.