### PR TITLE
Execute CALL {} subqueries instead of failing on their variables

### DIFF
--- a/docs/CYPHER_COMPATIBILITY.md
+++ b/docs/CYPHER_COMPATIBILITY.md
@@ -7,7 +7,7 @@
 
 There is **no measured OpenCypher coverage percentage** in this document, and there will not be one until the openCypher TCK is actually run (#434). A previous version of this page claimed "~90% OpenCypher coverage"; that figure was self-assessed, never checked against the TCK, and an earlier internal assessment of the same engine put the number at 40–50%. Rather than pick between two unverified numbers, the claim is withdrawn.
 
-What this page reports instead is narrower and checkable: **78 probes, 74 supported, 4 not.** Each probe is one representative query for one feature. Re-run it with:
+What this page reports instead is narrower and checkable: **78 probes, 75 supported, 3 not.** Each probe is one representative query for one feature. Re-run it with:
 
 ```
 cargo run --release --example cypher_matrix_probe
@@ -17,13 +17,12 @@ A ✅ here means *the query executed*. It does not certify semantics — a const
 
 ## What is not supported
 
-Four things, all verified:
+Three things, all verified:
 
 | Feature | Behaviour | Tracking |
 | :--- | :--- | :--- |
 | `split()` | `Unknown function: split` | — |
 | `FOREACH` | Parse error | — |
-| `CALL {}` subquery | Parses, then `Variable not found` — the subquery's columns are never exported | #458 |
 | `algo.bfs`, `algo.dijkstra` | Do not exist under those names — use `algo.shortestPath` and `algo.weightedPath` | — |
 
 ## Feature Matrix
@@ -52,7 +51,7 @@ Four things, all verified:
 | | `UNWIND` | ✅ | Including leading `UNWIND` |
 | | `UNION` / `UNION ALL` | ✅ | |
 | | `EXISTS { }` subquery | ✅ | |
-| | `CALL { }` subquery | ❌ | Parses but exports nothing — #458 |
+| | `CALL { }` subquery | ✅ | Leading, non-correlated form. Exports its columns; outer `WHERE`/`DISTINCT` apply. Fixed in #458. The importing form `MATCH (x) CALL { WITH x ... }` is still a parse error |
 | | `FOREACH` | ❌ | Parse error |
 | **String Functions** | `toUpper`, `toLower` | ✅ | |
 | | `trim`, `replace` | ✅ | |

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -167,6 +167,86 @@ impl<'a> QueryExecutor<'a> {
         self
     }
 
+    /// Execute a `CALL { ... }` subquery and apply the enclosing query to its rows.
+    ///
+    /// The subquery is parsed into its own `Query` but was never executed -- it
+    /// only ever appeared as a "bail out of this optimisation" flag in the
+    /// detectors -- so `CALL { RETURN 1 AS n } RETURN n` failed with
+    /// `Variable not found: n` (#458). An unsupported construct must raise a
+    /// typed error, not blame the user's variable names.
+    ///
+    /// Only the leading, non-correlated form reaches here: the grammar puts
+    /// `CALL` at the start of a statement, so the importing form
+    /// (`MATCH (x) CALL { WITH x ... }`) still fails at parse time. Shapes that
+    /// cannot be evaluated correctly return an error rather than a partial
+    /// answer -- a wrong row is worse than a refusal.
+    fn execute_call_subquery(&self, query: &Query, inner: &Query) -> ExecutionResult<RecordBatch> {
+        // Planning tells us whether the subquery writes. Say so plainly -- the
+        // read-only-executor message underneath is about internals the caller
+        // did not choose and cannot act on.
+        if self.planner.plan(inner, self.store).map(|p| p.is_write).unwrap_or(false) {
+            return Err(ExecutionError::RuntimeError(
+                "writes inside a CALL {} subquery are not supported".to_string(),
+            ));
+        }
+
+        let inner_batch = self.execute(inner)?;
+
+        // A subquery combined with further pattern matching would need a proper
+        // join against the outer pattern; refuse rather than guess.
+        if !query.match_clauses.is_empty() {
+            return Err(ExecutionError::RuntimeError(
+                "CALL {} subquery followed by MATCH is not supported".to_string(),
+            ));
+        }
+
+        // `CALL { ... }` with nothing after it yields the subquery's own rows.
+        let Some(return_clause) = &query.return_clause else {
+            return Ok(inner_batch);
+        };
+
+        let mut root: OperatorBox = Box::new(operator::MaterializedOperator::new(inner_batch.records));
+
+        if let Some(where_clause) = &query.where_clause {
+            root = Box::new(operator::FilterOperator::new(root, where_clause.predicate.clone()));
+        }
+
+        let projections: Vec<(crate::query::ast::Expression, String)> = return_clause
+            .items
+            .iter()
+            .map(|item| {
+                let alias = item.alias.clone().unwrap_or_else(|| match &item.expression {
+                    crate::query::ast::Expression::Variable(v) => v.clone(),
+                    crate::query::ast::Expression::Property { variable, property } => {
+                        format!("{variable}.{property}")
+                    }
+                    other => format!("{other:?}"),
+                });
+                (item.expression.clone(), alias)
+            })
+            .collect();
+        let columns: Vec<String> = projections.iter().map(|(_, alias)| alias.clone()).collect();
+        root = Box::new(operator::ProjectOperator::new(root, projections));
+
+        let mut records = Vec::new();
+        loop {
+            match root.next(self.store)? {
+                Some(r) => records.push(r),
+                None => break,
+            }
+        }
+
+        if return_clause.distinct {
+            let mut seen = std::collections::HashSet::new();
+            records.retain(|r| {
+                let key = format!("{:?}", r.bindings());
+                seen.insert(key)
+            });
+        }
+
+        Ok(RecordBatch { records, columns })
+    }
+
     /// Execute a read-only query and return results
     pub fn execute(&self, query: &Query) -> ExecutionResult<RecordBatch> {
         // Substitute parameters if any
@@ -180,6 +260,10 @@ impl<'a> QueryExecutor<'a> {
             query.clone()
         };
         let query = &query;
+
+        if let Some(inner) = &query.call_subquery {
+            return self.execute_call_subquery(query, inner);
+        }
 
         // Plan the query
         let plan = self.planner.plan(query, self.store)?;
@@ -348,6 +432,14 @@ impl<'a> MutQueryExecutor<'a> {
             query.clone()
         };
         let query = &query;
+
+        // A read-only `CALL {}` subquery goes through the same path as on the
+        // read executor. HTTP and RESP route every statement through here, so
+        // without this the fix would be invisible to almost every caller.
+        if let Some(inner) = &query.call_subquery {
+            let store_ref: &GraphStore = self.store;
+            return QueryExecutor::new(store_ref).execute_call_subquery(query, inner);
+        }
 
         // Plan the query (need immutable borrow temporarily)
         let plan = {

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -6801,6 +6801,44 @@ impl PhysicalOperator for SingleRowOperator {
     }
 }
 
+/// Emits a fixed, already-computed set of records.
+///
+/// Used as the source when a `CALL {}` subquery has been executed and its
+/// results become the input stream for the enclosing query.
+pub struct MaterializedOperator {
+    records: Vec<Record>,
+    idx: usize,
+}
+
+impl MaterializedOperator {
+    /// Create an operator that replays `records` in order.
+    pub fn new(records: Vec<Record>) -> Self {
+        Self { records, idx: 0 }
+    }
+}
+
+impl PhysicalOperator for MaterializedOperator {
+    fn next(&mut self, _store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        if self.idx >= self.records.len() {
+            Ok(None)
+        } else {
+            let r = self.records[self.idx].clone();
+            self.idx += 1;
+            Ok(Some(r))
+        }
+    }
+
+    fn reset(&mut self) { self.idx = 0; }
+
+    fn describe(&self) -> OperatorDescription {
+        OperatorDescription {
+            name: "Materialized".to_string(),
+            details: format!("{} rows", self.records.len()),
+            children: Vec::new(),
+        }
+    }
+}
+
 /// Algorithm operator: CALL algo.pageRank(...)
 pub struct AlgorithmOperator {
     /// Procedure name

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -1987,3 +1987,103 @@ fn ordinary_arithmetic_is_unaffected() {
     assert_eq!(scalar(&s, "RETURN \"a\" + \"b\" AS v"), "v=ab");
     assert_eq!(scalar(&s, "RETURN 7 % 3 AS v"), "v=1");
 }
+
+// ---------------------------------------------------------------------------
+// CALL {} subqueries (#458)
+//
+// The subquery was parsed into its own Query and then never executed -- it
+// only appeared as a "bail out of this optimisation" flag in the detectors --
+// so its columns were never bound and `CALL { RETURN 1 AS n } RETURN n` died
+// with `Variable not found: n`, blaming the user's variable name for an
+// engine gap.
+// ---------------------------------------------------------------------------
+
+fn three_p_nodes() -> GraphStore {
+    let e = QueryEngine::new();
+    let mut s = GraphStore::new();
+    for n in [1, 2, 2] {
+        e.execute_mut(&format!("CREATE (:P {{n: {n}}})"), &mut s, "default").unwrap();
+    }
+    s
+}
+
+#[test]
+fn call_subquery_exports_its_columns() {
+    // No graph access at all -- the simplest case, which also failed before.
+    assert_eq!(scalar(&GraphStore::new(), "CALL { RETURN 1 AS n } RETURN n"), "n=1");
+}
+
+#[test]
+fn call_subquery_over_a_match_exports_every_row() {
+    assert_eq!(
+        bag(&three_p_nodes(), "CALL { MATCH (p:P) RETURN p.n AS n } RETURN n"),
+        vec!["n=1", "n=2", "n=2"]
+    );
+}
+
+#[test]
+fn bare_call_subquery_yields_its_own_rows() {
+    // `CALL { ... }` with nothing after it is the subquery's result.
+    assert_eq!(
+        bag(&three_p_nodes(), "CALL { MATCH (p:P) RETURN p.n AS n }").len(),
+        3
+    );
+}
+
+#[test]
+fn call_subquery_respects_outer_distinct_and_where() {
+    assert_eq!(
+        bag(&three_p_nodes(), "CALL { MATCH (p:P) RETURN p.n AS n } RETURN DISTINCT n"),
+        vec!["n=1", "n=2"]
+    );
+    assert_eq!(
+        bag(&three_p_nodes(), "CALL { MATCH (p:P) RETURN p.n AS n } WHERE n > 1 RETURN n"),
+        vec!["n=2", "n=2"]
+    );
+}
+
+#[test]
+fn call_subquery_can_aggregate_inside() {
+    assert_eq!(
+        scalar(&three_p_nodes(), "CALL { MATCH (p:P) RETURN count(p) AS c } RETURN c"),
+        "c=3"
+    );
+}
+
+#[test]
+fn unsupported_call_shapes_fail_loudly_rather_than_partially() {
+    let e = QueryEngine::new();
+    let s = three_p_nodes();
+
+    // A subquery followed by more pattern matching needs a real join; refusing
+    // is correct, silently dropping the MATCH would not be.
+    let err = e
+        .execute("CALL { MATCH (p:P) RETURN p.n AS n } MATCH (q:P) RETURN n", &s)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("not supported"), "{err}");
+}
+
+#[test]
+fn a_write_inside_a_call_subquery_is_refused_and_writes_nothing() {
+    let e = QueryEngine::new();
+    let mut s = GraphStore::new();
+    let err = e
+        .execute_mut("CALL { CREATE (:X {a: 1}) }", &mut s, "default")
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("CALL {} subquery"), "{err}");
+    assert_eq!(s.node_count(), 0, "a refused subquery must not write");
+}
+
+#[test]
+fn call_subquery_works_on_the_write_path_too() {
+    // HTTP and RESP route every statement through the mutable executor, so a
+    // fix that only landed on the read path would be invisible to them.
+    let e = QueryEngine::new();
+    let mut s = three_p_nodes();
+    let batch = e
+        .execute_mut("CALL { MATCH (p:P) RETURN p.n AS n } RETURN n", &mut s, "default")
+        .unwrap();
+    assert_eq!(batch.records.len(), 3);
+}


### PR DESCRIPTION
Closes #458.

## The bug

`CALL {}` subqueries were parsed into their own `Query` and then **never executed**. The AST field appeared only as a "bail out of this optimisation" flag in the detectors — nothing in the planner or executor consumed it. So the subquery's columns were never bound, and the simplest possible case died on the variable it had just declared:

```cypher
CALL { RETURN 1 AS n } RETURN n     -- Variable not found: n
```

No graph access, no pattern scoping, no importing `WITH` — it still failed. And the error blames the user's variable name for an engine gap; someone reading it renames things and retries, because the message says the variable is the problem. LANG-03 asks that an unsupported construct raise a *typed* error, not misdirect.

## The change

`MaterializedOperator` replays an already-computed record set. The subquery runs through it: execute the inner query, feed its rows into the enclosing `WHERE` / `RETURN` / `DISTINCT`.

Applied on **both** executors. HTTP and RESP route every statement through the mutable one, so a read-path-only fix would have been invisible to nearly every caller — worth stating because it was nearly the shape of this patch.

```cypher
CALL { RETURN 1 AS n } RETURN n                              -- 1
CALL { MATCH (p:P) RETURN p.n AS n } RETURN n                -- 1, 2, 2
CALL { MATCH (p:P) RETURN p.n AS n }                         -- 1, 2, 2   (bare form)
CALL { MATCH (p:P) RETURN p.n AS n } RETURN DISTINCT n       -- 1, 2
CALL { MATCH (p:P) RETURN p.n AS n } WHERE n > 1 RETURN n    -- 2, 2
CALL { MATCH (p:P) RETURN count(p) AS c } RETURN c           -- 3
```

## What it refuses, deliberately

A partial answer here would be worse than no answer, so two shapes error instead:

- **Subquery followed by `MATCH`** — needs a real join against the outer pattern. Errors rather than silently dropping the `MATCH` and returning the subquery's rows as if they were the whole result.
- **A write inside a subquery** — errors and writes nothing, naming the actual restriction instead of surfacing `Cannot execute write query with read-only executor`, which is about internals the caller neither chose nor can act on.

The importing form `MATCH (x) CALL { WITH x ... }` still fails at parse time, unchanged: the grammar puts `CALL` at the start of a statement. That is honest, and it bounds this PR to the leading non-correlated form.

## Verification

8 tests, including the two refusal paths and an assertion that the refused write leaves `node_count() == 0`.

- `cypher_projection_semantics`: **85 passed, 0 failed**
- Package suite (`-p samyama`): **2382 passed, 0 failed**
- Measured matrix: **74/78 → 75/78** (doc updated here)