### PR TITLE
Measure the bulk-load path in the footprint harness

### DIFF
--- a/benches/memory_footprint.rs
+++ b/benches/memory_footprint.rs
@@ -161,8 +161,23 @@ fn main() {
     };
     let scale: usize = arg("--scale").and_then(|s| s.parse().ok()).unwrap_or(100_000);
     let avg_degree: usize = arg("--degree").and_then(|s| s.parse().ok()).unwrap_or(4);
+    // Bulk mode uses the stub inserts plus compact_adjacency() -- the path that
+    // only snapshot import takes today (#504). The stubs skip endpoint
+    // validation, the Edge struct, edge_type_index and the catalog, so this
+    // measures the ceiling of that route rather than a drop-in replacement.
+    let bulk = args.iter().any(|a| a == "--bulk");
+    // Compacting only at the end lowers steady-state memory but not the peak,
+    // because the whole write buffer is built before it is folded into CSR.
+    // `compact_adjacency_if_needed` exists for incremental compaction; this
+    // measures whether using it actually moves the peak.
+    let compact_every: usize = arg("--compact-every")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
 
-    println!("Memory footprint — {scale} nodes, target degree {avg_degree}");
+    println!(
+        "Memory footprint — {scale} nodes, target degree {avg_degree}{}",
+        if bulk { "  [BULK: stub inserts + compact_adjacency]" } else { "" }
+    );
     println!("{}", "-".repeat(78));
 
     let base_heap = live_heap();
@@ -176,7 +191,11 @@ fn main() {
     let labels = ["Person", "Post", "Forum", "Tag"];
     let mut node_ids = Vec::with_capacity(scale);
     for i in 0..scale {
-        let id = store.create_node(labels[i % labels.len()]);
+        let id = if bulk {
+            store.create_node_stub(labels[i % labels.len()])
+        } else {
+            store.create_node(labels[i % labels.len()])
+        };
         node_ids.push(id);
     }
     let after_bare_nodes = live_heap();
@@ -209,10 +228,22 @@ fn main() {
     for (i, &src) in node_ids.iter().enumerate() {
         for d in 0..avg_degree {
             let tgt = node_ids[(i * 7 + d * 31 + 1) % scale];
-            if store.create_edge(src, tgt, edge_types[(i + d) % edge_types.len()]).is_ok() {
+            let ok = if bulk {
+                store.create_edge_stub(src, tgt, edge_types[(i + d) % edge_types.len()]).is_ok()
+            } else {
+                store.create_edge(src, tgt, edge_types[(i + d) % edge_types.len()]).is_ok()
+            };
+            if ok {
                 edges += 1;
             }
         }
+        if bulk && compact_every > 0 && i % compact_every == 0 && i > 0 {
+            store.compact_adjacency_if_needed(1);
+        }
+    }
+    if bulk {
+        // The whole point of the unsorted append: sort once, into CSR.
+        store.compact_adjacency();
     }
     let after_edges = live_heap();
     let calls_edges = alloc_calls();


### PR DESCRIPTION
Refs #504, Phase 1.

## Why

#504 observed that `create_edge_stub` + `compact_adjacency()` already exists, carries a comment claiming *"Saves ~50% of edge phase time vs sorted insert"*, and is reached by **nothing except snapshot import**. Phase 1 of that issue is to check the claim before designing anything around it.

## Measured — 200k nodes, degree 8

| path | alloc/edge | edge rate | B/edge (RSS) | live heap |
|---|---:|---:|---:|---:|
| normal (`create_edge`) | 14.25 | 1.06M/s | 208.3 | 301 MB |
| **bulk** (stubs, compact at end) | **1.25** | **5.41M/s** | 207.5 | **249 MB** |
| bulk + compact every 20k | — | 2.75M/s | **190.0** | 263 MB |

**The documented ~2× is conservative — it is 5.1×**, and allocations per edge fall from 14.25 to **1.25**.

## Two things the comment does not mention

**Adjacency memory drops 37%** (143 MB → 91 MB), because CSR replaces a `Vec`-per-node in *both* directions. That is the structural item #477 identified as still outstanding, and it is already implemented.

**Peak RSS barely moves.** Compacting at the end means the whole write buffer is built before it is folded away, so the peak still contains it — 207.5 vs 208.3 B/edge is noise. Compacting **incrementally** does move the peak (208 → 190 B/edge) and costs roughly half the throughput gain.

## So it is a choice, not a free win

- compact at the end → maximum speed, lower steady-state memory, unchanged peak
- compact incrementally → lower peak, about half the speed gain

Worth knowing before routing the ordinary load paths through it, because "use the bulk path" reads like one decision and is actually two.

## Scope

This measures the **ceiling** of that route, not a drop-in replacement. The stubs skip endpoint validation, the `Edge` struct, `edge_type_index` and the catalog — which is why only snapshot import uses them today, and why #504 Phase 2 is about making the path safe to use generally rather than just fast.