### PR TITLE
feat(embed): reject an embed config whose dimension contradicts its model

### DIFF
--- a/src/persistence/tenant.rs
+++ b/src/persistence/tenant.rs
@@ -20,6 +20,10 @@ pub enum TenantError {
     #[error("Tenant not found: {0}")]
     NotFound(String),
 
+    /// Embed configuration is internally inconsistent
+    #[error("invalid embed config: {0}")]
+    InvalidEmbedConfig(String),
+
     /// Quota exceeded
     #[error("Quota exceeded for tenant {tenant}: {resource}")]
     QuotaExceeded {
@@ -285,6 +289,58 @@ fn default_embedding_property() -> String {
     "embedding".to_string()
 }
 
+/// Native output dimension of the embedding models we can recognise.
+///
+/// An embedding model has exactly one output dimension, but `vector_dimension` is set by
+/// hand and independently of `embedding_model`. When the two disagree the mismatch used to
+/// surface far downstream -- as a bare `DimensionMismatch` at insert time, per vector, or
+/// (once auto-embed was routed correctly) as a log line saying every embedding had been
+/// dropped. Recognising the common models lets the contradiction be caught when the config
+/// is set, which is the only point at which it can be fixed cheaply.
+///
+/// Unknown models are not rejected: this is a convenience check, not a whitelist, and
+/// self-hosted or fine-tuned models are legitimate.
+pub fn native_dimension_for_model(model: &str) -> Option<usize> {
+    let normalized = model.trim().to_ascii_lowercase();
+    let name = normalized.rsplit('/').next().unwrap_or(&normalized);
+    let base = name.split(':').next().unwrap_or(name);
+    Some(match base {
+        "text-embedding-3-small" | "text-embedding-ada-002" => 1536,
+        "text-embedding-3-large" => 3072,
+        "nomic-embed-text" => 768,
+        "mxbai-embed-large" => 1024,
+        "all-minilm-l6-v2" | "all-minilm" => 384,
+        "embed-english-v3.0" => 1024,
+        "text-embedding-004" | "embedding-001" => 768,
+        "mock" => 64,
+        _ => return None,
+    })
+}
+
+impl AutoEmbedConfig {
+    /// Check the configuration is internally consistent before it is stored.
+    ///
+    /// Only catches what is knowable at config time: a declared dimension that contradicts
+    /// the model's own. Vectors from *different* models are not comparable even at equal
+    /// dimensions, which this cannot detect -- see #275 for the index-provenance half.
+    pub fn validate(&self) -> Result<(), TenantError> {
+        if self.vector_dimension == 0 {
+            return Err(TenantError::InvalidEmbedConfig(
+                "vector_dimension must be greater than zero".to_string(),
+            ));
+        }
+        if let Some(native) = native_dimension_for_model(&self.embedding_model) {
+            if native != self.vector_dimension {
+                return Err(TenantError::InvalidEmbedConfig(format!(
+                    "model `{}` produces {}-dimensional vectors but vector_dimension is {}; every embedding would be rejected at insert time",
+                    self.embedding_model, native, self.vector_dimension
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
 /// Tenant manager - manages all tenants and their resources
 pub struct TenantManager {
     /// All tenants
@@ -475,6 +531,12 @@ impl TenantManager {
 
         let tenant = tenants.get_mut(tenant_id)
             .ok_or_else(|| TenantError::NotFound(tenant_id.to_string()))?;
+
+        // Reject a config that cannot work, rather than accepting it and dropping every
+        // embedding it produces.
+        if let Some(cfg) = &config {
+            cfg.validate()?;
+        }
 
         tenant.embed_config = config;
 

--- a/tests/embed_config_validation.rs
+++ b/tests/embed_config_validation.rs
@@ -1,0 +1,94 @@
+//! An embed config that cannot work is rejected when it is set (#275, failure mode 1).
+//!
+//! An embedding model has exactly one output dimension, but `vector_dimension` is set by
+//! hand and independently of `embedding_model`. When they disagreed, nothing said so at
+//! config time: the contradiction surfaced far downstream as a `DimensionMismatch` per
+//! vector at insert, discarded by callers that ignored the result — so a tenant could be
+//! configured, run, call the provider thousands of times, and store nothing.
+
+use std::collections::HashMap;
+
+use samyama::persistence::tenant::{
+    native_dimension_for_model, AutoEmbedConfig, LLMProvider,
+};
+use samyama::persistence::TenantManager;
+
+fn config(model: &str, dimension: usize) -> AutoEmbedConfig {
+    AutoEmbedConfig {
+        provider: LLMProvider::Ollama,
+        embedding_model: model.to_string(),
+        api_key: None,
+        api_base_url: None,
+        chunk_size: 512,
+        chunk_overlap: 0,
+        vector_dimension: dimension,
+        embedding_policies: HashMap::new(),
+        embedding_property: "embedding".to_string(),
+    }
+}
+
+#[test]
+fn a_dimension_contradicting_the_model_is_rejected() {
+    let tenants = TenantManager::new();
+
+    // nomic-embed-text is 768-dimensional; 1536 is the value the fixtures habitually carry
+    let err = tenants
+        .update_embed_config("default", Some(config("nomic-embed-text", 1536)))
+        .expect_err("should not accept a config that can never store a vector");
+
+    let msg = format!("{err}");
+    assert!(msg.contains("768"), "should name the model's real dimension: {msg}");
+    assert!(msg.contains("1536"), "should name the configured one: {msg}");
+}
+
+#[test]
+fn a_matching_dimension_is_accepted() {
+    let tenants = TenantManager::new();
+    tenants
+        .update_embed_config("default", Some(config("nomic-embed-text", 768)))
+        .expect("768 is correct for this model");
+    tenants
+        .update_embed_config("default", Some(config("text-embedding-3-small", 1536)))
+        .expect("1536 is correct for this model");
+}
+
+#[test]
+fn an_unrecognised_model_is_not_blocked() {
+    // This is a convenience check, not a whitelist: self-hosted and fine-tuned models are
+    // legitimate and we have no way to know their dimension.
+    let tenants = TenantManager::new();
+    tenants
+        .update_embed_config("default", Some(config("acme/our-own-embedder", 512)))
+        .expect("unknown models must still be configurable");
+}
+
+#[test]
+fn a_zero_dimension_is_rejected_whatever_the_model() {
+    let tenants = TenantManager::new();
+    let err = tenants
+        .update_embed_config("default", Some(config("acme/our-own-embedder", 0)))
+        .expect_err("zero cannot be right");
+    assert!(format!("{err}").contains("greater than zero"));
+}
+
+#[test]
+fn model_names_are_recognised_through_tags_and_namespaces() {
+    // Ollama names carry a `:tag`, and registries prefix an `org/`. Both refer to the same
+    // model and must resolve to the same dimension, or the check would quietly stop
+    // applying to the spellings people actually use.
+    for name in [
+        "nomic-embed-text",
+        "nomic-embed-text:latest",
+        "nomic-embed-text:v1.5",
+        "library/nomic-embed-text",
+        "  NOMIC-EMBED-TEXT  ",
+    ] {
+        assert_eq!(
+            native_dimension_for_model(name),
+            Some(768),
+            "unrecognised spelling: {name:?}"
+        );
+    }
+    assert_eq!(native_dimension_for_model("text-embedding-3-large"), Some(3072));
+    assert_eq!(native_dimension_for_model("something-nobody-has-heard-of"), None);
+}


### PR DESCRIPTION
Refs #275 — implements failure mode 1. Modes 2 and 3 need index provenance and are not addressed here.

## What was wrong

`vector_dimension` is set by hand, independently of `embedding_model`. An embedding model has exactly one output dimension, so the two can contradict — and nothing checked:

```json
{ "embedding_model": "nomic-embed-text", "vector_dimension": 1536 }   // accepted; 768 is correct
```

The contradiction surfaced far downstream as a `DimensionMismatch` per vector at insert time, discarded by callers that ignored the result. A tenant could be configured, run, call the provider thousands of times, and store nothing.

That is not hypothetical — it is what **#310** turned out to be, and the diagnostic added there is what made this issue's mode 1 visible on my own first test run:

```
WARN auto-embed: could not index Person.embedding for node 1: Dimension mismatch: expected 8, got 64
```

## The fix

`native_dimension_for_model` recognises the common models (OpenAI, Ollama, Gemini, Cohere, MiniLM, and the mock), and `AutoEmbedConfig::validate` runs where a config is set. The error names both numbers, since the useful information is the discrepancy:

```
model `nomic-embed-text` produces 768-dimensional vectors but vector_dimension is 1536;
every embedding would be rejected at insert time
```

Names resolve through Ollama `:tag` suffixes and `org/` prefixes (`nomic-embed-text:latest`, `library/nomic-embed-text`), because those are the spellings people write — a check that silently stops applying to the common spelling is worse than no check.

**Unknown models are accepted.** This is a convenience check, not a whitelist; self-hosted and fine-tuned models are legitimate and we cannot know their dimension. A test pins that.

## Not addressed

**Mode 2, model drift**, is the dangerous one and needs index provenance: a query embedded by the current model searching an index built by a different one at the same dimension throws nothing and returns confident, wrong neighbours. That requires recording `model_id` on the index and comparing at search time — worth doing, but a bigger change than this and better reviewed on its own.

**Mode 3, safe swap**, follows from mode 2.

## Verified

- Existing fixtures were checked for false positives: every one that names a recognised model already declares the right dimension, so nothing pre-existing is rejected.
- `cargo test --workspace`: **2486 passed, 0 failed**