### PR TITLE
Set HS and GSA test thresholds from their measured tails

### DIFF
--- a/crates/samyama-optimization/tests/test_solvers.rs
+++ b/crates/samyama-optimization/tests/test_solvers.rs
@@ -193,7 +193,12 @@ fn test_gsa_sphere() {
     let solver = GSASolver::new(config);
     let result = solver.solve(&problem);
 
-    assert!(result.best_fitness < 1.0, "GSA failed: fitness {}", result.best_fitness);
+    // Threshold set from the measured distribution, not picked by eye (#455).
+    // GSA over 2000 runs on this problem/config: p50 0.011, p99.9 0.669, max 1.025
+    // -- it crosses 1.0 about once in 2000 runs, so `< 1.0` is a ~0.05% flake.
+    // 5.0 clears the observed tail while leaving a ~450x margin against the
+    // median, so a solver that genuinely stopped converging still fails here.
+    assert!(result.best_fitness < 5.0, "GSA failed: fitness {}", result.best_fitness);
 }
 
 #[test]
@@ -203,7 +208,12 @@ fn test_hs_sphere() {
     let solver = HSSolver::new(config);
     let result = solver.solve(&problem);
 
-    assert!(result.best_fitness < 1.0, "HS failed: fitness {}", result.best_fitness);
+    // Threshold set from the measured distribution, not picked by eye (#455).
+    // HS over 2000 runs: p50 0.00094, p99 0.213, p99.9 0.539, max 2.259 -- this
+    // test is what actually failed a full workspace run, at a measured ~0.05%.
+    // 5.0 clears the worst observed value while leaving a ~5000x margin against
+    // the median. The real fix is a seedable RNG (#455); this stops the bleeding.
+    assert!(result.best_fitness < 5.0, "HS failed: fitness {}", result.best_fitness);
 }
 
 #[test]


### PR DESCRIPTION
Refs #455.

A full `cargo test --release --workspace` run failed on `test_hs_sphere`. It then passed **100/100** on re-run (40 isolated, 60 as the full binary) — a rare stochastic flake, not a regression.

## Why it flakes

Every solver in the crate draws from `thread_rng()` and **nothing accepts a seed**, so all 27 threshold assertions in `test_solvers.rs` are probabilistic claims with unmeasured failure rates. Measuring the two whose tails looked close, at the tests' own problem and config (Sphere 2D, pop 50, 500 iterations, 2000 runs each):

| Solver | p50 | p99 | p99.9 | max | runs ≥ 1.0 |
|---|---|---|---|---|---|
| **HS** | 0.00094 | 0.213 | 0.539 | **2.259** | 1 / 2000 |
| **GSA** | 0.011 | — | 0.669 | **1.025** | 1 / 2000 |

Both cross their `< 1.0` threshold at roughly one run in two thousand. A sweep of all 24 single-objective solvers confirmed these two are the only ones at risk — the other 22 finish three orders of magnitude inside their thresholds (most at exactly 0.000000).

Note GSA was **not** the test that failed; it was found by measuring rather than by waiting for it to bite.

## The change

Both thresholds go to `5.0`, with the measured distribution recorded in a comment beside each assertion.

This is chosen, not rounded up arbitrarily: 5.0 clears the worst observed value (2.259) while leaving a **5000×** margin against HS's median and **450×** against GSA's. A solver that genuinely stopped converging moves by orders of magnitude and still fails loudly.

## What this does not do

It does not make the crate reproducible. `thread_rng()` means no run of this optimizer can be re-derived — by a test or by a user — which for a crate backing published Rao-family results is a defect beyond CI hygiene. That needs a seedable `SolverConfig`, tracked in #455, including the part that actually needs care: `rao.rs`, `de.rs` and `gotlbo.rs` call `thread_rng()` inside rayon closures, where seeding only the outer RNG would yield results that look reproducible and are not.

`test_solvers`: **36 passed, 0 failed.**