### PR TITLE
Add split()

### DIFF
--- a/docs/CYPHER_COMPATIBILITY.md
+++ b/docs/CYPHER_COMPATIBILITY.md
@@ -7,7 +7,7 @@
 
 There is **no measured OpenCypher coverage percentage** in this document, and there will not be one until the openCypher TCK is actually run (#434). A previous version of this page claimed "~90% OpenCypher coverage"; that figure was self-assessed, never checked against the TCK, and an earlier internal assessment of the same engine put the number at 40–50%. Rather than pick between two unverified numbers, the claim is withdrawn.
 
-What this page reports instead is narrower and checkable: **78 probes, 75 supported, 3 not.** Each probe is one representative query for one feature. Re-run it with:
+What this page reports instead is narrower and checkable: **78 probes, 76 supported, 2 not.** Each probe is one representative query for one feature. Re-run it with:
 
 ```
 cargo run --release --example cypher_matrix_probe
@@ -17,11 +17,10 @@ A ✅ here means *the query executed*. It does not certify semantics — a const
 
 ## What is not supported
 
-Three things, all verified:
+Two things, all verified:
 
 | Feature | Behaviour | Tracking |
 | :--- | :--- | :--- |
-| `split()` | `Unknown function: split` | — |
 | `FOREACH` | Parse error | — |
 | `algo.bfs`, `algo.dijkstra` | Do not exist under those names — use `algo.shortestPath` and `algo.weightedPath` | — |
 
@@ -57,7 +56,7 @@ Three things, all verified:
 | | `trim`, `replace` | ✅ | |
 | | `substring`, `left`, `right` | ✅ | |
 | | `reverse`, `toString` | ✅ | |
-| | `split` | ❌ | |
+| | `split` | ✅ | Multi-char delimiters; empty delimiter splits into characters |
 | **Numeric Functions** | `abs`, `ceil`, `floor`, `round` | ✅ | |
 | | `sqrt`, `sign` | ✅ | |
 | | `toInteger`, `toFloat` | ✅ | |

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1014,6 +1014,25 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
             let s = extract_string(&args[0])?;
             Ok(Value::Property(PropertyValue::String(s.trim().to_string())))
         }
+        "split" => {
+            if args.len() < 2 {
+                return Err(ExecutionError::RuntimeError(
+                    "split() requires 2 arguments: split(string, delimiter)".to_string(),
+                ));
+            }
+            let s = extract_string(&args[0])?;
+            let delim = extract_string(&args[1])?;
+            // Cypher splits on an empty delimiter into single characters; Rust's
+            // split("") would additionally yield empty strings at both ends.
+            let parts: Vec<PropertyValue> = if delim.is_empty() {
+                s.chars().map(|c| PropertyValue::String(c.to_string())).collect()
+            } else {
+                s.split(delim.as_str())
+                    .map(|p| PropertyValue::String(p.to_string()))
+                    .collect()
+            };
+            Ok(Value::Property(PropertyValue::Array(parts)))
+        }
         "ltrim" => {
             let s = extract_string(&args[0])?;
             Ok(Value::Property(PropertyValue::String(s.trim_start().to_string())))

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -2165,3 +2165,51 @@ fn writing_through_a_map_path_is_still_rejected() {
     assert!(e.execute_mut("MATCH (d:D) SET d.plain = 6", &mut s, "default").is_ok());
     assert!(e.execute_mut("MATCH (d:D) REMOVE d.plain", &mut s, "default").is_ok());
 }
+
+// ---------------------------------------------------------------------------
+// split() (#437 probe finding)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn split_on_a_single_character() {
+    assert_eq!(scalar(&GraphStore::new(), "RETURN split(\"a,b,c\", \",\") AS v"), "v=[a,b,c]");
+}
+
+#[test]
+fn split_on_a_multi_character_delimiter() {
+    assert_eq!(scalar(&GraphStore::new(), "RETURN split(\"a::b\", \"::\") AS v"), "v=[a,b]");
+}
+
+#[test]
+fn split_that_matches_nothing_returns_the_whole_string() {
+    assert_eq!(scalar(&GraphStore::new(), "RETURN split(\"abc\", \",\") AS v"), "v=[abc]");
+}
+
+#[test]
+fn split_on_an_empty_delimiter_yields_characters() {
+    // Cypher splits into single characters here. Rust's split("") would also
+    // emit an empty string at each end, which is why this is special-cased.
+    assert_eq!(scalar(&GraphStore::new(), "RETURN split(\"abc\", \"\") AS v"), "v=[a,b,c]");
+}
+
+#[test]
+fn split_keeps_the_empty_field_a_trailing_delimiter_creates() {
+    // "a," is two fields, the second empty -- dropping it would lose information.
+    assert_eq!(scalar(&GraphStore::new(), "RETURN size(split(\"a,\", \",\")) AS v"), "v=2");
+}
+
+#[test]
+fn split_composes_with_size_and_indexing() {
+    let s = GraphStore::new();
+    assert_eq!(scalar(&s, "RETURN size(split(\"a,b,c\", \",\")) AS v"), "v=3");
+    assert_eq!(scalar(&s, "RETURN split(\"a,b,c\", \",\")[1] AS v"), "v=b");
+}
+
+#[test]
+fn split_with_the_wrong_arity_says_so() {
+    let err = QueryEngine::new()
+        .execute("RETURN split(\"a\") AS v", &GraphStore::new())
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("split() requires 2 arguments"), "{err}");
+}


### PR DESCRIPTION
`split()` was one of the few things `docs/CYPHER_COMPATIBILITY.md` was right to mark unsupported, and it is among the more commonly reached-for Cypher string functions.

```cypher
RETURN split("a,b,c", ",")            -- [a, b, c]
RETURN split("a::b", "::")            -- [a, b]        multi-char delimiter
RETURN split("abc", ",")              -- [abc]         no match
RETURN split("abc", "")               -- [a, b, c]     empty delimiter
RETURN size(split("a,b,c", ","))      -- 3
RETURN split("a,b,c", ",")[1]         -- b
RETURN split("a")                     -- split() requires 2 arguments: split(string, delimiter)
```

## Two behaviours worth pinning

Both are covered by tests rather than left to the implementation to imply:

- **Empty delimiter splits into characters.** Rust's `split("")` would additionally emit an empty string at each end, so this is special-cased rather than passed through.
- **A trailing delimiter keeps the empty field it creates.** `split("a,", ",")` is two elements, not one. Trimming it would silently lose information — the difference between a one-field and a two-field record.

## Verification

7 tests, including composition with `size()` and subscripting, and the arity error message.

- `cypher_projection_semantics`: **100 passed, 0 failed**
- Package suite (`-p samyama`): **2397 passed, 0 failed**
- Measured matrix: **75/78 → 76/78**

The two remaining probe failures are `FOREACH` and `algo.bfs`/`algo.dijkstra` (the latter being a naming gap — `algo.shortestPath` and `algo.weightedPath` exist and work).