### PR TITLE
Measure the whole bulk sequence, not just compaction

### DIFF
--- a/benches/memory_footprint.rs
+++ b/benches/memory_footprint.rs
@@ -242,8 +242,13 @@ fn main() {
         }
     }
     if bulk {
-        // The whole point of the unsorted append: sort once, into CSR.
-        store.compact_adjacency();
+        // The full finishing sequence, not just compaction. Measuring only
+        // `compact_adjacency()` here overstated the bulk path badly: it made
+        // edge inserts look 5.1x faster while omitting the edge-type index,
+        // catalog and vector-index rebuilds that a bulk load must also do.
+        // On real LDBC SF1 those rebuilds cost 14.3 s and consumed the entire
+        // insert gain, leaving load time unchanged (#504).
+        store.finish_bulk_load();
     }
     let after_edges = live_heap();
     let calls_edges = alloc_calls();


### PR DESCRIPTION
Refs #504. **This corrects a result I reported on that issue.**

## What I got wrong

The harness's `--bulk` mode called `compact_adjacency()` and stopped. That made the bulk path look **5.1× faster** on edge inserts — and the number was meaningless, because it omitted the edge-type index, catalog and vector-index rebuilds that a stub-loaded graph *must* also do before it can be queried.

## Measured properly

Calling `finish_bulk_load()` instead, at 200k nodes / degree 8:

| | edge rate | live heap | bytes/edge (RSS) |
|---|---:|---:|---:|
| normal (`create_edge`) | **1.112M/s** | **301 MB** | **208.2** |
| bulk (full finish) | 1.100M/s | 303 MB | 216.9 |

**Neutral on throughput, slightly worse on both memory figures.** The insert saving is real and it is entirely consumed by the finish.

## Confirmed on real data

I routed the 15.2M property-free LDBC relationship rows (72% of 21.1M edges) through `create_edge_stub` + `finish_bulk_load` and measured SF1 load:

```
before (create_edge):  33.9 s, 33.5 s
after  (bulk path):    33.9 s, 33.9 s     of which finish_bulk_load = 14.3 s
```

No difference. Queries stayed correct (21/21, 0 empty) and roughly the same speed. Peak RSS rose 3.4%.

**That loader change is not being kept** — it adds a per-file eligibility rule and a property-dropping hazard for zero measured benefit.

## What this means for #504

The issue's premise — *"a documented ~2× sitting unused"* — does not survive measuring the whole operation rather than its cheapest part. `create_edge_stub` is genuinely 5× faster at inserting; it just moves the work to a rebuild that costs the same.

Two things from the episode are worth keeping:

1. **`finish_bulk_load()`** (#508) still earns its place — not for speed, but because taking half the list is how the edge-type index and then the catalog each came to be missing after import.
2. **A stale baseline nearly hid this.** My first "18% faster" reading compared against a 41.4 s number measured before #493/#494/#495/#496 landed. At the same HEAD the honest before is 33.5 s. Worth re-taking a baseline whenever the thing under test has moved.