### PR TITLE
Reserve one MVCC version slot instead of four

### DIFF
--- a/benches/memory_footprint.rs
+++ b/benches/memory_footprint.rs
@@ -31,12 +31,27 @@ static ALLOCATED: AtomicUsize = AtomicUsize::new(0);
 static FREED: AtomicUsize = AtomicUsize::new(0);
 static ALLOC_CALLS: AtomicUsize = AtomicUsize::new(0);
 
+/// Allocation-size histogram, bucketed by power of two (index = log2 of size,
+/// capped). Knowing *what sizes* are being allocated is what turns "620 bytes
+/// of overhead per node" into a specific structure to go and look at.
+const BUCKETS: usize = 20;
+static SIZE_HIST: [AtomicUsize; BUCKETS] = [const { AtomicUsize::new(0) }; BUCKETS];
+
+fn bucket_of(size: usize) -> usize {
+    if size == 0 {
+        return 0;
+    }
+    let b = usize::BITS - size.leading_zeros();
+    ((b as usize).saturating_sub(1)).min(BUCKETS - 1)
+}
+
 struct Counting;
 
 unsafe impl GlobalAlloc for Counting {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         ALLOCATED.fetch_add(layout.size(), Ordering::Relaxed);
         ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+        SIZE_HIST[bucket_of(layout.size())].fetch_add(1, Ordering::Relaxed);
         unsafe { System.alloc(layout) }
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
@@ -66,6 +81,14 @@ fn live_heap() -> usize {
 /// per-object overhead is what a "collapse these Vecs" change removes.
 fn alloc_calls() -> usize {
     ALLOC_CALLS.load(Ordering::Relaxed)
+}
+
+fn hist_snapshot() -> [usize; BUCKETS] {
+    let mut out = [0usize; BUCKETS];
+    for (i, slot) in SIZE_HIST.iter().enumerate() {
+        out[i] = slot.load(Ordering::Relaxed);
+    }
+    out
 }
 
 /// Resident set size in bytes, or `None` off Linux.
@@ -144,6 +167,7 @@ fn main() {
 
     let base_heap = live_heap();
     let base_calls = alloc_calls();
+    let hist_base = hist_snapshot();
     let base_rss = rss();
     let t_start = std::time::Instant::now();
 
@@ -157,6 +181,7 @@ fn main() {
     }
     let after_bare_nodes = live_heap();
     let calls_bare_nodes = alloc_calls();
+    let hist_bare_nodes = hist_snapshot();
     let t_nodes = t_start.elapsed();
 
     // Phase 2: node properties.
@@ -234,6 +259,30 @@ fn main() {
         scale as f64 / t_nodes.as_secs_f64().max(1e-9),
         edges as f64 / edge_secs.max(1e-9),
     );
+    // Where the node-phase allocations went, by size class.
+    println!();
+    println!("node-phase allocations by size class:");
+    let mut shown = false;
+    for i in 0..BUCKETS {
+        let n = hist_bare_nodes[i].saturating_sub(hist_base[i]);
+        if n == 0 {
+            continue;
+        }
+        let lo = if i == 0 { 0 } else { 1usize << i };
+        let hi = (1usize << (i + 1)) - 1;
+        println!(
+            "  {:>6}..{:<6} B  {:>10} allocs  {:>6.2}/node",
+            lo,
+            hi,
+            n,
+            n as f64 / scale as f64
+        );
+        shown = true;
+    }
+    if !shown {
+        println!("  (none)");
+    }
+
     println!();
     println!("nodes: {scale}    edges: {edges}");
     println!("{:<28} {:>10.1}", "bytes/node (heap)", total_heap as f64 / scale as f64);

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -969,7 +969,18 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             );
         }
 
-        self.nodes[idx].push(node);
+        // `Vec` grows 0 -> capacity 4 on first push, and `Node` is 128 bytes, so
+        // the default path allocates 512 B per node for an MVCC version chain
+        // that holds one entry in the overwhelming majority of cases -- 384 B
+        // of it never used. Reserve exactly one; later versions grow normally
+        // from there, which is the rare path (#491).
+        {
+            let versions = &mut self.nodes[idx];
+            if versions.capacity() == 0 {
+                versions.reserve_exact(1);
+            }
+            versions.push(node);
+        }
         node_id
     }
 
