### PR TITLE
Reject unknown CREATE VECTOR INDEX options instead of ignoring them

### DIFF
--- a/examples/cypher_matrix_probe.rs
+++ b/examples/cypher_matrix_probe.rs
@@ -156,7 +156,7 @@ fn main() {
         ("Type Handling", "Temporal types", "RETURN date(\"2026-01-01\")", false),
         ("Type Handling", "Duration arithmetic", "RETURN duration({days: 1})", false),
 
-        ("Extensions", "CREATE VECTOR INDEX", "CREATE VECTOR INDEX probe_idx FOR (n:Person) ON (n.embedding) OPTIONS {dimension: 4, similarity: \"cosine\"}", true),
+        ("Extensions", "CREATE VECTOR INDEX", "CREATE VECTOR INDEX probe_idx FOR (n:Person) ON (n.embedding) OPTIONS {dimensions: 4, similarity: \"cosine\"}", true),
         ("Extensions", "algo.pageRank", "CALL algo.pageRank({iterations: 2}) YIELD nodeId, score RETURN count(*)", false),
         ("Extensions", "algo.wcc", "CALL algo.wcc() YIELD nodeId, componentId RETURN count(*)", false),
         ("Extensions", "algo.shortestPath", "CALL algo.shortestPath(0, 2) YIELD nodeId RETURN count(*)", false),

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -461,11 +461,50 @@ fn parse_create_vector_index_statement(pair: pest::iterators::Pair<Rule>, query:
             }
             Rule::options => {
                 let options_map = parse_properties(inner)?;
-                if let Some(PropertyValue::Integer(d)) = options_map.get("dimensions") {
-                    dimensions = *d as usize;
+
+                // Reject anything we do not honour. Silently discarding an
+                // unrecognised key builds an index the caller did not ask for
+                // and reports success: `{dimension: 4}` (singular) produced a
+                // 1536-dimension index, and the mismatch only surfaced later
+                // against the caller's *vector*, which is the wrong thing to
+                // blame (#474).
+                const ACCEPTED: [&str; 2] = ["dimensions", "similarity"];
+                let mut unknown: Vec<&String> = options_map
+                    .keys()
+                    .filter(|k| !ACCEPTED.contains(&k.as_str()))
+                    .collect();
+                if !unknown.is_empty() {
+                    unknown.sort();
+                    let listed = unknown
+                        .iter()
+                        .map(|k| format!("`{k}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    return Err(ParseError::SemanticError(format!(
+                        "CREATE VECTOR INDEX: unknown option {listed}. Accepted options are \
+`dimensions` (integer) and `similarity` (string)."
+                    )));
                 }
-                if let Some(PropertyValue::String(s)) = options_map.get("similarity") {
-                    similarity = s.clone();
+
+                if let Some(value) = options_map.get("dimensions") {
+                    match value {
+                        PropertyValue::Integer(d) if *d > 0 => dimensions = *d as usize,
+                        other => {
+                            return Err(ParseError::SemanticError(format!(
+                                "CREATE VECTOR INDEX: `dimensions` must be a positive integer, got {other:?}"
+                            )))
+                        }
+                    }
+                }
+                if let Some(value) = options_map.get("similarity") {
+                    match value {
+                        PropertyValue::String(s) => similarity = s.clone(),
+                        other => {
+                            return Err(ParseError::SemanticError(format!(
+                                "CREATE VECTOR INDEX: `similarity` must be a string, got {other:?}"
+                            )))
+                        }
+                    }
                 }
             }
             _ => {}

--- a/src/vector/index.rs
+++ b/src/vector/index.rs
@@ -57,7 +57,14 @@ pub enum VectorError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 
-    #[error("Dimension mismatch: expected {expected}, got {got}")]
+    // Naming only the two numbers left the caller reading it as "my embedding is
+    // the wrong size", when the usual cause is an index configured with a
+    // dimension nobody chose -- CREATE VECTOR INDEX defaults to 1536 when
+    // `dimensions` is omitted (#474). Point at the index configuration, since
+    // that is the side that is adjustable and the side that is usually wrong.
+    #[error("Dimension mismatch: the index expects {expected}-dimensional vectors, got {got}. \
+Set the index dimension with CREATE VECTOR INDEX ... OPTIONS {{dimensions: {got}}} \
+(the default is 1536 when `dimensions` is omitted).")]
     DimensionMismatch { expected: usize, got: usize },
 
     #[error("Search failed: {0}")]

--- a/tests/vector_query_test.rs
+++ b/tests/vector_query_test.rs
@@ -96,3 +96,104 @@ fn test_create_vector_index_query() {
     assert_eq!(result.records.len(), 1);
     assert_eq!(result.records[0].get("node.name").unwrap().as_property().unwrap().as_string(), Some("Alice"));
 }
+
+// ---------------------------------------------------------------------------
+// CREATE VECTOR INDEX option validation (#474)
+//
+// Unrecognised OPTIONS keys were discarded silently, so the index was built
+// with the 1536-dimension default and the statement reported success. The
+// failure surfaced only at query time, in a message that pointed at the
+// caller's vector rather than at the index they had misconfigured -- so the
+// natural reading was "my embedding is the wrong size".
+// ---------------------------------------------------------------------------
+
+fn create_index_with(options: &str) -> Result<(), String> {
+    let engine = QueryEngine::new();
+    let mut store = GraphStore::new();
+    engine
+        .execute_mut("CREATE (:T {emb: [0.1,0.2,0.3,0.4]})", &mut store, "default")
+        .unwrap();
+    engine
+        .execute_mut(
+            &format!("CREATE VECTOR INDEX ix FOR (n:T) ON (n.emb) OPTIONS {options}"),
+            &mut store,
+            "default",
+        )
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+#[test]
+fn the_documented_options_spelling_works_end_to_end() {
+    let engine = QueryEngine::new();
+    let mut store = GraphStore::new();
+    engine
+        .execute_mut("CREATE (:T {emb: [0.1,0.2,0.3,0.4]})", &mut store, "default")
+        .unwrap();
+    engine
+        .execute_mut(
+            "CREATE VECTOR INDEX ix FOR (n:T) ON (n.emb) OPTIONS {dimensions: 4, similarity: \"cosine\"}",
+            &mut store,
+            "default",
+        )
+        .unwrap();
+    // The point of the test is that a 4-dimensional probe now works, i.e. the
+    // option was actually applied rather than accepted and dropped.
+    let batch = engine
+        .execute(
+            "CALL db.index.vector.queryNodes(\"T\", \"emb\", [0.1,0.2,0.3,0.4], 5) YIELD node RETURN count(node) AS n",
+            &store,
+        )
+        .expect("4-dim query against a 4-dim index");
+    assert_eq!(batch.records.len(), 1);
+}
+
+#[test]
+fn a_singular_dimension_key_is_rejected_rather_than_ignored() {
+    // `dimension` vs `dimensions` is a coin flip without reading the source.
+    let err = create_index_with("{dimension: 4, similarity: \"cosine\"}").unwrap_err();
+    assert!(err.contains("unknown option"), "{err}");
+    assert!(err.contains("dimension"), "{err}");
+    assert!(err.contains("dimensions"), "the error should name the accepted spelling: {err}");
+}
+
+#[test]
+fn unknown_option_keys_are_all_named() {
+    let err = create_index_with("{banana: 4, wibble: \"x\"}").unwrap_err();
+    assert!(err.contains("banana"), "{err}");
+    assert!(err.contains("wibble"), "both unknown keys should be reported: {err}");
+}
+
+#[test]
+fn option_values_of_the_wrong_type_are_rejected() {
+    let err = create_index_with("{dimensions: \"4\"}").unwrap_err();
+    assert!(err.contains("positive integer"), "{err}");
+
+    let err = create_index_with("{dimensions: 0}").unwrap_err();
+    assert!(err.contains("positive integer"), "zero is not a usable dimension: {err}");
+}
+
+#[test]
+fn the_dimension_mismatch_error_points_at_the_index_not_the_vector() {
+    let engine = QueryEngine::new();
+    let mut store = GraphStore::new();
+    engine
+        .execute_mut("CREATE (:T {emb: [0.1,0.2,0.3,0.4]})", &mut store, "default")
+        .unwrap();
+    // Omitting `dimensions` is still allowed and still defaults to 1536; what
+    // must not happen is an error that reads as though the caller's vector is
+    // at fault.
+    engine
+        .execute_mut("CREATE VECTOR INDEX ix FOR (n:T) ON (n.emb) OPTIONS {}", &mut store, "default")
+        .unwrap();
+    let err = engine
+        .execute(
+            "CALL db.index.vector.queryNodes(\"T\", \"emb\", [0.1,0.2,0.3,0.4], 5) YIELD node RETURN count(node) AS n",
+            &store,
+        )
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("the index expects"), "{err}");
+    assert!(err.contains("dimensions: 4"), "the error should show the fix: {err}");
+    assert!(err.contains("default is 1536"), "and where 1536 came from: {err}");
+}


### PR DESCRIPTION
Closes #474.

## The bug

`OPTIONS {…}` accepted **any** keys. Unrecognised ones were discarded, the index was built with the 1536-dimension default, and the statement reported success:

```cypher
CREATE VECTOR INDEX ix FOR (n:T) ON (n.emb) OPTIONS {dimension: 4}   -- accepted ✅
CALL db.index.vector.queryNodes("T", "emb", [0.1,0.2,0.3,0.4], 5)
-- Dimension mismatch: expected 1536, got 4                           ❌
```

`dimension` vs `dimensions` is a coin flip without reading the source, and the natural reading of that error is *"my embedding is the wrong size"* — not *"my index is not the one I asked for"*. Someone porting from Neo4j (`indexConfig: {\`vector.dimensions\`: 384}`) lands here immediately.

## How quiet it was

`examples/cypher_matrix_probe.rs` — the probe written specifically to catch unsupported features — had the **singular** spelling and reported `CREATE VECTOR INDEX` as supported, because the option it passed was thrown away. The bug fooled its own detector. That is the argument for rejecting rather than defaulting.

## After

| OPTIONS | before | after |
|---|---|---|
| `{dimensions: 4, similarity: "cosine"}` | works | works ✅ |
| `{dimension: 4}` | accepted, index wrong | `unknown option \`dimension\`. Accepted options are \`dimensions\` (integer) and \`similarity\` (string).` |
| `{banana: 4, wibble: "x"}` | accepted | both keys named in one error |
| `{dimensions: "4"}` | silently skipped | `\`dimensions\` must be a positive integer, got String("4")` |
| `{dimensions: 0}` | accepted | rejected — zero is not a usable dimension |

Omitting `OPTIONS` **still** defaults to 1536; requiring it would break existing callers. But that remaining silent case now diagnoses itself:

```
Dimension mismatch: the index expects 1536-dimensional vectors, got 4.
Set the index dimension with CREATE VECTOR INDEX ... OPTIONS {dimensions: 4}
(the default is 1536 when `dimensions` is omitted).
```

It names the index side, the option that fixes it, and where 1536 came from.

## Verification

5 tests, including that the error names the accepted spelling when the singular is used, that *all* unknown keys are reported rather than just the first, and that the mismatch message contains the fix.

- `vector_query_test`: **8 passed, 0 failed**
- Package suite (`-p samyama`): **2414 passed, 0 failed**
- Matrix probe: still **77/78**, now with the spelling it should have had

Found while building a corpus to measure #445 — which is still open, and is where the ANN-then-filter planning question lives.