### PR TITLE
fix(hierarchy): report every cycle, with a paste-ready --exclude line

### DIFF
--- a/examples/ontology_loader.rs
+++ b/examples/ontology_loader.rs
@@ -228,7 +228,7 @@ fn main() {
         Err(samyama::index::hierarchy::HierarchyError::NotAcyclic {
             ordered,
             total,
-            example_cycle,
+            cycles,
         }) => {
             // Translate the internal node ids back into the identifiers the user supplied,
             // otherwise the diagnostic names nodes they have no way to look up.
@@ -243,14 +243,29 @@ fn main() {
                  nodes could not be ordered",
                 total - ordered
             );
-            if !example_cycle.is_empty() {
-                let path: Vec<String> = example_cycle.iter().map(|&i| code_of(i)).collect();
-                eprintln!("[ontology] example cycle: {}", path.join(" -> "));
+            if !cycles.is_empty() {
+                eprintln!("[ontology] {} cycle(s):", cycles.len());
+                for cyc in cycles.iter().take(20) {
+                    let path: Vec<String> = cyc.iter().map(|&i| code_of(i)).collect();
+                    eprintln!("[ontology]   {}", path.join(" -> "));
+                }
+                if cycles.len() > 20 {
+                    eprintln!("[ontology]   ... and {} more", cycles.len() - 20);
+                }
                 eprintln!(
                     "[ontology] a cycle in a subsumption relation is a data defect: it would \
                      make every roll-up over it wrong, so the build refuses rather than \
-                     condensing it. Exclude these terms or report them upstream."
+                     condensing it. Report them upstream, or exclude one term per cycle."
                 );
+                // One member of each cycle is enough to break it. Printed ready to paste so
+                // the fix takes one more run rather than one run per cycle.
+                let breakers: Vec<String> = cycles
+                    .iter()
+                    .filter_map(|c| c.first().map(|&i| code_of(i)))
+                    .collect();
+                if !breakers.is_empty() {
+                    eprintln!("[ontology] to load anyway: --exclude {}", breakers.join(","));
+                }
             }
             std::process::exit(1);
         }

--- a/src/index/hierarchy/poset.rs
+++ b/src/index/hierarchy/poset.rs
@@ -37,9 +37,10 @@ pub enum HierarchyError {
         ordered: usize,
         /// Total nodes in the poset.
         total: usize,
-        /// One cycle, as graph node ids, `a -> b -> ... -> a`. Empty only if the cycle
-        /// could not be recovered, which should not happen when `ordered < total`.
-        example_cycle: Vec<NodeId>,
+        /// Every distinct cycle found, each as graph node ids `a -> b -> ... -> a`.
+        /// Capped at 50 -- enough to act on, bounded for a pathological poset. Empty only
+        /// if no cycle could be recovered, which should not happen when `ordered < total`.
+        cycles: Vec<Vec<NodeId>>,
     },
     /// The poset is a DAG whose chain width exceeds the cap; a 2-hop index is the right
     /// substrate there. This is a *decline*, not a failure — see ADR-035.
@@ -66,19 +67,21 @@ impl std::fmt::Display for HierarchyError {
             HierarchyError::NotAcyclic {
                 ordered,
                 total,
-                example_cycle,
+                cycles,
             } => {
                 let unordered = total.saturating_sub(*ordered);
                 write!(
                     f,
-                    "covering relation has a cycle: {unordered} of {total} nodes could not be ordered"
+                    "covering relation has {} cycle(s): {unordered} of {total} nodes could not be ordered",
+                    cycles.len()
                 )?;
-                if !example_cycle.is_empty() {
-                    let path: Vec<String> = example_cycle
-                        .iter()
-                        .map(|n| n.as_u64().to_string())
-                        .collect();
-                    write!(f, "; example cycle: {}", path.join(" -> "))?;
+                for cyc in cycles.iter().take(5) {
+                    let path: Vec<String> =
+                        cyc.iter().map(|n| n.as_u64().to_string()).collect();
+                    write!(f, "; {}", path.join(" -> "))?;
+                }
+                if cycles.len() > 5 {
+                    write!(f, "; ... and {} more", cycles.len() - 5)?;
                 }
                 Ok(())
             }
@@ -235,16 +238,43 @@ impl Poset {
             let stalled: Vec<u32> = (0..n as u32)
                 .filter(|&i| indeg[i as usize] > 0)
                 .collect();
-            let example_cycle = stalled
-                .first()
-                .map(|&start| Self::recover_cycle(children, &indeg, start))
-                .unwrap_or_default();
+
+            // Recover *every* distinct cycle, not just one. A caller who has been told to
+            // exclude the offending terms can only act on the ones it can see, so reporting
+            // a single example costs one full reload per additional cycle (#441).
+            //
+            // Nodes already on a found cycle are skipped, so the walk is done once per
+            // cycle rather than once per stalled node -- most stalled nodes are merely
+            // downstream of a cycle, not on one.
+            const MAX_CYCLES: usize = 50;
+            let mut cycles: Vec<Vec<u32>> = Vec::new();
+            let mut on_a_cycle: std::collections::HashSet<u32> = std::collections::HashSet::new();
+            let mut seen_keys: std::collections::HashSet<Vec<u32>> = std::collections::HashSet::new();
+            for &start in &stalled {
+                if on_a_cycle.contains(&start) || cycles.len() >= MAX_CYCLES {
+                    continue;
+                }
+                let cyc = Self::recover_cycle(children, &indeg, start);
+                if cyc.is_empty() {
+                    continue;
+                }
+                // Canonical key: the cycle's node set, so the same loop entered at a
+                // different point is not reported twice.
+                let mut key: Vec<u32> = cyc.clone();
+                key.sort_unstable();
+                key.dedup();
+                if seen_keys.insert(key) {
+                    on_a_cycle.extend(cyc.iter().copied());
+                    cycles.push(cyc);
+                }
+            }
+
             return Err(HierarchyError::NotAcyclic {
                 ordered: order.len(),
                 total: n,
-                example_cycle: example_cycle
+                cycles: cycles
                     .into_iter()
-                    .map(|i| nodes[i as usize])
+                    .map(|c| c.into_iter().map(|i| nodes[i as usize]).collect())
                     .collect(),
             });
         }
@@ -463,9 +493,10 @@ mod tests {
             std::iter::empty(),
         )
         .unwrap_err();
-        let HierarchyError::NotAcyclic { example_cycle, .. } = &err else {
+        let HierarchyError::NotAcyclic { cycles, .. } = &err else {
             panic!("expected NotAcyclic, got {err:?}")
         };
+        let example_cycle = cycles.first().expect("at least one cycle recovered");
         // The cycle closes: first and last are the same node.
         assert!(example_cycle.len() >= 2, "got {example_cycle:?}");
         assert_eq!(
@@ -476,7 +507,68 @@ mod tests {
         let members: std::collections::HashSet<u64> =
             example_cycle.iter().map(|n| n.as_u64()).collect();
         assert_eq!(members, [0, 1, 2].into_iter().collect(), "got {example_cycle:?}");
-        assert!(format!("{err}").contains("example cycle"), "{err}");
+        // The message must name the cycle, not merely say one exists -- a caller told to
+        // exclude the offending terms can only act on names it can see.
+        let msg = format!("{err}");
+        assert!(msg.contains("cycle"), "{msg}");
+        for n in &members {
+            assert!(msg.contains(&n.to_string()), "message omits node {n}: {msg}");
+        }
+    }
+
+    #[test]
+    fn every_distinct_cycle_is_reported_not_just_the_first() {
+        // Two independent 2-cycles. Reporting only one costs the caller a full reload per
+        // additional cycle, because the advice ("exclude these terms") can only be followed
+        // for the terms it can see (#441).
+        let err = Poset::from_edges(
+            [
+                (NodeId::new(0), NodeId::new(1)),
+                (NodeId::new(1), NodeId::new(0)),
+                (NodeId::new(2), NodeId::new(3)),
+                (NodeId::new(3), NodeId::new(2)),
+            ]
+            .into_iter(),
+            std::iter::empty(),
+        )
+        .unwrap_err();
+        let HierarchyError::NotAcyclic { cycles, .. } = &err else {
+            panic!("expected NotAcyclic, got {err:?}")
+        };
+        assert_eq!(cycles.len(), 2, "both cycles should be reported: {cycles:?}");
+
+        // and each is a closed loop over its own pair, not the union of the two
+        let mut sets: Vec<Vec<u64>> = cycles
+            .iter()
+            .map(|c| {
+                let mut v: Vec<u64> = c.iter().map(|n| n.as_u64()).collect();
+                v.sort_unstable();
+                v.dedup();
+                v
+            })
+            .collect();
+        sets.sort();
+        assert_eq!(sets, vec![vec![0, 1], vec![2, 3]], "got {sets:?}");
+    }
+
+    #[test]
+    fn the_same_cycle_entered_from_two_nodes_is_reported_once() {
+        // A 3-cycle has three entry points. Walking from each must not produce three
+        // "distinct" cycles -- the canonical key is the node set, not the entry point.
+        let err = Poset::from_edges(
+            [
+                (NodeId::new(0), NodeId::new(1)),
+                (NodeId::new(1), NodeId::new(2)),
+                (NodeId::new(2), NodeId::new(0)),
+            ]
+            .into_iter(),
+            std::iter::empty(),
+        )
+        .unwrap_err();
+        let HierarchyError::NotAcyclic { cycles, .. } = &err else {
+            panic!("expected NotAcyclic, got {err:?}")
+        };
+        assert_eq!(cycles.len(), 1, "one loop, one report: {cycles:?}");
     }
 
     #[test]
@@ -493,9 +585,10 @@ mod tests {
             std::iter::empty(),
         )
         .unwrap_err();
-        let HierarchyError::NotAcyclic { example_cycle, .. } = &err else {
+        let HierarchyError::NotAcyclic { cycles, .. } = &err else {
             panic!("expected NotAcyclic")
         };
+        let example_cycle = cycles.first().expect("at least one cycle recovered");
         let members: std::collections::HashSet<u64> =
             example_cycle.iter().map(|n| n.as_u64()).collect();
         assert!(
@@ -520,9 +613,10 @@ mod tests {
             std::iter::empty(),
         )
         .unwrap_err();
-        let HierarchyError::NotAcyclic { example_cycle, .. } = &err else {
+        let HierarchyError::NotAcyclic { cycles, .. } = &err else {
             panic!("expected NotAcyclic")
         };
+        let example_cycle = cycles.first().expect("at least one cycle recovered");
         assert!(
             !example_cycle.is_empty(),
             "a cycle exists and must be recoverable from any stalled node: {err}"
@@ -539,9 +633,10 @@ mod tests {
         let err =
             Poset::from_edges(vec![(nid(7), nid(8)), (nid(8), nid(7))], std::iter::empty())
                 .unwrap_err();
-        let HierarchyError::NotAcyclic { example_cycle, ordered, total } = &err else {
+        let HierarchyError::NotAcyclic { cycles, ordered, total } = &err else {
             panic!("expected NotAcyclic")
         };
+        let example_cycle = cycles.first().expect("at least one cycle recovered");
         assert_eq!(*total, 2);
         assert_eq!(*ordered, 0);
         assert_eq!(example_cycle.first(), example_cycle.last());


### PR DESCRIPTION
Fixes #441. Completes the loop opened by #440.

## What was wrong

The cycle diagnostic named **one** example. Now that `--exclude` exists, the advice "exclude these terms" is actionable — but only for the terms it names. An ontology with several independent cycles costs one full reload per cycle, each run revealing the next name.

## After

```
[ontology] 1 cycle(s):
[ontology]   CL:0000163 -> CL:0000164 -> CL:0000163
[ontology] a cycle in a subsumption relation is a data defect: ...
[ontology] to load anyway: --exclude CL:0000163
```

One member per cycle is enough to break it, so that last line is a complete fix rather than a first instalment.

Verified end to end on real MONDO: the suggested command loads it and reaches a verdict (declined, chain width 36,393 over cap 1,834). It also settles a question #430 left open — MONDO has exactly **one** cycle; the 14 unorderable nodes were all downstream of it.

## Implementation notes

`NotAcyclic` carries `cycles: Vec<Vec<NodeId>>` in place of `example_cycle`.

- Recovery walks from each stalled node **not already on a found cycle**, so the cost is one walk per cycle rather than one per stalled node — most stalled nodes are downstream, not on a loop.
- Cycles are deduplicated by **node set**, so a 3-cycle entered from each of its three members is reported once. There's a test for exactly that, because it is the obvious way to get three "distinct" cycles that are one.
- Capped at 50, so a pathological poset produces a bounded diagnostic.

## One test rewritten rather than deleted

An existing test asserted the message contains the literal phrase `"example cycle"`, which the new wording drops. Rather than delete the assertion I changed it to check what it was really for — that the message names **every node on the cycle**:

```rust
for n in &members {
    assert!(msg.contains(&n.to_string()), "message omits node {n}: {msg}");
}
```

That is the property a caller depends on, and it now can't regress into "a cycle exists" with no names.

## Verified

- `cargo test --workspace`: **2497 passed, 0 failed**
- Two new tests: two independent cycles are both reported; one cycle entered from three nodes is reported once.