### PR TITLE
bench(hier): enable H9 — hierarchy-filtered vector search now runs

### DIFF
--- a/benchmarks/hier/generate_corpus.py
+++ b/benchmarks/hier/generate_corpus.py
@@ -229,16 +229,14 @@ for label in ["State", "City"]:
         f'MATCH (t:{label})<-[:LOCATED_IN*0..]-(d) RETURN t.code AS code, sum(d.units) AS v '
         f'ORDER BY sum(d.units) DESC')
 
-# ------------------------------------- H9 hierarchy-filtered vector search (blocked)
-BLOCKED = ("engine gap: CALL db.index.vector.queryNodes(...) YIELD node cannot be composed "
-           "with a following MATCH or WHERE that references `node`, so an ANN search cannot "
-           "be restricted to a subtree today. The ANN call and the subsumption predicate "
-           "each work in isolation; only the composition is missing.")
+# ---------------------------------------------- H9 hierarchy-filtered vector search
+# Unblocked by samyama-graph#439: a CALL's YIELD variables are now in scope for a
+# following MATCH's WHERE, which is what this composition needs. The ANN call and the
+# subsumption predicate always worked in isolation; only joining them was missing.
 for i, code in enumerate(["T0", "T05", "T1", "T"], start=1):
     add(f"H9-{i:02d}", "H9", f"200-NN vector search restricted to the {code} subtree",
         f'CALL db.index.vector.queryNodes("Term", "emb", [0.5, 0.5, 0.5, 0.5], 200) YIELD node, score '
-        f'MATCH (r:Term {{code: "{code}"}}) WHERE subsumes(node, r) RETURN count(node) AS n',
-        skip=BLOCKED)
+        f'MATCH (r:Term {{code: "{code}"}}) WHERE subsumes(node, r) RETURN count(node) AS n')
 
 # ------------------------------------------------------ H10 temporal roll-up windows
 n = 0
@@ -271,7 +269,7 @@ corpus = {
         "H6": "anti-subsumption and subtree set difference",
         "H7": "lowest common ancestor",
         "H8": "top-k over roll-up (roll-up called in a loop)",
-        "H9": "hierarchy-filtered vector search (specified; blocked, see `skip`)",
+        "H9": "hierarchy-filtered vector search",
         "H10": "temporal roll-up windows",
     },
     "queries": Q,

--- a/benchmarks/hier/queries.json
+++ b/benchmarks/hier/queries.json
@@ -12,7 +12,7 @@
   "H6": "anti-subsumption and subtree set difference",
   "H7": "lowest common ancestor",
   "H8": "top-k over roll-up (roll-up called in a loop)",
