### PR TITLE
Add map dot access and keys() over maps

### DIFF
--- a/docs/CYPHER_COMPATIBILITY.md
+++ b/docs/CYPHER_COMPATIBILITY.md
@@ -64,7 +64,7 @@ Three things, all verified:
 | | `rand`, `log`, `exp` | ✅ | Previously listed as a gap; shipped in v0.6.x |
 | **Collection Functions** | `size`, `length` | ✅ | |
 | | `head`, `last`, `tail` | ✅ | |
-| | `keys` | ✅ | Nodes and edges. Rejects maps — #452 |
+| | `keys` | ✅ | Nodes, edges and maps (#452) |
 | | `range` | ✅ | |
 | | `nodes()`, `relationships()` | ✅ | Previously listed as a gap; shipped in v0.6.x |
 | | List indexing `xs[0]` | ✅ | |
@@ -82,7 +82,7 @@ Three things, all verified:
 | | List comprehension | ✅ | |
 | | Map literal `{a: 1}` | ✅ | Nested to arbitrary depth |
 | | Map bracket access `m["a"]` | ✅ | Chaining fixed in #453 |
-| | Map dot access `m.a` | ❌ | Parse error — #452 |
+| | Map dot access `m.a` | ✅ | `d.meta.a`, `d.meta.c.d`; desugars to the same `Index` path as brackets. Fixed in #452. Reads only — `SET d.meta.a = 1` is still a parse error |
 | **Predicates** | `STARTS WITH`, `ENDS WITH`, `CONTAINS` | ✅ | |
 | | `=~` (regex) | ✅ | |
 | | `IN` (list membership) | ✅ | |

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -168,6 +168,7 @@ primary = {
     list_comprehension |
     count_star |
     function_call |
+    nested_property_access |
     property_access |
     parameter |
     value |
@@ -209,6 +210,10 @@ case_when = { ^"WHEN" ~ expression ~ ^"THEN" ~ expression }
 case_else = { ^"ELSE" ~ expression }
 
 property_access = { variable ~ "." ~ property_key }
+// Map path access: `d.meta.a`, `d.meta.a.b`. Kept separate from
+// `property_access` because that rule is shared with SET/REMOVE/constraints,
+// where a nested path would mean something this engine does not implement.
+nested_property_access = { variable ~ "." ~ property_key ~ ("." ~ property_key)+ }
 function_call = { function_name ~ "(" ~ distinct? ~ (expression ~ ("," ~ expression)*)? ~ ")" }
 function_name = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1329,7 +1329,17 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                         .collect();
                     Ok(Value::Property(PropertyValue::Array(keys)))
                 }
-                _ => Err(ExecutionError::TypeError("keys() requires node or edge".to_string())),
+                // keys() over a map property. Cypher defines keys() on maps as
+                // well as nodes and edges, and without this a map property can
+                // be stored and read whole but never enumerated (#452).
+                Value::Property(PropertyValue::Map(m)) => {
+                    let keys: Vec<PropertyValue> = m
+                        .keys()
+                        .map(|k| PropertyValue::String(k.clone()))
+                        .collect();
+                    Ok(Value::Property(PropertyValue::Array(keys)))
+                }
+                _ => Err(ExecutionError::TypeError("keys() requires a node, edge, or map".to_string())),
             }
         }
         "exists" => {

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1660,6 +1660,39 @@ fn parse_term(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
     }
 }
 
