### PR TITLE
Propagate null through arithmetic instead of raising a type error

### DIFF
--- a/docs/CYPHER_COMPATIBILITY.md
+++ b/docs/CYPHER_COMPATIBILITY.md
@@ -1,13 +1,13 @@
 # Cypher Compatibility Matrix
 
-**Verified against:** Samyama v1.7.0, commit `6f36a54`
+**Verified against:** Samyama v1.7.0, commit `6f36a54` (arithmetic null row re-verified after #457)
 **Method:** every row below was executed against the engine by `examples/cypher_matrix_probe.rs`. Nothing here is from memory.
 
 ## How to read this
 
 There is **no measured OpenCypher coverage percentage** in this document, and there will not be one until the openCypher TCK is actually run (#434). A previous version of this page claimed "~90% OpenCypher coverage"; that figure was self-assessed, never checked against the TCK, and an earlier internal assessment of the same engine put the number at 40–50%. Rather than pick between two unverified numbers, the claim is withdrawn.
 
-What this page reports instead is narrower and checkable: **78 probes, 73 supported, 5 not.** Each probe is one representative query for one feature. Re-run it with:
+What this page reports instead is narrower and checkable: **78 probes, 74 supported, 4 not.** Each probe is one representative query for one feature. Re-run it with:
 
 ```
 cargo run --release --example cypher_matrix_probe
@@ -17,14 +17,13 @@ A ✅ here means *the query executed*. It does not certify semantics — a const
 
 ## What is not supported
 
-Five things, all verified:
+Four things, all verified:
 
 | Feature | Behaviour | Tracking |
 | :--- | :--- | :--- |
 | `split()` | `Unknown function: split` | — |
 | `FOREACH` | Parse error | — |
 | `CALL {}` subquery | Parses, then `Variable not found` — the subquery's columns are never exported | #458 |
-| Null propagation in **arithmetic** | `1 + null` raises a type error instead of returning `null`; `p.a + p.missing` aborts the whole query | #457 |
 | `algo.bfs`, `algo.dijkstra` | Do not exist under those names — use `algo.shortestPath` and `algo.weightedPath` | — |
 
 ## Feature Matrix
@@ -93,7 +92,7 @@ Five things, all verified:
 | | `all` / `any` / `none` / `single` | ✅ | |
 | **Type Handling** | Integer/Float coercion | ✅ | |
 | | Null propagation — comparison | ✅ | `1 > null` → `null` |
-| | Null propagation — arithmetic | ❌ | `1 + null` raises a type error — #457 |
+| | Null propagation — arithmetic | ✅ | `1 + null` → `null`; `p.a + p.missing` nulls only its own row. Fixed in #457 |
 | | Temporal types | ✅ | `date()`, component access, arithmetic. No temporal index |
 | | Duration arithmetic | ✅ | |
 | **Extensions** | `CREATE VECTOR INDEX` | ✅ | |

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -183,6 +183,12 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
              PropertyValue::Duration { months: m2, days: d2, seconds: s2, nanos: n2 }) => {
                 PropertyValue::Duration { months: m1 + m2, days: d1 + d2, seconds: s1 + s2, nanos: n1 + n2 }
             }
+            // Cypher null propagation: any arithmetic with a null operand is null,
+            // not an error. Without this, `p.a + p.missing` aborts the whole query --
+            // and a property absent on some nodes is the ordinary state of a property
+            // graph, not an exceptional one (#457). The logical and comparison operators
+            // already propagate null this way; arithmetic was the outlier.
+            (PropertyValue::Null, _) | (_, PropertyValue::Null) => PropertyValue::Null,
             _ => return Err(ExecutionError::TypeError("Add requires numeric or string operands".to_string())),
         },
         BinaryOp::Sub => match (&left_prop, &right_prop) {
@@ -205,6 +211,7 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
              PropertyValue::Duration { months: m2, days: d2, seconds: s2, nanos: n2 }) => {
                 PropertyValue::Duration { months: m1 - m2, days: d1 - d2, seconds: s1 - s2, nanos: n1 - n2 }
             }
+            (PropertyValue::Null, _) | (_, PropertyValue::Null) => PropertyValue::Null,
             _ => return Err(ExecutionError::TypeError("Sub requires numeric operands".to_string())),
         },
         BinaryOp::Mul => match (&left_prop, &right_prop) {
@@ -212,6 +219,7 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
             (PropertyValue::Float(l), PropertyValue::Float(r)) => PropertyValue::Float(l * r),
             (PropertyValue::Integer(l), PropertyValue::Float(r)) => PropertyValue::Float(*l as f64 * r),
             (PropertyValue::Float(l), PropertyValue::Integer(r)) => PropertyValue::Float(l * *r as f64),
+            (PropertyValue::Null, _) | (_, PropertyValue::Null) => PropertyValue::Null,
             _ => return Err(ExecutionError::TypeError("Mul requires numeric operands".to_string())),
         },
         BinaryOp::Div => match (&left_prop, &right_prop) {
@@ -220,6 +228,7 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
             (PropertyValue::Float(l), PropertyValue::Float(r)) => PropertyValue::Float(l / r),
             (PropertyValue::Integer(l), PropertyValue::Float(r)) => PropertyValue::Float(*l as f64 / r),
             (PropertyValue::Float(l), PropertyValue::Integer(r)) => PropertyValue::Float(l / *r as f64),
+            (PropertyValue::Null, _) | (_, PropertyValue::Null) => PropertyValue::Null,
             _ => return Err(ExecutionError::TypeError("Div requires numeric operands".to_string())),
         },
         BinaryOp::Mod => match (&left_prop, &right_prop) {
@@ -228,6 +237,7 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
             (PropertyValue::Float(l), PropertyValue::Float(r)) => PropertyValue::Float(l % r),
             (PropertyValue::Integer(l), PropertyValue::Float(r)) => PropertyValue::Float(*l as f64 % r),
             (PropertyValue::Float(l), PropertyValue::Integer(r)) => PropertyValue::Float(l % *r as f64),
+            (PropertyValue::Null, _) | (_, PropertyValue::Null) => PropertyValue::Null,
             _ => return Err(ExecutionError::TypeError("Mod requires numeric operands".to_string())),
         },
         BinaryOp::StartsWith => match (&left_prop, &right_prop) {
@@ -280,6 +290,8 @@ fn eval_unary_op(op: &UnaryOp, val: Value) -> ExecutionResult<Value> {
         UnaryOp::Minus => match val {
             Value::Property(PropertyValue::Integer(i)) => Ok(Value::Property(PropertyValue::Integer(-i))),
             Value::Property(PropertyValue::Float(f)) => Ok(Value::Property(PropertyValue::Float(-f))),
+            // -null is null, matching NOT above and the binary arithmetic ops (#457).
+            Value::Null | Value::Property(PropertyValue::Null) => Ok(Value::Property(PropertyValue::Null)),
             _ => Err(ExecutionError::TypeError("Negation requires numeric type".to_string())),
         },
     }
@@ -2623,6 +2635,7 @@ impl FilterOperator {
                         match val {
                             Value::Property(PropertyValue::Integer(i)) => Ok(Value::Property(PropertyValue::Integer(-i))),
                             Value::Property(PropertyValue::Float(f)) => Ok(Value::Property(PropertyValue::Float(-f))),
+                            Value::Null | Value::Property(PropertyValue::Null) => Ok(Value::Property(PropertyValue::Null)),
                             _ => Err(ExecutionError::TypeError("Negation requires numeric type".to_string())),
                         }
                     }
@@ -2842,6 +2855,7 @@ impl FilterOperator {
             (PropertyValue::Integer(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(*l as f64 + r)),
             (PropertyValue::Float(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Float(l + *r as f64)),
             (PropertyValue::String(l), PropertyValue::String(r)) => Ok(PropertyValue::String(format!("{}{}", l, r))),
+            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
             _ => Err(ExecutionError::TypeError("Addition requires numeric or string operands".to_string())),
         }
     }
@@ -2852,6 +2866,7 @@ impl FilterOperator {
             (PropertyValue::Float(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(l - r)),
             (PropertyValue::Integer(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(*l as f64 - r)),
             (PropertyValue::Float(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Float(l - *r as f64)),
+            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
             _ => Err(ExecutionError::TypeError("Subtraction requires numeric operands".to_string())),
         }
     }
@@ -2862,6 +2877,7 @@ impl FilterOperator {
             (PropertyValue::Float(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(l * r)),
             (PropertyValue::Integer(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(*l as f64 * r)),
             (PropertyValue::Float(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Float(l * *r as f64)),
+            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
             _ => Err(ExecutionError::TypeError("Multiplication requires numeric operands".to_string())),
         }
     }
@@ -2873,6 +2889,7 @@ impl FilterOperator {
             (PropertyValue::Float(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(l / r)),
             (PropertyValue::Integer(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(*l as f64 / r)),
             (PropertyValue::Float(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Float(l / *r as f64)),
+            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
             _ => Err(ExecutionError::TypeError("Division requires numeric operands".to_string())),
         }
     }
@@ -2884,6 +2901,7 @@ impl FilterOperator {
             (PropertyValue::Float(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(l % r)),
             (PropertyValue::Integer(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(*l as f64 % r)),
             (PropertyValue::Float(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Float(l % *r as f64)),
+            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
             _ => Err(ExecutionError::TypeError("Modulo requires numeric operands".to_string())),
         }
     }

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -1931,3 +1931,59 @@ fn single_subscript_and_slice_still_work() {
     assert_eq!(scalar(&GraphStore::new(), "RETURN [1,2][0] AS v"), "v=1");
     assert_eq!(scalar(&GraphStore::new(), "RETURN [1,2,3][0..2] AS v"), "v=[1,2]");
 }
+
+// ---------------------------------------------------------------------------
+// Null propagation through arithmetic (#457)
+//
+// Comparison and logical operators already returned null for a null operand;
+// arithmetic raised a type error instead. The damaging case was not the
+// literal but `p.a + p.missing` -- a property absent on some nodes is the
+// ordinary state of a property graph, and it aborted the entire query.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn arithmetic_with_null_yields_null_not_an_error() {
+    let s = GraphStore::new();
+    for q in [
+        "RETURN 1 + null AS v",
+        "RETURN null + 1 AS v",
+        "RETURN 1 - null AS v",
+        "RETURN 1 * null AS v",
+        "RETURN 1 / null AS v",
+        "RETURN 1 % null AS v",
+        "RETURN \"a\" + null AS v",
+        "RETURN -null AS v",
+    ] {
+        assert_eq!(scalar(&s, q), "v=NULL", "{q}");
+    }
+}
+
+#[test]
+fn a_missing_property_nulls_only_its_own_row() {
+    let e = QueryEngine::new();
+    let mut s = GraphStore::new();
+    e.execute_mut("CREATE (:P {a: 1})", &mut s, "default").unwrap();
+    e.execute_mut("CREATE (:P {a: 2, b: 10})", &mut s, "default").unwrap();
+
+    // The row lacking `b` is null; the row that has it still computes. Before
+    // the fix this raised a type error and neither row came back.
+    assert_eq!(bag(&s, "MATCH (p:P) RETURN p.a + p.b AS v"), vec!["v=12", "v=NULL"]);
+}
+
+#[test]
+fn narrowing_null_did_not_disable_the_type_check() {
+    let e = QueryEngine::new();
+    let s = GraphStore::new();
+    // Genuinely non-numeric, non-null operands must still be rejected.
+    assert!(e.execute("RETURN \"a\" - 1 AS v", &s).is_err());
+    // And division by zero is still an error, not a null.
+    assert!(e.execute("RETURN 1 / 0 AS v", &s).is_err());
+}
+
+#[test]
+fn ordinary_arithmetic_is_unaffected() {
+    let s = GraphStore::new();
+    assert_eq!(scalar(&s, "RETURN 1 + 2 AS v"), "v=3");
+    assert_eq!(scalar(&s, "RETURN \"a\" + \"b\" AS v"), "v=ab");
+    assert_eq!(scalar(&s, "RETURN 7 % 3 AS v"), "v=1");
+}


### PR DESCRIPTION
Closes #457.

## The bug

Cypher requires `null` to propagate through arithmetic — `1 + null` is `null`. Every arithmetic operator raised a type error instead:

```cypher
RETURN 1 + null     -- Type error: Add requires numeric or string operands
RETURN 1 - null     -- Type error: Sub requires numeric operands
RETURN -null        -- Type error: Negation requires numeric type
```

The logical and comparison operators in the same file already propagated null correctly (`1 > null` → `null`, `null AND true` → `null`), which is what marks this as an oversight rather than a design choice.

## Why it mattered

The literal is not the painful case. This is:

```cypher
MATCH (p:P) RETURN p.a + p.missing
-- Type error: Add requires numeric or string operands
```

A property present on some nodes and absent on others is the **ordinary** state of a property graph — it is the reason `null` exists in the language. Any arithmetic touching such a property aborted the entire query. No partial result, no per-row null, and no way to express "add these, tolerating absence" short of wrapping every operand in `coalesce`.

After the fix, on two nodes where only one has `b`:

```cypher
MATCH (p:P) RETURN p.a + p.b   -- 12, NULL
```

## The change

The null arm is added to `Add`/`Sub`/`Mul`/`Div`/`Mod` and to unary minus, in **both** evaluator implementations — the free function and the method form, which had independently drifted into the same gap.

The type check is **narrowed, not removed**:

| Expression | Before | After |
|---|---|---|
| `1 + null` | type error | `null` |
| `"a" + null` | type error | `null` |
| `-null` | type error | `null` |
| `p.a + p.missing` | type error, whole query | `null`, that row only |
| `"a" - 1` | type error | type error ✅ |
| `1 / 0` | division by zero | division by zero ✅ |
| `1 + 2` | `3` | `3` ✅ |

## Verification

Four new tests: the eight operator forms, the per-row missing-property case, the two error cases that must survive, and ordinary arithmetic.

- `cypher_projection_semantics`: **77 passed, 0 failed**
- Package suite (`-p samyama`): **2374 passed, 0 failed**
- Measured matrix: **73/78 → 74/78**, arithmetic row ❌ → ✅ (doc updated in this PR)