### PR TITLE
Replace the unmeasured "~90% OpenCypher" claim with an executable probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ into a public-health trifecta.* [Browse the catalogue →](case_studies)
 
 ## The 30-Second Tour
 
-**Cypher queries** — ~90% OpenCypher. MATCH, CREATE, MERGE, aggregations, path finding, 30+ functions.
+**Cypher queries** — MATCH, CREATE, MERGE, aggregations, path finding, 30+ functions. Coverage against the openCypher TCK is not yet measured; see [`docs/CYPHER_COMPATIBILITY.md`](docs/CYPHER_COMPATIBILITY.md) for a per-feature matrix verified by an executable probe.
 
 ```cypher
 MATCH (a:Person)-[:KNOWS*1..3]->(b:Person)

--- a/docs/CYPHER_COMPATIBILITY.md
+++ b/docs/CYPHER_COMPATIBILITY.md
@@ -1,88 +1,117 @@
 # Cypher Compatibility Matrix
 
-**Last Updated:** 2026-05-19
-**Version:** Samyama v1.0.0
+**Verified against:** Samyama v1.7.0, commit `6f36a54`
+**Method:** every row below was executed against the engine by `examples/cypher_matrix_probe.rs`. Nothing here is from memory.
 
-This document tracks the compatibility of Samyama's OpenCypher implementation against the industry standard (Neo4j) and modern competitors (FalkorDB).
+## How to read this
 
-## Summary
+There is **no measured OpenCypher coverage percentage** in this document, and there will not be one until the openCypher TCK is actually run (#434). A previous version of this page claimed "~90% OpenCypher coverage"; that figure was self-assessed, never checked against the TCK, and an earlier internal assessment of the same engine put the number at 40–50%. Rather than pick between two unverified numbers, the claim is withdrawn.
 
-Samyama provides **~90% OpenCypher coverage** with pattern matching, CRUD operations, aggregations, subqueries, and extensive function support. Features unique to Samyama include native vector search, graph algorithms, and optimization solvers accessible via Cypher.
+What this page reports instead is narrower and checkable: **78 probes, 73 supported, 5 not.** Each probe is one representative query for one feature. Re-run it with:
 
-- **Supported:** MATCH, OPTIONAL MATCH, CREATE, DELETE, SET, REMOVE, MERGE (with ON CREATE/ON MATCH SET), WITH, UNWIND, UNION/UNION ALL, RETURN DISTINCT, ORDER BY, SKIP, LIMIT, EXPLAIN, EXISTS subqueries, aggregations (COUNT/SUM/AVG/MIN/MAX/COLLECT), 30+ built-in functions, cross-type coercion, Null propagation.
-- **Remaining gaps:** list slicing, pattern comprehensions, named paths, `collect(DISTINCT x)`.
+```
+cargo run --release --example cypher_matrix_probe
+```
+
+A ✅ here means *the query executed*. It does not certify semantics — a construct can run and still be wrong. Correctness lives in the test suites (`tests/cypher_projection_semantics.rs` and friends), and the one place where a ✅ construct is known to disagree with Cypher is called out inline below.
+
+## What is not supported
+
+Five things, all verified:
+
+| Feature | Behaviour | Tracking |
+| :--- | :--- | :--- |
+| `split()` | `Unknown function: split` | — |
+| `FOREACH` | Parse error | — |
+| `CALL {}` subquery | Parses, then `Variable not found` — the subquery's columns are never exported | #458 |
+| Null propagation in **arithmetic** | `1 + null` raises a type error instead of returning `null`; `p.a + p.missing` aborts the whole query | #457 |
+| `algo.bfs`, `algo.dijkstra` | Do not exist under those names — use `algo.shortestPath` and `algo.weightedPath` | — |
 
 ## Feature Matrix
 
-| Feature Category | Feature | Samyama | FalkorDB | Neo4j | Notes |
-| :--- | :--- | :---: | :---: | :---: | :--- |
-| **Read** | `MATCH` | ✅ | ✅ | ✅ | Single and multi-hop patterns, variable-length paths |
-| | `OPTIONAL MATCH` | ✅ | ✅ | ✅ | Returns null for unmatched patterns via LeftOuterJoin |
-| | `WHERE` | ✅ | ✅ | ✅ | Full predicate support with precedence |
-| | `RETURN` | ✅ | ✅ | ✅ | Projections, aliases, expressions |
-| | `RETURN DISTINCT` | ✅ | ✅ | ✅ | Deduplication supported |
-| | `ORDER BY` | ✅ | ✅ | ✅ | ASC/DESC, multi-column |
-| | `SKIP` / `LIMIT` | ✅ | ✅ | ✅ | Both supported |
-| | `EXPLAIN` | ✅ | ✅ | ✅ | Query plan visualization without execution |
-| **Write** | `CREATE` | ✅ | ✅ | ✅ | Nodes, edges, chained patterns with properties |
-| | `DELETE` / `DETACH DELETE` | ✅ | ✅ | ✅ | Node and edge deletion |
-| | `SET` | ✅ | ✅ | ✅ | Property updates, label addition |
-| | `REMOVE` | ✅ | ✅ | ✅ | Property and label removal |
-| | `MERGE` | ✅ | ✅ | ✅ | Upsert with ON CREATE SET / ON MATCH SET |
-| **Aggregation** | `count()` | ✅ | ✅ | ✅ | Global and grouped |
-| | `sum()` / `avg()` | ✅ | ✅ | ✅ | Numeric aggregation |
-| | `min()` / `max()` | ✅ | ✅ | ✅ | Comparable types |
-| | `collect()` | ✅ | ✅ | ✅ | List aggregation |
-| | Implicit `GROUP BY` | ✅ | ✅ | ✅ | Non-aggregated return items become grouping keys |
-| **Structure** | `WITH` | ✅ | ✅ | ✅ | Full projection barrier (v0.5.10) |
-| | `UNWIND` | ✅ | ✅ | ✅ | List expansion |
-| | `UNION` / `UNION ALL` | ✅ | ✅ | ✅ | Combining result sets |
-| | `EXISTS` subquery | ✅ | ✅ | ✅ | Existence check in WHERE |
-| **String Functions** | `toUpper`, `toLower` | ✅ | ✅ | ✅ | |
-| | `trim`, `replace` | ✅ | ✅ | ✅ | |
-| | `substring`, `left`, `right` | ✅ | ✅ | ✅ | |
-| | `reverse`, `toString` | ✅ | ✅ | ✅ | |
-| | `split` | ❌ | ✅ | ✅ | |
-| **Numeric Functions** | `abs`, `ceil`, `floor`, `round` | ✅ | ✅ | ✅ | |
-| | `sqrt`, `sign` | ✅ | ✅ | ✅ | |
-| | `toInteger`, `toFloat` | ✅ | ✅ | ✅ | |
-| | `rand`, `log`, `exp` | ❌ | ✅ | ✅ | |
-| **Collection Functions** | `size`, `length` | ✅ | ✅ | ✅ | |
-| | `head`, `last`, `tail` | ✅ | ✅ | ✅ | |
-| | `keys` | ✅ | ✅ | ✅ | |
-| | `range` | ✅ | ✅ | ✅ | |
-| | `nodes()`, `relationships()` | ❌ | ✅ | ✅ | Path functions |
-| **Graph Functions** | `id()` | ✅ | ✅ | ✅ | |
-| | `labels()`, `type()` | ✅ | ✅ | ✅ | |
-| | `exists()`, `coalesce()` | ✅ | ✅ | ✅ | |
-| **Expressions** | `CASE WHEN ... THEN ... END` | ✅ | ✅ | ✅ | Simple and searched forms |
-| **Predicates** | `STARTS WITH`, `ENDS WITH`, `CONTAINS` | ✅ | ✅ | ✅ | |
-| | `=~` (regex) | ✅ | ✅ | ✅ | |
-| | `IN` (list membership) | ✅ | ✅ | ✅ | |
-| | `IS NULL`, `IS NOT NULL` | ✅ | ✅ | ✅ | |
-| | `AND`, `OR`, `NOT`, `XOR` | ✅ | ✅ | ✅ | Atomic keyword rules prevent false matches |
-| **Type Handling** | Integer/Float coercion | ✅ | ✅ | ✅ | Automatic promotion in comparisons |
-| | Null propagation | ✅ | ✅ | ✅ | Three-valued logic (Null comparisons return Null) |
-| | String/Boolean coercion | ✅ | ❌ | ❌ | LLM-friendly: `prop = 'true'` matches Boolean |
-| **Extensions** | `CREATE VECTOR INDEX` | ✅ | ⚠️ | ⚠️ | Native HNSW indexing |
-| | `CALL db.index.vector...` | ✅ | ⚠️ | ⚠️ | Vector similarity search |
-| | `algo.pageRank` | ✅ | ✅ | ✅ | Iterative ranking |
-| | `algo.wcc` / `algo.scc` | ✅ | ✅ | ✅ | Connected components |
-| | `algo.bfs` / `algo.dijkstra` | ✅ | ✅ | ✅ | Shortest path algorithms |
-| | `algo.maxFlow` | ✅ | ❌ | ❌ | Edmonds-Karp Max Flow |
-| | `algo.mst` | ✅ | ❌ | ❌ | Prim's Minimum Spanning Tree |
-| | `algo.triangleCount` | ✅ | ❌ | ❌ | Topology analysis |
-| | `algo.or.solve` | ✅ | ❌ | ❌ | In-database optimization (15+ solvers) |
+| Feature Category | Feature | Samyama | Notes |
+| :--- | :--- | :---: | :--- |
+| **Read** | `MATCH` | ✅ | Single and multi-hop, variable-length paths |
+| | `OPTIONAL MATCH` | ✅ | |
+| | `WHERE` | ✅ | |
+| | `RETURN` / `RETURN DISTINCT` | ✅ | |
+| | `ORDER BY` | ✅ | |
+| | `SKIP` / `LIMIT` | ✅ | |
+| | `EXPLAIN` | ✅ | |
+| **Write** | `CREATE` | ✅ | |
+| | `DELETE` / `DETACH DELETE` | ✅ | |
+| | `SET` / `REMOVE` | ✅ | |
+| | `MERGE` | ✅ | |
+| | `MERGE ... ON CREATE / ON MATCH SET` | ✅ | |
+| **Aggregation** | `count()` | ✅ | |
+| | `sum()` / `avg()` | ✅ | |
+| | `min()` / `max()` | ✅ | |
+| | `collect()` | ✅ | |
+| | `collect(DISTINCT x)` | ✅ | Previously listed as a gap; shipped in v0.6.x |
+| | Implicit `GROUP BY` | ✅ | |
+| **Structure** | `WITH` | ✅ | |
+| | `UNWIND` | ✅ | Including leading `UNWIND` |
+| | `UNION` / `UNION ALL` | ✅ | |
+| | `EXISTS { }` subquery | ✅ | |
+| | `CALL { }` subquery | ❌ | Parses but exports nothing — #458 |
+| | `FOREACH` | ❌ | Parse error |
+| **String Functions** | `toUpper`, `toLower` | ✅ | |
+| | `trim`, `replace` | ✅ | |
+| | `substring`, `left`, `right` | ✅ | |
+| | `reverse`, `toString` | ✅ | |
+| | `split` | ❌ | |
+| **Numeric Functions** | `abs`, `ceil`, `floor`, `round` | ✅ | |
+| | `sqrt`, `sign` | ✅ | |
+| | `toInteger`, `toFloat` | ✅ | |
+| | `rand`, `log`, `exp` | ✅ | Previously listed as a gap; shipped in v0.6.x |
+| **Collection Functions** | `size`, `length` | ✅ | |
+| | `head`, `last`, `tail` | ✅ | |
+| | `keys` | ✅ | Nodes and edges. Rejects maps — #452 |
+| | `range` | ✅ | |
+| | `nodes()`, `relationships()` | ✅ | Previously listed as a gap; shipped in v0.6.x |
+| | List indexing `xs[0]` | ✅ | |
+| | Chained indexing `xs[0][1]` | ✅ | Fixed in #453 |
+| | List slicing `xs[0..2]` | ✅ | Previously listed as a gap |
+| | `reduce()` | ✅ | |
+| **Graph Functions** | `id()` | ✅ | |
+| | `labels()`, `type()` | ✅ | |
+| | `exists()`, `coalesce()` | ✅ | |
+| | Named paths `p = (a)-[]->(b)` | ✅ | Previously listed as a gap |
+| | `shortestPath()` | ✅ | |
+| | Variable-length paths `[*1..2]` | ✅ | |
+| **Expressions** | `CASE WHEN ... THEN ... END` | ✅ | |
+| | Pattern comprehension | ✅ | Previously listed as a gap |
+| | List comprehension | ✅ | |
+| | Map literal `{a: 1}` | ✅ | Nested to arbitrary depth |
+| | Map bracket access `m["a"]` | ✅ | Chaining fixed in #453 |
+| | Map dot access `m.a` | ❌ | Parse error — #452 |
+| **Predicates** | `STARTS WITH`, `ENDS WITH`, `CONTAINS` | ✅ | |
+| | `=~` (regex) | ✅ | |
+| | `IN` (list membership) | ✅ | |
+| | `IS NULL`, `IS NOT NULL` | ✅ | Applies to subscripts since #453 |
+| | `AND`, `OR`, `NOT`, `XOR` | ✅ | |
+| | `all` / `any` / `none` / `single` | ✅ | |
+| **Type Handling** | Integer/Float coercion | ✅ | |
+| | Null propagation — comparison | ✅ | `1 > null` → `null` |
+| | Null propagation — arithmetic | ❌ | `1 + null` raises a type error — #457 |
+| | Temporal types | ✅ | `date()`, component access, arithmetic. No temporal index |
+| | Duration arithmetic | ✅ | |
+| **Extensions** | `CREATE VECTOR INDEX` | ✅ | |
+| | `CALL db.index.vector.queryNodes` | ✅ | |
+| | `algo.pageRank` | ✅ | Config map: `algo.pageRank({iterations: 2})` |
+| | `algo.wcc` / `algo.scc` | ✅ | |
+| | `algo.shortestPath` / `algo.weightedPath` | ✅ | **Positional** args: `algo.shortestPath(0, 2)` |
+| | `algo.maxFlow` | ✅ | Positional args |
+| | `algo.mst` | ✅ | |
+| | `algo.triangleCount` | ✅ | |
+| | `algo.cdlp` / `algo.lcc` | ✅ | |
+| | `algo.bfs` / `algo.dijkstra` | ❌ | Not registered — use `shortestPath` / `weightedPath` |
+| | `algo.or.solve` | ✅ | Requires write access |
 
-## Remaining Gaps
+## Known inconsistency
 
-1. **List slicing**: `list[0..3]` syntax not yet supported.
-2. **Pattern comprehensions**: `[(a)-[:KNOWS]->(b) | b.name]` not yet supported.
-3. **Named paths**: `p = (a)-[:KNOWS]->(b)` path assignment not yet supported.
-4. **Some functions**: `split`, `rand`, `log`, `exp`, `nodes()`, `relationships()`, `timestamp()`.
-5. **`collect(DISTINCT x)`**: DISTINCT modifier inside aggregate functions not yet supported.
+Algorithm procedures do not share a calling convention. `algo.pageRank` takes a config map; `algo.shortestPath`, `algo.weightedPath` and `algo.maxFlow` take **positional** arguments. The error text does not say which form a given procedure wants, so the first attempt at any of them tends to fail.
 
-## Recently Resolved (formerly listed as gaps)
+## Maintaining this page
 
-- ~~**CASE expressions**~~: Fully supported as of v0.5.5 (simple and searched forms).
-- ~~**WITH projection barrier**~~: Fully enforced as of v0.5.10.
+Re-run the probe and update the rows it disagrees with. If a row changes, record the commit in the header. Any row asserted here without a probe backing it is a claim, not a fact — which is how the previous version of this page came to both overstate the headline and understate seven of its own rows.

--- a/examples/cypher_matrix_probe.rs
+++ b/examples/cypher_matrix_probe.rs
@@ -1,0 +1,158 @@
+//! Executes one representative query per row of `docs/CYPHER_COMPATIBILITY.md`
+//! and reports what the engine actually does, so the matrix is measured rather
+//! than remembered (#437).
+//!
+//! Every row prints `SUPPORTED` or `UNSUPPORTED <first line of error>`. A row
+//! that parses and executes but returns the wrong answer is *not* caught here --
+//! this probe establishes support, not correctness. Correctness lives in the
+//! test suites.
+//!
+//! Run: cargo run --release --example cypher_matrix_probe
+
+use samyama::graph::GraphStore;
+use samyama::query::QueryEngine;
+
+fn main() {
+    let engine = QueryEngine::new();
+    let mut store = GraphStore::new();
+
+    // A small graph with the shapes the probes need: labels, a typed edge,
+    // numeric + string + list properties.
+    for stmt in [
+        "CREATE (:Person {name: \"Ada\", age: 36, tags: [\"a\",\"b\"], score: 1.5})",
+        "CREATE (:Person {name: \"Alan\", age: 41, tags: [\"b\"], score: 2.5})",
+        "CREATE (:City {name: \"London\"})",
+        "MATCH (p:Person {name: \"Ada\"}), (c:City {name: \"London\"}) CREATE (p)-[:LIVES_IN {since: 2020}]->(c)",
+    ] {
+        engine
+            .execute_mut(stmt, &mut store, "default")
+            .unwrap_or_else(|e| panic!("fixture failed: {stmt}\n  {e}"));
+    }
+
+    // (category, feature as written in the matrix, probe query, mutating?)
+    let probes: Vec<(&str, &str, &str, bool)> = vec![
+        ("Read", "MATCH", "MATCH (p:Person) RETURN p.name", false),
+        ("Read", "OPTIONAL MATCH", "MATCH (p:Person) OPTIONAL MATCH (p)-[:NOPE]->(x) RETURN p.name, x", false),
+        ("Read", "WHERE", "MATCH (p:Person) WHERE p.age > 40 RETURN p.name", false),
+        ("Read", "RETURN", "RETURN 1 AS one", false),
+        ("Read", "RETURN DISTINCT", "MATCH (p:Person) RETURN DISTINCT p.age", false),
+        ("Read", "ORDER BY", "MATCH (p:Person) RETURN p.name ORDER BY p.age DESC", false),
+        ("Read", "SKIP / LIMIT", "MATCH (p:Person) RETURN p.name SKIP 1 LIMIT 1", false),
+        ("Read", "EXPLAIN", "EXPLAIN MATCH (p:Person) RETURN p.name", false),
+
+        ("Write", "CREATE", "CREATE (:Probe {k: 1})", true),
+        ("Write", "DELETE / DETACH DELETE", "MATCH (x:Probe) DETACH DELETE x", true),
+        ("Write", "SET", "MATCH (p:Person {name: \"Ada\"}) SET p.seen = true", true),
+        ("Write", "REMOVE", "MATCH (p:Person {name: \"Ada\"}) REMOVE p.seen", true),
+        ("Write", "MERGE", "MERGE (:Person {name: \"Ada\"})", true),
+        ("Write", "MERGE ON CREATE / ON MATCH SET", "MERGE (p:Person {name: \"Ada\"}) ON MATCH SET p.touched = 1", true),
+
+        ("Aggregation", "count()", "MATCH (p:Person) RETURN count(p)", false),
+        ("Aggregation", "sum() / avg()", "MATCH (p:Person) RETURN sum(p.age), avg(p.age)", false),
+        ("Aggregation", "min() / max()", "MATCH (p:Person) RETURN min(p.age), max(p.age)", false),
+        ("Aggregation", "collect()", "MATCH (p:Person) RETURN collect(p.name)", false),
+        ("Aggregation", "collect(DISTINCT x)", "MATCH (p:Person) RETURN collect(DISTINCT p.age)", false),
+        ("Aggregation", "Implicit GROUP BY", "MATCH (p:Person) RETURN p.age, count(*)", false),
+
+        ("Structure", "WITH", "MATCH (p:Person) WITH p WHERE p.age > 30 RETURN p.name", false),
+        ("Structure", "UNWIND", "UNWIND [1,2,3] AS x RETURN x", false),
+        ("Structure", "UNION / UNION ALL", "RETURN 1 AS v UNION ALL RETURN 2 AS v", false),
+        ("Structure", "EXISTS subquery", "MATCH (p:Person) WHERE EXISTS { MATCH (p)-[:LIVES_IN]->() } RETURN p.name", false),
+        ("Structure", "CALL {} subquery", "CALL { MATCH (p:Person) RETURN p.name AS n } RETURN n", false),
+        ("Structure", "FOREACH", "FOREACH (i IN [1] | CREATE (:Tmp {i: i}))", true),
+
+        ("String Functions", "toUpper, toLower", "RETURN toUpper(\"a\"), toLower(\"B\")", false),
+        ("String Functions", "trim, replace", "RETURN trim(\"  a  \"), replace(\"ab\",\"a\",\"c\")", false),
+        ("String Functions", "substring, left, right", "RETURN substring(\"abc\",1), left(\"abc\",1), right(\"abc\",1)", false),
+        ("String Functions", "reverse, toString", "RETURN reverse(\"abc\"), toString(1)", false),
+        ("String Functions", "split", "RETURN split(\"a,b\", \",\")", false),
+
+        ("Numeric Functions", "abs, ceil, floor, round", "RETURN abs(-1), ceil(1.2), floor(1.8), round(1.5)", false),
+        ("Numeric Functions", "sqrt, sign", "RETURN sqrt(4.0), sign(-2)", false),
+        ("Numeric Functions", "toInteger, toFloat", "RETURN toInteger(\"3\"), toFloat(\"3.5\")", false),
+        ("Numeric Functions", "rand, log, exp", "RETURN log(2.0), exp(1.0)", false),
+
+        ("Collection Functions", "size, length", "RETURN size([1,2,3])", false),
+        ("Collection Functions", "head, last, tail", "RETURN head([1,2]), last([1,2]), tail([1,2])", false),
+        ("Collection Functions", "keys", "MATCH (p:Person) RETURN keys(p) LIMIT 1", false),
+        ("Collection Functions", "range", "RETURN range(1,3)", false),
+        ("Collection Functions", "nodes(), relationships()", "MATCH path = (a:Person)-[:LIVES_IN]->(b) RETURN nodes(path), relationships(path)", false),
+        ("Collection Functions", "list slicing", "RETURN [1,2,3][0..2]", false),
+        ("Collection Functions", "list indexing", "RETURN [1,2,3][0]", false),
+        ("Collection Functions", "chained list indexing", "RETURN [[1,2],[3,4]][0][1]", false),
+        ("Collection Functions", "reduce()", "RETURN reduce(s = 0, x IN [1,2,3] | s + x)", false),
+
+        ("Graph Functions", "id()", "MATCH (p:Person) RETURN id(p) LIMIT 1", false),
+        ("Graph Functions", "labels(), type()", "MATCH (a)-[r]->(b) RETURN labels(a), type(r) LIMIT 1", false),
+        ("Graph Functions", "exists(), coalesce()", "MATCH (p:Person) RETURN coalesce(p.nope, 0) LIMIT 1", false),
+        ("Graph Functions", "named paths", "MATCH path = (a:Person)-[:LIVES_IN]->(b) RETURN path", false),
+        ("Graph Functions", "shortestPath", "MATCH (a:Person {name:\"Ada\"}), (c:City) MATCH p = shortestPath((a)-[*..3]-(c)) RETURN p", false),
+        ("Graph Functions", "variable-length paths", "MATCH (a:Person)-[*1..2]->(x) RETURN count(*)", false),
+
+        ("Expressions", "CASE WHEN ... THEN ... END", "MATCH (p:Person) RETURN CASE WHEN p.age > 40 THEN 1 ELSE 0 END LIMIT 1", false),
+        ("Expressions", "pattern comprehension", "MATCH (p:Person) RETURN [(p)-[:LIVES_IN]->(c) | c.name] LIMIT 1", false),
+        ("Expressions", "list comprehension", "RETURN [x IN [1,2,3] WHERE x > 1 | x * 2]", false),
+        ("Expressions", "map literal", "RETURN {a: 1, b: \"x\"}", false),
+        ("Expressions", "map bracket access", "RETURN {a: 1}[\"a\"]", false),
+        ("Expressions", "map dot access", "MATCH (p:Person) RETURN p.tags", false),
+
+        ("Predicates", "STARTS WITH, ENDS WITH, CONTAINS", "MATCH (p:Person) WHERE p.name STARTS WITH \"A\" AND p.name ENDS WITH \"a\" AND p.name CONTAINS \"d\" RETURN count(p)", false),
+        ("Predicates", "=~ (regex)", "MATCH (p:Person) WHERE p.name =~ \"A.*\" RETURN count(p)", false),
+        ("Predicates", "IN (list membership)", "MATCH (p:Person) WHERE p.age IN [36, 41] RETURN count(p)", false),
+        ("Predicates", "IS NULL, IS NOT NULL", "MATCH (p:Person) WHERE p.nope IS NULL RETURN count(p)", false),
+        ("Predicates", "AND, OR, NOT, XOR", "MATCH (p:Person) WHERE (p.age > 30 AND NOT p.age > 50) OR p.age = 1 RETURN count(p)", false),
+        ("Predicates", "all/any/none/single", "RETURN any(x IN [1,2] WHERE x > 1), all(x IN [1,2] WHERE x > 0)", false),
+
+        ("Type Handling", "Integer/Float coercion", "MATCH (p:Person) WHERE p.age > 30.5 RETURN count(p)", false),
+        ("Type Handling", "Null propagation (comparison)", "RETURN 1 > null", false),
+        ("Type Handling", "Null propagation (arithmetic)", "RETURN 1 + null", false),
+        ("Type Handling", "Temporal types", "RETURN date(\"2026-01-01\")", false),
+        ("Type Handling", "Duration arithmetic", "RETURN duration({days: 1})", false),
+
+        ("Extensions", "CREATE VECTOR INDEX", "CREATE VECTOR INDEX probe_idx FOR (n:Person) ON (n.embedding) OPTIONS {dimension: 4, similarity: \"cosine\"}", true),
+        ("Extensions", "algo.pageRank", "CALL algo.pageRank({iterations: 2}) YIELD nodeId, score RETURN count(*)", false),
+        ("Extensions", "algo.wcc", "CALL algo.wcc() YIELD nodeId, componentId RETURN count(*)", false),
+        ("Extensions", "algo.shortestPath", "CALL algo.shortestPath(0, 2) YIELD nodeId RETURN count(*)", false),
+        ("Extensions", "algo.weightedPath", "CALL algo.weightedPath(0, 2, \"since\") YIELD nodeId RETURN count(*)", false),
+        ("Extensions", "algo.scc", "CALL algo.scc() YIELD nodeId, componentId RETURN count(*)", false),
+        ("Extensions", "algo.mst", "CALL algo.mst() YIELD weight RETURN count(*)", false),
+        ("Extensions", "algo.cdlp", "CALL algo.cdlp() YIELD nodeId RETURN count(*)", false),
+        ("Extensions", "algo.lcc", "CALL algo.lcc() YIELD nodeId RETURN count(*)", false),
+        ("Extensions", "algo.bfs / algo.dijkstra", "CALL algo.bfs({startNodeId: 0}) YIELD nodeId RETURN count(*)", false),
+        ("Extensions", "algo.triangleCount", "CALL algo.triangleCount() YIELD nodeId, triangles RETURN count(*)", false),
+    ];
+
+    let mut supported = 0usize;
+    let mut unsupported = 0usize;
+    let mut last_cat = "";
+
+    println!("# Measured Cypher support probe");
+    println!();
+
+    for (cat, feature, q, mutating) in &probes {
+        if cat != &last_cat {
+            println!("\n## {cat}");
+            last_cat = cat;
+        }
+        let result = if *mutating {
+            engine.execute_mut(q, &mut store, "default").map(|_| ())
+        } else {
+            engine.execute(q, &store).map(|_| ())
+        };
+        match result {
+            Ok(()) => {
+                supported += 1;
+                println!("SUPPORTED    | {feature}");
+            }
+            Err(e) => {
+                unsupported += 1;
+                let msg = format!("{e}");
+                let first = msg.lines().next().unwrap_or("").trim().to_string();
+                println!("UNSUPPORTED  | {feature} | {first}");
+            }
+        }
+    }
+
+    println!();
+    println!("TOTAL {} probes: {} supported, {} unsupported", probes.len(), supported, unsupported);
+}


### PR DESCRIPTION
Closes #437.

## The claim

`docs/CYPHER_COMPATIBILITY.md` opened with **"~90% OpenCypher coverage"**. Self-assessed, never checked against the TCK, and an earlier internal assessment of the same engine put it at 40–50%. Choosing between two unverified numbers is not an improvement, so the figure is withdrawn from the matrix and the README until #434 produces a measured one.

## What replaces it

`examples/cypher_matrix_probe.rs` — one representative query per matrix row, executed against the engine:

```
cargo run --release --example cypher_matrix_probe
...
TOTAL 78 probes: 73 supported, 5 unsupported
```

The page now records the version and commit it was verified against (v1.7.0, `6f36a54`), and states plainly that a ✅ means *the query executed*, not that its semantics are certified.

## Measuring it changed nine rows

**Understated — seven rows marked ❌ that have worked since v0.6.x:** `rand`/`log`/`exp`, `nodes()`/`relationships()`, list slicing, pattern comprehensions, named paths, `collect(DISTINCT x)`. The page was telling prospects we lacked things we shipped a year ago.

**Overstated — two rows marked ✅ that do not work:**

- **Null propagation.** True for comparisons (`1 > null` → `null`), false for all arithmetic (`1 + null` → type error). The damaging case is `p.a + p.missing`, which aborts the entire query — so a property absent on some nodes, the ordinary state of a property graph, cannot be used in arithmetic at all. Filed as **#457**.
- **`algo.bfs` / `algo.dijkstra`.** Not registered under those names. The equivalents are `algo.shortestPath` and `algo.weightedPath`.

**Missing entirely — two features the matrix never listed:** `CALL {}` subqueries, which parse and then fail with `Variable not found` because the subquery's columns are never exported (**#458**), and `FOREACH`, which does not parse.

## Also recorded

Algorithm procedures do not share a calling convention: `algo.pageRank` takes a config map, while `algo.shortestPath`, `algo.weightedPath` and `algo.maxFlow` take positional arguments. The error text does not say which form a procedure wants, so the first attempt at any of them fails. That cost three iterations to discover while writing the probe, which is three more than a user will spend before concluding the feature is broken.

## On the DoD

The issue asks that every ✅ be backed by a TCK scenario or a repo test. This delivers the weaker but immediately available form — every ✅ is backed by a probe in the repo — which is what is achievable before #434 lands. The probe is the thing #434 can be diffed against.