### PR TITLE
bench(ldbc): a read returning 0 rows is not a pass

### DIFF
--- a/benches/ldbc_benchmark.rs
+++ b/benches/ldbc_benchmark.rs
@@ -785,6 +785,7 @@ async fn main() -> Result<(), Error> {
 
     let mut passed = 0usize;
     let mut errors = 0usize;
+    let mut empty_reads = 0usize;
     let mut last_category = "";
     let bench_start = Instant::now();
 
@@ -814,13 +815,21 @@ async fn main() -> Result<(), Error> {
             eprintln!("       {}", err);
             errors += 1;
         } else {
-            println!("{:<6}{:<32}{:>8}{:>12}{:>12}{:>12}  OK",
+            // A read that returns nothing is not a passing benchmark. LDBC's short and
+            // complex reads return rows by construction when their parameters resolve, so
+            // 0 rows means the parameters missed the data -- and a 0.03 ms "OK" for a query
+            // that traversed nothing is the most flattering possible wrong answer. Say so
+            // in the status rather than reporting it as a pass (#449).
+            let empty = result.rows == 0
+                && matches!(query.category, "short" | "complex");
+            println!("{:<6}{:<32}{:>8}{:>12}{:>12}{:>12}  {}",
                 result.id, result.name,
                 result.rows,
                 format_ms(result.min),
                 format_ms(result.median),
-                format_ms(result.max));
-            passed += 1;
+                format_ms(result.max),
+                if empty { "EMPTY" } else { "OK" });
+            if empty { empty_reads += 1; } else { passed += 1; }
         }
     }
 
@@ -830,14 +839,26 @@ async fn main() -> Result<(), Error> {
     // Summary
     // ========================================================================
     println!();
-    println!("Summary: {}/{} passed, {} errors (total benchmark time: {})",
-        passed, queries.len(), errors, format_duration(bench_time));
+    println!("Summary: {}/{} passed, {} empty, {} errors (total benchmark time: {})",
+        passed, queries.len(), empty_reads, errors, format_duration(bench_time));
+    if empty_reads > 0 {
+        println!();
+        println!("WARNING: {empty_reads} read(s) returned 0 rows. LDBC reads return rows by");
+        println!("         construction when their parameters resolve, so this almost certainly");
+        println!("         means the substitution parameters do not match this dataset -- ids");
+        println!("         are assigned per `datagen` run and are not portable between extracts.");
+        println!("         Timings above are therefore not measuring traversal. Supply matching");
+        println!("         parameters with --params-file <json>.");
+    }
 
     // Cache stats
     let stats = client.cache_stats();
     println!("AST cache: {} hits, {} misses", stats.hits(), stats.misses());
 
-    if errors > 0 {
+    // Any empty read is a configuration failure, not a pass. A run with 17 of 21 reads
+    // returning nothing measured nothing, and exiting 0 on it is how "21/21 passed in 32 ms"
+    // came to look like a result (#449).
+    if errors > 0 || empty_reads > 0 {
         std::process::exit(1);
     }
 

--- a/benchmarks/ldbc-sf1-params.example.json
+++ b/benchmarks/ldbc-sf1-params.example.json
@@ -1,0 +1,3 @@
+{"personId": 24189255816110, "person2Id": 24189255820514, "postId": 1236950581248, "messageId": 1236950581248,
+ "firstName": "Christopher", "tagName": "Hamid_Karzai", "countryX": "India", "countryY": "Pakistan",
+ "tagClassName": "MusicalArtist", "maxDate": 1354320000000, "startDate": 1338508800000, "endDate": 1341100800000}


### PR DESCRIPTION
Fixes #449. Contributes SF1 numbers to #296.

## What was wrong

```
Summary: 21/21 passed, 0 errors (total benchmark time: 32ms)
```

Every complex read finished in ~0.03 ms and returned **0 rows**, with Status `OK` — because "passed" meant "did not error".

`Params::default()` is labelled "SF1 defaults", but `personId=933` and `person2Id=4139` do not exist in this SF1 extract. Ids there are sparse and large (14 … 37,383,395,354,990); LDBC `datagen` assigns them per generation, so hardcoded ids are only valid for the extract they came from.

## After

```
IC9   Recent FoF Posts                       0      0.03ms   EMPTY
Summary: 4/21 passed, 17 empty, 0 errors (total benchmark time: 31ms)

WARNING: 17 read(s) returned 0 rows. LDBC reads return rows by
         construction when their parameters resolve, so this almost certainly
         means the substitution parameters do not match this dataset ...
```

Exit code 1. Any empty read fails the run — a suite where 17 of 21 reads return nothing measured nothing, and exiting 0 on it is precisely how "21/21 passed in 32 ms" came to look like a result.

## The numbers it was hiding

With parameters that resolve, the same suite takes **118 s** instead of 32 ms:

| query | default params | valid params |
|---|---|---|
| IC1 Transitive Friends by Name | 0 rows, 0.03 ms | 6 rows, **860 ms** |
| IC3 Friends in Countries | 0 rows, 0.03 ms | 20 rows, **2,529 ms** |
| IC5 New Forum Members | 0 rows, 0.02 ms | 20 rows, **5,043 ms** |
| IC6 Tag Co-occurrence | 0 rows, 0.02 ms | 10 rows, **2,530 ms** |
| IC9 Recent FoF Posts | 0 rows, 0.03 ms | 20 rows, **5,970 ms** |

On 3.7M nodes / 21M edges. #296 previously had only SF10 figures; these show the same shape two scale factors down, which makes it much cheaper to iterate on.

## Also included

`benchmarks/ldbc-sf1-params.example.json`, built from the loaded data (a person with 64 `KNOWS` edges, one of their friends, a real post), so reproducing a figure does not start with reverse-engineering the id space.

## Not done here

Deriving parameters automatically when the configured `personId` does not resolve would remove the root cause rather than report it. That is the better fix and is noted in #449; this change makes the failure impossible to miss first, since that is what protects every existing published number.

## Verified

- broken params → exit **1**, 17 EMPTY, warning printed
- valid params → exit **0**, 21/21 passed, 118 s
- `cargo test --workspace`: **2495 passed, 0 failed**