### PR TITLE
Allow chained subscripts, and let IS NULL apply to the indexed element

### DIFF
--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -153,7 +153,7 @@ order_direction = { ^"ASC" | ^"DESC" }
 // any comparison, which is the opposite of openCypher. Emitting it here lets the Pratt
 // parser give it a precedence between AND and the comparison operators.
 expression = { not_op* ~ term ~ (binary_op ~ not_op* ~ term)* }
-term = { unary_op* ~ primary ~ postfix_op? ~ index_op? }
+term = { unary_op* ~ primary ~ index_op* ~ postfix_op? }
 postfix_op = { ^"IS" ~ ^"NOT" ~ ^"NULL" | ^"IS" ~ ^"NULL" }
 index_op = { "[" ~ (slice_op | expression) ~ "]" }
 slice_op = { slice_start ~ ".." ~ slice_end | slice_start ~ ".." | ".." ~ slice_end | ".." }

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1569,36 +1569,23 @@ fn parse_term(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
             let mut prefix_ops = Vec::new();
             let mut primary_pair = None;
             let mut postfix_pair = None;
-            let mut index_pair = None;
+            let mut index_pairs = Vec::new();
 
             for inner in pair.into_inner() {
                 match inner.as_rule() {
                     Rule::unary_op => prefix_ops.push(inner),
                     Rule::primary => primary_pair = Some(inner),
                     Rule::postfix_op => postfix_pair = Some(inner),
-                    Rule::index_op => index_pair = Some(inner),
+                    Rule::index_op => index_pairs.push(inner),
                     _ => {}
                 }
             }
 
             let mut expr = parse_primary(primary_pair.unwrap())?;
 
-            // Apply postfix operator (IS NULL / IS NOT NULL)
-            if let Some(postfix) = postfix_pair {
-                let text = postfix.as_str().to_uppercase();
-                let op = if text.contains("NOT") {
-                    UnaryOp::IsNotNull
-                } else {
-                    UnaryOp::IsNull
-                };
-                expr = Expression::Unary {
-                    op,
-                    expr: Box::new(expr),
-                };
-            }
-
-            // Apply index operator [expr] or slice operator [start..end]
-            if let Some(index) = index_pair {
+            // Apply each index/slice suffix in source order, so chained
+            // subscripts like m["a"]["b"] and xs[0][1] compose left to right.
+            for index in index_pairs {
                 let mut handled = false;
                 for idx_inner in index.into_inner() {
                     if idx_inner.as_rule() == Rule::slice_op {
@@ -1636,6 +1623,20 @@ fn parse_term(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
                     }
                 }
                 let _ = handled;
+            }
+
+            // Apply postfix operator (IS NULL / IS NOT NULL)
+            if let Some(postfix) = postfix_pair {
+                let text = postfix.as_str().to_uppercase();
+                let op = if text.contains("NOT") {
+                    UnaryOp::IsNotNull
+                } else {
+                    UnaryOp::IsNull
+                };
+                expr = Expression::Unary {
+                    op,
+                    expr: Box::new(expr),
+                };
             }
 
             // Apply prefix operators in reverse order (innermost first)

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -1849,3 +1849,85 @@ fn counting_with_an_inline_property_filter_counts_only_the_matching_rows() {
     assert_eq!(scalar(&s, "MATCH (p:P) RETURN count(p) AS n"), "n=3");
     assert_eq!(scalar(&s, "MATCH (p:P) RETURN count(*) AS n"), "n=3");
 }
+
+// ---------------------------------------------------------------------------
+// Chained subscripting (#453)
+//
+// `term` in the grammar allowed at most one `index_op`, and placed it *after*
+// `postfix_op`. That made every chained subscript a parse error -- for lists as
+// well as maps -- and made `xs[0] IS NULL`, the idiomatic missing-element test,
+// unparseable too. The rule is now `primary ~ index_op* ~ postfix_op?`.
+// ---------------------------------------------------------------------------
+
+/// A map-valued property, the shape that has no dot-notation path access (#452).
+fn nested_map_fixture() -> GraphStore {
+    let mut s = GraphStore::new();
+    QueryEngine::new()
+        .execute_mut("CREATE (:D {meta: {c: {d: 9}}})", &mut s, "default")
+        .unwrap();
+    s
+}
+
+#[test]
+fn chained_list_index() {
+    assert_eq!(scalar(&GraphStore::new(), "RETURN [[1,2],[3,4]][0][1] AS v"), "v=2");
+}
+
+#[test]
+fn chained_index_three_deep() {
+    assert_eq!(scalar(&GraphStore::new(), "RETURN [[[5]]][0][0][0] AS v"), "v=5");
+}
+
+#[test]
+fn chained_list_then_map_key() {
+    assert_eq!(scalar(&GraphStore::new(), "RETURN [{a:1}][0][\"a\"] AS v"), "v=1");
+}
+
+#[test]
+fn chained_map_keys_on_stored_property() {
+    assert_eq!(
+        scalar(&nested_map_fixture(), "MATCH (d:D) RETURN d.meta[\"c\"][\"d\"] AS v"),
+        "v=9"
+    );
+}
+
+#[test]
+fn chained_map_key_in_where() {
+    assert_eq!(
+        scalar(
+            &nested_map_fixture(),
+            "MATCH (d:D) WHERE d.meta[\"c\"][\"d\"] = 9 RETURN count(d) AS v"
+        ),
+        "v=1"
+    );
+}
+
+#[test]
+fn index_then_slice_composes() {
+    assert_eq!(
+        scalar(&GraphStore::new(), "RETURN [[1,2,3],[4]][0][0..2] AS v"),
+        "v=[1,2]"
+    );
+}
+
+#[test]
+fn is_null_applies_to_indexed_element_not_container() {
+    // The out-of-range element is null even though the list itself is not.
+    assert_eq!(scalar(&GraphStore::new(), "RETURN [1,2][5] IS NULL AS v"), "v=true");
+    assert_eq!(scalar(&GraphStore::new(), "RETURN [1,2][0] IS NULL AS v"), "v=false");
+}
+
+#[test]
+fn is_null_on_missing_map_key() {
+    assert_eq!(scalar(&GraphStore::new(), "RETURN {a:1}[\"z\"] IS NULL AS v"), "v=true");
+    assert_eq!(
+        scalar(&GraphStore::new(), "RETURN {a:1}[\"a\"] IS NOT NULL AS v"),
+        "v=true"
+    );
+}
+
+#[test]
+fn single_subscript_and_slice_still_work() {
+    assert_eq!(scalar(&GraphStore::new(), "RETURN [1,2][0] AS v"), "v=1");
+    assert_eq!(scalar(&GraphStore::new(), "RETURN [1,2,3][0..2] AS v"), "v=[1,2]");
+}


### PR DESCRIPTION
Closes #453.

## The defect

One grammar line in `src/query/cypher.pest`:

```pest
term = { unary_op* ~ primary ~ postfix_op? ~ index_op? }
```

`index_op?` is optional rather than repeated, and sits *after* `postfix_op`. Two independent user-visible failures follow.

**Chained subscripts were a parse error** — and this was never map-specific. Any nested list was unreachable past its first level:

```cypher
RETURN [[1,2],[3,4]][0]         -- [1,2]         ✅
RETURN [[1,2],[3,4]][0][1]      -- Parse error   ❌
RETURN [{a:1}][0]["a"]          -- Parse error   ❌
RETURN [[1,2,3],[4]][0][0..2]   -- Parse error   ❌
```

**`IS NULL` could not apply to an indexed element**, because the postfix operator was ordered ahead of the subscript:

```cypher
RETURN [1,2][5] IS NULL         -- Parse error   ❌
RETURN {a:1}["z"] IS NULL       -- Parse error   ❌
```

That is the idiomatic missing-key / out-of-range test, so the workaround was `coalesce` gymnastics or pulling the whole container back to the client.

## The change

```pest
term = { unary_op* ~ primary ~ index_op* ~ postfix_op? }
```

Subscripts repeat, and bind tighter than the postfix operator — so `xs[0] IS NULL` asks about the *element*, not the container, which is how it reads. The parser collects the suffixes into a `Vec` and applies them left to right, with the `IS NULL` wrapper moved after the loop.

No new AST variant: `Expression::Index` already existed and its doc comment already said "List/**map** indexing". It simply could never be produced more than once per term.

## Verification

Nine tests in `tests/cypher_projection_semantics.rs`, covering both container types, the mixed list→map chain, three-deep chaining, index-then-slice composition, `IS NULL`/`IS NOT NULL` on subscripts, and — deliberately — the two **single**-subscript forms that already worked, so the `?`→`*` change cannot regress them silently.

That suite: **73 passed, 0 failed**. Full workspace suite run separately.

## Scope note

Dot notation (`d.meta.a`) is still a parse error and stays with #452, along with `keys()` rejecting maps. Bracket chaining now reaches everything dot notation would reach, so what remains there is ergonomics and openCypher conformance rather than capability. `property_access` is shared with `SET`/`REMOVE`/constraints, so making *it* repeatable is a separate change with its own question — whether `SET n.a.b = 1` should be admitted at all.