### PR TITLE
fix(case-studies): skip cleanly when a snapshot is not published yet

### DIFF
--- a/case_studies/_lib/run_case_study.sh
+++ b/case_studies/_lib/run_case_study.sh
@@ -20,6 +20,18 @@ CASE_DIR="$(pwd)"
 source "$CASE_DIR/case.env"
 : "${DOMAIN:?case.env must set DOMAIN}"
 : "${SNAPSHOT_URL:?case.env must set SNAPSHOT_URL}"
+# A case study whose snapshot has not been published yet carries a placeholder rather than
+# a URL. Detect it and skip cleanly: otherwise curl treats the placeholder as a hostname and
+# emits four DNS failures before the runner reports a generic "snapshot fetch failed", which
+# reads as a broken case study rather than an unpublished one (#428).
+case "$SNAPSHOT_URL" in
+  PENDING_UPLOAD|TODO|CHANGEME|"")
+    echo "SKIP: ${DOMAIN} — its snapshot has not been published yet (SNAPSHOT_URL=${SNAPSHOT_URL:-unset})."
+    echo "      Build it locally with the command in case.env, then pass --snapshot, or wait"
+    echo "      for the release. Skipping rather than failing: nothing here is broken."
+    exit 0
+    ;;
+esac
 : "${SNAPSHOT_SHA256:=-}"     # "-" to skip hash check
 : "${GRAPH:=default}"
 : "${DEDUP_KEY:=}"


### PR DESCRIPTION
Refs #428 — implements the graceful-skip half. The snapshot itself still needs publishing, so the issue stays open.

## What was wrong

`legal-judgments/case.env` carries `SNAPSHOT_URL=PENDING_UPLOAD`. curl treats that as a hostname:

```
[fetch] downloading PENDING_UPLOAD
curl: (6) Could not resolve host: PENDING_UPLOAD
Warning: Problem : timeout. Will retry in 1 seconds. 3 retries left.
...
[legal-judgments] ERROR: snapshot fetch failed
```

Four DNS failures and a generic error. That reads as a broken case study; it's an *unpublished* one, which is a different thing.

## After

```
SKIP: legal-judgments — its snapshot has not been published yet (SNAPSHOT_URL=PENDING_UPLOAD).
      Build it locally with the command in case.env, then pass --snapshot, or wait
      for the release. Skipping rather than failing: nothing here is broken.
```

Exit 0. Also catches `TODO`, `CHANGEME` and empty, since the same thing will happen next time a case study is added before its artifact exists.

## What this does not do

It does not publish the snapshot. `SNAPSHOT_SHA256` **is** filled in, so the artifact was built and hashed at some point — whoever has it can finish the job by uploading and setting the URL, with the hash already there to verify against. That's an outward-facing release action, so I've left it.

## Verified

- `legal-judgments` → skips, exit 0
- `football` → still runs end to end, 8/8 queries — the guard doesn't affect real case studies