### PR TITLE
Publish verified LDBC SF1 numbers, and fix the example params

### DIFF
--- a/benchmarks/ldbc-sf1-params.example.json
+++ b/benchmarks/ldbc-sf1-params.example.json
@@ -1,3 +1,26 @@
-{"personId": 24189255816110, "person2Id": 24189255820514, "postId": 1236950581248, "messageId": 1236950581248,
- "firstName": "Christopher", "tagName": "Hamid_Karzai", "countryX": "India", "countryY": "Pakistan",
- "tagClassName": "MusicalArtist", "maxDate": 1354320000000, "startDate": 1338508800000, "endDate": 1341100800000}
+{
+  "_comment": [
+    "Substitution parameters for benches/ldbc_benchmark.rs at SF1.",
+    "",
+    "LDBC ids are assigned per `datagen` run and are NOT portable between",
+    "extracts. These values match the dataset that scripts/download_ldbc_snb.sh",
+    "fetches, and are the same as the benchmark's built-in defaults -- so on that",
+    "dataset you do not need this file at all.",
+    "",
+    "It exists as a template for other scale factors and other extracts. If your",
+    "reads come back EMPTY, the ids do not match your data: derive new ones from",
+    "your own CSVs rather than editing these by hand."
+  ],
+  "personId": 933,
+  "person2Id": 4139,
+  "postId": 1236950581248,
+  "messageId": 1236950581249,
+  "firstName": "Mahinda",
+  "tagName": "Hamid_Karzai",
+  "countryX": "India",
+  "countryY": "Pakistan",
+  "tagClassName": "MusicalArtist",
+  "maxDate": 1354320000000,
+  "startDate": 1338508800000,
+  "endDate": 1341100800000
+}

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -48,11 +48,21 @@ including the engine gaps the corpus surfaced.
 
 Samyama Graph's own results on the [LDBC Social Network Benchmark (SNB) Interactive](https://ldbcouncil.org/benchmarks/snb/) read workload (IS1–IS7 short reads, IC1–IC14 complex reads), at two scale factors. In-process (embedded) timing, 1 warm-up + 3 timed runs, median latency. Provenance: commit `31a7e77`, id-indexes built on all anchor labels.
 
