### PR TITLE
Correct the SF1 node and edge counts, with the derivation

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -56,8 +56,22 @@ Samyama Graph's own results on the [LDBC Social Network Benchmark (SNB) Interact
 
 | Scale | Nodes | Edges | Load |
 |---|---|---|---|
-| **SF1** | 3,181,724 | 17,256,038 | 78.5 s |
+| **SF1** | 3,727,429 | 21,140,212 | 78.5 s |
 | **SF10** | 29,987,835 | 176,623,433 | 575 s |
+
+> **SF1 counts, and how they were obtained.** Counted from the source CSVs in
+> `social_network-sf1-CsvBasic-LongDateFormatter/`, independent of the loader: the 8 entity
+> files sum to **3,727,429** rows, and the 25 relationship files sum to 21,161,452. The
+> loader reports **21,140,212** edges; the 21,240 difference is exactly
+> `person_email_emailaddress` (10,620) plus `person_speaks_language` (10,620), which are
+> attributes stored as node properties rather than as edges. Both figures account to the row.
+>
+> The previously documented 3,181,724 / 17,256,038 matched neither, and was 17% and 22% low
+> (#500). Anything divided by those counts was wrong by the same margin.
+>
+> The load time above is unchanged: it was measured on the host recorded at the foot of this
+> section, and substituting a figure from a different machine would trade a stale number for
+> an unprovenanced one.
 
 ## Short reads (IS1–IS7)
 


### PR DESCRIPTION
Closes #500.

## The correction

| | documented | actual |
|---|---:|---:|
| nodes | 3,181,724 | **3,727,429** |
| edges | 17,256,038 | **21,140,212** |

17% and 22% low.

## Counted, not assumed

I counted the source CSVs directly rather than trusting the loader:

- **8 entity files sum to 3,727,429** — matching the loader exactly.
- **25 relationship files sum to 21,161,452.** The loader reports 21,140,212, short by exactly **21,240** — which is `person_email_emailaddress` (10,620) plus `person_speaks_language` (10,620), attributes stored as node properties rather than as edges.

Both figures account **to the row**, so the loader is provably right and the table was wrong. The derivation is now recorded next to the table so nobody repeats the count.

## Why it matters beyond the table

Dividing 9,565 MB of resident memory by 21.1M edges gives **474 B/edge**. Against the old denominator it reads **581** — which would have made a real 12.9% improvement look like a regression. Any figure derived from these counts was wrong by the same margin.

## What is deliberately not changed

**The load time.** It was measured on the host recorded in that section, and substituting my laptop's 39.5 s would trade a stale number for an unprovenanced one — the same trap avoided in #471 with the HIER class speedups.

Same staleness class as #476: a published number whose underlying artifact moved and was never rechecked.