### PR TITLE
perf(snapshot): dedup pre-populate is scoped to the snapshot's own labels

### DIFF
--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -322,21 +322,38 @@ fn import_tenant_inner(
     // Only populated when the caller provides dedup_keys.
     let mut dedup_index: HashMap<(String, String, String), NodeId> = HashMap::new();
 
-    // Pre-populate dedup index from existing store nodes (only if dedup requested)
+    // Pre-populate dedup index from existing store nodes (only if dedup requested).
+    //
+    // Only the labels this snapshot actually contains are indexed, and they are reached
+    // through the label index rather than by walking the whole store. A node whose label
+    // does not appear in the incoming file can never merge with anything in it, so
+    // indexing it is pure cost -- and that cost was O(store) on *every* import, which for
+    // a federation growing 66M -> 266M nodes means re-scanning a store that gets larger
+    // each time and indexing hundreds of millions of nodes that can never match (#316).
+    //
+    // The header is an exact inventory: `export_tenant` materialises `labels` by scanning
+    // the data it writes, so it cannot drift from the file's contents.
     if !dedup_keys.is_empty() {
-    for node in store.all_nodes() {
-        // Index under *every* label, not just whichever one iterated first. `labels` is a
-        // set, so "first" is not a stable contract: a dual-labelled node such as
-        // :ChemblTarget + :Protein could be indexed under either, and if the two snapshots
-        // happened to iterate differently the keys never matched and the merge silently did
-        // not happen (#317). Indexing under all labels makes the merge depend on label
-        // *intersection*, which is order-independent.
-        let labels: Vec<String> = if node.labels.is_empty() {
-            vec![String::new()]
-        } else {
-            node.labels.iter().map(|l| l.as_str().to_string()).collect()
-        };
-        for label in &labels {
+    let snapshot_labels: Vec<crate::graph::Label> = header
+        .labels
+        .iter()
+        .map(|l| crate::graph::Label::new(l.as_str()))
+        .collect();
+    for snapshot_label in &snapshot_labels {
+        let label = snapshot_label.as_str().to_string();
+        let node_ids: Vec<NodeId> = store
+            .get_nodes_by_label(snapshot_label)
+            .iter()
+            .map(|n| n.id)
+            .collect();
+        for node_id in node_ids {
+        let Some(node) = store.get_node(node_id) else { continue };
+        // Indexed under this label specifically, not "whichever label iterated first":
+        // `labels` is a set, so "first" is not a stable contract, and a dual-labelled node
+        // such as :ChemblTarget + :Protein could be indexed under either. If the two sides
+        // disagreed the lookup missed and the merge silently did not happen (#317).
+        // Matching now depends on label *intersection*, which is order-independent.
+        {
         for &key in dedup_keys {
             // Check node HashMap properties
             if let Some(val) = node.get_property(key) {
@@ -358,6 +375,7 @@ fn import_tenant_inner(
                 }
                 _ => {}
             }
+        }
         }
         }
     }

--- a/tests/entity_dedup_labels.rs
+++ b/tests/entity_dedup_labels.rs
@@ -122,3 +122,42 @@ fn dedup_is_still_off_by_default() {
     assert_eq!(stats.merged_count, 0);
     assert_eq!(store.all_nodes().len(), 2);
 }
+
+#[test]
+fn labels_absent_from_the_snapshot_are_not_indexed_or_merged() {
+    // The pre-populate pass used to walk the entire store for every import, indexing nodes
+    // whose labels the incoming file does not even contain and which therefore can never
+    // merge. Scoping it to the snapshot's own labels must not change what merges: the store
+    // here is dominated by :Article, which the snapshot knows nothing about.
+    let snapshot = snapshot_with_label_order("[\"ChemblTarget\",\"Protein\"]");
+
+    let mut store = uniprot_side(); // one :Protein with accession P12345
+    for i in 0..5000 {
+        let id = store.create_node("Article");
+        store.get_node_mut(id).unwrap().set_property(
+            "accession".to_string(),
+            PropertyValue::String(format!("P{i}")),
+        );
+    }
+    // an :Article carrying the *same* accession must still not merge — different entity
+    let clash = store.create_node("Article");
+    store.get_node_mut(clash).unwrap().set_property(
+        "accession".to_string(),
+        PropertyValue::String("P12345".to_string()),
+    );
+    let before = store.all_nodes().len();
+
+    let stats = import_tenant_with_dedup(&mut store, &snapshot[..], &["accession"]).expect("import");
+
+    assert_eq!(stats.merged_count, 1, "should merge only with the :Protein");
+    assert_eq!(
+        store.all_nodes().len(),
+        before,
+        "the merge reuses the existing :Protein, so the node count is unchanged"
+    );
+    // the clashing :Article is untouched
+    let articles = store
+        .get_nodes_by_label(&samyama::graph::Label::new("Article"))
+        .len();
+    assert_eq!(articles, 5001);
+}


### PR DESCRIPTION
Refs #316 — implements the header pre-pass the issue proposes, at the single-import level.

## What was wrong

`import_tenant_with_dedup` pre-populated its index by walking `store.all_nodes()` **on every import**, for every dedup key. A node whose label doesn't appear in the incoming file can never merge with anything in it, so all of that is wasted — and it was O(store) each time. Federating to 266M nodes meant re-scanning a store that grows with every import while indexing hundreds of millions of nodes that can never match.

## The fix

As the issue points out, the header is already an exact inventory — `export_tenant` materialises `labels` by scanning the data it writes, so it can't drift from the file. The pre-populate now reads only those labels, and reaches them **through the label index** rather than walking the store.

## Measured

| store contents | before | after |
|---|---|---|
| 20,000 unrelated `:Article` nodes | 5.49 ms | **52 µs** |
| 100,000 unrelated `:Article` nodes | 25.05 ms | **51 µs** |

Linear in store size before (5× the nodes → 4.6× the time), constant after. The gap widens with the store, which is the point — this is the cost that made the 15-snapshot federation painful.

## Semantics unchanged

Only labels shared with the snapshot could ever match, so scoping to them changes nothing about what merges. The test suite covers the risk directly: a store with **5,001 `:Article` nodes**, one of which carries the *same* accession as the `:Protein` being merged, must still merge exactly once and leave the `:Article` untouched.

## What this does not do

The issue's larger proposal — read all 15 headers up front, intersect them, and dedup only labels appearing in more than one snapshot — is a *cross-import* planning step and needs a caller that sees all the files. This change gets most of the benefit per-import without one.

The noted gap still stands: headers list labels but not property keys, so they can say *which labels overlap* but not *which key to merge on*. Adding a per-label property-key inventory to the header would make fully header-driven merge planning possible, and is worth its own issue.

## Verified

- `cargo test --workspace`: **2481 passed, 0 failed**