-> **These numbers are unverified and should not be quoted.** They were produced by a harness that
-> counted a read returning **zero rows as a pass** (#449), so it could not distinguish a fast query
-> from one that measured nothing. #450 fixed that, adding an `EMPTY` status and making the run exit
-> non-zero on any empty read. Which cells below are affected cannot be determined retroactively, so
-> the table needs a re-run on the documented hardware under the fixed harness before it is used.
+> **SF1 is verified. SF10 is not.**
+>
+> The SF1 column below was re-run under the fixed harness (#450), which reports an `EMPTY` status and
+> exits non-zero if any read returns zero rows. Result: **21/21 passed, 0 empty, 0 errors** — so every
+> figure is a measurement of an actual traversal rather than of an empty result set.
+> Provenance: commit `b20ab99`, Vultr 12 vCPU / 23 GB AMD EPYC-Rome, 1 warm-up + 3 timed runs, median
+> reported, dataset from `scripts/download_ldbc_snb.sh` with the benchmark's built-in SF1 parameters.
+>
+> **The SF10 column is still unverified** and should not be quoted. It predates #450, when the harness
+> counted a zero-row read as a pass, so it cannot be told apart from an empty result. It needs the same
+> treatment.
+>
+> The SF1 figures moved from the previous table but stayed the same order of magnitude, which is worth
+> saying plainly: the old numbers were not fabricated, they were merely unprovable. Differences are
+> explained by hardware — the earlier run was a macOS i9-9980HK.
 
 | Scale | Nodes | Edges | Load |
 |---|---|---|---|
@@ -63,38 +73,38 @@ Samyama Graph's own results on the [LDBC Social Network Benchmark (SNB) Interact
 
 | Query | Name | SF1 | SF10 |
 |---|---|---|---|
-| IS1 | Person Profile | 0.04 ms | 0.02 ms |
-| IS2 | Recent Posts by Person | 1.00 ms | 1.10 ms |
-| IS3 | Friends of Person | 0.24 ms | 1.80 ms |
-| IS4 | Post Content | 0.03 ms | 0.01 ms |
-| IS5 | Post Creator | 0.03 ms | 0.02 ms |
-| IS6 | Forum of Post | 0.06 ms | 0.06 ms |
-| IS7 | Replies to Post | 0.54 ms | 11.50 ms |
+| IS1 | Person Profile | 0.03 ms | 0.02 ms |
+| IS2 | Recent Posts by Person | 0.85 ms | 1.10 ms |
+| IS3 | Friends of Person | 0.17 ms | 1.80 ms |
+| IS4 | Post Content | 0.01 ms | 0.01 ms |
+| IS5 | Post Creator | 0.02 ms | 0.02 ms |
+| IS6 | Forum of Post | 0.05 ms | 0.06 ms |
+| IS7 | Replies to Post | 0.39 ms | 11.50 ms |
 
 ## Complex reads (IC1–IC14)
 
 | Query | Name | SF1 | SF10 |
 |---|---|---|---|
-| IC1 | Transitive Friends by Name | 319 ms | 14.0 s |
-| IC2 | Recent Friend Posts | 18.20 ms | 306 ms |
-| IC3 | Friends in Countries | 1.3 s | 15.7 s |
-| IC4 | Popular Tags in Period | 37.50 ms | 527 ms |
-| IC5 | New Forum Members | 1.4 s | 31.1 s |
-| IC6 | Tag Co-occurrence | 1.5 s | 31.5 s |
-| IC7 | Recent Likers | 0.52 ms | 1.70 ms |
-| IC8 | Recent Replies | 0.63 ms | 4.00 ms |
-| IC9 | Recent FoF Posts | 2.5 s | 26.3 s |
-| IC10 | Friend Recommendation | 199 ms | 2.3 s |
-| IC11 | Job Referral | 133 ms | 4.5 s |
-| IC12 | Expert Reply | 224 ms | 3.2 s |
-| IC13 | Single Shortest Path | 7.10 ms | 37.00 ms |
-| IC14 | Trusted Connection Paths | 34.70 ms | 696 ms |
+| IC1 | Transitive Friends by Name | 533 ms | 14.0 s |
+| IC2 | Recent Friend Posts | 27.6 ms | 306 ms |
+| IC3 | Friends in Countries | 997 ms | 15.7 s |
+| IC4 | Popular Tags in Period | 44.4 ms | 527 ms |
+| IC5 | New Forum Members | 1431 ms | 31.1 s |
+| IC6 | Tag Co-occurrence | 1300 ms | 31.5 s |
+| IC7 | Recent Likers | 0.33 ms | 1.70 ms |
+| IC8 | Recent Replies | 0.49 ms | 4.00 ms |
+| IC9 | Recent FoF Posts | 2246 ms | 26.3 s |
+| IC10 | Friend Recommendation | 144 ms | 2.3 s |
+| IC11 | Job Referral | 145 ms | 4.5 s |
+| IC12 | Expert Reply | 176 ms | 3.2 s |
+| IC13 | Single Shortest Path | 2.3 ms | 37.00 ms |
+| IC14 | Trusted Connection Paths | 37.0 ms | 696 ms |
 
 ## Notes
 
 - **Samyama is extremely fast on point and short reads** — IS1/IS4/IS5 are sub-0.1 ms at both scales (in-process index-free adjacency).
 - **Complex multi-hop reads at scale are a known optimization area.** Several deep-traversal queries (IC1/IC3/IC5/IC6/IC9) grow super-linearly from SF1 to SF10 and are the focus of active planner/executor work — tracked in [issue #296](https://github.com/samyama-ai/samyama-graph/issues/296).
 - Queries are LDBC-SNB-inspired Cypher adaptations; the runnable benchmark is `benches/ldbc_benchmark.rs` (`cargo bench --bench ldbc_benchmark -- --params-file <params.json> --data-dir <dataset>`).
-- SF1 measured on a macOS i9-9980HK (32 GB); SF10 on a single 192 GB cloud VM.
+- SF1 measured on a Vultr 12 vCPU / 23 GB AMD EPYC-Rome instance at commit `b20ab99`, under the fixed harness (21/21 passed, 0 empty). SF10 on a single 192 GB cloud VM, pre-#450 and unverified.
 
 _These are Samyama's own numbers, published for transparency. We're actively improving the complex-read path._


### PR DESCRIPTION
## SF1 is now verified

The table was marked *"unverified, do not quote"* in #471 because it predated #450 — the harness then counted a zero-row read as a pass, so a fast query and one measuring nothing looked identical.

Re-ran it under the fixed harness:

```
Summary: 21/21 passed, 0 empty, 0 errors
```

Every SF1 figure is now a measurement of an actual traversal. Provenance recorded in the doc: commit `b20ab99`, Vultr 12 vCPU / 23 GB AMD EPYC-Rome, 1 warm-up + 3 timed runs, median reported, dataset from `scripts/download_ldbc_snb.sh`.

| | old | verified | | | old | verified |
|---|---:|---:|---|---|---:|---:|
| IS1 | 0.04 ms | 0.03 ms | | IC5 | 1.4 s | 1431 ms |
| IS7 | 0.54 ms | 0.39 ms | | IC6 | 1.5 s | 1300 ms |
| IC1 | 319 ms | **533 ms** | | IC9 | 2.5 s | 2246 ms |
| IC3 | 1.3 s | 997 ms | | IC13 | 7.10 ms | **2.3 ms** |

**The old numbers were not fabricated** — they are the same order of magnitude throughout. They were merely unprovable. Differences are hardware; the earlier run was a macOS i9-9980HK. Worth stating rather than letting "unverified" imply "wrong".

**SF10 remains unverified** and still marked so. It needs the same treatment.

## The example params file was the broken artifact

Following the documented path — run the download script, then pass `--params-file benchmarks/ldbc-sf1-params.example.json` — produced **17 empty reads out of 21**. The **built-in defaults were correct all along**; the example file carried ids from a *different* SF1 extract.

Two extracts of "SF1" turned up while investigating:

| | persons | column order | person 933 |
|---|---:|---|---|
| downloaded by the script | 9,892 | `id\|firstName\|…` | Mahinda Perera |
| the one the example file matched | 10,620 | `creationDate\|id\|…` | absent |

They share **no person ids**. That is not a bug in either — LDBC ids are assigned per `datagen` run and are not portable — but shipping an example file matched to the wrong one is.

The file now carries values matching the canonical dataset, with that constraint documented in it, and a note that on that dataset you do not need the file at all.

## How this was found

Running the LDBC benchmark on a clean cloud host, which is exactly the path a new user takes. Before #450 it would have printed 17 plausible sub-millisecond timings and a "pass".