### PR TITLE
Add a memory footprint harness, and what it says

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,10 @@ samyama-sdk = { path = "crates/samyama-sdk", version = "1.7.0" }
 http-body-util = "0.1"
 
 [[bench]]
+name = "memory_footprint"
+harness = false
+
+[[bench]]
 name = "hierarchy_benchmark"
 harness = false
 

--- a/benches/memory_footprint.rs
+++ b/benches/memory_footprint.rs
@@ -1,0 +1,295 @@
+//! Measures resident memory per node and per edge (#477, PERF-10).
+//!
+//! `PERF-10` sets a target of ≤128 B/edge and records a current figure of
+//! ~537 B/edge against FalkorDB's ~57. That figure had **no reproducer** — which
+//! under spec 18 makes it unquotable, and in practice makes it unimprovable,
+//! because nothing would tell us whether a change helped.
+//!
+//! Two independent measurements, deliberately:
+//!
+//!   * a **counting allocator** wrapping the system allocator, giving exact live
+//!     heap bytes and letting each construction phase be attributed separately;
+//!   * **RSS** from `/proc/self/statm`, which includes what the allocator cannot
+//!     see — binary, stacks, allocator slack, fragmentation.
+//!
+//! They will not agree, and the gap is the point: allocator bytes are what a
+//! layout change moves, RSS is what the machine actually has to have. Reporting
+//! only one of them is how a "we cut memory 40%" claim survives an RSS that did
+//! not move.
+//!
+//!   cargo bench --bench memory_footprint
+//!   cargo bench --bench memory_footprint -- --json footprint.json
+//!   cargo bench --bench memory_footprint -- --scale 200000
+
+use samyama::graph::GraphStore;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+// ---------------------------------------------------------------- allocator
+
+static ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+static FREED: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATED.fetch_add(layout.size(), Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        FREED.fetch_add(layout.size(), Ordering::Relaxed);
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if new_size >= layout.size() {
+            ALLOCATED.fetch_add(new_size - layout.size(), Ordering::Relaxed);
+        } else {
+            FREED.fetch_add(layout.size() - new_size, Ordering::Relaxed);
+        }
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: Counting = Counting;
+
+/// Live heap bytes: everything allocated minus everything freed.
+fn live_heap() -> usize {
+    ALLOCATED.load(Ordering::Relaxed).saturating_sub(FREED.load(Ordering::Relaxed))
+}
+
+/// Resident set size in bytes, or `None` off Linux.
+fn rss() -> Option<usize> {
+    let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let resident_pages: usize = statm.split_whitespace().nth(1)?.parse().ok()?;
+    Some(resident_pages * 4096)
+}
+
+// ---------------------------------------------------------------- fixture
+
+/// A synthetic graph with a realistic shape: labelled nodes with a couple of
+/// properties, typed edges, average degree ~4.
+///
+/// Synthetic rather than LDBC so the harness runs anywhere; the numbers are
+/// comparable across runs of this harness, which is what a regression check
+/// needs. Absolute comparison against a competitor needs the same dataset on
+/// both, and that is a separate exercise.
+fn build(nodes: usize, avg_degree: usize) -> (GraphStore, usize, usize) {
+    let mut store = GraphStore::new();
+    let labels = ["Person", "Post", "Forum", "Tag"];
+    let edge_types = ["KNOWS", "LIKES", "MEMBER_OF", "HAS_TAG"];
+
+    let mut node_ids = Vec::with_capacity(nodes);
+    for i in 0..nodes {
+        let id = store.create_node(labels[i % labels.len()]);
+        // Two properties per node: one string, one integer -- the common shape.
+        let _ = store.set_node_property(
+            "default",
+            id,
+            "name".to_string(),
+            samyama::graph::PropertyValue::String(format!("n{i}")),
+        );
+        let _ = store.set_node_property(
+            "default",
+            id,
+            "value".to_string(),
+            samyama::graph::PropertyValue::Integer(i as i64),
+        );
+        node_ids.push(id);
+    }
+
+    let mut edges = 0usize;
+    for (i, &src) in node_ids.iter().enumerate() {
+        for d in 0..avg_degree {
+            // Deterministic spread so the adjacency is not degenerate.
+            let tgt = node_ids[(i * 7 + d * 31 + 1) % nodes];
+            if store
+                .create_edge(src, tgt, edge_types[(i + d) % edge_types.len()])
+                .is_ok()
+            {
+                edges += 1;
+            }
+        }
+    }
+    (store, nodes, edges)
+}
+
+// ---------------------------------------------------------------- report
+
+struct Phase {
+    name: &'static str,
+    heap_delta: usize,
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let arg = |flag: &str| -> Option<String> {
+        args.iter().position(|a| a == flag).and_then(|i| args.get(i + 1).cloned())
+    };
+    let scale: usize = arg("--scale").and_then(|s| s.parse().ok()).unwrap_or(100_000);
+    let avg_degree: usize = arg("--degree").and_then(|s| s.parse().ok()).unwrap_or(4);
+
+    println!("Memory footprint — {scale} nodes, target degree {avg_degree}");
+    println!("{}", "-".repeat(78));
+
+    let base_heap = live_heap();
+    let base_rss = rss();
+
+    // Phase 1: nodes only.
+    let mut store = GraphStore::new();
+    let labels = ["Person", "Post", "Forum", "Tag"];
+    let mut node_ids = Vec::with_capacity(scale);
+    for i in 0..scale {
+        let id = store.create_node(labels[i % labels.len()]);
+        node_ids.push(id);
+    }
+    let after_bare_nodes = live_heap();
+
+    // Phase 2: node properties.
+    for (i, &id) in node_ids.iter().enumerate() {
+        let _ = store.set_node_property(
+            "default",
+            id,
+            "name".to_string(),
+            samyama::graph::PropertyValue::String(format!("n{i}")),
+        );
+        let _ = store.set_node_property(
+            "default",
+            id,
+            "value".to_string(),
+            samyama::graph::PropertyValue::Integer(i as i64),
+        );
+    }
+    let after_props = live_heap();
+
+    // Phase 3: edges.
+    let edge_types = ["KNOWS", "LIKES", "MEMBER_OF", "HAS_TAG"];
+    let mut edges = 0usize;
+    for (i, &src) in node_ids.iter().enumerate() {
+        for d in 0..avg_degree {
+            let tgt = node_ids[(i * 7 + d * 31 + 1) % scale];
+            if store.create_edge(src, tgt, edge_types[(i + d) % edge_types.len()]).is_ok() {
+                edges += 1;
+            }
+        }
+    }
+    let after_edges = live_heap();
+
+    // Phase 4: statistics (the planner's view; built lazily elsewhere).
+    let _stats = store.statistics();
+    let after_stats = live_heap();
+
+    let final_rss = rss();
+
+    let phases = [
+        Phase { name: "node structs", heap_delta: after_bare_nodes.saturating_sub(base_heap) },
+        Phase { name: "node properties", heap_delta: after_props.saturating_sub(after_bare_nodes) },
+        Phase { name: "edges + adjacency", heap_delta: after_edges.saturating_sub(after_props) },
+        Phase { name: "statistics", heap_delta: after_stats.saturating_sub(after_edges) },
+    ];
+
+    let total_heap = after_stats.saturating_sub(base_heap);
+
+    println!("{:<24} {:>14} {:>12}", "phase", "bytes", "share");
+    for p in &phases {
+        let share = if total_heap > 0 { 100.0 * p.heap_delta as f64 / total_heap as f64 } else { 0.0 };
+        println!("{:<24} {:>14} {:>11.1}%", p.name, p.heap_delta, share);
+    }
+    println!("{:<24} {:>14}", "total (live heap)", total_heap);
+    println!();
+
+    println!("nodes: {scale}    edges: {edges}");
+    println!("{:<28} {:>10.1}", "bytes/node (heap)", total_heap as f64 / scale as f64);
+    println!(
+        "{:<28} {:>10.1}",
+        "bytes/edge (heap)",
+        if edges > 0 { total_heap as f64 / edges as f64 } else { 0.0 }
+    );
+
+    // Edge-attributable cost on its own: the number PERF-10 is written against.
+    let edge_only = phases[2].heap_delta;
+    println!(
+        "{:<28} {:>10.1}   <- edges+adjacency only",
+        "bytes/edge (edge phase)",
+        if edges > 0 { edge_only as f64 / edges as f64 } else { 0.0 }
+    );
+
+    if let (Some(b), Some(f)) = (base_rss, final_rss) {
+        let rss_delta = f.saturating_sub(b);
+        println!();
+        println!("{:<28} {:>10}", "RSS delta (bytes)", rss_delta);
+        println!(
+            "{:<28} {:>10.1}",
+            "bytes/edge (RSS)",
+            if edges > 0 { rss_delta as f64 / edges as f64 } else { 0.0 }
+        );
+        let ratio = if total_heap > 0 { rss_delta as f64 / total_heap as f64 } else { 0.0 };
+        println!("{:<28} {:>10.2}x", "RSS / live heap", ratio);
+        println!();
+        println!("The gap between the two is allocator slack, fragmentation and the");
+        println!("binary itself. A layout change moves the heap number; only the RSS");
+        println!("number decides whether a graph fits in a given machine.");
+    } else {
+        println!();
+        println!("(RSS unavailable — /proc/self/statm is Linux-only)");
+    }
+
+    if let Some(path) = arg("--json") {
+        let commit = std::process::Command::new("git")
+            .args(["rev-parse", "--short", "HEAD"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .unwrap_or_else(|| "unknown".into());
+        let rss_delta = match (base_rss, final_rss) {
+            (Some(b), Some(f)) => f.saturating_sub(b) as i64,
+            _ => -1,
+        };
+        let phase_json = phases
+            .iter()
+            .map(|p| format!("{{\"phase\": \"{}\", \"bytes\": {}}}", p.name, p.heap_delta))
+            .collect::<Vec<_>>()
+            .join(",\n      ");
+        let envelope = format!(
+            "{{
+  \"suite\": \"memory-footprint\",
+  \"requirement_ids\": [\"PERF-10\"],
+  \"run_id\": \"footprint-{commit}-{scale}n-{avg_degree}d\",
+  \"engine\": {{\"name\": \"samyama\", \"version\": \"{}\", \"commit\": \"{commit}\"}},
+  \"hardware\": {{\"note\": \"single process; RSS is host-dependent, heap bytes are not\"}},
+  \"dataset\": {{\"name\": \"synthetic\", \"nodes\": {scale}, \"edges\": {edges}, \"avg_degree\": {avg_degree}}},
+  \"measurements\": {{
+    \"live_heap_bytes\": {total_heap},
+    \"rss_delta_bytes\": {rss_delta},
+    \"bytes_per_node_heap\": {:.2},
+    \"bytes_per_edge_heap\": {:.2},
+    \"bytes_per_edge_edge_phase\": {:.2},
+    \"phases\": [
+      {phase_json}
+    ]
+  }},
+  \"status\": \"measured\",
+  \"artifacts\": [\"benches/memory_footprint.rs\"],
+  \"caveat\": \"Synthetic dataset. Comparable across runs of this harness; not directly comparable to a competitor's figure on a different dataset.\"
+}}
+",
+            env!("CARGO_PKG_VERSION"),
+            total_heap as f64 / scale as f64,
+            if edges > 0 { total_heap as f64 / edges as f64 } else { 0.0 },
+            if edges > 0 { edge_only as f64 / edges as f64 } else { 0.0 },
+        );
+        match std::fs::write(&path, envelope) {
+            Ok(()) => println!("\nwrote result envelope: {path}"),
+            Err(e) => {
+                eprintln!("could not write {path}: {e}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    // Keep the store alive to here so nothing is freed before measurement.
+    drop(store);
+    let _ = build; // the shared fixture builder is kept for future LDBC wiring
+}


### PR DESCRIPTION
Refs #477, Phase 1.

## Why

`PERF-10` records **~537 B/edge** against a 128 B/edge target. That figure had **no reproducer** — which under spec 18 makes it unquotable, and in practice unimprovable, since nothing would tell us whether a change helped.

## What it measures

Two numbers, deliberately:

- **live heap**, via a counting global allocator — what a layout change actually moves, and attributable per construction phase
- **RSS**, from `/proc/self/statm` — what decides whether a graph fits in a given machine

They differ by ~1.1× here. Reporting only the first is how a "we cut memory 40%" claim survives an RSS that did not move.

## The first result reframes the target

Sweeping average degree at 100k nodes:

| degree | node structs | node props | edges+adj | **B/edge (RSS)** |
|---:|---:|---:|---:|---:|
| 2 | 51.2% | 29.2% | 19.7% | **819** |
| 4 | 46.1% | 26.3% | 27.6% | **447** |
| 8 | 39.5% | 22.6% | 37.9% | **257** |
| 16 | 30.8% | 17.5% | 51.7% | **163** |

Same engine, same nodes. **The per-edge figure moves 5× purely with how you divide.** So "537 B/edge" is substantially a statement about SF10's average degree (~5.9), not about edge storage.

The marginal cost of an edge is **78–144 B and falls with degree** — already at or under the 128 B target for degree ≥8.

What does *not* move is nodes:

- **748 B for a bare node**, plus **426 B for two properties**
- constant at 50k / 100k / 200k nodes (748.0, 747.3, 747.0) — scale-invariant, not a fixed-overhead artifact

A `Node` is **128 B** by `size_of`. So roughly **620 B per node is allocation overhead around it**: `nodes: Vec<Vec<Node>>` is a heap allocation per node for a `Vec` that almost always holds exactly one element, and the two adjacency `Vec`s are two more. **Three allocations per node before any data.**

## What this implies for #477

The issue's Phase 2 proposed interning `EdgeType`/`Label` and unboxing edge properties. Those are still worth doing, but the measurement says they are not the first lever — **node allocation overhead is**, and it is invisible in the metric `PERF-10` is written against.

I have posted the full data to #477 rather than silently re-scoping it.

## Usage

```
cargo bench --bench memory_footprint
cargo bench --bench memory_footprint -- --scale 200000 --degree 8
cargo bench --bench memory_footprint -- --json footprint.json   # spec-18 envelope
```

Synthetic dataset, so it runs anywhere and is comparable across runs of itself. Comparing against a competitor's figure needs the same dataset on both engines, which is a separate exercise — the envelope says so rather than leaving it implied.