### PR TITLE
Stop cloning labels and edge types on every edge insert

### DIFF
--- a/benches/memory_footprint.rs
+++ b/benches/memory_footprint.rs
@@ -145,6 +145,7 @@ fn main() {
     let base_heap = live_heap();
     let base_calls = alloc_calls();
     let base_rss = rss();
+    let t_start = std::time::Instant::now();
 
     // Phase 1: nodes only.
     let mut store = GraphStore::new();
@@ -156,6 +157,7 @@ fn main() {
     }
     let after_bare_nodes = live_heap();
     let calls_bare_nodes = alloc_calls();
+    let t_nodes = t_start.elapsed();
 
     // Phase 2: node properties.
     for (i, &id) in node_ids.iter().enumerate() {
@@ -174,6 +176,7 @@ fn main() {
     }
     let after_props = live_heap();
     let calls_props = alloc_calls();
+    let t_props = t_start.elapsed();
 
     // Phase 3: edges.
     let edge_types = ["KNOWS", "LIKES", "MEMBER_OF", "HAS_TAG"];
@@ -188,6 +191,7 @@ fn main() {
     }
     let after_edges = live_heap();
     let calls_edges = alloc_calls();
+    let t_edges = t_start.elapsed();
 
     // Phase 4: statistics (the planner's view; built lazily elsewhere).
     let _stats = store.statistics();
@@ -220,6 +224,15 @@ fn main() {
         (calls_props - calls_bare_nodes) as f64 / scale as f64,
         calls_edges - calls_props,
         if edges > 0 { (calls_edges - calls_props) as f64 / edges as f64 } else { 0.0 },
+    );
+    // Throughput matters as much as bytes here: allocation count caps insert
+    // rate independently of how much memory each object ends up occupying,
+    // which is the PERF-14 half of this measurement.
+    let edge_secs = (t_edges - t_props).as_secs_f64();
+    println!(
+        "insert rate: {:.0} nodes/s, {:.0} edges/s",
+        scale as f64 / t_nodes.as_secs_f64().max(1e-9),
+        edges as f64 / edge_secs.max(1e-9),
     );
     println!();
     println!("nodes: {scale}    edges: {edges}");

--- a/src/graph/catalog.rs
+++ b/src/graph/catalog.rs
@@ -103,16 +103,27 @@ impl GraphCatalog {
     ///
     /// For a multi-label source and multi-label target, this generates
     /// one triple entry per (src_label, edge_type, tgt_label) combination.
-    pub fn on_edge_created(
+    /// Generic over the label collections so a caller holding a `HashSet<Label>`
+    /// -- which `Node` does -- can pass it directly. `GraphStore::create_edge`
+    /// previously collected two `Vec<Label>` per edge purely to satisfy a
+    /// `&[Label]` parameter, cloning every label `String` on every insert
+    /// (#491). `&[Label]` still coerces, so existing callers are unchanged.
+    pub fn on_edge_created<'a, S, T>(
         &mut self,
         source_id: NodeId,
-        src_labels: &[Label],
+        src_labels: S,
         edge_type: &EdgeType,
         target_id: NodeId,
-        tgt_labels: &[Label],
-    ) {
+        tgt_labels: T,
+    ) where
+        S: IntoIterator<Item = &'a Label>,
+        // Clone because the inner loop re-iterates the targets for every
+        // source. `&[Label]` and `&HashSet<Label>` are both references, so the
+        // clone is a pointer copy and costs nothing.
+        T: IntoIterator<Item = &'a Label> + Clone,
+    {
         for src_label in src_labels {
-            for tgt_label in tgt_labels {
+            for tgt_label in tgt_labels.clone() {
                 let pattern = TriplePattern::new(src_label.clone(), edge_type.clone(), tgt_label.clone());
 
                 // Update source degree tracking

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -1500,16 +1500,44 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         }
         self.edge_type_ids[idx] = type_id;
 
-        // Update edge type index
-        self.edge_type_index
-            .entry(edge_type.clone())
-            .or_insert_with(HashSet::new)
-            .insert(edge_id);
+        // Update edge type index. `get_mut` first so the common case -- a type
+        // already seen, which after the first few edges is every case -- does
+        // not clone the type string just to hand `entry()` a key it will throw
+        // away (#491).
+        match self.edge_type_index.get_mut(&edge_type) {
+            Some(set) => {
+                set.insert(edge_id);
+            }
+            None => {
+                self.edge_type_index
+                    .entry(edge_type.clone())
+                    .or_insert_with(HashSet::new)
+                    .insert(edge_id);
+            }
+        }
 
         // Update catalog triple stats
-        let src_labels: Vec<Label> = self.get_node(source).map(|n| n.labels.iter().cloned().collect()).unwrap_or_default();
-        let tgt_labels: Vec<Label> = self.get_node(target).map(|n| n.labels.iter().cloned().collect()).unwrap_or_default();
-        self.catalog.on_edge_created(source, &src_labels, &edge_type, target, &tgt_labels);
+        // Borrow the label sets straight from the nodes rather than collecting
+        // two `Vec<Label>` per edge. The collect existed only to end the borrow
+        // on `self` before touching `self.catalog`; borrowing the two fields
+        // disjointly does the same thing without cloning a `String` per label
+        // on every single insert (#491).
+        let version = self.current_version;
+        let nodes = &self.nodes;
+        let label_set = |id: NodeId| -> Option<&std::collections::HashSet<Label>> {
+            nodes
+                .get(id.as_u64() as usize)?
+                .iter()
+                .rev()
+                .find(|n| n.version <= version)
+                .map(|n| &n.labels)
+        };
+        static NO_LABELS: std::sync::OnceLock<std::collections::HashSet<Label>> =
+            std::sync::OnceLock::new();
+        let empty = NO_LABELS.get_or_init(std::collections::HashSet::new);
+        let src_labels = label_set(source).unwrap_or(empty);
+        let tgt_labels = label_set(target).unwrap_or(empty);
+        self.catalog.on_edge_created(source, src_labels, &edge_type, target, tgt_labels);
 
         Ok(edge_id)
     }
@@ -1579,16 +1607,44 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             self.edge_properties.insert(edge_id, edge.properties.clone());
         }
 
-        // Update edge type index
-        self.edge_type_index
-            .entry(edge_type.clone())
-            .or_insert_with(HashSet::new)
-            .insert(edge_id);
+        // Update edge type index. `get_mut` first so the common case -- a type
+        // already seen, which after the first few edges is every case -- does
+        // not clone the type string just to hand `entry()` a key it will throw
+        // away (#491).
+        match self.edge_type_index.get_mut(&edge_type) {
+            Some(set) => {
+                set.insert(edge_id);
+            }
+            None => {
+                self.edge_type_index
+                    .entry(edge_type.clone())
+                    .or_insert_with(HashSet::new)
+                    .insert(edge_id);
+            }
+        }
 
         // Update catalog triple stats
-        let src_labels: Vec<Label> = self.get_node(source).map(|n| n.labels.iter().cloned().collect()).unwrap_or_default();
-        let tgt_labels: Vec<Label> = self.get_node(target).map(|n| n.labels.iter().cloned().collect()).unwrap_or_default();
-        self.catalog.on_edge_created(source, &src_labels, &edge_type, target, &tgt_labels);
+        // Borrow the label sets straight from the nodes rather than collecting
+        // two `Vec<Label>` per edge. The collect existed only to end the borrow
+        // on `self` before touching `self.catalog`; borrowing the two fields
+        // disjointly does the same thing without cloning a `String` per label
+        // on every single insert (#491).
+        let version = self.current_version;
+        let nodes = &self.nodes;
+        let label_set = |id: NodeId| -> Option<&std::collections::HashSet<Label>> {
+            nodes
+                .get(id.as_u64() as usize)?
+                .iter()
+                .rev()
+                .find(|n| n.version <= version)
+                .map(|n| &n.labels)
+        };
+        static NO_LABELS: std::sync::OnceLock<std::collections::HashSet<Label>> =
+            std::sync::OnceLock::new();
+        let empty = NO_LABELS.get_or_init(std::collections::HashSet::new);
+        let src_labels = label_set(source).unwrap_or(empty);
+        let tgt_labels = label_set(target).unwrap_or(empty);
+        self.catalog.on_edge_created(source, src_labels, &edge_type, target, tgt_labels);
 
         Ok(edge_id)
     }


### PR DESCRIPTION
Refs #491 (Phase 1), #477.

## Measured before and after

| | allocations/edge | insert rate |
|---|---:|---:|
| before | **19.50** | 828K edges/s |
| after | **14.50** | **1.09M edges/s** |

Three runs after the change: 1.088M, 1.130M, 1.109M edges/s — so the ~30% is not noise. Measured with `cargo bench --bench memory_footprint`.

## What was happening

**Two `Vec<Label>` per edge.** `create_edge` collected the labels of both endpoints, cloning every label `String`:

```rust
let src_labels: Vec<Label> = self.get_node(source)
    .map(|n| n.labels.iter().cloned().collect()).unwrap_or_default();
let tgt_labels: Vec<Label> = ...
self.catalog.on_edge_created(source, &src_labels, &edge_type, target, &tgt_labels);
```

The collect existed only to **end the immutable borrow on `self`** before touching `self.catalog` — a borrow-checker workaround with a per-insert cost. Borrowing `self.nodes` and `self.catalog` as disjoint fields does the same job without allocating.

`on_edge_created` is now generic over `IntoIterator<Item = &Label>`, so the store passes the node's own `HashSet` directly. **Every existing `&[Label]` caller still compiles** — there are ~30, nearly all tests, and none needed touching.

**The edge type cloned a second time** to key `edge_type_index` through `entry()`. After the first few edges the type is always already present, so a `get_mut` fast path skips the clone in what is by then every case.

## What this does not do

**It does not reduce memory.** Bytes/edge is unchanged at 405 B heap / 447 B RSS, because these allocations were transient — allocated and freed within the call, never appearing in live heap. What they cost was *time*.

That is worth stating plainly: this is a **PERF-14** result (ingestion; target 1M edges/s, tree measured at ~307K on SF10) rather than a PERF-10 one, even though it was found while chasing PERF-10.

## What remains

14.5 allocations per edge still. Those need a representation change rather than a tidy-up: `Edge` owns an `EdgeType(String)` while `edge_type_ids` already holds the interned id for the same edge — DS-07c was added *beside* the legacy representation rather than replacing it. That is #491 Phase 2.

## Verification

Workspace suite: **2576 passed, 0 failed.**