### PR TITLE
Package the post-bulk-load rebuilds into one call

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -2359,6 +2359,31 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
     /// pathological plans on snapshot-imported graphs.
     ///
     /// Snapshot import calls this after `compact_adjacency()`.
+    /// Finish a bulk load: compact adjacency and rebuild everything the stub
+    /// inserts deliberately skipped.
+    ///
+    /// `create_node_stub` and `create_edge_stub` are fast because they omit
+    /// index and statistics maintenance. That is a good trade only if the
+    /// omitted work is done once at the end, and the failure mode when it is
+    /// not is silent: the data is all present and correct, and only the
+    /// planner is wrong.
+    ///
+    /// That has now happened twice. The edge-type index was missing after
+    /// import until someone noticed `OPTIONAL MATCH` falling back to
+    /// `NodeScan(all)` and timing out; the catalog's triple statistics were
+    /// missing until `estimate_expand_out` was found returning its "1 edge per
+    /// node" default on every imported graph. Both were a rebuild call nobody
+    /// had added to a list that was not written down anywhere.
+    ///
+    /// So the list lives here, and callers take all of it or none. Each step
+    /// no-ops on an empty store, so this is safe to call unconditionally.
+    pub fn finish_bulk_load(&mut self) {
+        self.compact_adjacency();
+        self.rebuild_edge_type_index();
+        self.rebuild_catalog();
+        self.rebuild_vector_index();
+    }
+
     /// Recompute the catalog from the current store contents.
     ///
     /// `create_edge_stub` skips `catalog.on_edge_created` for speed, so a

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -658,31 +658,13 @@ fn import_tenant_inner(
         // Skip unrecognized lines
     }
 
-    // Compact adjacency lists to CSR for memory efficiency (DS-07)
-    if imported_edge_count > 0 {
-        store.compact_adjacency();
-        // Bulk-loaded edges go through create_edge_stub which intentionally
-        // skips edge_type_index updates for speed. Rebuild the index so the
-        // planner can see the imported edge types — without this, OPTIONAL
-        // MATCH plans against imported snapshots fall back to NodeScan(all)
-        // and time out on multi-million-node stores.
-        store.rebuild_edge_type_index();
-        // Triple statistics too: create_edge_stub skips catalog.on_edge_created,
-        // so without this the cost model sees zero triple stats and
-        // estimate_expand_out returns its "1 edge per node" default on every
-        // imported graph -- a 20x under-estimate at degree 20, and the same
-        // class of defect as #303 (a plan chosen from statistics that were
-        // never computed).
-        store.rebuild_catalog();
-    }
-
-    // Backfill HNSW vector indices from imported node properties.
-    // create_node_stub / create_node bypass the event loop that normally calls
-    // add_vector, so Vector properties are readable via Cypher but invisible to
-    // queryNodes. Rebuild here mirrors rebuild_edge_type_index above.
-    // No-op when no vector indices are registered (common case).
-    if imported_node_count > 0 {
-        store.rebuild_vector_index();
+    // Everything the stub inserts skipped: CSR compaction, the edge-type index,
+    // the catalog's triple statistics, and the HNSW vector index. Kept as one
+    // call because taking half of this list is exactly how the edge-type index
+    // and then the catalog each came to be missing after import -- both times
+    // leaving data that was entirely correct and a planner that was not.
+    if imported_node_count > 0 || imported_edge_count > 0 {
+        store.finish_bulk_load();
     }
 
     if merged_node_count > 0 {


### PR DESCRIPTION
Refs #504, Phase 2.

## The pattern worth fixing

`create_node_stub` and `create_edge_stub` are fast because they skip index and statistics maintenance. That is a good trade **only if the skipped work is done once at the end** — and the failure mode when it is not is silent: the data is entirely correct, and only the planner is wrong.

That has now happened **twice, for the same reason**:

| missed rebuild | how it surfaced |
|---|---|
| `edge_type_index` | `OPTIONAL MATCH` against imported snapshots fell back to `NodeScan(all)` and timed out on multi-million-node stores |
| catalog triple stats | `estimate_expand_out` returned its "1 edge per node" default on **every** imported graph — a 20× under-estimate at degree 20 (#507) |

Neither was a hard bug. Both were a rebuild call absent from a list that existed only as a habit, in a comment, next to the other calls.

## The change

```rust
pub fn finish_bulk_load(&mut self) {
    self.compact_adjacency();
    self.rebuild_edge_type_index();
    self.rebuild_catalog();
    self.rebuild_vector_index();
}
```

The list now lives in one place, with the two incidents recorded in the doc comment so the next person adding a step knows why it is a single call. Each step already no-ops on an empty store, so it is safe unconditionally and **there is no half of it to take**.

Snapshot import now calls it instead of open-coding three of the four.

## Why this matters beyond tidiness

#503 (parallel ingestion) and #504 Phase 3 (routing CSV import and the KG loaders through the bulk path) both add *new* callers of the stub inserts. Each one is another chance to forget an entry. With this, a new bulk loader gets the whole list by construction.

## Verification

Workspace suite: **2579 passed, 0 failed**, including the snapshot round-trip tests and the catalog regression tests from #507.