### PR TITLE
Bind the loop variable in FOREACH CREATE instead of dropping the property

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -8322,6 +8322,16 @@ impl PhysicalOperator for ForeachOperator {
                 // Execute CREATE operations
                 for pattern in &self.create_patterns {
                     for path in &pattern.paths {
+                        // A relationship pattern would need the surrounding
+                        // variables joined up; creating just the start node
+                        // would silently produce an orphan instead of an edge.
+                        if !path.segments.is_empty() {
+                            return Err(ExecutionError::RuntimeError(
+                                "CREATE of a relationship pattern inside FOREACH is not supported"
+                                    .to_string(),
+                            ));
+                        }
+
                         let label_str = path.start.labels.first()
                             .map(|l| l.as_str())
                             .unwrap_or("Node");
@@ -8329,6 +8339,28 @@ impl PhysicalOperator for ForeachOperator {
                         if let Some(props) = &path.start.properties {
                             for (k, v) in props {
                                 let _ = store.set_node_property(tenant_id, node_id, k.to_string(), v.clone());
+                            }
+                        }
+                        // Property values that are expressions rather than
+                        // literals -- crucially including the loop variable
+                        // itself. These live in `property_exprs`, and not
+                        // evaluating them meant `CREATE (:T {i: i})` created
+                        // the node and silently dropped `i` (#467): the right
+                        // number of nodes, none of the data.
+                        if let Some(prop_exprs) = &path.start.property_exprs {
+                            for (k, expr) in prop_exprs {
+                                let val = eval_expression(expr, &inner_record, store)?;
+                                let prop_val = match val {
+                                    Value::Property(p) => p,
+                                    Value::Null => PropertyValue::Null,
+                                    other => {
+                                        return Err(ExecutionError::TypeError(format!(
+                                            "FOREACH CREATE: property `{k}` evaluated to {other:?}, \
+which cannot be stored as a property value"
+                                        )))
+                                    }
+                                };
+                                let _ = store.set_node_property(tenant_id, node_id, k.to_string(), prop_val);
                             }
                         }
                     }

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -2246,3 +2246,100 @@ fn common_wrong_names_are_redirected_to_the_right_procedure() {
     assert!(algo_error("CALL algo.louvain() YIELD nodeId RETURN count(*) AS v")
         .contains("use algo.cdlp"));
 }
+
+// ---------------------------------------------------------------------------
+// FOREACH CREATE binds the loop variable (#467)
+//
+// The CREATE branch read only `path.start.properties` -- the already-literal
+// map. A property whose value is an *expression*, which includes the loop
+// variable itself, lives in `property_exprs` and was never evaluated. So
+// `CREATE (:T {i: i})` created the node and silently dropped `i`: the right
+// number of nodes, none of the data, and a successful-looking statement.
+// ---------------------------------------------------------------------------
+
+fn foreach_store() -> GraphStore {
+    let mut s = GraphStore::new();
+    QueryEngine::new()
+        .execute_mut("CREATE (:P {n: 0})", &mut s, "default")
+        .unwrap();
+    s
+}
+
+#[test]
+fn foreach_create_stores_the_loop_variable() {
+    let e = QueryEngine::new();
+    let mut s = foreach_store();
+    e.execute_mut(
+        "MATCH (p:P) FOREACH (i IN [7,8] | CREATE (:T {i: i, lit: 99}))",
+        &mut s,
+        "default",
+    )
+    .unwrap();
+
+    // The property must exist as a key, not merely read back as null -- before
+    // the fix it was never created at all.
+    assert_eq!(bag(&s, "MATCH (t:T) RETURN t.i AS v"), vec!["v=7", "v=8"]);
+    assert_eq!(bag(&s, "MATCH (t:T) RETURN t.lit AS v"), vec!["v=99", "v=99"]);
+}
+
+#[test]
+fn foreach_create_handles_the_canonical_tag_case() {
+    // The shape from the docs, and the one that silently produced nameless
+    // nodes: right count, no data, no error.
+    let e = QueryEngine::new();
+    let mut s = foreach_store();
+    e.execute_mut(
+        "MATCH (p:P) FOREACH (tag IN [\"a\",\"b\"] | CREATE (:Tag {name: tag}))",
+        &mut s,
+        "default",
+    )
+    .unwrap();
+    assert_eq!(bag(&s, "MATCH (t:Tag) RETURN t.name AS v"), vec!["v=a", "v=b"]);
+}
+
+#[test]
+fn foreach_create_evaluates_expressions_over_the_loop_variable() {
+    let e = QueryEngine::new();
+    let mut s = foreach_store();
+    e.execute_mut(
+        "MATCH (p:P) FOREACH (i IN [1,2] | CREATE (:Calc {v: i * 10}))",
+        &mut s,
+        "default",
+    )
+    .unwrap();
+    assert_eq!(bag(&s, "MATCH (c:Calc) RETURN c.v AS v"), vec!["v=10", "v=20"]);
+}
+
+#[test]
+fn foreach_set_still_binds_the_loop_variable() {
+    // SET was always correct; pin it so the CREATE fix cannot regress it.
+    let e = QueryEngine::new();
+    let mut s = foreach_store();
+    e.execute_mut("MATCH (p:P) FOREACH (i IN [5] | SET p.n = i)", &mut s, "default").unwrap();
+    assert_eq!(scalar(&s, "MATCH (p:P) RETURN p.n AS v"), "v=5");
+}
+
+#[test]
+fn foreach_create_of_a_relationship_is_refused_not_silently_orphaned() {
+    // Only the start node was ever created, so this produced a stray node
+    // instead of an edge. Refusing is the honest answer.
+    let e = QueryEngine::new();
+    let mut s = foreach_store();
+    let before = s.node_count();
+    let err = e
+        .execute_mut("MATCH (p:P) FOREACH (i IN [1] | CREATE (p)-[:R]->(:X))", &mut s, "default")
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("relationship pattern inside FOREACH"), "{err}");
+    assert_eq!(s.node_count(), before, "a refused FOREACH must not leave nodes behind");
+}
+
+#[test]
+fn foreach_over_an_empty_list_is_a_no_op() {
+    let e = QueryEngine::new();
+    let mut s = foreach_store();
+    let before = s.node_count();
+    e.execute_mut("MATCH (p:P) FOREACH (i IN [] | CREATE (:Empty {i: i}))", &mut s, "default")
+        .unwrap();
+    assert_eq!(s.node_count(), before);
+}


### PR DESCRIPTION
Closes #467.

## The bug

`FOREACH`'s `CREATE` branch read only `path.start.properties` — the map of already-**literal** values. A property whose value is an *expression*, which includes the loop variable itself, lives in `property_exprs`, and it never evaluated those.

```cypher
MATCH (p:P) FOREACH (i IN [7,8] | CREATE (:T {i: i, lit: 99}));

MATCH (t:T) RETURN count(t)   -- 2                 ✅ right number of nodes
MATCH (t:T) RETURN keys(t)    -- ["lit"], ["lit"]  ❌ `i` never written
MATCH (t:T) RETURN t.lit      -- 99, 99            ✅ literals survive
```

Not null — **absent**. The property was never created, and the statement reported success.

So the documented use of `FOREACH` lost data outright:

```cypher
FOREACH (tag IN ["a","b","c"] | CREATE (:Tag {name: tag}))
```

produced three **nameless** `Tag` nodes and returned success. Nothing in the result flagged it; the node count was exactly what the author expected, which is the number most people check. A bulk-load path built on this yields a graph of the right size and empty of content, discovered much later as "why are all these properties null".

LANG-03 asks for zero silent wrong answers. This was one of the worst shapes of it: plausible output, no error, wrong data.

## The fix

Evaluate `property_exprs` against the record that already has the loop variable bound.

```cypher
FOREACH (i IN [7,8]   | CREATE (:T {i: i, lit: 99}))    -- i = 7, 8      ✅
FOREACH (tag IN [a,b] | CREATE (:Tag {name: tag}))      -- a, b          ✅
FOREACH (i IN [1,2]   | CREATE (:Calc {v: i * 10}))     -- 10, 20        ✅
```

`SET` inside `FOREACH` always bound the variable correctly, so the loop binding existed all along — only `CREATE` failed to consult it. A test pins the `SET` behaviour so this fix cannot regress it.

## Also refused

`CREATE (p)-[:R]->(:X)` inside `FOREACH`. Only the start node was ever created, so a relationship pattern silently produced a **stray orphan** rather than an edge. It now errors, and a test asserts the refused statement leaves the node count unchanged. Joining up the surrounding variables properly is separate work.

## Verification

6 tests: the loop variable stored as a real key (not merely reading back non-null), the canonical tag case, an expression over the loop variable, `SET` unchanged, the refused relationship leaving nothing behind, and an empty list as a no-op.

- `cypher_projection_semantics`: **108 passed, 0 failed**
- Package suite (`-p samyama`): **2405 passed, 0 failed**

Leading `FOREACH` (`FOREACH (...)` with no preceding `MATCH`) is still a parse error — `foreach_clause` exists only as a trailing clause of `match_stmt`/`unwind_stmt`. That is a missing feature rather than a correctness bug, and stays with #465.