+/// `d.meta.a`, `d.meta.a.b` -- a property lookup followed by map key lookups.
+///
+/// The first segment is the stored property; every segment after it indexes into
+/// the map that property holds. Desugaring to `Expression::Index` reuses the map
+/// indexing that `d.meta["a"]` already goes through, so there is one evaluation
+/// path for both spellings rather than two that can drift apart (#452).
+fn parse_nested_property_access(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
+    let mut variable = None;
+    let mut keys: Vec<String> = Vec::new();
+    for inner in pair.into_inner() {
+        match inner.as_rule() {
+            Rule::variable => variable = Some(inner.as_str().to_string()),
+            Rule::property_key => keys.push(inner.as_str().to_string()),
+            _ => {}
+        }
+    }
+    let variable = variable
+        .ok_or_else(|| ParseError::SemanticError("Missing variable in property path".to_string()))?;
+    let mut it = keys.into_iter();
+    let first = it
+        .next()
+        .ok_or_else(|| ParseError::SemanticError("Missing property in property path".to_string()))?;
+
+    let mut expr = Expression::Property { variable, property: first };
+    for key in it {
+        expr = Expression::Index {
+            expr: Box::new(expr),
+            index: Box::new(Expression::Literal(PropertyValue::String(key))),
+        };
+    }
+    Ok(expr)
+}
+
 fn parse_primary(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
     for inner in pair.into_inner() {
         match inner.as_rule() {
@@ -1705,6 +1738,9 @@ fn parse_primary(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
             }
             Rule::property_access => {
                 return parse_property_access(inner);
+            }
+            Rule::nested_property_access => {
+                return parse_nested_property_access(inner);
             }
             Rule::function_call => {
                 return parse_function_call(inner);

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -2087,3 +2087,81 @@ fn call_subquery_works_on_the_write_path_too() {
         .unwrap();
     assert_eq!(batch.records.len(), 3);
 }
+
+// ---------------------------------------------------------------------------
+// Map dot access and keys() over maps (#452)
+//
+// Map properties stored and round-tripped intact to arbitrary depth, but the
+// only way in was `m["k"]`. Dot notation was a parse error and keys() rejected
+// maps outright, so a map's fields could not even be enumerated.
+// ---------------------------------------------------------------------------
+
+fn map_property_fixture() -> GraphStore {
+    let mut s = GraphStore::new();
+    QueryEngine::new()
+        .execute_mut(
+            "CREATE (:D {meta: {a: 1, c: {d: 9}}, plain: 5})",
+            &mut s,
+            "default",
+        )
+        .unwrap();
+    s
+}
+
+#[test]
+fn dot_access_reaches_one_level_into_a_map() {
+    assert_eq!(scalar(&map_property_fixture(), "MATCH (d:D) RETURN d.meta.a AS v"), "v=1");
+}
+
+#[test]
+fn dot_access_chains_arbitrarily_deep() {
+    assert_eq!(scalar(&map_property_fixture(), "MATCH (d:D) RETURN d.meta.c.d AS v"), "v=9");
+}
+
+#[test]
+fn dot_access_works_in_a_predicate() {
+    let s = map_property_fixture();
+    assert_eq!(scalar(&s, "MATCH (d:D) WHERE d.meta.a = 1 RETURN count(d) AS v"), "v=1");
+    assert_eq!(scalar(&s, "MATCH (d:D) WHERE d.meta.c.d = 9 RETURN count(d) AS v"), "v=1");
+}
+
+#[test]
+fn dot_and_bracket_access_are_the_same_path() {
+    // Both spellings desugar to Expression::Index, so they cannot drift apart.
+    let s = map_property_fixture();
+    assert_eq!(
+        scalar(&s, "MATCH (d:D) RETURN d.meta.c[\"d\"] AS v"),
+        scalar(&s, "MATCH (d:D) RETURN d.meta[\"c\"][\"d\"] AS v")
+    );
+}
+
+#[test]
+fn a_missing_map_key_is_null_not_an_error() {
+    assert_eq!(scalar(&map_property_fixture(), "MATCH (d:D) RETURN d.meta.nope AS v"), "v=NULL");
+}
+
+#[test]
+fn plain_property_access_is_unaffected() {
+    assert_eq!(scalar(&map_property_fixture(), "MATCH (d:D) RETURN d.plain AS v"), "v=5");
+}
+
+#[test]
+fn keys_enumerates_a_map_and_still_a_node() {
+    let s = map_property_fixture();
+    assert_eq!(bag(&s, "MATCH (d:D) RETURN keys(d.meta) AS v"), vec!["v=[a,c]"]);
+    assert_eq!(bag(&s, "MATCH (d:D) RETURN keys(d) AS v"), vec!["v=[meta,plain]"]);
+}
+
+#[test]
+fn writing_through_a_map_path_is_still_rejected() {
+    // Reads gained dot access; writes did not, because writing into a map is
+    // not implemented. Accepting the syntax and dropping the write would be
+    // worse than refusing it.
+    let e = QueryEngine::new();
+    let mut s = map_property_fixture();
+    assert!(e.execute_mut("MATCH (d:D) SET d.meta.a = 5", &mut s, "default").is_err());
+    assert!(e.execute_mut("MATCH (d:D) REMOVE d.meta.a", &mut s, "default").is_err());
+    // Ordinary single-segment SET/REMOVE keep working.
+    assert!(e.execute_mut("MATCH (d:D) SET d.plain = 6", &mut s, "default").is_ok());
+    assert!(e.execute_mut("MATCH (d:D) REMOVE d.plain", &mut s, "default").is_ok());
+}


### PR DESCRIPTION
Closes #452.

## The gap

Map properties store and round-trip intact to arbitrary depth, but the only way into one was `m["k"]`:

```cypher
MATCH (d:D) RETURN d.meta.a       -- Parse error
MATCH (d:D) RETURN keys(d.meta)   -- Type error: keys() requires node or edge
```

So a document-shaped property could be written and read whole — and little else. Its fields could not be projected by name in the natural spelling, and could not be enumerated at all.

## The change

```cypher
MATCH (d:D) RETURN d.meta.a                       -- 1
MATCH (d:D) RETURN d.meta.c.d                     -- 9
MATCH (d:D) WHERE d.meta.c.d = 9 RETURN count(d)  -- 1
MATCH (d:D) RETURN d.meta.c["d"]                  -- 9   (mixed spellings)
MATCH (d:D) RETURN keys(d.meta)                   -- [a, c]
MATCH (d:D) RETURN d.meta.nope                    -- null, not an error
```

Two decisions worth naming:

**A separate grammar rule, not a change to `property_access`.** That rule is shared with `SET`, `REMOVE` and constraints, where a nested path would mean *writing into* a map — which is not implemented. Accepting `SET d.meta.a = 1` and silently dropping the write would be worse than refusing it, so reads gained the path and writes did not:

```cypher
MATCH (d:D) SET d.meta.a = 5    -- Parse error   (unchanged, deliberate)
MATCH (d:D) SET d.plain = 6     -- ok            (unchanged)
```

**Ordering.** `nested_property_access` is tried *before* `property_access` in `primary`. PEG takes the first alternative that matches, so the shorter rule would otherwise consume `d.meta` and leave `.a` dangling.

**One evaluation path.** The path desugars to `Expression::Index` with string literals — the same machinery `d.meta["a"]` already used — so the two spellings cannot drift apart. A test asserts they return identical results rather than merely both working.

## Verification

8 tests: one and two levels, predicate position, mixed dot/bracket equivalence, missing key → null, plain property access unchanged, `keys()` on both a map and a node, and the write-path rejection alongside single-segment `SET`/`REMOVE` still succeeding.

- `cypher_projection_semantics`: **93 passed, 0 failed**
- Package suite (`-p samyama`): **2390 passed, 0 failed**

With this, every gap in #452 is closed: bracket chaining landed in #453/#454, dot notation and `keys()` here.