### PR TITLE
Rebuild the catalog after snapshot import

### DIFF
--- a/src/graph/catalog.rs
+++ b/src/graph/catalog.rs
@@ -319,14 +319,16 @@ impl GraphCatalog {
             let outgoing = store.get_outgoing_edge_targets(node.id);
             for (_, _, target_id, edge_type) in &outgoing {
                 if let Some(target_node) = store.get_node(*target_id) {
-                    let src_labels: Vec<Label> = node.labels.iter().cloned().collect();
-                    let tgt_labels: Vec<Label> = target_node.labels.iter().cloned().collect();
+                    // Borrowed, not collected: `on_edge_created` is generic over
+                    // `IntoIterator<Item = &Label>` since #493, so a full rebuild
+                    // over 176M edges no longer allocates two Vecs and clones a
+                    // String per edge just to satisfy a `&[Label]` parameter.
                     catalog.on_edge_created(
                         node.id,
-                        &src_labels,
+                        &node.labels,
                         &edge_type,
                         *target_id,
-                        &tgt_labels,
+                        &target_node.labels,
                     );
                     // Undo the generation bump from on_edge_created (we'll set it at the end)
                     catalog.generation -= 1;

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -2359,6 +2359,22 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
     /// pathological plans on snapshot-imported graphs.
     ///
     /// Snapshot import calls this after `compact_adjacency()`.
+    /// Recompute the catalog from the current store contents.
+    ///
+    /// `create_edge_stub` skips `catalog.on_edge_created` for speed, so a
+    /// bulk-loaded graph has label counts (the node stub does maintain those)
+    /// and **no triple statistics at all**. `estimate_expand_out` then falls
+    /// back to "assume 1 edge per node" -- a 20x under-estimate on a graph
+    /// where each node has 20 outgoing edges, and worse as degree rises.
+    ///
+    /// That is the #303 failure mode in a different statistic: a plan chosen
+    /// from statistics that were never computed. Rebuild after any bulk load.
+    pub fn rebuild_catalog(&mut self) {
+        // The immutable borrow for the scan ends before the assignment.
+        let catalog = GraphCatalog::recompute_full(self);
+        self.catalog = catalog;
+    }
+
     pub fn rebuild_edge_type_index(&mut self) {
         self.edge_type_index.clear();
         let len = self.edge_type_ids.len();

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -667,6 +667,13 @@ fn import_tenant_inner(
         // MATCH plans against imported snapshots fall back to NodeScan(all)
         // and time out on multi-million-node stores.
         store.rebuild_edge_type_index();
+        // Triple statistics too: create_edge_stub skips catalog.on_edge_created,
+        // so without this the cost model sees zero triple stats and
+        // estimate_expand_out returns its "1 edge per node" default on every
+        // imported graph -- a 20x under-estimate at degree 20, and the same
+        // class of defect as #303 (a plan chosen from statistics that were
+        // never computed).
+        store.rebuild_catalog();
     }
 
     // Backfill HNSW vector indices from imported node properties.

--- a/tests/catalog_after_import.rs
+++ b/tests/catalog_after_import.rs
@@ -1,0 +1,111 @@
+//! The cost model's triple statistics must survive a snapshot import.
+//!
+//! This is the sibling of `anchored_scan_after_import.rs` (#303). That one
+//! covered *property* statistics, which were sampled from row storage and so
+//! came back empty from a columnar-only import. This covers the **catalog**,
+//! which is emptied by a different mechanism:
+//!
+//!   * `create_node_stub` does call `catalog.on_label_added`, so label counts
+//!     survive -- which is exactly what makes the gap hard to notice;
+//!   * `create_edge_stub` does **not** call `catalog.on_edge_created`, so
+//!     triple statistics are absent entirely.
+//!
+//! With no triple stats, `estimate_expand_out` returns its documented default
+//! of "assume 1 edge per node". On a graph where each node has 20 outgoing
+//! edges that is a 20x under-estimate, and it grows with degree -- on LDBC,
+//! where a Person knows tens of others, it is the difference between planning
+//! an expansion as cheap and planning it correctly.
+
+use samyama::graph::{EdgeType, GraphStore, Label};
+use samyama::query::QueryEngine;
+use samyama::snapshot::{export_tenant, import_tenant};
+
+const NODES: usize = 200;
+const OUT_DEGREE: usize = 20;
+
+/// A graph with a known, uniform out-degree, so the expected estimate is exact.
+fn built_store() -> GraphStore {
+    let engine = QueryEngine::new();
+    let mut store = GraphStore::new();
+    for i in 0..NODES {
+        engine
+            .execute_mut(&format!("CREATE (:Person {{id: {i}}})"), &mut store, "default")
+            .unwrap();
+    }
+    for i in 0..NODES {
+        for k in 1..=OUT_DEGREE {
+            engine
+                .execute_mut(
+                    &format!(
+                        "MATCH (a:Person {{id: {i}}}), (b:Person {{id: {}}}) CREATE (a)-[:KNOWS]->(b)",
+                        (i + k) % NODES
+                    ),
+                    &mut store,
+                    "default",
+                )
+                .unwrap();
+        }
+    }
+    store
+}
+
+fn round_trip(store: &GraphStore) -> GraphStore {
+    let mut buf: Vec<u8> = Vec::new();
+    export_tenant(store, &mut buf).expect("export");
+    let mut imported = GraphStore::new();
+    import_tenant(&mut imported, &buf[..]).expect("import");
+    imported
+}
+
+#[test]
+fn triple_statistics_survive_a_snapshot_import() {
+    let store = built_store();
+    let person = Label::new("Person");
+    let knows = EdgeType::new("KNOWS");
+
+    let before = store.catalog().estimate_expand_out(&person, &knows);
+    assert!(
+        (before - OUT_DEGREE as f64).abs() < 0.5,
+        "fixture is wrong: expected ~{OUT_DEGREE}, got {before}"
+    );
+
+    let imported = round_trip(&store);
+    assert_eq!(imported.node_count(), NODES, "nodes did not survive");
+    assert_eq!(imported.edge_count(), NODES * OUT_DEGREE, "edges did not survive");
+
+    let after = imported.catalog().estimate_expand_out(&person, &knows);
+    assert!(
+        (after - before).abs() < 0.5,
+        "expand estimate changed across a snapshot round-trip: {before} -> {after}. \
+         A value of 1.0 means the catalog was never rebuilt and the cost model is \
+         falling back to 'assume 1 edge per node'."
+    );
+}
+
+#[test]
+fn triple_statistics_are_not_merely_present_but_correct() {
+    // A rebuild that produced *some* stats but wrong ones would pass a
+    // non-empty check, so assert the value rather than the count.
+    let imported = round_trip(&built_store());
+    assert!(
+        !imported.catalog().all_triple_stats().is_empty(),
+        "no triple statistics after import"
+    );
+    let estimate = imported
+        .catalog()
+        .estimate_expand_out(&Label::new("Person"), &EdgeType::new("KNOWS"));
+    assert!(
+        estimate > 1.0,
+        "estimate is exactly the 'no statistics' default of 1.0"
+    );
+}
+
+#[test]
+fn label_counts_survive_too() {
+    // These always survived -- `create_node_stub` maintains them -- which is
+    // why the missing triple stats were easy to miss. Pinned so a future
+    // change to the node stub cannot quietly break them either.
+    let imported = round_trip(&built_store());
+    let n = imported.catalog().estimate_label_scan(&Label::new("Person"));
+    assert!((n - NODES as f64).abs() < 0.5, "label count after import: {n}");
+}


### PR DESCRIPTION
## The bug

Every snapshot-imported graph had **zero triple statistics**, so the cost model fell back to "assume 1 edge per node" on all of them.

```
before export: estimate_expand_out(Person, KNOWS) = 20.00   (correct)
after  import: estimate_expand_out(Person, KNOWS) =  1.00
after  import: triple_stats entries = 0
```

200 nodes and 4,000 edges import perfectly. Only the statistics are gone: `create_edge_stub` skips `catalog.on_edge_created` for speed, and nothing put them back.

**A 20× under-estimate at out-degree 20**, and worse as degree rises. On LDBC a Person knows tens of others — and snapshot import is how the large KGs are loaded, so this hits the graphs where planning matters most.

## Why it was hard to spot

This is **#303 in a different statistic** — a plan chosen from statistics that were never computed. But it hides better than #303 did, because `create_node_stub` *does* maintain label counts. So the catalog is **half**-populated: `estimate_label_scan` returns the right answer while `estimate_expand_out` silently returns 1.0.

Snapshot import already rebuilds the edge-type index and the vector index for exactly this reason. The edge-type one even documents the consequence of forgetting:

> without this, `OPTIONAL MATCH` plans against imported snapshots fall back to `NodeScan(all)` and time out on multi-million-node stores

The catalog is the one nobody added to that list.

## Cost

**~31% of import time**, measured at 500k and 2M edges, linear in edges:

| | import total | catalog rebuild |
|---|---:|---:|
| 50k nodes / 500k edges | 429 ms | 130 ms |
| 200k nodes / 2M edges | 1.72 s | 528 ms |

That is a real price against `PERF-15`, and it is cheaper than planning every imported graph blind. Making it lazy the way `statistics()` already is would remove the cost for callers that never plan a query — noted as a follow-up rather than done here, because correctness first is the precedent #303 set.

## Also

`recompute_full` stops collecting two `Vec<Label>` per edge. `on_edge_created` became generic over `IntoIterator<Item = &Label>` in #493, so the rebuild can borrow — on a 176M-edge graph that is ~352M allocations avoided during the rebuild itself.

## Verification

3 tests in `tests/catalog_after_import.rs`, deliberately the sibling of `anchored_scan_after_import.rs`. One asserts the estimate is **correct**, not merely present — a rebuild producing wrong stats would pass a non-empty check.

Workspace suite: **2579 passed, 0 failed.**