### PR TITLE
Make unknown-algorithm errors name what exists

### DIFF
--- a/docs/CYPHER_COMPATIBILITY.md
+++ b/docs/CYPHER_COMPATIBILITY.md
@@ -102,12 +102,12 @@ Two things, all verified:
 | | `algo.mst` | ✅ | |
 | | `algo.triangleCount` | ✅ | |
 | | `algo.cdlp` / `algo.lcc` | ✅ | |
-| | `algo.bfs` / `algo.dijkstra` | ❌ | Not registered — use `shortestPath` / `weightedPath` |
+| | `algo.bfs` / `algo.dijkstra` | ❌ | Not registered. The error now redirects to `algo.shortestPath` / `algo.weightedPath` and lists every procedure with its argument shape |
 | | `algo.or.solve` | ✅ | Requires write access |
 
 ## Known inconsistency
 
-Algorithm procedures do not share a calling convention. `algo.pageRank` takes a config map; `algo.shortestPath`, `algo.weightedPath` and `algo.maxFlow` take **positional** arguments. The error text does not say which form a given procedure wants, so the first attempt at any of them tends to fail.
+Algorithm procedures do not share a calling convention. `algo.pageRank` and `algo.or.solve` take a config map; `algo.shortestPath`, `algo.weightedPath`, `algo.maxFlow`, `algo.mst`, `algo.cdlp` and `algo.lcc` take **positional** arguments. This is still inconsistent, but an unknown or misused name now reports the full list with each procedure's argument shape, so it costs one failed attempt rather than three.
 
 ## Maintaining this page
 

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -6883,6 +6883,35 @@ pub struct AlgorithmOperator {
 }
 
 impl AlgorithmOperator {
+    /// Every algorithm this operator dispatches, with its calling convention.
+    ///
+    /// `Unknown algorithm: algo.bfs` gave the caller nothing to go on -- the
+    /// name they wanted (`algo.shortestPath`) is not guessable from it, and
+    /// the procedures do not share an argument shape either, so even the right
+    /// name fails on the first attempt. Listing both removes two rounds of
+    /// trial and error.
+    fn available() -> &'static str {
+        "pageRank({config}), shortestPath(source, target), weightedPath(source, target, weightProperty), \
+maxFlow(source, sink [, capacityProperty]), mst([weightProperty]), cdlp([label, edgeType, config]), \
+lcc([label, edgeType]), wcc(), scc(), triangleCount(), or.solve({config})"
+    }
+
+    /// Error for a procedure name that does not dispatch, naming what does.
+    fn unknown_algorithm(name: &str) -> ExecutionError {
+        let hint = match name.to_lowercase().replace("algo.", "").as_str() {
+            "bfs" | "breadthfirstsearch" => " -- for an unweighted path, use algo.shortestPath",
+            "dijkstra" | "shortestpathweighted" => " -- for a weighted path, use algo.weightedPath",
+            "pagerank2" | "prank" => " -- did you mean algo.pageRank?",
+            "louvain" | "labelpropagation" => " -- for community detection, use algo.cdlp",
+            "connectedcomponents" | "components" => " -- use algo.wcc or algo.scc",
+            _ => "",
+        };
+        ExecutionError::RuntimeError(format!(
+            "Unknown algorithm: {name}{hint}. Available: {}",
+            Self::available()
+        ))
+    }
+
     pub fn new(name: String, args: Vec<crate::query::ast::Expression>) -> Self {
         Self {
             name,
@@ -7505,7 +7534,7 @@ impl PhysicalOperator for AlgorithmOperator {
                 "cdlp" => self.execute_cdlp(store)?,
                 "lcc" => self.execute_lcc(store)?,
                 "or.solve" => return Err(ExecutionError::RuntimeError("algo.or.solve requires write access (MutQueryExecutor)".to_string())),
-                _ => return Err(ExecutionError::RuntimeError(format!("Unknown algorithm: {}", self.name))),
+                _ => return Err(Self::unknown_algorithm(&self.name)),
             }
             self.executed = true;
         }
@@ -7536,7 +7565,7 @@ impl PhysicalOperator for AlgorithmOperator {
                 "trianglecount" => self.execute_triangle_count(store)?,
                 "cdlp" => self.execute_cdlp(store)?,
                 "lcc" => self.execute_lcc(store)?,
-                _ => return Err(ExecutionError::RuntimeError(format!("Unknown algorithm: {}", self.name))),
+                _ => return Err(Self::unknown_algorithm(&self.name)),
             }
             self.executed = true;
         }

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -2213,3 +2213,36 @@ fn split_with_the_wrong_arity_says_so() {
         .to_string();
     assert!(err.contains("split() requires 2 arguments"), "{err}");
 }
