### PR TITLE
fix(query): YIELD variables are in scope for a later WHERE

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -555,6 +555,30 @@ impl QueryPlanner {
         Ok(())
     }
 
+    /// Variables that exist only *above* the match pipeline, and so cannot be referenced by
+    /// a predicate evaluated during match planning.
+    ///
+    /// Two sources, both of which bind their variables in an operator that sits on top of
+    /// the matches: a leading UNWIND, and a `CALL ... YIELD`. A predicate mentioning one of
+    /// these must be left to the top-level WHERE filter, which runs after both are joined
+    /// in. Assigning it to a MATCH instead puts the filter underneath the operator that
+    /// binds the variable, and the query dies with "Variable not found" even though the
+    /// same variable projects fine in RETURN (#429).
+    fn late_bound_variables(query: &Query) -> HashSet<String> {
+        let mut vars = HashSet::new();
+        if query.unwind_leading {
+            if let Some(u) = &query.unwind_clause {
+                vars.insert(u.variable.clone());
+            }
+        }
+        if let Some(call) = &query.call_clause {
+            for item in &call.yield_items {
+                vars.insert(item.alias.clone().unwrap_or_else(|| item.name.clone()));
+            }
+        }
+        vars
+    }
+
     pub fn plan(&self, query: &Query, store: &GraphStore) -> ExecutionResult<ExecutionPlan> {
         Self::reject_unevaluated_property_exprs(query)?;
         let mut plan = self.plan_inner(query, store)?;
@@ -951,19 +975,13 @@ impl QueryPlanner {
         // the Unwind operator that binds it sits above the matches. The top-level WHERE
         // filter re-applies the full predicate after the Unwind, so dropping it here loses
         // nothing.
-        let deferred_unwind_var_pre: Option<String> = if query.unwind_leading {
-            query.unwind_clause.as_ref().map(|u| u.variable.clone())
-        } else {
-            None
-        };
+        let late_bound_pre = Self::late_bound_variables(query);
 
         for pred in pre_where_preds {
             let mut pred_vars = HashSet::new();
             Self::collect_expression_variables(&pred, &mut pred_vars);
-            if let Some(uv) = &deferred_unwind_var_pre {
-                if pred_vars.contains(uv) {
-                    continue;
-                }
+            if pred_vars.iter().any(|v| late_bound_pre.contains(v)) {
+                continue;
             }
 
             let target = pre_match_var_sets.iter().position(|match_vars| {
@@ -1096,19 +1114,13 @@ impl QueryPlanner {
             // the Unwind and the query died with "Variable not found". Dropping it from the
             // decomposition is safe because the top-level WHERE filter, applied after the
             // Unwind, evaluates the full predicate anyway.
-            let deferred_unwind_var: Option<String> = if query.unwind_leading {
-                query.unwind_clause.as_ref().map(|u| u.variable.clone())
-            } else {
-                None
-            };
+            let late_bound = Self::late_bound_variables(query);
 
             for pred in where_preds {
                 let mut pred_vars = HashSet::new();
                 Self::collect_expression_variables(&pred, &mut pred_vars);
-                if let Some(uv) = &deferred_unwind_var {
-                    if pred_vars.contains(uv) {
-                        continue;
-                    }
+                if pred_vars.iter().any(|v| late_bound.contains(v)) {
+                    continue;
                 }
                 let target = match_var_sets.iter().position(|match_vars| {
                     pred_vars.is_empty() || pred_vars.iter().all(|v| match_vars.contains(v))

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -1671,3 +1671,82 @@ fn match_and_merge_refuse_non_literal_property_values_rather_than_ignoring_them(
         vec!["v=1"]
     );
 }
+
+// ---------------------------------------------------------------------------
+// YIELD variables are in scope for a following MATCH's WHERE (#429)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_yielded_variable_can_be_referenced_by_a_later_where() {
+    // `CALL ... YIELD x` binds x in an operator that sits *above* the match pipeline, so a
+    // predicate mentioning x was being assigned to a MATCH and evaluated underneath the
+    // operator that binds it -- "Variable not found", even though the same variable
+    // projects fine in RETURN. That asymmetry is what made it confusing: the join was
+    // already happening, only the filter was placed on the wrong side of it.
+    let mut s = GraphStore::new();
+    let engine = QueryEngine::new();
+    for i in 0..5 {
+        engine
+            .execute_mut(&format!("CREATE (:Term {{code: \"T{i}\"}})"), &mut s, "default")
+            .unwrap();
+    }
+
+    // db.labels() yields exactly one row here: "Term"
+    assert_eq!(bag(&s, "CALL db.labels() YIELD label RETURN label"), vec!["label=Term"]);
+
+    // The predicate must *filter*, not merely parse. `t.code` is T0..T4 and `label` is
+    // "Term", so this is never true -- a dropped predicate would give 5.
+    assert_eq!(
+        scalar(
+            &s,
+            "CALL db.labels() YIELD label MATCH (t:Term) WHERE t.code = label RETURN count(t) AS n"
+        ),
+        "n=0"
+    );
+
+    // always true -> every row survives
+    assert_eq!(
+        scalar(
+            &s,
+            "CALL db.labels() YIELD label MATCH (t:Term) WHERE label = \"Term\" RETURN count(t) AS n"
+        ),
+        "n=5"
+    );
+
+    // a predicate spanning both sides of the join
+    assert_eq!(
+        scalar(
+            &s,
+            "CALL db.labels() YIELD label MATCH (t:Term) \
+             WHERE label = \"Term\" AND t.code = \"T2\" RETURN count(t) AS n"
+        ),
+        "n=1"
+    );
+    assert_eq!(
+        scalar(
+            &s,
+            "CALL db.labels() YIELD label MATCH (t:Term) \
+             WHERE label = \"Nope\" AND t.code = \"T2\" RETURN count(t) AS n"
+        ),
+        "n=0"
+    );
+
+    // a match-only predicate must still be pushed down to the MATCH, not deferred
+    assert_eq!(
+        scalar(
+            &s,
+            "CALL db.labels() YIELD label MATCH (t:Term) WHERE t.code = \"T1\" RETURN count(t) AS n"
+        ),
+        "n=1"
+    );
+
+    // and the previously-working shapes are unchanged
+    assert_eq!(
+        scalar(&s, "CALL db.labels() YIELD label MATCH (t:Term) RETURN count(t) AS n"),
+        "n=5"
+    );
+    assert_eq!(
+        scalar(&s, "CALL db.labels() YIELD label WHERE label = \"Term\" RETURN count(*) AS n"),
+        "n=1"
+    );
+}


### PR DESCRIPTION
Fixes #429

## What was wrong

```cypher
CALL db.labels() YIELD label MATCH (t:Term) WHERE t.code = label RETURN count(t)
-- Variable not found: label
```

`CALL ... YIELD x` binds `x` in an operator **above** the match pipeline. Predicate decomposition assigned any predicate mentioning `x` to a MATCH, which places the filter *underneath* the operator that binds it.

The asymmetry was the tell — the same variable projects fine:

```cypher
CALL db.labels() YIELD label MATCH (t:Term) RETURN label, count(t)   -- works
```

The join was already happening (the plan shows a `CartesianProduct`); only the filter sat on the wrong side of it.

## The fix

This is the same shape as the leading-UNWIND case fixed earlier, so the two now share one rule. `late_bound_variables` collects the variables bound above the matches — a leading UNWIND's variable and every CALL YIELD item — and predicates mentioning them are left to the top-level WHERE filter, which runs after both are joined in.

Replacing two near-identical `deferred_unwind_var` blocks with one helper means the next such source only has to be added in one place.

## Tests assert filtering, not parsing

The trap here is that `count(t)` returns one row whether or not the predicate ran, so a row-count assertion would pass on a dropped filter — which is exactly the failure mode I've hit repeatedly in this codebase. So:

| predicate | expected |
|---|---|
| `t.code = label` (never true — codes are `T0..T4`, label is `Term`) | **0** |
| `label = "Term"` (always true) | **5** |
| `label = "Term" AND t.code = "T2"` (spans the join) | **1** |
| `label = "Nope" AND t.code = "T2"` | **0** |
| `t.code = "T1"` (match-only — must still push down) | **1** |

## Unblocks HIER H9

`benchmarks/hier/queries.json` skips 4 queries with a hardcoded note that subtree-restricted ANN search cannot be expressed, because it needs exactly this shape:

```cypher
CALL db.index.vector.queryNodes("Term","emb",[...],200) YIELD node, score
MATCH (r:Term {code: "T0"}) WHERE subsumes(node, r) RETURN count(node)
```

That skip is a static string rather than a live probe, so it will keep skipping until someone edits the JSON — worth doing as a follow-up now that the composition works.

## Verified

- `cargo test --workspace`: **2491 passed, 0 failed**
- Conformance suite: 61 passed, 0 ignored