### PR TITLE
perf(query): count edges of one type from metadata instead of scanning

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2396,6 +2396,70 @@ impl PhysicalOperator for LabelCountOperator {
     }
 }
 
+/// Edge count operator: resolves `MATCH ()-[r:TYPE]->() RETURN count(r)` from the stats
+/// cache, for one edge type or for all of them.
+///
+/// The *grouped* form (`RETURN type(r), count(r)`) already had an O(1) path, and node label
+/// counts have had one for longer -- but a count filtered to a single edge type fell back to
+/// a full Expand + Aggregate. On a billion-edge federation that is the difference between
+/// answering from metadata and hitting the 120s timeout (#304), while the structurally
+/// simpler grouped query returned instantly.
+pub struct EdgeCountOperator {
+    /// `None` counts every edge, whatever its type.
+    edge_type: Option<String>,
+    alias: String,
+    executed: bool,
+}
+
+impl EdgeCountOperator {
+    pub fn new(edge_type: Option<String>, alias: String) -> Self {
+        Self { edge_type, alias, executed: false }
+    }
+
+    fn count(&self, store: &GraphStore) -> i64 {
+        let stats = store.statistics();
+        match &self.edge_type {
+            Some(t) => stats
+                .edge_type_counts
+                .iter()
+                .find(|(et, _)| et.as_str() == t.as_str())
+                .map(|(_, c)| *c as i64)
+                .unwrap_or(0),
+            None => stats.edge_type_counts.values().map(|c| *c as i64).sum(),
+        }
+    }
+}
+
+impl PhysicalOperator for EdgeCountOperator {
+    fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        if self.executed {
+            return Ok(None);
+        }
+        self.executed = true;
+        let mut record = Record::new();
+        record.bind(
+            self.alias.clone(),
+            Value::Property(PropertyValue::Integer(self.count(store))),
+        );
+        Ok(Some(record))
+    }
+
+    fn reset(&mut self) {
+        self.executed = false;
+    }
+
+    fn describe(&self) -> OperatorDescription {
+        OperatorDescription {
+            name: "EdgeCount".to_string(),
+            details: match &self.edge_type {
+                Some(t) => format!("type={}, alias={}", t, self.alias),
+                None => format!("all types, alias={}", self.alias),
+            },
+            children: Vec::new(),
+        }
+    }
+}
+
 /// Edge type count operator: resolves `MATCH ()-[r]->() RETURN type(r), count(r)` from stats cache.
 /// Returns one row per edge type with its count, avoiding a full edge scan.
 pub struct EdgeTypeCountOperator {

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -62,7 +62,7 @@ use std::sync::Mutex;
 use crate::query::executor::{
     ExecutionError, ExecutionResult, OperatorBox,
     // Added CreateNodeOperator and CreateNodesAndEdgesOperator for CREATE statement support
-    operator::{NodeScanOperator, FilterOperator, ExpandOperator, ProjectOperator, LimitOperator, SkipOperator, CreateNodeOperator, CreateNodesAndEdgesOperator, CartesianProductOperator, VectorSearchOperator, JoinOperator, LeftOuterJoinOperator, CreateVectorIndexOperator, CreateIndexOperator, CompositeCreateIndexOperator, CreateConstraintOperator, DropIndexOperator, ShowIndexesOperator, ShowConstraintsOperator, DistinctOperator, ShowLabelsOperator, ShowRelationshipTypesOperator, ShowPropertyKeysOperator, SchemaVisualizationOperator, AlgorithmOperator, IndexScanOperator, AggregateOperator, AggregateType, AggregateFunction, AlgorithmOperator as _AlgoOp, SortOperator, DeleteOperator, SetPropertyOperator, RemovePropertyOperator, UnwindOperator, MergeOperator, ForeachOperator, ShortestPathOperator, VarLengthExpandOperator, WithBarrierOperator, LabelCountOperator, EdgeTypeCountOperator},
+    operator::{NodeScanOperator, FilterOperator, ExpandOperator, ProjectOperator, LimitOperator, SkipOperator, CreateNodeOperator, CreateNodesAndEdgesOperator, CartesianProductOperator, VectorSearchOperator, JoinOperator, LeftOuterJoinOperator, CreateVectorIndexOperator, CreateIndexOperator, CompositeCreateIndexOperator, CreateConstraintOperator, DropIndexOperator, ShowIndexesOperator, ShowConstraintsOperator, DistinctOperator, ShowLabelsOperator, ShowRelationshipTypesOperator, ShowPropertyKeysOperator, SchemaVisualizationOperator, AlgorithmOperator, IndexScanOperator, AggregateOperator, AggregateType, AggregateFunction, AlgorithmOperator as _AlgoOp, SortOperator, DeleteOperator, SetPropertyOperator, RemovePropertyOperator, UnwindOperator, MergeOperator, ForeachOperator, ShortestPathOperator, VarLengthExpandOperator, WithBarrierOperator, LabelCountOperator, EdgeTypeCountOperator, EdgeCountOperator},
 };
 use crate::graph::EdgeType;  // Added for CREATE edge support
 use std::collections::{HashMap, HashSet};  // Added for CREATE properties and JOIN logic
@@ -1666,7 +1666,58 @@ impl QueryPlanner {
                 && matches!(&group_by[0].0, Expression::Function { name, args, .. }
                     if name == "type" && args.len() == 1 && matches!(&args[0], Expression::Variable(_)));
 
-            if use_edge_type_count {
+            // O(1) count for a single edge type (or all edges): the metadata that already
+            // answers `type(r), count(r)` and node label counts can answer this too, but
+            // this shape fell through to a full Expand + Aggregate -- on a billion-edge
+            // graph, a timeout for a question the statistics already hold (#304).
+            //
+            // Requires the counted variable to be the *edge* (or `count(*)`): counting a
+            // node variable over the same expand is a different question once the pattern
+            // has labels, and the label-free case is handled below anyway.
+            let edge_var = if query.match_clauses.len() == 1
+                && query.match_clauses[0].pattern.paths.len() == 1
+                && query.match_clauses[0].pattern.paths[0].segments.len() == 1
+            {
+                query.match_clauses[0].pattern.paths[0].segments[0]
+                    .edge
+                    .variable
+                    .clone()
+            } else {
+                None
+            };
+            let use_edge_count = has_aggregation
+                && aggregates.len() == 1
+                && group_by.is_empty()
+                && matches!(aggregates[0].func, AggregateType::Count)
+                && !aggregates[0].distinct
+                && query.where_clause.is_none()
+                && query.with_clause.is_none()
+                && query.order_by.is_none()
+                && query.match_clauses.len() == 1
+                && query.match_clauses[0].pattern.paths.len() == 1
+                && query.match_clauses[0].pattern.paths[0].segments.len() == 1
+                && query.match_clauses[0].pattern.paths[0].start.labels.is_empty()
+                && query.match_clauses[0].pattern.paths[0].start.properties.as_ref().is_none_or(|p| p.is_empty())
+                && query.match_clauses[0].pattern.paths[0].segments[0].node.labels.is_empty()
+                && query.match_clauses[0].pattern.paths[0].segments[0].node.properties.as_ref().is_none_or(|p| p.is_empty())
+                && query.match_clauses[0].pattern.paths[0].segments[0].edge.length.is_none()
+                && query.match_clauses[0].pattern.paths[0].segments[0].edge.types.len() <= 1
+                && match &aggregates[0].expr {
+                    Expression::Literal(_) => true,
+                    Expression::Variable(v) => Some(v) == edge_var.as_ref(),
+                    _ => false,
+                };
+
+            if use_edge_count {
+                let edge_type = query.match_clauses[0].pattern.paths[0].segments[0]
+                    .edge
+                    .types
+                    .first()
+                    .map(|t| t.as_str().to_string());
+                let alias = aggregates[0].alias.clone();
+                operator = Box::new(EdgeCountOperator::new(edge_type, alias));
+                operator = Box::new(ProjectOperator::new(operator, post_projections));
+            } else if use_edge_type_count {
                 let type_alias = group_by[0].1.clone();
                 let count_alias = aggregates[0].alias.clone();
                 operator = Box::new(EdgeTypeCountOperator::new(type_alias, count_alias));

--- a/tests/edge_type_count.rs
+++ b/tests/edge_type_count.rs
@@ -1,0 +1,122 @@
+//! `MATCH ()-[r:TYPE]->() RETURN count(r)` is answered from metadata (#304).
+//!
+//! Node label counts have had an O(1) path for a while, and so has the *grouped* edge form
+//! (`RETURN type(r), count(r)`). A count filtered to a single edge type did not, and fell
+//! through to a full Expand + Aggregate — on a 1.22B-edge federation, a 120s timeout for a
+//! question the statistics already answer, while the structurally more complex grouped
+//! query returned instantly.
+//!
+//! The risk in a shortcut like this is not slowness, it is a *wrong* count when the pattern
+//! says more than the metadata knows. Most of what follows checks it declines to fire.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::record::Value;
+use samyama::query::QueryEngine;
+
+/// 10 :A, 5 :B. CITES: 10 A->A and 5 A->B. LIKES: 3 A->A.
+fn fixture() -> GraphStore {
+    let mut store = GraphStore::new();
+    let a: Vec<_> = (0..10)
+        .map(|i| {
+            let id = store.create_node("A");
+            store
+                .get_node_mut(id)
+                .unwrap()
+                .set_property("i", PropertyValue::Integer(i));
+            id
+        })
+        .collect();
+    let b: Vec<_> = (0..5).map(|_| store.create_node("B")).collect();
+
+    for i in 0..10 {
+        store.create_edge(a[i], a[(i + 1) % 10], "CITES").unwrap();
+    }
+    for i in 0..5 {
+        store.create_edge(a[i], b[i], "CITES").unwrap();
+    }
+    for i in 0..3 {
+        store.create_edge(a[i], a[(i + 2) % 10], "LIKES").unwrap();
+    }
+    store
+}
+
+fn count(store: &GraphStore, query: &str) -> i64 {
+    let engine = QueryEngine::new();
+    let batch = engine
+        .execute(query, store)
+        .unwrap_or_else(|e| panic!("{query}\n  {e}"));
+    match batch.records[0].get("c") {
+        Some(Value::Property(PropertyValue::Integer(n))) => *n,
+        other => panic!("{query}: expected an integer count, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_single_edge_type_count_is_answered_from_metadata() {
+    let store = fixture();
+
+    assert_eq!(count(&store, "MATCH ()-[r:CITES]->() RETURN count(r) AS c"), 15);
+    assert_eq!(count(&store, "MATCH ()-[r:LIKES]->() RETURN count(r) AS c"), 3);
+    assert_eq!(count(&store, "MATCH ()-[r]->() RETURN count(r) AS c"), 18);
+    assert_eq!(count(&store, "MATCH ()-[r:CITES]->() RETURN count(*) AS c"), 15);
+
+    // an edge type nobody has used is 0, not an error and not the total
+    assert_eq!(count(&store, "MATCH ()-[r:NOSUCH]->() RETURN count(r) AS c"), 0);
+
+    // and it really is the shortcut
+    let engine = QueryEngine::new();
+    let plan = format!(
+        "{:?}",
+        engine
+            .execute("EXPLAIN MATCH ()-[r:CITES]->() RETURN count(r) AS c", &store)
+            .unwrap()
+            .records[0]
+            .get("plan")
+    );
+    assert!(plan.contains("EdgeCount"), "expected the O(1) path, plan was: {plan}");
+}
+
+#[test]
+fn the_shortcut_declines_when_the_pattern_says_more_than_the_metadata_knows() {
+    // Each of these constrains the count in a way edge-type totals cannot express. Firing
+    // the shortcut here would return a fast, confident, wrong number — which is worse than
+    // the timeout it replaces.
+    let store = fixture();
+
+    assert_eq!(count(&store, "MATCH ()-[r:CITES]->(:B) RETURN count(r) AS c"), 5);
+    assert_eq!(count(&store, "MATCH (:A)-[r:CITES]->(:A) RETURN count(r) AS c"), 10);
+    assert_eq!(
+        count(&store, "MATCH (x)-[r:CITES]->() WHERE x.i = 0 RETURN count(r) AS c"),
+        2
+    );
+    assert_eq!(
+        count(&store, "MATCH (x {i: 0})-[r:CITES]->() RETURN count(r) AS c"),
+        2
+    );
+
+    let engine = QueryEngine::new();
+    for query in [
+        "EXPLAIN MATCH ()-[r:CITES]->(:B) RETURN count(r) AS c",
+        "EXPLAIN MATCH (x)-[r:CITES]->() WHERE x.i = 0 RETURN count(r) AS c",
+    ] {
+        let plan = format!("{:?}", engine.execute(query, &store).unwrap().records[0].get("plan"));
+        assert!(
+            !plan.contains("EdgeCount"),
+            "shortcut must not fire for {query}, plan was: {plan}"
+        );
+    }
+}
+
+#[test]
+fn the_grouped_form_and_label_counts_are_unaffected() {
+    let store = fixture();
+    let engine = QueryEngine::new();
+
+    let grouped = engine
+        .execute("MATCH ()-[r]->() RETURN type(r) AS t, count(r) AS c", &store)
+        .unwrap();
+    assert_eq!(grouped.records.len(), 2, "one row per edge type");
+
+    assert_eq!(count(&store, "MATCH (a:A) RETURN count(a) AS c"), 10);
+    assert_eq!(count(&store, "MATCH (b:B) RETURN count(b) AS c"), 5);
+}


### PR DESCRIPTION
Refs #304 — the edge-cardinality half. Global top-N is untouched; see below.

## What was wrong

```cypher
MATCH (a:A)            RETURN count(a)              -- 38 µs, from metadata
MATCH ()-[r]->()       RETURN type(r), count(r)     -- 27 µs, from metadata
MATCH ()-[r:CITES]->() RETURN count(r)              -- 39 ms, full Expand + Aggregate
```

The **simpler** query was the slow one. Node label counts had an O(1) path, and so did the *grouped* edge form — a count filtered to one edge type was the gap, and on 1.22B edges that gap is the 120s timeout in Q08/Q09.

## The fix

An `EdgeCount` operator reading the same `edge_type_counts` the grouped form already used.

| query | before | after |
|---|---|---|
| `MATCH ()-[r:CITES]->() RETURN count(r)` | 39 ms | **259 µs** |
| `MATCH ()-[r]->() RETURN count(r)` | 34 ms | **20 µs** |

## The part worth reviewing

The danger in a metadata shortcut is not slowness — it's returning a **fast, confident, wrong number** when the pattern constrains more than edge-type totals can express. That would be worse than the timeout it replaces.

It fires only for a single unadorned segment: both endpoints label-free *and* property-free, no WHERE, no WITH, no ORDER BY, no variable-length, at most one edge type, and the counted variable must be the edge itself or `count(*)`.

Each way of constraining it further is tested for **both** the right answer and that the shortcut declined:

| query | answer | shortcut |
|---|---|---|
| `()-[r:CITES]->(:B)` | 5 | declines |
| `(:A)-[r:CITES]->(:A)` | 10 | declines |
| `(x)-[r:CITES]->() WHERE x.i = 0` | 2 | declines |
| `(x {i: 0})-[r:CITES]->()` | 2 | declines |
| `count(DISTINCT r)` | 15 | declines |
| `()-[r:NOSUCH]->()` | **0** | fires |

That last one matters: an unused edge type must be 0, not the total and not an error.

## Not addressed

Global top-N (Q19/Q20 — most-cited articles, most-prolific authors) still materialises the full grouping before taking K. That needs a bounded/streaming aggregation and is a separate change.

## Verified

- `cargo test --workspace`: **2488 passed, 0 failed**