### PR TITLE
Build node index events only where they are consumed

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -944,17 +944,29 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             self.incoming.resize(idx + 1, Vec::new());
         }
 
-        let event = crate::graph::event::IndexEvent::NodeCreated {
-            tenant_id: "default".to_string(),
-            id: node_id,
-            labels: node.labels.iter().cloned().collect(),
-            properties: node.properties.clone(),
-        };
-
+        // Build the event only where it is actually consumed. A subscriber may
+        // care about a bare node creation, so the sender path always gets one;
+        // the local path only indexes *properties*, and `Node::new` starts with
+        // none, so constructing the event there allocated a tenant String, a
+        // Vec of cloned labels and a properties clone to feed a loop that
+        // iterates zero times (#491).
         if let Some(sender) = &self.index_sender {
-            let _ = sender.send(event);
-        } else {
-            self.handle_index_event(event, None);
+            let _ = sender.send(crate::graph::event::IndexEvent::NodeCreated {
+                tenant_id: "default".to_string(),
+                id: node_id,
+                labels: node.labels.iter().cloned().collect(),
+                properties: node.properties.clone(),
+            });
+        } else if !node.properties.is_empty() {
+            self.handle_index_event(
+                crate::graph::event::IndexEvent::NodeCreated {
+                    tenant_id: "default".to_string(),
+                    id: node_id,
+                    labels: node.labels.iter().cloned().collect(),
+                    properties: node.properties.clone(),
+                },
+                None,
+            );
         }
 
         self.nodes[idx].push(node);
@@ -1004,17 +1016,26 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             self.incoming.resize(idx + 1, Vec::new());
         }
 
-        let event = crate::graph::event::IndexEvent::NodeCreated {
-            tenant_id: tenant_id.to_string(),
-            id: node_id,
-            labels: node.labels.iter().cloned().collect(),
-            properties: node.properties.clone(),
-        };
-
+        // Same as `create_node`: the local path only indexes properties, so
+        // building the event for a property-less node allocates to feed a loop
+        // that iterates zero times (#491).
         if let Some(sender) = &self.index_sender {
-            let _ = sender.send(event);
-        } else {
-            self.handle_index_event(event, None);
+            let _ = sender.send(crate::graph::event::IndexEvent::NodeCreated {
+                tenant_id: tenant_id.to_string(),
+                id: node_id,
+                labels: node.labels.iter().cloned().collect(),
+                properties: node.properties.clone(),
+            });
+        } else if !node.properties.is_empty() {
+            self.handle_index_event(
+                crate::graph::event::IndexEvent::NodeCreated {
+                    tenant_id: tenant_id.to_string(),
+                    id: node_id,
+                    labels: node.labels.iter().cloned().collect(),
+                    properties: node.properties.clone(),
+                },
+                None,
+            );
         }
 
         self.nodes[idx].push(node);


### PR DESCRIPTION
Refs #491, #477.

## What was happening

Both node-creation paths built an `IndexEvent` unconditionally, then decided what to do with it:

```rust
let event = IndexEvent::NodeCreated {
    tenant_id: tenant_id.to_string(),                 // allocation
    id: node_id,
    labels: node.labels.iter().cloned().collect(),    // Vec + a String clone per label
    properties: node.properties.clone(),              // map clone
};

if let Some(sender) = &self.index_sender { sender.send(event) }
else { self.handle_index_event(event, None) }
```

The local branch only indexes **properties** — `handle_index_event`'s `NodeCreated` arm is a `for (key, value) in properties` loop and nothing else. And `Node::new` starts with an **empty** `PropertyMap`.

So for every node created through these paths, that loop runs **zero times**, and everything allocated to feed it is discarded. (The `tenant_id` is bound as `tenant_id: _` in the handler, so it was never read at all.)

## The change

A subscriber may legitimately care about a bare node creation, so the **sender path is unchanged**. The local path builds the event only when there is a property to index.

| | before | after |
|---|---:|---:|
| allocations / node | **9.00** | **6.00** |

Insert rate moves from ~1.6–1.8M to ~1.8–2.1M nodes/s across runs. **The allocation count is exact and repeatable; the rate is noisy on this machine and the ranges overlap**, so I would treat it as indicative rather than as a measurement. The allocation count is the result worth quoting.

## What this does not do

Bytes/node is unchanged at 1621 B heap. These allocations were transient — allocated and freed within the call, never appearing in live heap. What they cost was time.

That is the second such finding in this area, and worth naming as a pattern: **the memory harness found a throughput problem, not a memory problem.** The 748 B/node of *resident* cost is still there and still structural (`nodes: Vec<Vec<Node>>` is one allocation per node for a Vec that holds one element).

## Not changed here

Three other event sites (`PropertySet`, `NodeDeleted`, `LabelAdded`) share the shape but are not on the bulk-insert path, and for those the properties are usually non-empty anyway, so the guard would rarely fire. Left alone rather than changed speculatively.

## Verification

Workspace suite: **2576 passed, 0 failed.**