### PR TITLE
fix(benches): point the shared-module includes at its new path

### DIFF
--- a/benches/common/bench_setup.rs
+++ b/benches/common/bench_setup.rs
@@ -1,6 +1,6 @@
 //! Shared benchmark setup: GPU status reporting.
 //!
-//! Each benchmark includes this via `#[path = "bench_setup.rs"] mod bench_setup;`
+//! Each benchmark includes this via `#[path = "common/bench_setup.rs"] mod bench_setup;`
 //! and calls `bench_setup::init()` at the top of `main()`.
 //!
 //! In OSS there is no license gate: GPU acceleration is on by default whenever a

--- a/benches/finbench_benchmark.rs
+++ b/benches/finbench_benchmark.rs
@@ -20,7 +20,7 @@ use std::time::{Duration, Instant};
 
 use samyama_sdk::{EmbeddedClient, SamyamaClient};
 
-#[path = "bench_setup.rs"]
+#[path = "common/bench_setup.rs"]
 mod bench_setup;
 
 mod finbench_common;

--- a/benches/full_benchmark.rs
+++ b/benches/full_benchmark.rs
@@ -14,7 +14,7 @@ use std::time::Instant;
 use std::sync::Arc;
 use rand::Rng;
 
-#[path = "bench_setup.rs"]
+#[path = "common/bench_setup.rs"]
 mod bench_setup;
 
 const VECTOR_DIM: usize = 128;

--- a/benches/graph_optimization_benchmark.rs
+++ b/benches/graph_optimization_benchmark.rs
@@ -6,7 +6,7 @@ use rand::Rng;
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
-#[path = "bench_setup.rs"]
+#[path = "common/bench_setup.rs"]
 mod bench_setup;
 
 /// A Problem definition that wraps a reference to the Graph Store.

--- a/benches/graphalytics_benchmark.rs
+++ b/benches/graphalytics_benchmark.rs
@@ -32,7 +32,7 @@ use samyama_graph_algorithms::{
     local_clustering_coefficient_directed,
 };
 
-#[path = "bench_setup.rs"]
+#[path = "common/bench_setup.rs"]
 mod bench_setup;
 
 mod graphalytics_common;

--- a/benches/late_materialization_bench.rs
+++ b/benches/late_materialization_bench.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 use std::collections::HashSet;
 use rand::Rng;
 
-#[path = "bench_setup.rs"]
+#[path = "common/bench_setup.rs"]
 mod bench_setup;
 
 const NUM_NODES: usize = 10_000;

--- a/benches/ldbc_benchmark.rs
+++ b/benches/ldbc_benchmark.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, Instant};
 
 use samyama_sdk::{EmbeddedClient, SamyamaClient};
 
-#[path = "bench_setup.rs"]
+#[path = "common/bench_setup.rs"]
 mod bench_setup;
 
 mod ldbc_common;

--- a/benches/ldbc_bi_benchmark.rs
+++ b/benches/ldbc_bi_benchmark.rs
@@ -25,7 +25,7 @@ use std::time::{Duration, Instant};
 
 use samyama_sdk::{EmbeddedClient, SamyamaClient};
 
-#[path = "bench_setup.rs"]
+#[path = "common/bench_setup.rs"]
 mod bench_setup;
 
 mod ldbc_bi_common;

--- a/benches/mvcc_benchmark.rs
+++ b/benches/mvcc_benchmark.rs
@@ -13,7 +13,7 @@ use samyama::graph::{GraphStore, Label, PropertyValue};
 use std::time::Instant;
 use std::hint::black_box;
 
-#[path = "bench_setup.rs"]
+#[path = "common/bench_setup.rs"]
 mod bench_setup;
 
 const ARENA_NODES: usize = 1_000_000;

--- a/benches/vector_benchmark.rs
+++ b/benches/vector_benchmark.rs
@@ -13,7 +13,7 @@ use std::collections::HashSet;
 use std::time::Instant;
 use rand::Rng;
 
-#[path = "bench_setup.rs"]
+#[path = "common/bench_setup.rs"]
 mod bench_setup;
 
 fn format_number(n: usize) -> String {


### PR DESCRIPTION
Fixes #427. Also repairs main.

## Repairing main first

**`cargo build --benches` is broken on main right now.** #431 moved `benches/bench_setup.rs` → `benches/common/bench_setup.rs` but did not carry the ten `#[path = ...]` includes with it.

That was my error, and worth naming precisely: `git mv` **stages** the rename, so when I committed the unrelated docs change the move went along with it, while the edits that make it work were sitting in a stash. `git commit` commits the index, not the files you name.

This PR adds the ten include updates the move needed.

## The change #427 asked for

`bench_setup.rs` is a shared module — its own doc comment says so, and each benchmark pulls it in via `#[path = "..."] mod bench_setup;`. Sitting at the top level of `benches/` made Cargo auto-discover it as a bench target. It was the only bench file not declared in `Cargo.toml`, and it broke tooling that iterates bench targets:

```
$ cargo bench --bench bench_setup -- --warm-up-time 1 --measurement-time 3
error: Unrecognized option: 'warm-up-time'
error: bench failed, to rerun pass `--bench bench_setup`
```

A subdirectory is not auto-discovered, and it matches the convention the other shared bench modules already follow — `finbench_common/`, `graphalytics_common/`, `hier_common/`, `ldbc_common/`, `ldbc_bi_common/`.

## Verified

- `cargo build --benches` succeeds
- `cargo bench --bench bench_setup` → no longer a target (cargo lists the real benches instead)
- `cargo bench --bench mvcc_benchmark -- --warm-up-time 1 --measurement-time 2 --sample-size 10` runs, so criterion flags work on the real targets