### PR TITLE
fix(examples): say what data is missing instead of panicking

### DIFF
--- a/examples/amr_stewardship_demo.rs
+++ b/examples/amr_stewardship_demo.rs
@@ -99,7 +99,13 @@ fn build_amr_kg(catalog: &std::path::Path)
     -> (GraphStore, Vec<(String, String, String, String)>) // (gene_family, class, subclass, taxa)
 {
     let mut store = GraphStore::new();
-    let f = File::open(catalog).expect("catalog");
+    let f = File::open(catalog).unwrap_or_else(|e| {
+        eprintln!("Error: cannot read the NCBI Reference Gene Catalog: {}", catalog.display());
+        eprintln!("       {e}");
+        eprintln!("       this example needs data that is not part of this repository;");
+        eprintln!("       pass --catalog PATH to point at your own copy.");
+        std::process::exit(1);
+    });
     let mut header: Vec<String> = Vec::new();
     let mut rows = Vec::new();
 

--- a/examples/clinical_trial_sites_demo.rs
+++ b/examples/clinical_trial_sites_demo.rs
@@ -117,7 +117,13 @@ fn main() {
     eprintln!("loading {} ...", a.snapshot.display());
     let mut store = GraphStore::new();
     let t0 = Instant::now();
-    let f = File::open(&a.snapshot).expect("snapshot open");
+    let f = File::open(&a.snapshot).unwrap_or_else(|e| {
+        eprintln!("Error: cannot read the clinical-trials snapshot: {}", &a.snapshot.display());
+        eprintln!("       {e}");
+        eprintln!("       this example needs data that is not part of this repository;");
+        eprintln!("       pass --snapshot PATH to point at your own copy.");
+        std::process::exit(1);
+    });
     let stats = samyama::snapshot::import_tenant(&mut store, f).expect("import");
     let load_ms = t0.elapsed().as_millis();
     eprintln!("loaded {} nodes, {} edges in {} ms",

--- a/examples/drug_repurposing_demo.rs
+++ b/examples/drug_repurposing_demo.rs
@@ -123,7 +123,13 @@ fn main() {
     eprintln!("loading {} ...", a.snapshot.display());
     let mut store = GraphStore::new();
     let t0 = Instant::now();
-    let f = File::open(&a.snapshot).expect("snapshot open");
+    let f = File::open(&a.snapshot).unwrap_or_else(|e| {
+        eprintln!("Error: cannot read the drug-interactions snapshot: {}", &a.snapshot.display());
+        eprintln!("       {e}");
+        eprintln!("       this example needs data that is not part of this repository;");
+        eprintln!("       pass --snapshot PATH to point at your own copy.");
+        std::process::exit(1);
+    });
     let stats = samyama::snapshot::import_tenant(&mut store, f).expect("import");
     let load_ms = t0.elapsed().as_millis();
     eprintln!("loaded {} nodes, {} edges in {} ms",

--- a/examples/grid_dispatch_demo.rs
+++ b/examples/grid_dispatch_demo.rs
@@ -110,7 +110,13 @@ fn build_grid_kg(data_dir: &std::path::Path) -> (GraphStore, Vec<Generator>, Vec
     // Generators.
     let gen_csv = data_dir.join("sample_generators.csv");
     let mut gens = Vec::new();
-    let f = File::open(&gen_csv).expect("generators csv");
+    let f = File::open(&gen_csv).unwrap_or_else(|e| {
+        eprintln!("Error: cannot read the smart-grid sample data: {}", &gen_csv.display());
+        eprintln!("       {e}");
+        eprintln!("       this example needs data that is not part of this repository;");
+        eprintln!("       pass --data-dir PATH to point at your own copy.");
+        std::process::exit(1);
+    });
     for (i, line) in BufReader::new(f).lines().enumerate() {
         let line = line.unwrap();
         if i == 0 { continue; } // header

--- a/examples/healthcare_allocation_demo.rs
+++ b/examples/healthcare_allocation_demo.rs
@@ -113,7 +113,13 @@ fn main() {
     eprintln!("loading {} ...", a.snapshot.display());
     let mut store = GraphStore::new();
     let t0 = Instant::now();
-    let f = File::open(&a.snapshot).expect("snapshot open");
+    let f = File::open(&a.snapshot).unwrap_or_else(|e| {
+        eprintln!("Error: cannot read the health-systems snapshot: {}", &a.snapshot.display());
+        eprintln!("       {e}");
+        eprintln!("       this example needs data that is not part of this repository;");
+        eprintln!("       pass --snapshot PATH to point at your own copy.");
+        std::process::exit(1);
+    });
     let stats = samyama::snapshot::import_tenant(&mut store, f).expect("import");
     let load_ms = t0.elapsed().as_millis();
     eprintln!("loaded {} nodes, {} edges in {} ms",

--- a/examples/supply_chain_snapshot.rs
+++ b/examples/supply_chain_snapshot.rs
@@ -35,7 +35,16 @@ fn main() {
     eprintln!("spec : {}", spec_path.display());
 
     let mut s = String::new();
-    File::open(&nodes_path).expect("nodes").read_to_string(&mut s).unwrap();
+    File::open(&nodes_path)
+        .unwrap_or_else(|e| {
+            eprintln!("Error: cannot read the supply-chain nodes file: {}", nodes_path.display());
+            eprintln!("       {e}");
+            eprintln!("       this example needs data that is not part of this repository;");
+            eprintln!("       pass --nodes PATH to point at your own copy.");
+            std::process::exit(1);
+        })
+        .read_to_string(&mut s)
+        .unwrap();
     let nodes_json: serde_json::Value = serde_json::from_str(&s).expect("nodes json");
     s.clear();
     File::open(&spec_path).expect("spec").read_to_string(&mut s).unwrap();

--- a/examples/uc4_aact_real.rs
+++ b/examples/uc4_aact_real.rs
@@ -101,7 +101,13 @@ fn as_f(v: &serde_json::Value) -> f64 {
 
 async fn cypher(client: &RemoteClient, q: &str) -> samyama_sdk::QueryResult {
     client.query_readonly("default", q).await
-        .unwrap_or_else(|e| panic!("cypher error: {e}\n{q}"))
+        .unwrap_or_else(|e| {
+            eprintln!("Error: query failed against the server: {e}");
+            eprintln!("       {q}");
+            eprintln!("       this example talks to a running samyama server on :8080;");
+            eprintln!("       start one with `./target/release/samyama` and load the AACT data first.");
+            std::process::exit(1);
+        })
 }
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]

--- a/examples/wildfire_evac_demo.rs
+++ b/examples/wildfire_evac_demo.rs
@@ -113,7 +113,13 @@ fn haversine_km(a: (f64, f64), b: (f64, f64)) -> f64 {
 fn parse_osm(path: &std::path::Path)
     -> (GraphStore, Vec<OsmNode>, HashMap<i64, usize>)
 {
-    let mut file = File::open(path).expect("OSM JSON");
+    let mut file = File::open(path).unwrap_or_else(|e| {
+        eprintln!("Error: cannot read an OSM JSON extract: {}", path.display());
+        eprintln!("       {e}");
+        eprintln!("       this example needs data that is not part of this repository;");
+        eprintln!("       pass --osm PATH to point at your own copy.");
+        std::process::exit(1);
+    });
     let mut buf = String::new();
     file.read_to_string(&mut buf).expect("read");
     let v: serde_json::Value = serde_json::from_str(&buf).expect("json parse");


### PR DESCRIPTION
Fixes #426

## What was wrong

Eight examples died with a bare OS error when their data was absent:

```
thread 'main' panicked at examples/amr_stewardship_demo.rs:102:33:
catalog: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

Naming neither the file nor where to get it. All of them reach for a sibling repository — `../amr-kg`, `../clinicaltrials-kg`, `../druginteractions-kg`, `../health-systems-kg`, `../optimization` — that a fresh clone doesn't have and doesn't mention.

## After

```
Error: cannot read the NCBI Reference Gene Catalog: /nonexistent/x.txt
       No such file or directory (os error 2)
       this example needs data that is not part of this repository;
       pass --catalog PATH to point at your own copy.
```

Exit 1, no panic. Each names the flag that actually overrides its path — `--catalog`, `--snapshot`, `--data-dir`, `--osm`, `--nodes` — checked per example rather than assumed.

`uc4_aact_real` is the odd one out: it needs a running server, not a file, so it says that.

## This is the repo's own convention

20 of the 55 examples already do this correctly (`Error: "--variants PATH is required"`). These eight had skipped it, which is what made it an inconsistency rather than a missing design.

## On verifying it

Worth flagging: **this machine has the sibling repos**, so six of the eight ran to completion here and would have looked fine. The gap was only visible on the clean Vultr host. I verified the new path by pointing each example at a file that does not exist and checking both the message and `exit=1` — rather than trusting a local run that never took the branch.

## Verified

- `cargo build --release --examples` clean
- Error path confirmed for all eight, exit code 1
- `cargo test --workspace`: **2491 passed, 0 failed**