### PR TITLE
Estimate equality selectivity from the value, not from 1/distinct_count

### DIFF
--- a/benches/cardinality_accuracy.rs
+++ b/benches/cardinality_accuracy.rs
@@ -135,34 +135,63 @@ fn main() {
         println!("  {:<8} {:>10} {:>12} {:>10}", "value", "actual", "estimate", "est/actual");
 
         let mut ratios: Vec<f64> = Vec::new();
+        let mut mcv_ratios: Vec<f64> = Vec::new();
         let mut sorted: Vec<(&String, &usize)> = truth.iter().collect();
         sorted.sort_by(|a, b| b.1.cmp(a.1));
+        println!("  {:<8} {:>10} {:>12} {:>10} {:>12} {:>10}", "", "", "uniform", "", "value-aware", "");
         for (value, actual) in &sorted {
             let ratio = if **actual > 0 { estimated_rows / **actual as f64 } else { f64::INFINITY };
             ratios.push(ratio);
-            println!("  {:<8} {:>10} {:>12.0} {:>9.2}x", value, actual, estimated_rows, ratio);
+
+            let mcv_sel = stats.estimate_equality_selectivity_for_value(
+                &label,
+                "prop",
+                &PropertyValue::String((*value).clone()),
+            );
+            let mcv_rows = label_count as f64 * mcv_sel;
+            let mcv_ratio = if **actual > 0 { mcv_rows / **actual as f64 } else { f64::INFINITY };
+            mcv_ratios.push(mcv_ratio);
+
+            println!(
+                "  {:<8} {:>10} {:>12.0} {:>9.2}x {:>12.0} {:>9.2}x",
+                value, actual, estimated_rows, ratio, mcv_rows, mcv_ratio
+            );
         }
 
         // The question PERF-08 actually asks.
-        let within_2x = ratios.iter().filter(|r| **r >= 0.5 && **r <= 2.0).count();
-        let worst = ratios.iter().cloned().fold(1.0f64, |a, b| {
-            let err = if b >= 1.0 { b } else { 1.0 / b };
-            a.max(err)
-        });
+        let score = |rs: &[f64]| -> (usize, f64) {
+            let w = rs.iter().filter(|r| **r >= 0.5 && **r <= 2.0).count();
+            let worst = rs.iter().cloned().fold(1.0f64, |a, b| {
+                let err = if b >= 1.0 { b } else { 1.0 / b };
+                a.max(err)
+            });
+            (w, worst)
+        };
+        let (within_2x, worst) = score(&ratios);
+        let (mcv_within_2x, mcv_worst) = score(&mcv_ratios);
         println!(
-            "  within 2x: {}/{} ({:.0}%)   worst error: {:.1}x",
+            "  uniform      within 2x: {}/{} ({:.0}%)   worst: {:.1}x",
             within_2x,
             ratios.len(),
             100.0 * within_2x as f64 / ratios.len() as f64,
             worst
         );
+        println!(
+            "  value-aware  within 2x: {}/{} ({:.0}%)   worst: {:.1}x",
+            mcv_within_2x,
+            mcv_ratios.len(),
+            100.0 * mcv_within_2x as f64 / mcv_ratios.len() as f64,
+            mcv_worst
+        );
 
         json_cases.push(format!(
-            "{{\"case\": \"{}\", \"values\": {}, \"within_2x\": {}, \"worst_error\": {:.2}}}",
+            "{{\"case\": \"{}\", \"values\": {}, \"within_2x_uniform\": {}, \"worst_error_uniform\": {:.2}, \"within_2x_value_aware\": {}, \"worst_error_value_aware\": {:.2}}}",
             case.name,
             ratios.len(),
             within_2x,
-            worst
+            worst,
+            mcv_within_2x,
+            mcv_worst
         ));
     }
 

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -202,8 +202,26 @@ pub struct PropertyStats {
     /// Estimated number of distinct values
     pub distinct_count: usize,
     /// Selectivity: probability of matching a random value (1/distinct_count)
+    ///
+    /// This is the uniform-distribution assumption. It is exactly right when
+    /// the data is uniform and wrong in both directions at once when it is
+    /// not -- measured at 30% of values within 2x under heavy skew, with the
+    /// most common value underestimated 5x while the rarest was overestimated
+    /// 20x (`benches/cardinality_accuracy.rs`, #478). `most_common` is what
+    /// corrects the head of the distribution, where that damage concentrates.
     pub selectivity: f64,
+    /// The most frequently observed values and their sampled frequency, as a
+    /// fraction of non-null observations. Bounded to `MAX_MCV` entries.
+    ///
+    /// Empty when a property was never sampled, which is why the value-aware
+    /// estimator falls back rather than assuming absence means rarity.
+    pub most_common: Vec<(PropertyValue, f64)>,
 }
