### PR TITLE
Add a CI lane that actually runs the tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+# The lane that gates merges. Until this existed, 2500+ tests gated nothing:
+# the only workflow that ran tests was `workflow_dispatch`-only, because its
+# self-hosted GPU runner is offline (#480).
+#
+# Two tiers, because the full sweep (scripts/verify-sweep.sh — tests, every
+# example, 12 benches, 11 case studies) takes ~50 minutes. That is the right
+# shape for a nightly and the wrong shape for a pull request.
+#
+#   this file  : fast lane, every PR and push to main
+#   nightly.yml: full sweep, once a day
+#
+# Tests run in the dev profile deliberately. Release compilation of the test
+# binaries dominates the wall clock (~8 minutes even warm); the tests
+# themselves take under a second. Dev builds far faster and runs them just as
+# thoroughly. Anything that genuinely needs release timings belongs in the
+# nightly sweep, not here.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  # A new push supersedes an in-flight run for the same ref.
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  # Debug symbols are the bulk of the target dir and nothing here reads them.
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  RUST_BACKTRACE: "1"
+
+jobs:
+  test:
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        # libclang is required by zstd-sys and is the single most common
+        # first-build failure on a clean host (CONTRIBUTING documents it).
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq build-essential cmake pkg-config libssl-dev clang libclang-dev
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Share the cache across jobs in this workflow; key on Cargo.lock.
+          shared-key: ci-test
+
+      # `cargo fmt --check` and `cargo clippy -D warnings` are deliberately NOT
+      # here yet. The tree currently has ~5,000 rustfmt diffs and ~680 clippy
+      # warnings, so either gate would be red on arrival -- and a gate that is
+      # always red is one everybody learns to ignore, which is worse than not
+      # having it. Adopting both needs a mechanical reformat commit and a lint
+      # ratchet; tracked separately so this lane can start green and mean
+      # something from its first run.
+
+      - name: Tests
+        # --no-fail-fast so one failing crate does not hide the rest; a PR
+        # author should see every failure in one run, not one per push.
+        run: cargo test --workspace --no-fail-fast
+
+      - name: Examples and benches compile
+        # The sweep runs these; here we only prove they still build, which is
+        # what actually breaks when a signature changes.
+        run: cargo check --workspace --all-targets

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,75 @@
+name: Nightly sweep
+
+# The full verification sweep: tests, every example, every bench, every case
+# study. This is what has been catching the defects a plain `cargo test` does
+# not -- an example that panics instead of saying what data it needs (#433), a
+# bench reporting success while measuring nothing (#449), a case study whose
+# snapshot URL was never filled in (#442).
+#
+# It takes ~50 minutes, which is why it is nightly rather than per-PR (see
+# ci.yml for the fast lane).
+#
+# PASS/FAIL ONLY. The bench timings produced here are on a shared hosted
+# runner and are not comparable between runs -- do not quote them. Published
+# numbers come from a fixed machine with a recorded host, per spec 18. This
+# job answers "does everything still run", not "how fast is it".
+
+on:
+  schedule:
+    # 02:30 UTC daily. Off the hour to avoid the top-of-hour scheduling crowd.
+    - cron: "30 2 * * *"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: "1"
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: nightly-sweep
+
+      - name: Run the full sweep
+        id: sweep
+        # --provision installs the system dependencies the script documents.
+        run: ./scripts/verify-sweep.sh --provision --out "${{ runner.temp }}/sweep"
+
+      - name: Upload results
+        # Always: the results are most useful precisely when the step above failed.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sweep-results
+          path: ${{ runner.temp }}/sweep/results/
+          retention-days: 30
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sweep-logs
+          path: ${{ runner.temp }}/sweep/logs/
+          retention-days: 14
+
+      - name: Summarise into the run page
+        if: always()
+        run: |
+          {
+            echo '## Nightly sweep'
+            echo '```'
+            cat "${{ runner.temp }}/sweep/results/run.txt" 2>/dev/null || echo "(no run.txt)"
+            echo
+            for f in tests examples benches case-studies; do
+              echo "--- $f ---"
+              cat "${{ runner.temp }}/sweep/results/$f.txt" 2>/dev/null || echo "(missing)"
+            done
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Refs #480.

## What was missing

`.github/workflows/` had three workflows. The only one that ran tests was `workflow_dispatch`-only — its own header explains why: the self-hosted GPU runner is offline, so push/PR triggers queued forever. Recent Actions history is `GPU CI | pull_request | cancelled`, repeatedly.

So **2,576 tests gated nothing.** Every merge was gated by whoever remembered to run them by hand. That has worked, and it is not a control: it depends on the person and leaves no record on the PR either way.

## Two tiers

| | trigger | contents | budget |
|---|---|---|---|
| `ci.yml` | every PR, push to main | tests + `cargo check --all-targets` | ~7 min warm |
| `nightly.yml` | 02:30 UTC, dispatch | `scripts/verify-sweep.sh --provision` | ~50 min |

The split exists because the full sweep runs every example, 12 benches and 11 case studies. That is the right shape for a nightly and the wrong shape for something a person waits on.

## Dev profile, measured not assumed

| lane | wall |
|---|---|
| `cargo test --release --workspace` (already warm) | **462 s** |
| `cargo test --workspace` (dev, from partial clean) | **398 s** — 2576 passed, 0 failed |

Release compilation of the *test binaries* dominates; the tests themselves finish in under a second either way. The heaviest single suite (26 solver-reproducibility tests, each running a full optimisation) builds and runs in 8 s in dev. Anything genuinely needing release timings belongs in the nightly.

## What is deliberately not gated

`cargo fmt --check` and `cargo clippy -- -D warnings`. The tree currently has **~5,000 rustfmt diffs** and **~680 clippy warnings**, so either would be red on its first run — and a gate that is always red is one everybody learns to route around, which is worse than not having it.

Adopting them needs a mechanical reformat commit plus a lint ratchet, which is a separate change with a separate review problem. This lane starts green so that a red tick carries information. The reasoning is recorded in the workflow itself rather than left for someone to rediscover.

## Not folded in

The GPU lane stays as it is. It is correctly dispatch-only while its runner is offline and its header documents that at length; adding a general lane beside it should not disturb that.

## Remaining DoD from #480

- [ ] Make `test` a **required status check** on `main` (repo setting, needs admin)
- [ ] Demonstrate a deliberately broken test fails the check — an untested CI config is not a control either

Both need this merged first, and I will do them straight after.