+
+// ---------------------------------------------------------------------------
+// Unknown-algorithm errors name what exists (#437 probe finding)
+//
+// `Unknown algorithm: algo.bfs` gave the caller nothing: the name they wanted
+// is not guessable from it, and the procedures do not share an argument shape
+// either, so even the right name failed on the first attempt.
+// ---------------------------------------------------------------------------
+
+fn algo_error(q: &str) -> String {
+    QueryEngine::new()
+        .execute(q, &GraphStore::new())
+        .unwrap_err()
+        .to_string()
+}
+
+#[test]
+fn unknown_algorithm_lists_the_available_ones_with_their_arguments() {
+    let err = algo_error("CALL algo.nonsense() YIELD nodeId RETURN count(*) AS v");
+    assert!(err.contains("shortestPath(source, target)"), "{err}");
+    assert!(err.contains("weightedPath(source, target, weightProperty)"), "{err}");
+    assert!(err.contains("pageRank({config})"), "{err}");
+}
+
+#[test]
+fn common_wrong_names_are_redirected_to_the_right_procedure() {
+    assert!(algo_error("CALL algo.bfs() YIELD nodeId RETURN count(*) AS v")
+        .contains("use algo.shortestPath"));
+    assert!(algo_error("CALL algo.dijkstra() YIELD nodeId RETURN count(*) AS v")
+        .contains("use algo.weightedPath"));
+    assert!(algo_error("CALL algo.louvain() YIELD nodeId RETURN count(*) AS v")
+        .contains("use algo.cdlp"));
+}


### PR DESCRIPTION
## The problem

```
CALL algo.bfs(...)   -- Runtime error: Unknown algorithm: algo.bfs
```

That message gives the caller nothing. The procedure they want (`algo.shortestPath`) is not guessable from it, and the procedures **do not share an argument shape** — `algo.pageRank` takes a config map, `algo.shortestPath` takes positional node ids — so even landing on the right name still fails on the first attempt.

This is measured, not hypothetical: writing the compatibility probe in #459 cost three rounds of trial and error on exactly this. A user who hits it twice concludes the feature is broken.

## After

```
Unknown algorithm: algo.bfs -- for an unweighted path, use algo.shortestPath.
Available: pageRank({config}), shortestPath(source, target),
weightedPath(source, target, weightProperty), maxFlow(source, sink [, capacityProperty]),
mst([weightProperty]), cdlp([label, edgeType, config]), lcc([label, edgeType]),
wcc(), scc(), triangleCount(), or.solve({config})
```

Redirects cover the names people reach for first: `bfs` → `shortestPath`, `dijkstra` → `weightedPath`, `louvain`/`labelPropagation` → `cdlp`, `connectedComponents` → `wcc`/`scc`.

## On the signatures

They were read off each implementation rather than assumed. A first draft of this message listed `mst()`, `cdlp()` and `lcc()` as taking no arguments and `maxFlow`'s capacity property as required — all four wrong. Publishing an inaccurate signature list would have reproduced the exact failure this change exists to fix, so each one was checked against its `execute_*` body.

## Verification

2 tests — that the list appears with argument shapes, and that the three common wrong names redirect.

- `cypher_projection_semantics`: **102 passed, 0 failed**
- Package suite (`-p samyama`): **2399 passed, 0 failed**

The calling-convention inconsistency itself remains, and the matrix still records it. This makes it cost one failed attempt instead of three.