@@ -1038,7 +1049,18 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             );
         }
 
-        self.nodes[idx].push(node);
+        // `Vec` grows 0 -> capacity 4 on first push, and `Node` is 128 bytes, so
+        // the default path allocates 512 B per node for an MVCC version chain
+        // that holds one entry in the overwhelming majority of cases -- 384 B
+        // of it never used. Reserve exactly one; later versions grow normally
+        // from there, which is the rare path (#491).
+        {
+            let versions = &mut self.nodes[idx];
+            if versions.capacity() == 0 {
+                versions.reserve_exact(1);
+            }
+            versions.push(node);
+        }
         node_id
     }
 
@@ -1122,7 +1144,18 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             self.incoming.resize(idx + 1, Vec::new());
         }
 
-        self.nodes[idx].push(node);
+        // `Vec` grows 0 -> capacity 4 on first push, and `Node` is 128 bytes, so
+        // the default path allocates 512 B per node for an MVCC version chain
+        // that holds one entry in the overwhelming majority of cases -- 384 B
+        // of it never used. Reserve exactly one; later versions grow normally
+        // from there, which is the rare path (#491).
+        {
+            let versions = &mut self.nodes[idx];
+            if versions.capacity() == 0 {
+                versions.reserve_exact(1);
+            }
+            versions.push(node);
+        }
         node_id
     }
 
@@ -2941,7 +2974,18 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         }
 
         // Insert the node
-        self.nodes[idx].push(node);
+        // `Vec` grows 0 -> capacity 4 on first push, and `Node` is 128 bytes, so
+        // the default path allocates 512 B per node for an MVCC version chain
+        // that holds one entry in the overwhelming majority of cases -- 384 B
+        // of it never used. Reserve exactly one; later versions grow normally
+        // from there, which is the rare path (#491).
+        {
+            let versions = &mut self.nodes[idx];
+            if versions.capacity() == 0 {
+                versions.reserve_exact(1);
+            }
+            versions.push(node);
+        }
 
         // Update next_node_id to be higher than any recovered node
         if node_id.as_u64() >= self.next_node_id {


### PR DESCRIPTION
Refs #477, #491.

## How it was found

Added an allocation-**size histogram** to the footprint harness. The node phase, per node:

```
     2..3      B    1.00/node
     4..7      B    3.00/node
    64..127    B    1.00/node
   512..1023   B    1.00/node     <- everything else is small
```

One allocation per node in the 512–1023 byte class, and nothing else per-node anywhere near it. That is the whole 748 B/node story in one line.

## The cause

`Node` is **128 bytes**. Rust's `Vec` grows 0 → **capacity 4** on its first push. So:

```rust
self.nodes[idx].push(node);   // allocates 4 × 128 = 512 bytes
```

Every node allocated 512 bytes for an MVCC version chain that holds **exactly one entry** for any node that is never updated. **384 bytes per node, never used.**

## The fix

Reserve exactly one slot on the first push. Later versions grow from there by normal doubling — the rare path, unaffected.

| | before | after |
|---|---:|---:|
| node struct memory (100k nodes) | 74.7 MB | **36.3 MB** |
| bytes/node | 1621 | **1237** |

By average degree, bytes/edge (RSS):

| degree | before | after |
|---:|---:|---:|
| 2 | 819 | **628** |
| 4 | 447 | **351** |
| 8 | 257 | **209** |
| 16 | 163 | **139** |

## Why this one is different

The previous two changes in this series (#493, #494) removed *transient* allocations — they cost time and never appeared in live heap. **This is the first that moves memory.**

At degree 16 the graph is now within 11 bytes of `PERF-10`'s **128 B/edge** H2 target. The H1 target of ≤256 B/edge is met at degree ≥8.

## Scope

Applied at all four sites that push a node version. MVCC semantics are unchanged — a second version simply grows the vector as before.

## Verification

Workspace suite: **2576 passed, 0 failed.**