### PR TITLE
Say what this page covers and what it does not

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,5 +1,33 @@
 # Samyama Graph — Benchmarks
 
+## What is on this page, and what is not
+
+**On this page: Samyama's own numbers**, each with the commit and host it was
+measured on. Every figure here has a reproducer in this repository that you can
+run yourself:
+
+| Suite | Run it with |
+|---|---|
+| LDBC SNB Interactive | `cargo bench --bench ldbc_benchmark` (data: `scripts/download_ldbc_snb.sh`) |
+| LDBC SNB BI | `cargo bench --bench ldbc_bi_benchmark` |
+| FinBench | `cargo bench --bench finbench_benchmark` |
+| Graphalytics | `cargo bench --bench graphalytics_benchmark` |
+| HIER (hierarchy) | `cargo run --release --example hier_benchmark` (corpus: `benchmarks/hier/`) |
+| Memory footprint | `cargo bench --bench memory_footprint` |
+| Cardinality accuracy | `cargo bench --bench cardinality_accuracy` |
+| Ingestion profile | `cargo bench --bench ingest_profile` |
+
+**Not on this page: cross-engine comparisons.** Results against Neo4j,
+FalkorDB and TigerGraph are maintained internally alongside the competitor
+configurations and licence terms those runs depend on, and are published
+selectively rather than continuously. The Neo4j figures quoted in the HIER
+section below come from that work.
+
+The split follows from where a reader can act: a number you can reproduce
+belongs next to the code that produces it; a number that required another
+vendor's licensed software to obtain does not.
+
+
 Two suites are documented here: the LDBC SNB Interactive results below, and **HIER**, the
 hierarchy category introduced with ADR-035.
 


### PR DESCRIPTION
Part of a cross-repo benchmark consolidation (samyama-graph-competitor-benchmarks#18).

Benchmark artifacts were spread across four repos with no statement of which held what — and three published numbers drifted from their artifacts in a single week as a result (#500 SF1 counts 17%/22% low, #476 HIER CSV disagreeing with its own summary, #502 LDBC params matching a different extract).

This adds the public half of the rule to `docs/BENCHMARKS.md`:

- **on this page** — Samyama's own numbers, each with commit and host, each with a reproducer **now listed by command** so a reader can run any of them
- **not on this page** — cross-engine comparisons, which depend on competitor configurations and licensed software and are maintained alongside those

The split follows from where a reader can act: a number you can reproduce belongs next to the code that produces it; a number that needed another vendor's licensed software to obtain does not.

Companion changes: an `INDEX.md` in the benchmarks repo recording every suite's reproducer, results location and last-run date; and samyama-cloud's stale results archived with pointers rather than deleted, since the wiki cites them.