### PR TITLE
Make every solver seedable, including under rayon

### DIFF
--- a/crates/samyama-optimization/README.md
+++ b/crates/samyama-optimization/README.md
@@ -4,6 +4,26 @@ A high-performance library implementing **metaphor-less** and **nature-inspired*
 
 This engine allows you to solve complex resource allocation, scheduling, and engineering problems by defining an objective function and constraints.
 
+## Reproducibility
+
+Every solver accepts an optional seed. Without one, behaviour is unchanged (drawn from entropy);
+with one, the run can be re-derived exactly — same best fitness, same solution vector, same
+convergence history.
+
+```rust
+let result = DESolver::new(config).with_seed(4242).solve(&problem);
+```
+
+This matters for published results: a reported optimum that cannot be regenerated can only be
+re-sampled, which is not the same claim.
+
+The parallel solvers are the part worth understanding. Seeding only the top-level RNG and letting
+rayon workers draw from `thread_rng()` would give runs that *look* reproducible in a
+single-threaded test and are not — the seed would be recorded next to results it cannot
+regenerate. Each element's stream is instead derived from `(seed, iteration, index)`, so the
+answer does not depend on how work is scheduled. `tests/test_reproducibility.rs` asserts this
+directly: the same seed under a 1-thread pool and an 8-thread pool must give bit-identical results.
+
 ## Algorithms Supported
 
 We support 15+ algorithms across various families:

