### PR TITLE
bench(ldbc): skip when the default dataset is absent, error when it was asked for

### DIFF
--- a/benches/ldbc_benchmark.rs
+++ b/benches/ldbc_benchmark.rs
@@ -646,6 +646,7 @@ async fn main() -> Result<(), Error> {
     let args: Vec<String> = std::env::args().collect();
 
     let default_dir = "data/ldbc-sf1/social_network-sf1-CsvBasic-LongDateFormatter";
+    let explicit_data_dir = args.iter().any(|a| a == "--data-dir");
     let data_dir = if let Some(pos) = args.iter().position(|a| a == "--data-dir") {
         PathBuf::from(args.get(pos + 1).expect("--data-dir requires a path argument"))
     } else {
@@ -679,9 +680,18 @@ async fn main() -> Result<(), Error> {
     };
 
     if !data_dir.exists() {
-        eprintln!("ERROR: Data directory not found: {}", data_dir.display());
-        eprintln!("Download LDBC SF1 data and extract to: {}", default_dir);
-        std::process::exit(1);
+        // An explicitly requested directory that does not exist is a mistake worth failing
+        // on. The *default* dataset simply not being present means this benchmark was not
+        // run, which is not the same as it failing -- a clean host has no LDBC SF1 and
+        // should report a skip, so "run every benchmark" is not permanently red.
+        if explicit_data_dir {
+            eprintln!("ERROR: Data directory not found: {}", data_dir.display());
+            std::process::exit(1);
+        }
+        eprintln!("SKIP: LDBC SF1 dataset not present at {}", data_dir.display());
+        eprintln!("      Download and extract it there, or pass --data-dir PATH.");
+        eprintln!("      Skipping rather than failing: the benchmark did not run, it did not break.");
+        return Ok(());
     }
 
     // ========================================================================

--- a/benches/ldbc_bi_benchmark.rs
+++ b/benches/ldbc_bi_benchmark.rs
@@ -541,6 +541,7 @@ async fn main() -> Result<(), Error> {
     let args: Vec<String> = std::env::args().collect();
 
     let default_dir = "data/ldbc-sf1/social_network-sf1-CsvBasic-LongDateFormatter";
+    let explicit_data_dir = args.iter().any(|a| a == "--data-dir");
     let data_dir = if let Some(pos) = args.iter().position(|a| a == "--data-dir") {
         PathBuf::from(args.get(pos + 1).expect("--data-dir requires a path argument"))
     } else {
@@ -567,12 +568,18 @@ async fn main() -> Result<(), Error> {
     };
 
     if !data_dir.exists() {
-        eprintln!("ERROR: Data directory not found: {}", data_dir.display());
-        eprintln!(
-            "Download LDBC SF1 data and extract to: {}",
-            default_dir
-        );
-        std::process::exit(1);
+        // An explicitly requested directory that does not exist is a mistake worth failing
+        // on. The *default* dataset simply not being present means this benchmark was not
+        // run, which is not the same as it failing -- a clean host has no LDBC SF1 and
+        // should report a skip, so "run every benchmark" is not permanently red.
+        if explicit_data_dir {
+            eprintln!("ERROR: Data directory not found: {}", data_dir.display());
+            std::process::exit(1);
+        }
+        eprintln!("SKIP: LDBC SF1 dataset not present at {}", data_dir.display());
+        eprintln!("      Download and extract it there, or pass --data-dir PATH.");
+        eprintln!("      Skipping rather than failing: the benchmark did not run, it did not break.");
+        return Ok(());
     }
 
     // ========================================================================


### PR DESCRIPTION
## What was wrong

On a clean host both LDBC benchmarks exit 1:

```
ERROR: Data directory not found: data/ldbc-sf1/social_network-sf1-CsvBasic-LongDateFormatter
```

That makes "run every benchmark" permanently red for something that is not a defect. The benchmark did not run; it did not break. In the clean-host sweep, 10 of 12 benches passed and these two were the only failures — both for a missing 1 GB dataset.

## The distinction

| invocation | before | after |
|---|---|---|
| `--data-dir /nope` (asked for, missing) | exit 1, ERROR | exit 1, ERROR — unchanged |
| default dataset absent | exit 1, ERROR | **exit 0, SKIP** |

An explicitly requested directory that doesn't exist is a mistake in the invocation and should still fail. A default dataset that was never downloaded is simply not available.

## Precedent in the repo

`finbench_benchmark` already draws this line, and better: with no `--data-dir` it falls back to a **synthetic** dataset rather than failing. That is exactly why it was the one LDBC-family benchmark that passed on the clean host.

A synthetic SNB generator is a much larger piece of work and worth considering separately — LDBC's own `datagen` exists for this. Skipping cleanly is the part worth having now, and it makes the difference between a sweep that reports "10 OK, 2 SKIP" and one that reports two failures every time.

## Verified

Both paths tested against a machine that *does* have the dataset, by moving it aside:

```
--data-dir /nonexistent/ldbc  →  exit=1   ERROR: Data directory not found: /nonexistent/ldbc
default absent               →  exit=0   SKIP: LDBC SF1 dataset not present at data/ldbc-sf1/...
```

`cargo test --workspace`: **2494 passed, 0 failed**