-  "H9": "hierarchy-filtered vector search (specified; blocked, see `skip`)",
+  "H9": "hierarchy-filtered vector search",
   "H10": "temporal roll-up windows"
  },
  "queries": [
@@ -682,29 +682,25 @@
    "id": "H9-01",
    "class": "H9",
    "name": "200-NN vector search restricted to the T0 subtree",
-   "cypher": "CALL db.index.vector.queryNodes(\"Term\", \"emb\", [0.5, 0.5, 0.5, 0.5], 200) YIELD node, score MATCH (r:Term {code: \"T0\"}) WHERE subsumes(node, r) RETURN count(node) AS n",
-   "skip": "engine gap: CALL db.index.vector.queryNodes(...) YIELD node cannot be composed with a following MATCH or WHERE that references `node`, so an ANN search cannot be restricted to a subtree today. The ANN call and the subsumption predicate each work in isolation; only the composition is missing."
+   "cypher": "CALL db.index.vector.queryNodes(\"Term\", \"emb\", [0.5, 0.5, 0.5, 0.5], 200) YIELD node, score MATCH (r:Term {code: \"T0\"}) WHERE subsumes(node, r) RETURN count(node) AS n"
   },
   {
    "id": "H9-02",
    "class": "H9",
    "name": "200-NN vector search restricted to the T05 subtree",
-   "cypher": "CALL db.index.vector.queryNodes(\"Term\", \"emb\", [0.5, 0.5, 0.5, 0.5], 200) YIELD node, score MATCH (r:Term {code: \"T05\"}) WHERE subsumes(node, r) RETURN count(node) AS n",
-   "skip": "engine gap: CALL db.index.vector.queryNodes(...) YIELD node cannot be composed with a following MATCH or WHERE that references `node`, so an ANN search cannot be restricted to a subtree today. The ANN call and the subsumption predicate each work in isolation; only the composition is missing."
+   "cypher": "CALL db.index.vector.queryNodes(\"Term\", \"emb\", [0.5, 0.5, 0.5, 0.5], 200) YIELD node, score MATCH (r:Term {code: \"T05\"}) WHERE subsumes(node, r) RETURN count(node) AS n"
   },
   {
    "id": "H9-03",
    "class": "H9",
    "name": "200-NN vector search restricted to the T1 subtree",
-   "cypher": "CALL db.index.vector.queryNodes(\"Term\", \"emb\", [0.5, 0.5, 0.5, 0.5], 200) YIELD node, score MATCH (r:Term {code: \"T1\"}) WHERE subsumes(node, r) RETURN count(node) AS n",
-   "skip": "engine gap: CALL db.index.vector.queryNodes(...) YIELD node cannot be composed with a following MATCH or WHERE that references `node`, so an ANN search cannot be restricted to a subtree today. The ANN call and the subsumption predicate each work in isolation; only the composition is missing."
+   "cypher": "CALL db.index.vector.queryNodes(\"Term\", \"emb\", [0.5, 0.5, 0.5, 0.5], 200) YIELD node, score MATCH (r:Term {code: \"T1\"}) WHERE subsumes(node, r) RETURN count(node) AS n"
   },
   {
    "id": "H9-04",
    "class": "H9",
    "name": "200-NN vector search restricted to the T subtree",
-   "cypher": "CALL db.index.vector.queryNodes(\"Term\", \"emb\", [0.5, 0.5, 0.5, 0.5], 200) YIELD node, score MATCH (r:Term {code: \"T\"}) WHERE subsumes(node, r) RETURN count(node) AS n",
-   "skip": "engine gap: CALL db.index.vector.queryNodes(...) YIELD node cannot be composed with a following MATCH or WHERE that references `node`, so an ANN search cannot be restricted to a subtree today. The ANN call and the subsumption predicate each work in isolation; only the composition is missing."
+   "cypher": "CALL db.index.vector.queryNodes(\"Term\", \"emb\", [0.5, 0.5, 0.5, 0.5], 200) YIELD node, score MATCH (r:Term {code: \"T\"}) WHERE subsumes(node, r) RETURN count(node) AS n"
   },
   {
    "id": "H10-01",


### PR DESCRIPTION
Follows #439.

## What changed

The four H9 queries — *"200-NN vector search restricted to the T0 subtree"* — were specified but carried a hardcoded `skip`:

> engine gap: `CALL db.index.vector.queryNodes(...) YIELD node` cannot be composed with a following MATCH or WHERE that references `node` … The ANN call and the subsumption predicate each work in isolation; only the composition is missing.

#439 fixed exactly that. Nothing else was missing: the corpus already gives Terms a deterministic 4-dimensional `emb` and already declares `CREATE VECTOR INDEX termvec FOR (t:Term) ON (t.emb) OPTIONS {dimensions: 4}`. The engine gap was the only thing between the corpus and the question it was written to ask.

## Result

```
HIER benchmark — 112 queries, 5 reps, median of each
class      n   agree   indexed ms  baseline ms   speedup
H9         4    4/4        0.008        0.007      0.9x
ALL      112 112/112       3.911       11.347      2.9x
```

**112/112 agree** with the unindexed ground truth, where it was 108 of 112 with four declared unrunnable.

## H9 is 0.9× and that is the point of reporting it

The index does not help here. With 200 nearest neighbours the subsumption filter is cheap however it is evaluated, so an order-embedding has nothing to save. The overall figure moves 3.0× → 2.9× for the same reason — the honest arithmetic of adding four queries that tie.

Per Axiom 7 in the charter, a suite that only keeps the classes it wins is not one anybody else will run. This is a class where the structure earns nothing at this scale, and saying so is more useful than the 0.1× it costs the headline.

Whether it *would* pay at a corpus where the candidate set is large relative to the subtree is a separate question the corpus does not currently ask.

## One thing worth remembering

The skip was a **static string**, not a live probe. It could not expire on its own — it would have kept skipping indefinitely after the engine gained the capability, and only a human re-reading the note would have noticed. The other capability notes in this corpus have the same property.