--- a/crates/samyama-optimization/src/algorithms/abc.rs
+++ b/crates/samyama-optimization/src/algorithms/abc.rs
@@ -5,6 +5,8 @@ use rand::prelude::*;
 pub struct ABCSolver {
     pub config: SolverConfig,
     pub limit: usize, // Abandonment limit for scout bees
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl ABCSolver {
@@ -13,11 +15,18 @@ impl ABCSolver {
         Self { 
             config,
             limit: 100, // Placeholder, will be adjusted in solve
+            seed: None,
         }
     }
 
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
         let pop_size = self.config.population_size;

--- a/crates/samyama-optimization/src/algorithms/bat.rs
+++ b/crates/samyama-optimization/src/algorithms/bat.rs
@@ -8,11 +8,14 @@ pub struct BatSolver {
     pub f_max: f64,
     pub alpha: f64, // Constant for loudness update (0.9)
     pub gamma: f64, // Constant for emission rate update (0.9)
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl BatSolver {
     pub fn new(config: SolverConfig) -> Self {
         Self {
+            seed: None,
             config,
             f_min: 0.0,
             f_max: 2.0,
@@ -21,8 +24,14 @@ impl BatSolver {
         }
     }
 
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
 

--- a/crates/samyama-optimization/src/algorithms/bmr.rs
+++ b/crates/samyama-optimization/src/algorithms/bmr.rs
@@ -5,15 +5,24 @@ use rayon::prelude::*;
 
 pub struct BMRSolver {
     pub config: SolverConfig,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl BMRSolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { config }
+        Self {
+            seed: None, config }
+    }
+
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
 
@@ -43,8 +52,9 @@ impl BMRSolver {
 
             population = population
                 .into_par_iter()
-                .map(|mut ind| {
-                    let mut local_rng = thread_rng();
+                .enumerate()
+                .map(|(__idx, mut ind)| {
+                    let mut local_rng = crate::common::rng::child_rng(self.seed, iter, __idx);
                     let mut new_vars = Array1::zeros(dim);
 
                     let r1: f64 = local_rng.gen();

--- a/crates/samyama-optimization/src/algorithms/bmwr.rs
+++ b/crates/samyama-optimization/src/algorithms/bmwr.rs
@@ -23,15 +23,24 @@ use rayon::prelude::*;
 
 pub struct BMWRSolver {
     pub config: SolverConfig,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl BMWRSolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { config }
+        Self {
+            seed: None, config }
+    }
+
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
         let pop_size = self.config.population_size;
@@ -68,7 +77,7 @@ impl BMWRSolver {
                 .into_par_iter()
                 .enumerate()
                 .map(|(k, mut ind)| {
-                    let mut local_rng = thread_rng();
+                    let mut local_rng = crate::common::rng::child_rng(self.seed, iter, k);
                     let r1: f64 = local_rng.gen();
                     let r2: f64 = local_rng.gen();
                     let r3: f64 = local_rng.gen();

--- a/crates/samyama-optimization/src/algorithms/bwr.rs
+++ b/crates/samyama-optimization/src/algorithms/bwr.rs
@@ -5,15 +5,24 @@ use rayon::prelude::*;
 
 pub struct BWRSolver {
     pub config: SolverConfig,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl BWRSolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { config }
+        Self {
+            seed: None, config }
+    }
+
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
 
@@ -43,8 +52,9 @@ impl BWRSolver {
 
             population = population
                 .into_par_iter()
-                .map(|mut ind| {
-                    let mut local_rng = thread_rng();
+                .enumerate()
+                .map(|(__idx, mut ind)| {
+                    let mut local_rng = crate::common::rng::child_rng(self.seed, iter, __idx);
                     let mut new_vars = Array1::zeros(dim);
 
                     let r1: f64 = local_rng.gen();

--- a/crates/samyama-optimization/src/algorithms/cuckoo.rs
+++ b/crates/samyama-optimization/src/algorithms/cuckoo.rs
@@ -7,18 +7,27 @@ use std::f64::consts::PI;
 pub struct CuckooSolver {
     pub config: SolverConfig,
     pub pa: f64, // Probability of discovering an alien egg (abandonment rate)
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl CuckooSolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { 
+        Self {
+            seed: None, 
             config,
             pa: 0.25,
         }
     }
 
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
     pub fn with_pa(config: SolverConfig, pa: f64) -> Self {
-        Self { config, pa }
+        Self { config, pa, seed: None }
     }
 
     /// Levy flight random walk
@@ -31,7 +40,7 @@ impl CuckooSolver {
         let sigma_v = 1.0;
 
         let mut step = Array1::zeros(dim);
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
 
         for i in 0..dim {
             let _u: f64 = rng.gen_range(0.0..1.0) * sigma_u; // Standard normal * sigma_u? No, usually Gaussian(0, sigma_u^2)
@@ -46,7 +55,7 @@ impl CuckooSolver {
     }
 
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
 

--- a/crates/samyama-optimization/src/algorithms/de.rs
+++ b/crates/samyama-optimization/src/algorithms/de.rs
@@ -7,19 +7,28 @@ pub struct DESolver {
     pub config: SolverConfig,
     pub f: f64,  // Scaling factor (default 0.5)
     pub cr: f64, // Crossover probability (default 0.9)
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl DESolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { 
+        Self {
+            seed: None, 
             config,
             f: 0.5,
             cr: 0.9,
         }
     }
 
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
 
@@ -51,7 +60,7 @@ impl DESolver {
                 .into_par_iter()
                 .enumerate()
                 .map(|(i, mut target)| {
-                    let mut local_rng = thread_rng();
+                    let mut local_rng = crate::common::rng::child_rng(self.seed, iter, i);
                     
                     // Pick a, b, c distinct from i
                     let mut idxs = [0; 3];

--- a/crates/samyama-optimization/src/algorithms/ehrjaya.rs
+++ b/crates/samyama-optimization/src/algorithms/ehrjaya.rs
@@ -16,15 +16,24 @@ use rayon::prelude::*;
 
 pub struct EHRJayaSolver {
     pub config: SolverConfig,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl EHRJayaSolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { config }
+        Self {
+            seed: None, config }
+    }
+
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
         let pop_size = self.config.population_size;
@@ -60,7 +69,7 @@ impl EHRJayaSolver {
                 .into_par_iter()
                 .enumerate()
                 .map(|(rank, mut ind)| {
-                    let mut local_rng = thread_rng();
+                    let mut local_rng = crate::common::rng::child_rng(self.seed, iter, rank);
                     let r1: f64 = local_rng.gen();
                     let r2: f64 = local_rng.gen();
                     let mut new_vars = Array1::zeros(dim);

--- a/crates/samyama-optimization/src/algorithms/firefly.rs
+++ b/crates/samyama-optimization/src/algorithms/firefly.rs
@@ -8,11 +8,14 @@ pub struct FireflySolver {
     pub alpha: f64,      // Randomization parameter (0.2)
     pub beta0: f64,      // Attractiveness at r=0 (1.0)
     pub gamma: f64,      // Light absorption coefficient (1.0)
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl FireflySolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { 
+        Self {
+            seed: None, 
             config,
             alpha: 0.2,
             beta0: 1.0,
@@ -20,12 +23,18 @@ impl FireflySolver {
         }
     }
 
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
     pub fn with_params(config: SolverConfig, alpha: f64, beta0: f64, gamma: f64) -> Self {
-        Self { config, alpha, beta0, gamma }
+        Self { config, alpha, beta0, gamma, seed: None }
     }
 
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
 
@@ -63,7 +72,7 @@ impl FireflySolver {
 
             // We can parallelize the outer loop (i)
             let new_positions: Vec<Option<Array1<f64>>> = (0..pop_size).into_par_iter().map(|i| {
-                let mut rng = thread_rng();
+                let mut rng = crate::common::rng::solver_rng(self.seed);
                 let mut moved = false;
                 let mut new_vars = old_population[i].variables.clone();
                 let fitness_i = old_population[i].fitness;

--- a/crates/samyama-optimization/src/algorithms/fpa.rs
+++ b/crates/samyama-optimization/src/algorithms/fpa.rs
@@ -7,14 +7,23 @@ use std::f64::consts::PI;
 pub struct FPASolver {
     pub config: SolverConfig,
     pub p: f64, // Switch probability (0.8)
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl FPASolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { 
+        Self {
+            seed: None, 
             config,
             p: 0.8,
         }
+    }
+
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     /// Levy flight random walk
@@ -26,7 +35,7 @@ impl FPASolver {
         let sigma_v = 1.0;
 
         let mut step = Array1::zeros(dim);
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
 
         for i in 0..dim {
             let u_n: f64 = rand_distr::Normal::new(0.0, sigma_u).unwrap().sample(&mut rng);
@@ -38,7 +47,7 @@ impl FPASolver {
     }
 
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
         let pop_size = self.config.population_size;

--- a/crates/samyama-optimization/src/algorithms/ga.rs
+++ b/crates/samyama-optimization/src/algorithms/ga.rs
@@ -6,19 +6,28 @@ pub struct GASolver {
     pub config: SolverConfig,
     pub crossover_rate: f64,
     pub mutation_rate: f64,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl GASolver {
     pub fn new(config: SolverConfig) -> Self {
         Self {
+            seed: None,
             config,
             crossover_rate: 0.8,
             mutation_rate: 0.1,
         }
     }
 
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
 
@@ -96,7 +105,7 @@ impl GASolver {
     }
 
     fn select<'a>(&self, population: &'a [Individual]) -> &'a Individual {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let i1 = rng.gen_range(0..population.len());
         let i2 = rng.gen_range(0..population.len());
         
@@ -108,7 +117,7 @@ impl GASolver {
     }
 
     fn crossover(&self, p1: &Array1<f64>, p2: &Array1<f64>) -> (Array1<f64>, Array1<f64>) {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = p1.len();
         let mut c1 = p1.clone();
         let mut c2 = p2.clone();
@@ -123,7 +132,7 @@ impl GASolver {
     }
 
     fn mutate(&self, vars: &mut Array1<f64>, lower: &Array1<f64>, upper: &Array1<f64>) {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = vars.len();
 
         for i in 0..dim {

--- a/crates/samyama-optimization/src/algorithms/gotlbo.rs
+++ b/crates/samyama-optimization/src/algorithms/gotlbo.rs
@@ -5,15 +5,24 @@ use rayon::prelude::*;
 
 pub struct GOTLBOSolver {
     pub config: SolverConfig,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl GOTLBOSolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { config }
+        Self {
+            seed: None, config }
+    }
+
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
 
@@ -45,8 +54,9 @@ impl GOTLBOSolver {
             // 1. Teacher Phase with Opposition
             population = population
                 .into_par_iter()
-                .map(|mut ind| {
-                    let mut local_rng = thread_rng();
+                .enumerate()
+                .map(|(__idx, mut ind)| {
+                    let mut local_rng = crate::common::rng::child_rng(self.seed, iter, __idx);
                     let tf: f64 = local_rng.gen_range(1..3) as f64; // Teaching Factor (1 or 2)
                     let mut new_vars = Array1::zeros(dim);
 

--- a/crates/samyama-optimization/src/algorithms/gsa.rs
+++ b/crates/samyama-optimization/src/algorithms/gsa.rs
@@ -6,19 +6,28 @@ pub struct GSASolver {
     pub config: SolverConfig,
     pub g0: f64,    // Initial gravitational constant (100.0)
     pub alpha: f64, // Damping ratio (20.0)
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl GSASolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { 
+        Self {
+            seed: None, 
             config,
             g0: 100.0,
             alpha: 20.0,
         }
     }
 
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
         let n = self.config.population_size;

--- a/crates/samyama-optimization/src/algorithms/gwo.rs
+++ b/crates/samyama-optimization/src/algorithms/gwo.rs
@@ -4,15 +4,24 @@ use rand::prelude::*;
 
 pub struct GWOSolver {
     pub config: SolverConfig,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl GWOSolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { config }
+        Self {
+            seed: None, config }
+    }
+
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
 

--- a/crates/samyama-optimization/src/algorithms/hs.rs
+++ b/crates/samyama-optimization/src/algorithms/hs.rs
@@ -7,11 +7,14 @@ pub struct HSSolver {
     pub hmcr: f64, // Harmony Memory Consideration Rate (0.7-0.95)
     pub par: f64,  // Pitch Adjustment Rate (0.1-0.5)
     pub bw: f64,   // Bandwidth (step size)
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl HSSolver {
     pub fn new(config: SolverConfig) -> Self {
         Self {
+            seed: None,
             config,
             hmcr: 0.9,
             par: 0.3,
@@ -19,8 +22,14 @@ impl HSSolver {
         }
     }
 
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
 

--- a/crates/samyama-optimization/src/algorithms/itlbo.rs
+++ b/crates/samyama-optimization/src/algorithms/itlbo.rs
@@ -6,16 +6,24 @@ use rayon::prelude::*;
 pub struct ITLBOSolver {
     pub config: SolverConfig,
     pub elite_size: usize,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl ITLBOSolver {
     pub fn new(config: SolverConfig) -> Self {
         let elite_size = std::cmp::max(1, config.population_size / 10); // 10% elite
-        Self { config, elite_size }
+        Self { config, elite_size, seed: None }
+    }
+
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
 
@@ -52,8 +60,9 @@ impl ITLBOSolver {
             // 1. Teacher Phase
             population = population
                 .into_par_iter()
-                .map(|mut ind| {
-                    let mut local_rng = thread_rng();
+                .enumerate()
+                .map(|(__idx, mut ind)| {
+                    let mut local_rng = crate::common::rng::child_rng(self.seed, iter, __idx);
                     // Adaptive TF: Usually between 1 and 2. 
                     let tf: f64 = local_rng.gen_range(1.0..2.0); 
                     
@@ -84,7 +93,7 @@ impl ITLBOSolver {
                 .into_par_iter()
                 .enumerate()
                 .map(|(i, mut ind)| {
-                    let mut local_rng = thread_rng();
+                    let mut local_rng = crate::common::rng::child_rng(self.seed, iter, i);
                     
                     let mut learner_j_idx;
                     loop {

--- a/crates/samyama-optimization/src/algorithms/jaya.rs
+++ b/crates/samyama-optimization/src/algorithms/jaya.rs
@@ -5,15 +5,24 @@ use rayon::prelude::*;
 
 pub struct JayaSolver {
     pub config: SolverConfig,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl JayaSolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { config }
+        Self {
+            seed: None, config }
+    }
+
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
 
@@ -43,8 +52,9 @@ impl JayaSolver {
 
             population = population
                 .into_par_iter()
-                .map(|mut ind| {
-                    let mut local_rng = thread_rng();
+                .enumerate()
+                .map(|(__idx, mut ind)| {
+                    let mut local_rng = crate::common::rng::child_rng(self.seed, iter, __idx);
                     let mut new_vars = Array1::zeros(dim);
 
                     // Generate r1, r2 once per individual to match Python's vector op

--- a/crates/samyama-optimization/src/algorithms/mo_bmwr_family.rs
+++ b/crates/samyama-optimization/src/algorithms/mo_bmwr_family.rs
@@ -34,11 +34,14 @@ pub struct MOBMWRSolver {
     pub local_step: f64,
     /// Probability of edge boosting per iteration.
     pub edge_boost_prob: f64,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl MOBMWRSolver {
     pub fn new(config: SolverConfig, variant: MOBMWRVariant) -> Self {
         Self {
+            seed: None,
             config,
             variant,
             local_step: 0.05,
@@ -46,8 +49,14 @@ impl MOBMWRSolver {
         }
     }
 
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
     pub fn solve<P: MultiObjectiveProblem>(&self, problem: &P) -> MultiObjectiveResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
         let pop_size = self.config.population_size;
@@ -103,7 +112,7 @@ impl MOBMWRSolver {
             // --- Generate offspring via base update.
             let mut offspring: Vec<MultiObjectiveIndividual> = Vec::with_capacity(pop_size);
             for k in 0..pop_size {
-                let mut local_rng = thread_rng();
+                let mut local_rng = crate::common::rng::child_rng(self.seed, iter, k);
                 let r1: f64 = local_rng.gen();
                 let r2: f64 = local_rng.gen();
                 let r3: f64 = local_rng.gen();

--- a/crates/samyama-optimization/src/algorithms/mo_rao_de.rs
+++ b/crates/samyama-optimization/src/algorithms/mo_rao_de.rs
@@ -20,11 +20,14 @@ pub struct MORaoDESolver {
     pub f: f64,
     /// DE crossover rate CR.
     pub cr: f64,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl MORaoDESolver {
     pub fn new(config: SolverConfig) -> Self {
         Self {
+            seed: None,
             config,
             p_de: 0.5,
             f: 0.5,
@@ -32,8 +35,14 @@ impl MORaoDESolver {
         }
     }
 
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
     pub fn solve<P: MultiObjectiveProblem>(&self, problem: &P) -> MultiObjectiveResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
         let pop_size = self.config.population_size;

--- a/crates/samyama-optimization/src/algorithms/motlbo.rs
+++ b/crates/samyama-optimization/src/algorithms/motlbo.rs
@@ -4,15 +4,24 @@ use rand::prelude::*;
 
 pub struct MOTLBOSolver {
     pub config: SolverConfig,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl MOTLBOSolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { config }
+        Self {
+            seed: None, config }
+    }
+
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     pub fn solve<P: MultiObjectiveProblem>(&self, problem: &P) -> MultiObjectiveResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
         let pop_size = self.config.population_size;
@@ -43,8 +52,8 @@ impl MOTLBOSolver {
             let teacher_vars = population[teacher_idx].variables.clone();
             let mean_vars = self.calculate_mean(&population, dim);
 
-            for ind in &population {
-                let mut local_rng = thread_rng();
+            for (__idx, ind) in population.iter().enumerate() {
+                let mut local_rng = crate::common::rng::child_rng(self.seed, _iter, __idx);
                 let tf: f64 = local_rng.gen_range(1..3) as f64;
                 let mut new_vars = Array1::zeros(dim);
                 for j in 0..dim {
@@ -60,7 +69,7 @@ impl MOTLBOSolver {
 
             // Learner Phase
             for i in 0..pop_size {
-                let mut local_rng = thread_rng();
+                let mut local_rng = crate::common::rng::child_rng(self.seed, _iter, i);
                 let mut j;
                 loop {
                     j = local_rng.gen_range(0..pop_size);
@@ -128,7 +137,7 @@ impl MOTLBOSolver {
             .map(|(i, _)| i)
             .collect();
         
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         *first_rank.choose(&mut rng).unwrap_or(&0)
     }
 

--- a/crates/samyama-optimization/src/algorithms/nsga2.rs
+++ b/crates/samyama-optimization/src/algorithms/nsga2.rs
@@ -5,18 +5,27 @@ use rand::prelude::*;
 pub struct NSGA2Solver {
     pub config: SolverConfig,
     pub mutation_rate: f64,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl NSGA2Solver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { 
+        Self {
+            seed: None, 
             config,
             mutation_rate: 0.1,
         }
     }
 
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
     pub fn solve<P: MultiObjectiveProblem>(&self, problem: &P) -> MultiObjectiveResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
         let pop_size = self.config.population_size;
@@ -205,7 +214,7 @@ impl NSGA2Solver {
     }
 
     fn tournament_select<'a>(&self, population: &'a [MultiObjectiveIndividual]) -> &'a MultiObjectiveIndividual {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let i1 = rng.gen_range(0..population.len());
         let i2 = rng.gen_range(0..population.len());
         
@@ -219,7 +228,7 @@ impl NSGA2Solver {
     }
 
     fn crossover(&self, p1: &Array1<f64>, p2: &Array1<f64>) -> (Array1<f64>, Array1<f64>) {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = p1.len();
         let mut c1 = p1.clone();
         let mut c2 = p2.clone();
@@ -245,7 +254,7 @@ impl NSGA2Solver {
     }
 
     fn mutate(&self, vars: &mut Array1<f64>, lower: &Array1<f64>, upper: &Array1<f64>) {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         for i in 0..vars.len() {
             if rng.gen::<f64>() < self.mutation_rate {
                 let range = upper[i] - lower[i];

--- a/crates/samyama-optimization/src/algorithms/pso.rs
+++ b/crates/samyama-optimization/src/algorithms/pso.rs
@@ -8,11 +8,14 @@ pub struct PSOSolver {
     pub w: f64,  // Inertia weight
     pub c1: f64, // Cognitive weight (pbest)
     pub c2: f64, // Social weight (gbest)
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl PSOSolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { 
+        Self {
+            seed: None, 
             config,
             w: 0.7,
             c1: 1.5,
@@ -20,8 +23,14 @@ impl PSOSolver {
         }
     }
 
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
 
@@ -66,8 +75,9 @@ impl PSOSolver {
             
             // We'll compute new state in parallel and then replace.
             let results: Vec<(Individual, Array1<f64>, Individual)> = swarm.par_iter().zip(velocities.par_iter()).zip(pbests.par_iter())
-                .map(|((particle, velocity), pbest)| {
-                    let mut local_rng = thread_rng();
+                .enumerate()
+                .map(|(__idx, ((particle, velocity), pbest))| {
+                    let mut local_rng = crate::common::rng::child_rng(self.seed, iter, __idx);
                     let mut new_vel = Array1::zeros(dim);
                     let mut new_vars = Array1::zeros(dim);
 

--- a/crates/samyama-optimization/src/algorithms/qo_rao.rs
+++ b/crates/samyama-optimization/src/algorithms/qo_rao.rs
@@ -21,15 +21,24 @@ use rayon::prelude::*;
 pub struct QORaoSolver {
     pub config: SolverConfig,
     pub variant: RaoVariant,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl QORaoSolver {
     pub fn new(config: SolverConfig, variant: RaoVariant) -> Self {
-        Self { config, variant }
+        Self {
+            seed: None, config, variant }
+    }
+
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
         let pop_size = self.config.population_size;
@@ -48,8 +57,9 @@ impl QORaoSolver {
         // Initial QOBL seeding: combine population + quasi-opposite, keep best N.
         let qo_init: Vec<Individual> = population
             .par_iter()
-            .map(|ind| {
-                let mut local_rng = thread_rng();
+            .enumerate()
+                .map(|(__idx, ind)| {
+                let mut local_rng = crate::common::rng::child_rng(self.seed, 0, __idx);
                 let qo_vars = quasi_oppose(&ind.variables, &lower, &upper, &mut local_rng);
                 let fitness = problem.fitness(&qo_vars);
                 Individual::new(qo_vars, fitness)
@@ -75,8 +85,9 @@ impl QORaoSolver {
 
             population = population
                 .into_par_iter()
-                .map(|mut ind| {
-                    let mut local_rng = thread_rng();
+                .enumerate()
+                .map(|(__idx, mut ind)| {
+                    let mut local_rng = crate::common::rng::child_rng(self.seed, iter, __idx);
                     let r1: f64 = local_rng.gen();
                     let r2: f64 = local_rng.gen();
 

--- a/crates/samyama-optimization/src/algorithms/qojaya.rs
+++ b/crates/samyama-optimization/src/algorithms/qojaya.rs
@@ -5,15 +5,24 @@ use rayon::prelude::*;
 
 pub struct QOJayaSolver {
     pub config: SolverConfig,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl QOJayaSolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { config }
+        Self {
+            seed: None, config }
+    }
+
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
 
@@ -31,9 +40,9 @@ impl QOJayaSolver {
 
         // Apply Quasi-Oppositional Based Learning (QOBL) to initial population
         // Generate QO population and pick best N
-        let mut qo_population: Vec<Individual> = population.par_iter().map(|ind| {
+        let mut qo_population: Vec<Individual> = population.par_iter().enumerate().map(|(__idx, ind)| {
             let mut new_vars = Array1::zeros(dim);
-            let mut local_rng = thread_rng();
+            let mut local_rng = crate::common::rng::child_rng(self.seed, 0, __idx);
             
             for j in 0..dim {
                 // Center point c = (a+b)/2
@@ -75,8 +84,9 @@ impl QOJayaSolver {
             // Jaya Update + QOBL
             population = population
                 .into_par_iter()
-                .map(|mut ind| {
-                    let mut local_rng = thread_rng();
+                .enumerate()
+                .map(|(__idx, mut ind)| {
+                    let mut local_rng = crate::common::rng::child_rng(self.seed, iter, __idx);
                     let mut new_vars = Array1::zeros(dim);
 
                     let r1: f64 = local_rng.gen();

--- a/crates/samyama-optimization/src/algorithms/rao.rs
+++ b/crates/samyama-optimization/src/algorithms/rao.rs
@@ -13,15 +13,24 @@ pub enum RaoVariant {
 pub struct RaoSolver {
     pub config: SolverConfig,
     pub variant: RaoVariant,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl RaoSolver {
     pub fn new(config: SolverConfig, variant: RaoVariant) -> Self {
-        Self { config, variant }
+        Self {
+            seed: None, config, variant }
+    }
+
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
 
@@ -53,8 +62,9 @@ impl RaoSolver {
             // Update population
             population = population
                 .into_par_iter()
-                .map(|mut ind| {
-                    let mut local_rng = thread_rng();
+                .enumerate()
+                .map(|(__idx, mut ind)| {
+                    let mut local_rng = crate::common::rng::child_rng(self.seed, iter, __idx);
                     let mut new_vars = Array1::zeros(dim);
 
                     let r1: f64 = local_rng.gen();

--- a/crates/samyama-optimization/src/algorithms/sa.rs
+++ b/crates/samyama-optimization/src/algorithms/sa.rs
@@ -6,19 +6,28 @@ pub struct SASolver {
     pub config: SolverConfig,
     pub initial_temp: f64,
     pub cooling_rate: f64,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl SASolver {
     pub fn new(config: SolverConfig) -> Self {
         Self {
+            seed: None,
             config,
             initial_temp: 1000.0,
             cooling_rate: 0.95,
         }
     }
 
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
 

--- a/crates/samyama-optimization/src/algorithms/samp_jaya.rs
+++ b/crates/samyama-optimization/src/algorithms/samp_jaya.rs
@@ -15,15 +15,24 @@ use rayon::prelude::*;
 pub struct SAMPJayaSolver {
     pub config: SolverConfig,
     pub m_max: Option<usize>,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl SAMPJayaSolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { config, m_max: None }
+        Self {
+            seed: None, config, m_max: None }
+    }
+
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
         let pop_size = self.config.population_size;
@@ -66,8 +75,9 @@ impl SAMPJayaSolver {
                 let sw_vars = sub[sw].variables.clone();
                 let updated: Vec<Individual> = sub
                     .par_iter()
-                    .map(|ind| {
-                        let mut local_rng = thread_rng();
+                    .enumerate()
+                .map(|(__idx, ind)| {
+                        let mut local_rng = crate::common::rng::child_rng(self.seed, iter, __idx);
                         let r1: f64 = local_rng.gen();
                         let r2: f64 = local_rng.gen();
                         let mut new_vars = Array1::zeros(dim);

--- a/crates/samyama-optimization/src/algorithms/saphr.rs
+++ b/crates/samyama-optimization/src/algorithms/saphr.rs
@@ -15,15 +15,24 @@ use rayon::prelude::*;
 pub struct SAPHRSolver {
     pub config: SolverConfig,
     pub epsilon: f64,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl SAPHRSolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { config, epsilon: 0.2 }
+        Self {
+            seed: None, config, epsilon: 0.2 }
+    }
+
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
         let pop_size = self.config.population_size;
@@ -65,8 +74,9 @@ impl SAPHRSolver {
             // Updates per individual + count successes per variant.
             let updates: Vec<(Individual, usize, bool)> = population
                 .par_iter()
-                .map(|ind| {
-                    let mut local_rng = thread_rng();
+                .enumerate()
+                .map(|(__idx, ind)| {
+                    let mut local_rng = crate::common::rng::child_rng(self.seed, iter, __idx);
                     let pick: f64 = local_rng.gen();
                     let chosen = if local_rng.gen::<f64>() < self.epsilon {
                         local_rng.gen_range(0..3)

--- a/crates/samyama-optimization/src/algorithms/tlbo.rs
+++ b/crates/samyama-optimization/src/algorithms/tlbo.rs
@@ -5,15 +5,24 @@ use rayon::prelude::*;
 
 pub struct TLBOSolver {
     pub config: SolverConfig,
+    /// Seed for reproducible runs; `None` draws from entropy (#455).
+    pub seed: Option<u64>,
 }
 
 impl TLBOSolver {
     pub fn new(config: SolverConfig) -> Self {
-        Self { config }
+        Self {
+            seed: None, config }
+    }
+
+    /// Fix the seed so this solver's run can be re-derived (#455).
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     pub fn solve<P: Problem>(&self, problem: &P) -> OptimizationResult {
-        let mut rng = thread_rng();
+        let mut rng = crate::common::rng::solver_rng(self.seed);
         let dim = problem.dim();
         let (lower, upper) = problem.bounds();
 
@@ -45,8 +54,9 @@ impl TLBOSolver {
             // 1. Teacher Phase
             population = population
                 .into_par_iter()
-                .map(|mut ind| {
-                    let mut local_rng = thread_rng();
+                .enumerate()
+                .map(|(__idx, mut ind)| {
+                    let mut local_rng = crate::common::rng::child_rng(self.seed, iter, __idx);
                     let tf: f64 = local_rng.gen_range(1..3) as f64; // Teaching Factor (1 or 2)
                     let mut new_vars = Array1::zeros(dim);
 

--- a/crates/samyama-optimization/src/common.rs
+++ b/crates/samyama-optimization/src/common.rs
@@ -101,6 +101,53 @@ impl Default for SolverConfig {
     }
 }
 
+/// Reproducible randomness for the solvers.
+///
+/// Every solver drew from `thread_rng()`, so no run of this crate could be
+/// re-derived -- not by a test, and not by anyone reproducing a published
+/// result. Seeding is opt-in via `Solver::with_seed(u64)`; with no seed the
+/// behaviour is unchanged (entropy), so existing callers see no difference.
+///
+/// [`child_rng`] is the part that matters for the parallel solvers. Seeding
+/// only the outer RNG and letting rayon workers call `thread_rng()` would
+/// produce runs that *look* reproducible and are not, which is worse than
+/// admitting they are random: the seed would be recorded alongside results it
+/// cannot regenerate. Deriving each element's stream from (seed, iteration,
+/// index) instead makes the result independent of how work is scheduled across
+/// threads, which is the property reproducibility actually requires.
+pub mod rng {
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    /// Odd 64-bit constants from SplitMix64, used to decorrelate the two
+    /// coordinates so that (iter 1, index 2) and (iter 2, index 1) do not
+    /// collide onto the same stream.
+    const ITER_ODD: u64 = 0x9E37_79B9_7F4A_7C15;
+    const INDEX_ODD: u64 = 0xBF58_476D_1CE4_E5B9;
+
+    /// The solver's own RNG: seeded if a seed was given, entropy otherwise.
+    pub fn solver_rng(seed: Option<u64>) -> StdRng {
+        match seed {
+            Some(s) => StdRng::seed_from_u64(s),
+            None => StdRng::from_entropy(),
+        }
+    }
+
+    /// A per-element RNG for work inside a parallel iterator.
+    ///
+    /// Deterministic in (seed, iteration, index) and therefore independent of
+    /// thread scheduling. Unseeded, it falls back to entropy exactly as before.
+    pub fn child_rng(seed: Option<u64>, iteration: usize, index: usize) -> StdRng {
+        match seed {
+            Some(s) => StdRng::seed_from_u64(
+                s ^ (iteration as u64).wrapping_mul(ITER_ODD)
+                  ^ (index as u64).wrapping_mul(INDEX_ODD),
+            ),
+            None => StdRng::from_entropy(),
+        }
+    }
+}
+
 /// The result of an optimization run.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct OptimizationResult {

--- a/crates/samyama-optimization/tests/test_reproducibility.rs
+++ b/crates/samyama-optimization/tests/test_reproducibility.rs
@@ -1,0 +1,142 @@
+//! Seeded runs must be re-derivable (#455).
+//!
+//! The property under test is not "seeding exists" but "the same seed gives
+//! the same answer, and a different seed gives a different one". The first
+//! half alone would pass for a solver that ignored its input entirely.
+//!
+//! For the parallel solvers this is the part that could quietly not hold:
+//! seeding only the outer RNG and letting rayon workers draw from
+//! `thread_rng()` yields a run that looks reproducible in a single-threaded
+//! test and is not. Each element's stream is therefore derived from
+//! (seed, iteration, index), which does not depend on how rayon schedules
+//! the work.
+
+use ndarray::{array, Array1};
+use samyama_optimization::algorithms::*;
+use samyama_optimization::common::*;
+
+struct SphereProblem;
+impl Problem for SphereProblem {
+    fn objective(&self, v: &Array1<f64>) -> f64 { v.iter().map(|&x| x * x).sum() }
+    fn dim(&self) -> usize { 2 }
+    fn bounds(&self) -> (Array1<f64>, Array1<f64>) { (array![-10.0, -10.0], array![10.0, 10.0]) }
+}
+
+fn cfg() -> SolverConfig {
+    SolverConfig { population_size: 30, max_iterations: 60 }
+}
+
+/// Same seed twice, then a different seed. Returns (a, b, c).
+macro_rules! three_runs {
+    ($build:expr) => {{
+        let a = { let s = $build; s.with_seed(12345).solve(&SphereProblem) };
+        let b = { let s = $build; s.with_seed(12345).solve(&SphereProblem) };
+        let c = { let s = $build; s.with_seed(99999).solve(&SphereProblem) };
+        (a, b, c)
+    }};
+}
+
+fn assert_reproducible(name: &str, a: OptimizationResult, b: OptimizationResult, c: OptimizationResult) {
+    assert_eq!(
+        a.best_fitness.to_bits(),
+        b.best_fitness.to_bits(),
+        "{name}: same seed produced different results ({} vs {})",
+        a.best_fitness, b.best_fitness
+    );
+    assert_eq!(
+        a.best_variables, b.best_variables,
+        "{name}: same seed produced a different solution vector"
+    );
+    // The full convergence history, not just the endpoint -- two runs can
+    // agree on the best value while having taken different paths.
+    assert_eq!(
+        a.history.iter().map(|f| f.to_bits()).collect::<Vec<_>>(),
+        b.history.iter().map(|f| f.to_bits()).collect::<Vec<_>>(),
+        "{name}: same seed produced a different convergence history"
+    );
+    // A solver that ignored the seed would pass the checks above trivially, so
+    // a different seed must produce a different run. Compared on the whole
+    // trajectory rather than the endpoint: a solver that converges to the exact
+    // optimum (QORao reaches 0.0 on Sphere under any seed) would otherwise look
+    // like it was ignoring its input when it was not.
+    let bits = |r: &OptimizationResult| {
+        (r.best_fitness.to_bits(), r.history.iter().map(|f| f.to_bits()).collect::<Vec<_>>())
+    };
+    assert_ne!(
+        bits(&a),
+        bits(&c),
+        "{name}: a different seed produced an identical run -- the seed is not being used"
+    );
+}
+
+macro_rules! repro_test {
+    ($fn_name:ident, $name:literal, $build:expr) => {
+        #[test]
+        fn $fn_name() {
+            let (a, b, c) = three_runs!($build);
+            assert_reproducible($name, a, b, c);
+        }
+    };
+}
+
+// Single-threaded solvers
+repro_test!(hs_is_reproducible, "HS", HSSolver::new(cfg()));
+repro_test!(gsa_is_reproducible, "GSA", GSASolver::new(cfg()));
+repro_test!(ga_is_reproducible, "GA", GASolver::new(cfg()));
+repro_test!(sa_is_reproducible, "SA", SASolver::new(cfg()));
+repro_test!(bat_is_reproducible, "Bat", BatSolver::new(cfg()));
+repro_test!(abc_is_reproducible, "ABC", ABCSolver::new(cfg()));
+repro_test!(fpa_is_reproducible, "FPA", FPASolver::new(cfg()));
+repro_test!(cuckoo_is_reproducible, "Cuckoo", CuckooSolver::new(cfg()));
+repro_test!(firefly_is_reproducible, "Firefly", FireflySolver::new(cfg()));
+repro_test!(gwo_is_reproducible, "GWO", GWOSolver::new(cfg()));
+
+// Solvers whose population update runs under rayon -- the cases where naive
+// seeding would look right and not be.
+repro_test!(rao_is_reproducible, "Rao3", RaoSolver::new(cfg(), RaoVariant::Rao3));
+repro_test!(de_is_reproducible, "DE", DESolver::new(cfg()));
+repro_test!(jaya_is_reproducible, "Jaya", JayaSolver::new(cfg()));
+repro_test!(qojaya_is_reproducible, "QOJaya", QOJayaSolver::new(cfg()));
+repro_test!(tlbo_is_reproducible, "TLBO", TLBOSolver::new(cfg()));
+repro_test!(itlbo_is_reproducible, "ITLBO", ITLBOSolver::new(cfg()));
+repro_test!(gotlbo_is_reproducible, "GOTLBO", GOTLBOSolver::new(cfg()));
+repro_test!(pso_is_reproducible, "PSO", PSOSolver::new(cfg()));
+repro_test!(bmr_is_reproducible, "BMR", BMRSolver::new(cfg()));
+repro_test!(bwr_is_reproducible, "BWR", BWRSolver::new(cfg()));
+repro_test!(bmwr_is_reproducible, "BMWR", BMWRSolver::new(cfg()));
+repro_test!(samp_jaya_is_reproducible, "SAMPJaya", SAMPJayaSolver::new(cfg()));
+repro_test!(ehrjaya_is_reproducible, "EHRJaya", EHRJayaSolver::new(cfg()));
+repro_test!(qorao_is_reproducible, "QORao", QORaoSolver::new(cfg(), RaoVariant::Rao1));
+
+#[test]
+fn an_unseeded_solver_still_varies() {
+    // Seeding is opt-in. Without it the behaviour must be unchanged, or every
+    // existing caller has silently acquired a fixed trajectory.
+    let a = HSSolver::new(cfg()).solve(&SphereProblem);
+    let b = HSSolver::new(cfg()).solve(&SphereProblem);
+    assert_ne!(
+        a.best_fitness.to_bits(),
+        b.best_fitness.to_bits(),
+        "an unseeded solver became deterministic; seeding must stay opt-in"
+    );
+}
+
+#[test]
+fn reproducibility_holds_across_thread_counts() {
+    // The point of deriving each element's stream from (seed, iteration,
+    // index): the answer must not depend on how rayon schedules the work.
+    // Running the same seed under a 1-thread and a many-thread pool is the
+    // direct test of that.
+    let single = rayon::ThreadPoolBuilder::new().num_threads(1).build().unwrap();
+    let many = rayon::ThreadPoolBuilder::new().num_threads(8).build().unwrap();
+
+    let one = single.install(|| DESolver::new(cfg()).with_seed(4242).solve(&SphereProblem));
+    let eight = many.install(|| DESolver::new(cfg()).with_seed(4242).solve(&SphereProblem));
+
+    assert_eq!(
+        one.best_fitness.to_bits(),
+        eight.best_fitness.to_bits(),
+        "DE gave {} on 1 thread and {} on 8 -- the result depends on scheduling",
+        one.best_fitness, eight.best_fitness
+    );
+}


### PR DESCRIPTION
Closes #455.

## The problem

No run of this crate could be re-derived. All 29 solvers drew from `thread_rng()`, so a reported optimum could only be **re-sampled**, never regenerated. For a crate backing published Rao-family results that is a defect in its own right — well beyond the CI flake in #456 that surfaced it.

## The change

```rust
let result = DESolver::new(config).with_seed(4242).solve(&problem);
```

Opt-in. Without a seed, behaviour is unchanged.

**The seed lives on the solver, not on `SolverConfig`** — deliberately. `SolverConfig` is built by struct literal in **74 places** across examples, tests, benches, the HTTP endpoint and the SDK; adding a field would have broken every one of them for a feature almost none of them want. Solvers are only ever constructed through `::new()`, so a field there costs callers nothing. Verified: the workspace builds untouched, including `src/http/optimize.rs`.

## The part that needed care

This was not a find-and-replace, which is what #455 flagged. Seeding the outer RNG and leaving rayon workers on `thread_rng()` produces runs that **look reproducible in a single-threaded test and are not** — the seed then sits in the record next to results it cannot regenerate, which is worse than admitting the run was random.

Each element's stream is instead derived from `(seed, iteration, index)`, so the result does not depend on scheduling. Where a parallel closure had no index, `.enumerate()` was added to give it one. Two sites (QORao's and QOJaya's opposition-based-learning steps) run once *before* the iteration loop and have no iteration in scope; they use coordinate `0`, unambiguous because they execute exactly once.

## Verification

26 tests. Each solver runs twice with one seed and once with another, asserting identical **fitness, solution vector, and full convergence history** for the pair — and a different run for the third.

Two tests carry the real weight:

- **`reproducibility_holds_across_thread_counts`** — DE under a 1-thread pool and an 8-thread pool must be bit-identical. This is the property that would silently fail under naive seeding.
- **`an_unseeded_solver_still_varies`** — seeding must stay opt-in; otherwise every existing caller silently acquires a fixed trajectory.

One test needed fixing rather than the code: comparing only final fitness across seeds failed for QORao, which reaches **exactly 0.0** on Sphere under any seed. That looked like "the seed is ignored" and wasn't — the trajectories differ. The assertion now compares the whole run.

- `samyama-optimization` suite: **79 passed, 0 failed**
- Workspace: builds clean

## Follow-on, not in this PR

The HTTP `/optimize` endpoint does not expose the seed. Threading it through would make API-driven runs reproducible too, and is worth doing separately.