+
+/// How many values to retain per (label, property). Small on purpose: the
+/// point is to capture the head of a skewed distribution, and the tail is what
+/// histograms are for.
+pub const MAX_MCV: usize = 16;
 
 impl GraphStatistics {
     /// Estimate the number of rows from a label scan
@@ -219,12 +237,58 @@ impl GraphStatistics {
         }
     }
 
-    /// Estimate selectivity of an equality filter on a property
+    /// Estimate selectivity of an equality filter on a property.
+    ///
+    /// Value-agnostic, and therefore uniform-assuming. Prefer
+    /// [`Self::estimate_equality_selectivity_for_value`] wherever the compared
+    /// value is known -- which, at the one planner call site, it is.
     pub fn estimate_equality_selectivity(&self, label: &Label, property: &str) -> f64 {
         self.property_stats
             .get(&(label.clone(), property.to_string()))
             .map(|ps| ps.selectivity)
             .unwrap_or(0.1) // Default 10% selectivity
+    }
+
+    /// Estimate selectivity of `property = value`, using the most-common-value
+    /// list when the value is in it.
+    ///
+    /// The uniform estimate is `1/distinct_count` for every value alike. Under
+    /// skew that is wrong in both directions simultaneously -- too low for the
+    /// values that dominate the scan and too high for the ones that barely
+    /// occur -- which inverts the plan ordering rather than merely blurring it.
+    /// An MCV hit answers with the frequency actually observed.
+    ///
+    /// A miss deliberately does **not** assume the value is rare. It could be
+    /// absent from the list because it is genuinely uncommon, or because the
+    /// sample missed it; guessing "rare" on the second case reintroduces the
+    /// under-estimate this exists to remove. Instead the residual mass not
+    /// covered by the MCVs is spread over the remaining distinct values, which
+    /// is the standard treatment and degrades to the old answer when there are
+    /// no MCVs at all.
+    pub fn estimate_equality_selectivity_for_value(
+        &self,
+        label: &Label,
+        property: &str,
+        value: &PropertyValue,
+    ) -> f64 {
+        let Some(ps) = self.property_stats.get(&(label.clone(), property.to_string())) else {
+            return 0.1;
+        };
+        if let Some((_, freq)) = ps.most_common.iter().find(|(v, _)| v == value) {
+            return *freq;
+        }
+        if ps.most_common.is_empty() {
+            return ps.selectivity;
+        }
+        let mcv_mass: f64 = ps.most_common.iter().map(|(_, f)| *f).sum();
+        let remaining_mass = (1.0 - mcv_mass).max(0.0);
+        let remaining_distinct = ps.distinct_count.saturating_sub(ps.most_common.len());
+        if remaining_distinct == 0 {
+            // Every distinct value is in the list and this is not one of them.
+            // Still not zero: the sample may simply not have seen it.
+            return ps.selectivity.min(remaining_mass.max(f64::EPSILON));
+        }
+        remaining_mass / remaining_distinct as f64
     }
 
     /// Format statistics as human-readable text
@@ -2440,6 +2504,11 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             let sample_size = node_ids.len().min(1000);
             let mut property_presence: HashMap<String, usize> = HashMap::new();
             let mut property_distinct: HashMap<String, HashSet<u64>> = HashMap::new();
+            // Observed counts per value, keyed by hash with one representative
+            // value retained, so the most common values can be reported without
+            // holding every distinct value seen.
+            let mut property_values: HashMap<String, HashMap<u64, (PropertyValue, usize)>> =
+                HashMap::new();
 
             for (i, &node_id) in node_ids.iter().enumerate() {
                 if i >= sample_size { break; }
@@ -2461,6 +2530,15 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
                             hasher.finish()
                         };
                         property_distinct.entry(key.clone()).or_default().insert(hash);
+
+                        let counts = property_values.entry(key.clone()).or_default();
+                        // Bound the working set: once enough distinct values
+                        // have been seen to pick a head from, stop adding new
+                        // ones and only keep counting the ones already tracked.
+                        if counts.len() < MAX_MCV * 8 || counts.contains_key(&hash) {
+                            let slot = counts.entry(hash).or_insert_with(|| (val.clone(), 0));
+                            slot.1 += 1;
+                        }
                     }
                 }
             }
