### PR TITLE
Allow FOREACH with no preceding MATCH

### DIFF
--- a/docs/CYPHER_COMPATIBILITY.md
+++ b/docs/CYPHER_COMPATIBILITY.md
@@ -7,7 +7,7 @@
 
 There is **no measured OpenCypher coverage percentage** in this document, and there will not be one until the openCypher TCK is actually run (#434). A previous version of this page claimed "~90% OpenCypher coverage"; that figure was self-assessed, never checked against the TCK, and an earlier internal assessment of the same engine put the number at 40–50%. Rather than pick between two unverified numbers, the claim is withdrawn.
 
-What this page reports instead is narrower and checkable: **78 probes, 76 supported, 2 not.** Each probe is one representative query for one feature. Re-run it with:
+What this page reports instead is narrower and checkable: **78 probes, 77 supported, 1 not.** Each probe is one representative query for one feature. Re-run it with:
 
 ```
 cargo run --release --example cypher_matrix_probe
@@ -25,11 +25,10 @@ A ✅ here means *the query executed*. It does not certify semantics — a const
 
 ## What is not supported
 
-Two things, all verified:
+One thing, verified:
 
 | Feature | Behaviour | Tracking |
 | :--- | :--- | :--- |
-| `FOREACH` | Parse error | — |
 | `algo.bfs`, `algo.dijkstra` | Do not exist under those names — use `algo.shortestPath` and `algo.weightedPath` | — |
 
 ## Feature Matrix
@@ -59,7 +58,7 @@ Two things, all verified:
 | | `UNION` / `UNION ALL` | ✅ | |
 | | `EXISTS { }` subquery | ✅ | |
 | | `CALL { }` subquery | ✅ | Leading, non-correlated form. Exports its columns; outer `WHERE`/`DISTINCT` apply. Fixed in #458. The importing form `MATCH (x) CALL { WITH x ... }` is still a parse error |
-| | `FOREACH` | ❌ | Parse error |
+| | `FOREACH` | ✅ | Leading and trailing forms; `CREATE`/`SET` bodies. A relationship pattern in the body is refused (#467); `MERGE`/`DELETE`/nested bodies remain unimplemented (#465) |
 | **String Functions** | `toUpper`, `toLower` | ✅ | |
 | | `trim`, `replace` | ✅ | |
 | | `substring`, `left`, `right` | ✅ | |

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -8,7 +8,7 @@ COMMENT = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ("//" ~ (!"\n" ~ ANY)*) }
 query = { SOI ~ explain_clause? ~ statement ~ (union_clause ~ statement)* ~ ";"? ~ EOI }
 explain_clause = { ^"PROFILE" | ^"EXPLAIN" }
 union_clause = { ^"UNION" ~ ^"ALL"? }
-statement = { show_hierarchy_indexes_stmt | show_indexes_stmt | show_constraints_stmt | drop_hierarchy_index_stmt | drop_index_stmt | create_constraint_stmt | create_vector_index_stmt | create_hierarchy_index_stmt | create_index_stmt | rebuild_hierarchy_index_stmt | call_stmt | merge_stmt | unwind_stmt | match_stmt | create_stmt | with_return_stmt | return_stmt }
+statement = { show_hierarchy_indexes_stmt | show_indexes_stmt | show_constraints_stmt | drop_hierarchy_index_stmt | drop_index_stmt | create_constraint_stmt | create_vector_index_stmt | create_hierarchy_index_stmt | create_index_stmt | rebuild_hierarchy_index_stmt | call_stmt | foreach_stmt | merge_stmt | unwind_stmt | match_stmt | create_stmt | with_return_stmt | return_stmt }
 with_return_stmt = { with_clause ~ return_clause ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
 return_stmt = { return_clause ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
 
@@ -70,6 +70,9 @@ on_match_set = { ^"ON" ~ ^"MATCH" ~ ^"SET" ~ set_item ~ ("," ~ set_item)* }
 
 // MATCH statement: sequence of reading clauses, optional write, finishing with RETURN
 match_stmt = { (optional_match_clause | match_clause)+ ~ where_clause? ~ call_clause? ~ unwind_clause? ~ ((optional_match_clause | match_clause)+ ~ where_clause?)* ~ (with_clause ~ unwind_clause? ~ ((optional_match_clause | match_clause)+ ~ where_clause?)*)* ~ create_clause? ~ merge_inline? ~ delete_clause? ~ foreach_clause? ~ set_clause* ~ remove_clause* ~ return_clause? ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
+// A FOREACH with no preceding MATCH/UNWIND. It drives itself off a single
+// empty row, the same way a bare RETURN does, so no pattern is required.
+foreach_stmt = { foreach_clause }
 foreach_clause = { ^"FOREACH" ~ "(" ~ variable ~ in_op ~ expression ~ "|" ~ foreach_body+ ~ ")" }
 foreach_body = _{ set_clause | remove_clause | delete_clause | create_clause }
 unwind_clause = { ^"UNWIND" ~ expression ~ ^"AS" ~ variable }

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -925,6 +925,40 @@ impl QueryPlanner {
             }
             }
 
+            // A leading FOREACH has no pattern to drive it, so it runs against a
+            // single empty row -- the same way a bare RETURN does. The loop
+            // variable is bound per element inside ForeachOperator, so nothing
+            // upstream needs to supply bindings.
+            if query.foreach_clause.is_some() && query.unwind_clause.is_none() {
+                let foreach_clause = query.foreach_clause.as_ref().expect("checked above");
+                let mut set_items = Vec::new();
+                for set_clause in &foreach_clause.set_clauses {
+                    for item in &set_clause.items {
+                        set_items.push((item.variable.clone(), item.property.clone(), item.value.clone()));
+                    }
+                }
+                let create_patterns: Vec<Pattern> = foreach_clause
+                    .create_clauses
+                    .iter()
+                    .map(|c| c.pattern.clone())
+                    .collect();
+                let root: OperatorBox = Box::new(ForeachOperator::new(
+                    Box::new(crate::query::executor::operator::SingleRowOperator::new()),
+                    foreach_clause.variable.clone(),
+                    foreach_clause.expression.clone(),
+                    set_items,
+                    create_patterns,
+                ));
+                return Ok(ExecutionPlan {
+                    root,
+                    output_columns: Vec::new(),
+                    is_write: true,
+                    candidates_evaluated: 0,
+                    chosen_plan_cost: 0.0,
+                    candidate_costs: Vec::new(),
+                });
+            }
+
             if query.unwind_clause.is_none() {
                 return Err(ExecutionError::PlanningError(
                     "Query must have at least one MATCH, CALL, CREATE, or RETURN clause".to_string()

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -195,6 +195,15 @@ fn parse_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -> Pars
             Rule::merge_stmt => {
                 parse_merge_statement(inner, query)?;
             }
+            Rule::foreach_stmt => {
+                // A leading FOREACH: no pattern to match, so the clause is all
+                // there is. It runs against one empty row (see the planner).
+                for fe in inner.into_inner() {
+                    if fe.as_rule() == Rule::foreach_clause {
+                        query.foreach_clause = Some(parse_foreach_clause(fe)?);
+                    }
+                }
+            }
             Rule::match_stmt | Rule::unwind_stmt => {
                 // Same clause set, so the same builder applies -- it already dispatches on
                 // each inner rule rather than assuming a fixed clause order. The rule

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -2343,3 +2343,47 @@ fn foreach_over_an_empty_list_is_a_no_op() {
         .unwrap();
     assert_eq!(s.node_count(), before);
 }
+
+// ---------------------------------------------------------------------------
+// Leading FOREACH (#465)
+//
+// `foreach_clause` existed only as a trailing clause of match_stmt/unwind_stmt,
+// so a FOREACH with nothing before it was a parse error at 1:1. It has no
+// pattern to drive it, so it runs against one empty row -- the same way a bare
+// RETURN does.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn leading_foreach_creates_with_the_loop_variable_bound() {
+    let e = QueryEngine::new();
+    let mut s = GraphStore::new();
+    e.execute_mut("FOREACH (i IN [1,2,3] | CREATE (:L {i: i}))", &mut s, "default").unwrap();
+    assert_eq!(bag(&s, "MATCH (l:L) RETURN l.i AS v"), vec!["v=1", "v=2", "v=3"]);
+}
+
+#[test]
+fn leading_foreach_over_an_empty_list_is_a_no_op() {
+    let e = QueryEngine::new();
+    let mut s = GraphStore::new();
+    e.execute_mut("FOREACH (i IN [] | CREATE (:Z {i: i}))", &mut s, "default").unwrap();
+    assert_eq!(s.node_count(), 0);
+}
+
+#[test]
+fn leading_foreach_is_a_write_and_the_read_executor_refuses_it() {
+    // The plan is marked is_write, so a read-only executor rejects it rather
+    // than running it and discarding the effects.
+    let e = QueryEngine::new();
+    let s = GraphStore::new();
+    assert!(e.execute("FOREACH (i IN [1] | CREATE (:RO {i: i}))", &s).is_err());
+}
+
+#[test]
+fn trailing_foreach_is_unaffected_by_the_leading_form() {
+    let e = QueryEngine::new();
+    let mut s = GraphStore::new();
+    e.execute_mut("CREATE (:P {n: 0})", &mut s, "default").unwrap();
+    e.execute_mut("MATCH (p:P) FOREACH (i IN [9] | CREATE (:M2 {i: i}))", &mut s, "default")
+        .unwrap();
+    assert_eq!(scalar(&s, "MATCH (m:M2) RETURN m.i AS v"), "v=9");
+}


### PR DESCRIPTION
Refs #465.

## The gap

`foreach_clause` existed only as a **trailing** clause of `match_stmt` and `unwind_stmt`, so a `FOREACH` that led a statement was a parse error — even though the identical body worked with any `MATCH` in front of it:

```cypher
FOREACH (i IN [1,2,3] | CREATE (:L {i: i}))              -- Parse error --> 1:1
MATCH (p:P) FOREACH (i IN [1,2,3] | CREATE (:L {i: i}))  -- fine
```

The workaround was to invent a `MATCH` whose only purpose was to satisfy the grammar.

## The change

A leading `FOREACH` has no pattern to drive it, so it runs against a **single empty row** — the same shape a bare `RETURN` already uses, via `SingleRowOperator`. The loop variable is bound per element inside `ForeachOperator`, so nothing upstream needs to supply bindings.

```cypher
FOREACH (i IN [1,2,3] | CREATE (:L {i: i}))       -- l.i = 1, 2, 3
FOREACH (t IN ["a","b"] | CREATE (:S {t: t}))     -- s.t = a, b
FOREACH (i IN [] | CREATE (:Z {i: i}))            -- no-op
```

The plan is marked `is_write`, so the read-only executor refuses it rather than running it and discarding the effects — a test pins that, since silently accepting a write on the read path would be the worse failure.

## Verification

4 tests: the leading form binding the loop variable, an empty list as a no-op, the read-path refusal, and the trailing form still working unchanged.

- `cypher_projection_semantics`: **112 passed, 0 failed**
- Package suite (`-p samyama`): **2409 passed, 0 failed**
- Measured matrix: **76/78 → 77/78**

## What is left

The single remaining probe failure is `algo.bfs` / `algo.dijkstra`, which is a **naming** gap rather than a missing capability — `algo.shortestPath` and `algo.weightedPath` do the work, and since #464 the error redirects to them by name.

Within `FOREACH` itself, #465 still covers `MERGE`/`DELETE`/nested bodies, which have nowhere to live in `ForeachClause` (it carries only `set_clauses` and `create_clauses`), and relationship patterns in the body, which #467 made refuse rather than silently orphan.