@@ -2468,10 +2546,28 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             for (prop, count) in &property_presence {
                 let distinct = property_distinct.get(prop).map(|s| s.len()).unwrap_or(0);
                 let selectivity = if distinct > 0 { 1.0 / distinct as f64 } else { 1.0 };
+
+                // Most common values, as a fraction of the non-null
+                // observations for this property.
+                let mut most_common: Vec<(PropertyValue, f64)> = Vec::new();
+                if let Some(counts) = property_values.get(prop) {
+                    let observed = *count as f64;
+                    if observed > 0.0 {
+                        let mut ranked: Vec<&(PropertyValue, usize)> = counts.values().collect();
+                        ranked.sort_by(|a, b| b.1.cmp(&a.1));
+                        most_common = ranked
+                            .into_iter()
+                            .take(MAX_MCV)
+                            .map(|(v, c)| (v.clone(), *c as f64 / observed))
+                            .collect();
+                    }
+                }
+
                 property_stats.insert((label.clone(), prop.clone()), PropertyStats {
                     null_fraction: 1.0 - (*count as f64 / sample_size as f64),
                     distinct_count: distinct,
                     selectivity,
+                    most_common,
                 });
             }
         }

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -3367,8 +3367,12 @@ fn choose_anchor_index(nodes: &[PathNodeRef], path_preds: &[Expression], store: 
                 Some(n) => n as f64,
                 None => {
                     let base = stats.estimate_label_scan(&label) as f64;
+                    // Value-aware: the uniform `1/distinct_count` answer is
+                    // wrong in both directions under skew, which inverts the
+                    // ordering between common and rare anchors rather than
+                    // just blurring it (#478).
                     let selectivity = if matches!(op, BinaryOp::Eq) {
-                        stats.estimate_equality_selectivity(&label, &property)
+                        stats.estimate_equality_selectivity_for_value(&label, &property, &val)
                     } else {
                         0.3
                     };


### PR DESCRIPTION
Refs #478.

## The problem, measured

`estimate_equality_selectivity(label, property)` returned the **same answer for every value** — `1/distinct_count`. That is the uniform-distribution assumption, and since the signature took no value it could not do otherwise even in principle.

On a heavy-skew distribution (one value on ~50% of nodes, long tail — the shape of any social or biomedical graph, and what LDBC's generator deliberately produces):

| | within 2× | worst error |
|---|---:|---:|
| uniform estimator | **30%** | **20.0×** |

Worse than the magnitude was the **direction**: the most common value underestimated 5×, the rarest overestimated 20×, *simultaneously*. That inverts the ordering between candidate anchors rather than blurring it — which is how a planner comes to scan the wrong end of a pattern (#303, and plausibly #296).

## The change

`PropertyStats` carries up to 16 most-common values with their sampled frequency, collected in the pass that **already** walked the same values to count distinct ones. `estimate_equality_selectivity_for_value` answers from that list on a hit.

On a miss it deliberately does **not** assume the value is rare — it may be absent because the sample missed it, and guessing "rare" there reintroduces exactly the under-estimate this exists to remove. The residual mass not covered by the MCVs is spread over the remaining distinct values, which degrades cleanly to the old answer when there are no MCVs at all.

## Results

| distribution | uniform | value-aware |
|---|---|---|
| uniform (10 equal) | 100% within 2× | 100%, worst 1.1× |
| mild skew | 100%, worst 1.8× | 100%, worst 1.3× |
| **heavy skew** | **30%, worst 20.0×** | **90–100%, worst 1.2–2.5×** |

Heavy-skew over 5 runs: 100%, 90%, 100%, 100%, 100%. **The variance is real** — it comes from sampling 1000 nodes per label — so this is a range, not a point. I have quoted it as such rather than picking the best run.

`PERF-08` asks for **70% within 2× at H1** and 90% at H2.

## Cost

- Statistics memory: **2 KB → 11 KB** on a 100k-node graph — 0.0% of total
- Insert rate: unchanged, so no `PERF-15` time-to-ready regression
- MCV collection bounds its working set to `MAX_MCV * 8` distinct values per property, so a high-cardinality property cannot blow up the statistics pass

## Scope

Single-property **equality** on the **unindexed** path. Where a property is indexed the planner already asks the index for an exact count and never reaches this estimator — that path is unchanged. Range predicates still use a flat 0.3 and want histograms, which is the next piece of #478.

## Verification

Workspace suite: **2576 passed, 0 failed.**