### PR TITLE
Attribute a query's wall-clock to the operators that spent it

### DIFF
--- a/benches/ldbc_benchmark.rs
+++ b/benches/ldbc_benchmark.rs
@@ -692,6 +692,12 @@ async fn main() -> Result<(), Error> {
         None
     };
 
+    // `--profile` runs each selected query once under PROFILE and prints the
+    // per-operator breakdown instead of a timing table. This is the
+    // `CH-PROFILE-01` deliverable: the gate is "at least 90% of wall-clock
+    // attributed" for IC1/IC6/IC9, and a total by itself attributes nothing.
+    let profile_mode = args.iter().any(|a| a == "--profile");
+
     let include_updates = args.iter().any(|a| a == "--updates");
     let include_deletes = args.iter().any(|a| a == "--deletes");
 
@@ -885,6 +891,35 @@ async fn main() -> Result<(), Error> {
 
         let cypher = params.apply(query.cypher);
 
+
+        if profile_mode {
+            match client.query("default", &format!("PROFILE {}", cypher)).await {
+                Ok(batch) => {
+                    println!("\n================ {} — {} ================", query.id, query.name);
+                    println!("{}", cypher);
+                    println!();
+                    // PROFILE returns a single row whose one column holds the
+                    // annotated plan. Printing the JSON value directly would
+                    // escape every newline and make the tree unreadable, so
+                    // unwrap the string.
+                    for record in &batch.records {
+                        for cell in record {
+                            match cell.as_str() {
+                                Some(text) => println!("{}", text),
+                                None => println!("{}", cell),
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    println!("\n================ {} — {} ================", query.id, query.name);
+                    println!("ERROR: {}", e);
+                    errors += 1;
+                }
+            }
+            continue;
+        }
+
         let result = run_benchmark(&client, query, &cypher, runs).await;
 
         if let Some(ref err) = result.error {
@@ -912,6 +947,16 @@ async fn main() -> Result<(), Error> {
     }
 
     let bench_time = bench_start.elapsed();
+
+    if profile_mode {
+        println!();
+        println!("Profiled {} query/queries in {}.", queries.len(), format_duration(bench_time));
+        if errors > 0 {
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
+
 
     // ========================================================================
     // Summary

--- a/src/query/executor/hierarchy_ops.rs
+++ b/src/query/executor/hierarchy_ops.rs
@@ -381,6 +381,10 @@ fn record_node_id(record: &Record, var: &str) -> Option<NodeId> {
 }
 
 impl PhysicalOperator for HierarchyOrderTestOperator {
+    fn children_mut(&mut self) -> Vec<&mut crate::query::executor::operator::OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         let entry = store.hierarchy_index.get(&self.index_name).ok_or_else(|| {
             ExecutionError::RuntimeError(format!(

--- a/src/query/executor/leapfrog.rs
+++ b/src/query/executor/leapfrog.rs
@@ -351,6 +351,10 @@ impl TrieJoinOperator {
 }
 
 impl PhysicalOperator for TrieJoinOperator {
+    fn children_mut(&mut self) -> Vec<&mut crate::query::executor::operator::OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         loop {
             // Emit buffered matches

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -85,6 +85,7 @@ pub mod leapfrog;
 pub mod logical_optimizer;
 pub mod logical_plan;
 pub mod operator;
+pub mod profile;
 pub mod physical_planner;
 pub mod plan_enumerator;
 pub mod planner;
@@ -280,19 +281,44 @@ impl<'a> QueryExecutor<'a> {
             ));
         }
 
-        // Handle PROFILE - execute query and return plan + timing info (like EXPLAIN)
+        // Handle PROFILE - execute the query and attribute the wall-clock to
+        // the operators that spent it (`CH-PROFILE-01`).
+        //
+        // The plan is built and run twice: once with every node wrapped, to
+        // get the breakdown, and once plain, to get a total that instrumenting
+        // did not inflate. Reporting only the instrumented total would
+        // overstate the query's real cost; reporting only the plain one would
+        // leave the breakdown unattributable.
+        //
+        // Instrumented first, plain second, deliberately: the second run reads
+        // a warm cache, so the reported instrumentation overhead is if
+        // anything too high. Flattering our own tooling in a measurement whose
+        // whole purpose is to decide what to optimise is the failure mode
+        // worth designing against.
         if query.profile {
             use crate::graph::PropertyValue;
 
             let plan_text = plan.root.describe().format(0);
-            let start = std::time::Instant::now();
-            let result = self.execute_plan(plan)?;
-            let elapsed = start.elapsed();
+
+            let mut instrumented = plan;
+            let nodes = profile::instrument(&mut instrumented.root);
+            let profiled_start = std::time::Instant::now();
+            let _ = self.execute_plan(instrumented)?;
+            let profiled_elapsed = profiled_start.elapsed();
+
+            let plain_plan = self.planner.plan(query, self.store)?;
+            let plain_start = std::time::Instant::now();
+            let result = self.execute_plan(plain_plan)?;
+            let plain_elapsed = plain_start.elapsed();
 
             let stats = self.store.statistics();
             let profile_text = format!(
-                "{}\n\n--- Profile ---\nRows: {}, Execution time: {:.3}ms\n\n--- Statistics ---\n{}",
-                plan_text, result.records.len(), elapsed.as_secs_f64() * 1000.0, stats.format()
+                "{}\n\n--- Profile ---\nRows: {}, Execution time: {:.3}ms\n\n{}\n--- Statistics ---\n{}",
+                plan_text,
+                result.records.len(),
+                plain_elapsed.as_secs_f64() * 1000.0,
+                profile::report(&nodes, profiled_elapsed, Some(plain_elapsed)),
+                stats.format()
             );
 
             let mut record = Record::new();

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2102,6 +2102,21 @@ pub trait PhysicalOperator: Send {
     /// Reset the operator to start from the beginning
     fn reset(&mut self);
 
+    /// The operators this one pulls from, in the order `describe()` lists
+    /// them.
+    ///
+    /// Defaults to none, which is right for every leaf (scans, DDL, static
+    /// inputs). Operators that hold an input must override it, or a tree walk
+    /// stops at them.
+    ///
+    /// This exists so a pass can rewrite the tree in place — `PROFILE` wraps
+    /// every node to attribute wall-clock (`CH-PROFILE-01`), and it is the
+    /// mutable counterpart of the children `describe()` already returns for
+    /// EXPLAIN.
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        Vec::new()
+    }
+
     /// Returns true if this operator mutates the graph store
     fn is_mutating(&self) -> bool {
         false
@@ -2981,6 +2996,10 @@ impl FilterOperator {
 }
 
 impl PhysicalOperator for FilterOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         while let Some(record) = self.input.next(store)? {
             if self.evaluate_predicate(&record, store)? {
@@ -3156,6 +3175,10 @@ impl ExpandOperator {
 }
 
 impl PhysicalOperator for ExpandOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         loop {
             // If we have edges from current record, return them
@@ -3482,6 +3505,10 @@ fn reconstruct_path(
 }
 
 impl PhysicalOperator for VarLengthExpandOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         loop {
             if let Some(rec) = self.pending.pop_front() {
@@ -3621,6 +3648,10 @@ impl ProjectOperator {
 }
 
 impl PhysicalOperator for ProjectOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         if let Some(record) = self.input.next(store)? {
             let mut new_record = Record::new();
@@ -4086,6 +4117,10 @@ impl AggregateOperator {
 }
 
 impl PhysicalOperator for AggregateOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         if !self.executed {
             self.execute_all(store)?;
@@ -4528,6 +4563,10 @@ impl AdjacencyCountAggregateOperator {
 }
 
 impl PhysicalOperator for AdjacencyCountAggregateOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         // Grouped path: accumulate per-(prop_values) counts on first call,
         // then emit one record per group. Correctness-preserving fast path
@@ -4626,6 +4665,10 @@ impl LimitOperator {
 }
 
 impl PhysicalOperator for LimitOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         if self.count >= self.limit {
             return Ok(None);
@@ -4772,6 +4815,10 @@ impl SortOperator {
 }
 
 impl PhysicalOperator for SortOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         if !self.executed {
             self.execute_all(store)?;
@@ -5102,6 +5149,10 @@ impl CartesianProductOperator {
 }
 
 impl PhysicalOperator for CartesianProductOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.left, &mut self.right]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         self.materialize_left(store)?;
         if self.left_records.is_empty() {
@@ -5257,6 +5308,10 @@ impl JoinOperator {
 }
 
 impl PhysicalOperator for JoinOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.left, &mut self.right]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         self.materialize(store)?;
 
@@ -5415,6 +5470,10 @@ impl LeftOuterJoinOperator {
 }
 
 impl PhysicalOperator for LeftOuterJoinOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.left, &mut self.right]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         self.materialize(store)?;
 
@@ -5996,6 +6055,10 @@ impl DistinctOperator {
 }
 
 impl PhysicalOperator for DistinctOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         while let Some(record) = self.input.next(store)? {
             if self.seen.insert(Self::key(&record)) {
@@ -6331,6 +6394,10 @@ impl CreateEdgeOperator {
 }
 
 impl PhysicalOperator for CreateEdgeOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        self.input.iter_mut().collect()
+    }
+
     fn next(&mut self, _store: &GraphStore) -> ExecutionResult<Option<Record>> {
         Err(ExecutionError::RuntimeError(
             "CreateEdgeOperator requires mutable store access. Use next_mut instead.".to_string()
@@ -6445,6 +6512,10 @@ impl CreateNodesAndEdgesOperator {
 }
 
 impl PhysicalOperator for CreateNodesAndEdgesOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.node_operator]
+    }
+
     fn next(&mut self, _store: &GraphStore) -> ExecutionResult<Option<Record>> {
         Err(ExecutionError::RuntimeError(
             "CreateNodesAndEdgesOperator requires mutable store access. Use next_mut instead.".to_string()
@@ -6576,6 +6647,10 @@ impl MatchCreateEdgeOperator {
 }
 
 impl PhysicalOperator for MatchCreateEdgeOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, _store: &GraphStore) -> ExecutionResult<Option<Record>> {
         Err(ExecutionError::RuntimeError(
             "MatchCreateEdgeOperator requires mutable store access. Use next_mut instead.".to_string()
@@ -6719,6 +6794,10 @@ impl MatchMergeEdgeOperator {
 }
 
 impl PhysicalOperator for MatchMergeEdgeOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, _store: &GraphStore) -> ExecutionResult<Option<Record>> {
         Err(ExecutionError::RuntimeError("MatchMergeEdgeOperator requires mutable store access".to_string()))
     }
@@ -7604,6 +7683,10 @@ impl SkipOperator {
 }
 
 impl PhysicalOperator for SkipOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         while self.skipped < self.skip {
             if self.input.next(store)?.is_some() {
@@ -7667,6 +7750,10 @@ impl DeleteOperator {
 }
 
 impl PhysicalOperator for DeleteOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         self.input.next(store)
     }
@@ -7733,6 +7820,10 @@ impl SetPropertyOperator {
 }
 
 impl PhysicalOperator for SetPropertyOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         self.input.next(store)
     }
@@ -7811,6 +7902,10 @@ impl RemovePropertyOperator {
 }
 
 impl PhysicalOperator for RemovePropertyOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         self.input.next(store)
     }
@@ -7876,6 +7971,10 @@ impl UnwindOperator {
 }
 
 impl PhysicalOperator for UnwindOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         loop {
             if self.buffer_idx < self.buffer.len() {
@@ -8277,6 +8376,10 @@ impl ForeachOperator {
 }
 
 impl PhysicalOperator for ForeachOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, _store: &GraphStore) -> ExecutionResult<Option<Record>> {
         Err(ExecutionError::RuntimeError(
             "ForeachOperator requires mutable store access. Use next_mut instead.".to_string()
@@ -8540,6 +8643,10 @@ impl ShortestPathOperator {
 }
 
 impl PhysicalOperator for ShortestPathOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         if !self.executed {
             self.execute_all(store)?;
@@ -8836,6 +8943,10 @@ impl WithBarrierOperator {
 }
 
 impl PhysicalOperator for WithBarrierOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         if !self.executed {
             self.execute_all(store)?;
@@ -8922,6 +9033,10 @@ impl ExpandIntoOperator {
 }
 
 impl PhysicalOperator for ExpandIntoOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         loop {
             let record = match self.input.next(store)? {

--- a/src/query/executor/profile.rs
+++ b/src/query/executor/profile.rs
@@ -1,0 +1,474 @@
+//! Per-operator wall-clock and row attribution for `PROFILE` (`CH-PROFILE-01`).
+//!
+//! # What this answers
+//!
+//! `PROFILE` used to report one number: how long the whole query took. That is
+//! the same information the client already had, so the first question anyone
+//! asks about a 6-second complex read — *where did the six seconds go?* — had
+//! no answer inside the engine, and the only way to get one was a sampling
+//! profiler on a debug build.
+//!
+//! The roadmap gate is explicit about the bar: **≥90% of wall-clock
+//! attributed** for `IC1/IC6/IC9/BI-6/CR-7`. The charter is equally explicit
+//! about why it comes first — deep multi-hop traversal is 1–4 orders of
+//! magnitude behind competitors, and "measurement before construction" is the
+//! rule that the fabricated-speedup episode exists to enforce. Optimising the
+//! wrong operator is the expensive failure here, and it is the one that a
+//! single total makes likely.
+//!
+//! # How it works
+//!
+//! The plan is a Volcano tree of `Box<dyn PhysicalOperator>`. Instrumentation
+//! wraps every node in a [`ProfiledOperator`] that times the call and counts
+//! the rows that come back. Because a parent's `next()` calls its children's
+//! `next()`, a node's measured time **includes its children**; the exclusive
+//! ("self") time is that total minus the totals of its children, which is what
+//! the report ranks by.
+//!
+//! Two consequences worth stating rather than discovering:
+//!
+//! * **The instrumented run is slower than the real one.** Two `Instant::now()`
+//!   calls per `next()` is ~40 ns against operators that can do useful work in
+//!   less than that. On a row-at-a-time plan producing millions of intermediate
+//!   rows the overhead is real, so the report prints the instrumented total
+//!   next to the uninstrumented one and never claims the two are the same
+//!   number. Proportions are what a profile is for; absolute latency comes from
+//!   the benchmark.
+//! * **Nothing is instrumented unless `PROFILE` was asked for.** The wrapper
+//!   is built at profile time and the ordinary execution path never allocates
+//!   it, so a normal query pays nothing at all — not a branch, not a counter.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::graph::GraphStore;
+use crate::query::executor::operator::{
+    OperatorBox, OperatorDescription, PhysicalOperator,
+};
+use crate::query::executor::{ExecutionResult, Record, RecordBatch};
+
+/// Counters written by one instrumented operator.
+///
+/// Atomics rather than a `Cell` because `PhysicalOperator` is `Send`; the
+/// operations are all `Relaxed` since nothing orders on them and the reader
+/// runs after execution has finished.
+#[derive(Debug, Default)]
+pub struct NodeCounters {
+    /// Nanoseconds spent inside this operator's `next`/`next_batch`,
+    /// **including** its children.
+    nanos: AtomicU64,
+    /// Rows this operator handed to its parent.
+    rows: AtomicU64,
+    /// Times this operator was pulled from. A high call count against a low
+    /// row count is an operator being asked and answering nothing.
+    calls: AtomicU64,
+}
+
+/// One node of the instrumented plan, in pre-order.
+pub struct ProfileNode {
+    pub name: String,
+    pub details: String,
+    pub depth: usize,
+    /// Index into the same `Vec`; `None` for the root.
+    pub parent: Option<usize>,
+    counters: Arc<NodeCounters>,
+}
+
+impl ProfileNode {
+    /// Time in this operator and everything below it.
+    pub fn inclusive(&self) -> Duration {
+        Duration::from_nanos(self.counters.nanos.load(Ordering::Relaxed))
+    }
+
+    /// Rows produced.
+    pub fn rows(&self) -> u64 {
+        self.counters.rows.load(Ordering::Relaxed)
+    }
+
+    /// Pull calls received.
+    pub fn calls(&self) -> u64 {
+        self.counters.calls.load(Ordering::Relaxed)
+    }
+}
+
+/// A wrapper that times the operator it holds and forwards everything else.
+///
+/// Deliberately forwards rather than reimplements: an operator that overrides
+/// `next_batch` for vectorised execution must keep using its own override, and
+/// `try_push_limit` must still reach the scan underneath or instrumenting a
+/// query would change the plan it measures.
+struct ProfiledOperator {
+    inner: OperatorBox,
+    counters: Arc<NodeCounters>,
+}
+
+impl ProfiledOperator {
+    fn record<T>(&self, started: Instant, produced: usize, out: T) -> T {
+        self.counters
+            .nanos
+            .fetch_add(started.elapsed().as_nanos() as u64, Ordering::Relaxed);
+        self.counters.calls.fetch_add(1, Ordering::Relaxed);
+        if produced > 0 {
+            self.counters.rows.fetch_add(produced as u64, Ordering::Relaxed);
+        }
+        out
+    }
+}
+
+impl PhysicalOperator for ProfiledOperator {
+    fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        let started = Instant::now();
+        let result = self.inner.next(store);
+        let produced = usize::from(matches!(result, Ok(Some(_))));
+        self.record(started, produced, result)
+    }
+
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        let started = Instant::now();
+        let result = self.inner.next_mut(store, tenant_id);
+        let produced = usize::from(matches!(result, Ok(Some(_))));
+        self.record(started, produced, result)
+    }
+
+    fn next_batch(&mut self, store: &GraphStore, batch_size: usize) -> ExecutionResult<Option<RecordBatch>> {
+        let started = Instant::now();
+        let result = self.inner.next_batch(store, batch_size);
+        let produced = match &result {
+            Ok(Some(batch)) => batch.records.len(),
+            _ => 0,
+        };
+        self.record(started, produced, result)
+    }
+
+    fn next_batch_mut(
+        &mut self,
+        store: &mut GraphStore,
+        tenant_id: &str,
+        batch_size: usize,
+    ) -> ExecutionResult<Option<RecordBatch>> {
+        let started = Instant::now();
+        let result = self.inner.next_batch_mut(store, tenant_id, batch_size);
+        let produced = match &result {
+            Ok(Some(batch)) => batch.records.len(),
+            _ => 0,
+        };
+        self.record(started, produced, result)
+    }
+
+    fn try_push_limit(&mut self, n: usize) -> bool {
+        self.inner.try_push_limit(n)
+    }
+
+    fn reset(&mut self) {
+        self.inner.reset()
+    }
+
+    fn is_mutating(&self) -> bool {
+        self.inner.is_mutating()
+    }
+
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        self.inner.children_mut()
+    }
+
+    fn describe(&self) -> OperatorDescription {
+        self.inner.describe()
+    }
+}
+
+/// A stand-in used only while a slot is being swapped. Never executed.
+struct Vacated;
+
+impl PhysicalOperator for Vacated {
+    fn next(&mut self, _store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        Ok(None)
+    }
+    fn reset(&mut self) {}
+}
+
+/// Wrap every node of `root` in a [`ProfiledOperator`], returning the nodes in
+/// pre-order so the report can be printed as a tree.
+///
+/// Names and details are taken **before** wrapping, so the report shows the
+/// plan the planner produced rather than a tree of wrappers.
+pub fn instrument(root: &mut OperatorBox) -> Vec<ProfileNode> {
+    let mut nodes = Vec::new();
+    wrap(root, None, 0, &mut nodes);
+    nodes
+}
+
+fn wrap(slot: &mut OperatorBox, parent: Option<usize>, depth: usize, nodes: &mut Vec<ProfileNode>) {
+    let description = slot.describe();
+    let index = nodes.len();
+    let counters = Arc::new(NodeCounters::default());
+    nodes.push(ProfileNode {
+        name: description.name,
+        details: description.details,
+        depth,
+        parent,
+        counters: Arc::clone(&counters),
+    });
+
+    for child in slot.children_mut() {
+        wrap(child, Some(index), depth + 1, nodes);
+    }
+
+    let inner = std::mem::replace(slot, Box::new(Vacated));
+    *slot = Box::new(ProfiledOperator { inner, counters });
+}
+
+/// Exclusive time per node: its own total minus its children's totals.
+///
+/// Clamped at zero. A child can out-measure its parent by a few nanoseconds
+/// because the two timers are taken at slightly different points; reporting a
+/// negative self-time would be worse than reporting nothing.
+fn self_times(nodes: &[ProfileNode]) -> Vec<Duration> {
+    let mut child_totals = vec![Duration::ZERO; nodes.len()];
+    for node in nodes {
+        if let Some(parent) = node.parent {
+            child_totals[parent] += node.inclusive();
+        }
+    }
+    nodes
+        .iter()
+        .zip(&child_totals)
+        .map(|(node, children)| node.inclusive().saturating_sub(*children))
+        .collect()
+}
+
+/// Render the profile: the plan tree annotated with time and rows, then the
+/// operators ranked by exclusive time.
+///
+/// `wall` is the measured duration of the instrumented execution. The
+/// attributed fraction is printed because the gate is stated as a fraction,
+/// and because a low one means this report is not yet answering the question.
+pub fn report(nodes: &[ProfileNode], wall: Duration, uninstrumented: Option<Duration>) -> String {
+    let mut out = String::new();
+    if nodes.is_empty() {
+        return "--- Profile ---\n(no operators instrumented)\n".to_string();
+    }
+
+    let selves = self_times(nodes);
+    let root_total = nodes[0].inclusive();
+    let attributed: Duration = selves.iter().copied().sum();
+    let pct = |d: Duration| {
+        if wall.is_zero() {
+            0.0
+        } else {
+            d.as_secs_f64() / wall.as_secs_f64() * 100.0
+        }
+    };
+
+    out.push_str("--- Profile (per operator) ---\n");
+    out.push_str(&format!(
+        "{:<38} {:>10} {:>10} {:>7} {:>12} {:>10}\n",
+        "operator", "self", "total", "self %", "rows", "calls"
+    ));
+    for (node, self_time) in nodes.iter().zip(&selves) {
+        let indent = "  ".repeat(node.depth);
+        let mut label = format!("{}{}", indent, node.name);
+        if !node.details.is_empty() {
+            // The details can be a whole predicate; a plan tree that wraps is
+            // unreadable, so it is truncated here and printed in full by
+            // EXPLAIN, which exists for exactly that.
+            let detail: String = node.details.chars().take(24).collect();
+            label.push_str(&format!(" ({})", detail));
+        }
+        label.truncate(38);
+        out.push_str(&format!(
+            "{:<38} {:>9.2}ms {:>9.2}ms {:>6.1}% {:>12} {:>10}\n",
+            label,
+            self_time.as_secs_f64() * 1000.0,
+            node.inclusive().as_secs_f64() * 1000.0,
+            pct(*self_time),
+            node.rows(),
+            node.calls(),
+        ));
+    }
+
+    // Ranked, because on a deep plan the tree order is not the cost order and
+    // the whole purpose is to say what to look at first.
+    let mut ranked: Vec<(usize, Duration)> = selves.iter().copied().enumerate().collect();
+    ranked.sort_by(|a, b| b.1.cmp(&a.1));
+    out.push_str("\nHottest operators by exclusive time:\n");
+    for (i, (index, self_time)) in ranked.iter().take(5).enumerate() {
+        if self_time.is_zero() {
+            break;
+        }
+        out.push_str(&format!(
+            "  {}. {:<28} {:>9.2}ms  {:>5.1}%  {} rows\n",
+            i + 1,
+            nodes[*index].name,
+            self_time.as_secs_f64() * 1000.0,
+            pct(*self_time),
+            nodes[*index].rows(),
+        ));
+    }
+
+    out.push_str(&format!(
+        "\nInstrumented execution: {:.2}ms; attributed to operators: {:.2}ms ({:.1}%)\n",
+        wall.as_secs_f64() * 1000.0,
+        attributed.as_secs_f64() * 1000.0,
+        pct(attributed),
+    ));
+    if root_total < wall {
+        out.push_str(&format!(
+            "Outside the operator tree: {:.2}ms (planning, result assembly, deadline checks)\n",
+            (wall - root_total).as_secs_f64() * 1000.0
+        ));
+    }
+    if let Some(plain) = uninstrumented {
+        out.push_str(&format!(
+            "Uninstrumented execution of the same plan: {:.2}ms — instrumentation costs {:.1}x.\n\
+             Use the proportions above; take absolute latency from the benchmark, not from here.\n",
+            plain.as_secs_f64() * 1000.0,
+            if plain.is_zero() { 0.0 } else { wall.as_secs_f64() / plain.as_secs_f64() },
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Yields a fixed list of records, then nothing. A leaf, so it has no
+    /// `children_mut` override and the walk must stop at it.
+    struct FixedRows {
+        records: Vec<Record>,
+        cursor: usize,
+    }
+
+    impl PhysicalOperator for FixedRows {
+        fn next(&mut self, _store: &GraphStore) -> ExecutionResult<Option<Record>> {
+            let out = self.records.get(self.cursor).cloned();
+            if out.is_some() {
+                self.cursor += 1;
+            }
+            Ok(out)
+        }
+        fn reset(&mut self) {
+            self.cursor = 0;
+        }
+        fn describe(&self) -> OperatorDescription {
+            OperatorDescription {
+                name: "FixedRows".to_string(),
+                details: format!("{} rows", self.records.len()),
+                children: Vec::new(),
+            }
+        }
+    }
+
+    /// A plan of `FixedRows -> Limit`, so there is a parent and a child to
+    /// attribute between.
+    fn two_level_plan(rows: usize) -> OperatorBox {
+        use crate::query::executor::operator::LimitOperator;
+        let mut records = Vec::new();
+        for i in 0..rows {
+            let mut r = Record::new();
+            r.bind(
+                "n".to_string(),
+                crate::query::executor::Value::Property(crate::graph::PropertyValue::Integer(i as i64)),
+            );
+            records.push(r);
+        }
+        Box::new(LimitOperator::new(
+            Box::new(FixedRows { records, cursor: 0 }),
+            rows,
+        ))
+    }
+
+    fn drain(op: &mut OperatorBox, store: &GraphStore) -> usize {
+        let mut n = 0;
+        while let Some(_r) = op.next(store).unwrap() {
+            n += 1;
+        }
+        n
+    }
+
+    #[test]
+    fn instrumentation_finds_every_node_of_the_tree() {
+        let mut plan = two_level_plan(3);
+        let nodes = instrument(&mut plan);
+        assert_eq!(nodes.len(), 2, "root and its input");
+        assert_eq!(nodes[0].depth, 0);
+        assert_eq!(nodes[0].parent, None);
+        assert_eq!(nodes[1].depth, 1);
+        assert_eq!(nodes[1].parent, Some(0));
+    }
+
+    #[test]
+    fn instrumentation_does_not_change_the_answer() {
+        // The failure that would make a profile worse than useless: measuring
+        // a plan that no longer produces what the real one does.
+        let store = GraphStore::new();
+        let mut plain = two_level_plan(5);
+        let expected = drain(&mut plain, &store);
+
+        let mut profiled = two_level_plan(5);
+        let _nodes = instrument(&mut profiled);
+        assert_eq!(drain(&mut profiled, &store), expected);
+    }
+
+    #[test]
+    fn rows_are_counted_per_operator() {
+        let store = GraphStore::new();
+        let mut plan = two_level_plan(4);
+        let nodes = instrument(&mut plan);
+        drain(&mut plan, &store);
+        assert_eq!(nodes[0].rows(), 4, "the limit passed 4 rows up");
+        assert_eq!(nodes[1].rows(), 4, "the input produced 4");
+        assert!(nodes[0].calls() >= 5, "one pull per row plus the terminating one");
+    }
+
+    #[test]
+    fn a_parents_total_includes_its_child() {
+        let store = GraphStore::new();
+        let mut plan = two_level_plan(200);
+        let nodes = instrument(&mut plan);
+        drain(&mut plan, &store);
+        assert!(
+            nodes[0].inclusive() >= nodes[1].inclusive(),
+            "parent {:?} should include child {:?}",
+            nodes[0].inclusive(),
+            nodes[1].inclusive()
+        );
+    }
+
+    #[test]
+    fn self_time_never_goes_negative() {
+        let store = GraphStore::new();
+        let mut plan = two_level_plan(50);
+        let nodes = instrument(&mut plan);
+        drain(&mut plan, &store);
+        // Duration cannot be negative, so the check that matters is that the
+        // saturating subtraction is what produced them: the sum of self times
+        // must not exceed the root's inclusive time.
+        let selves = self_times(&nodes);
+        let sum: Duration = selves.iter().copied().sum();
+        assert!(sum <= nodes[0].inclusive() + Duration::from_millis(1));
+    }
+
+    #[test]
+    fn the_report_names_the_hottest_operator_and_states_the_attributed_fraction() {
+        let store = GraphStore::new();
+        let mut plan = two_level_plan(500);
+        let nodes = instrument(&mut plan);
+        let started = Instant::now();
+        drain(&mut plan, &store);
+        let wall = started.elapsed();
+
+        let text = report(&nodes, wall, None);
+        assert!(text.contains("Hottest operators by exclusive time"), "{text}");
+        assert!(text.contains("attributed to operators"), "{text}");
+        assert!(text.contains("Limit"), "the tree must name real operators: {text}");
+        assert!(text.contains("FixedRows"), "children must appear too: {text}");
+    }
+
+    #[test]
+    fn an_empty_tree_reports_rather_than_panicking() {
+        let text = report(&[], Duration::from_millis(1), None);
+        assert!(text.contains("no operators instrumented"), "{text}");
+    }
+}

--- a/tests/profile_attribution.rs
+++ b/tests/profile_attribution.rs
@@ -1,0 +1,154 @@
+//! `PROFILE` attributes wall-clock to the operators that spent it
+//! (`CH-PROFILE-01`).
+//!
+//! The gate this serves is stated as a fraction — *at least 90% of wall-clock
+//! attributed* on the LDBC complex reads — so the properties worth testing are
+//! the ones that fraction depends on: every operator in the plan appears, the
+//! numbers nest correctly, and profiling does not change the answer.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+
+/// A graph with enough shape that a plan has several operators: a scan, an
+/// expand, a filter, an aggregate and a sort.
+fn fixture() -> GraphStore {
+    let mut store = GraphStore::new();
+    let people: Vec<_> = (0..200)
+        .map(|i| {
+            let id = store.create_node("Person");
+            let _ = store.set_node_property("default", id, "age".to_string(), PropertyValue::Integer(i % 60));
+            let _ = store.set_node_property(
+                "default",
+                id,
+                "name".to_string(),
+                PropertyValue::String(format!("p{i}")),
+            );
+            id
+        })
+        .collect();
+    for (i, &src) in people.iter().enumerate() {
+        for d in 1..=6 {
+            let _ = store.create_edge(src, people[(i + d * 7) % people.len()], "KNOWS");
+        }
+    }
+    store
+}
+
+fn profile_text(store: &GraphStore, cypher: &str) -> String {
+    let query = parse_query(cypher).expect("query should parse");
+    let executor = QueryExecutor::new(store);
+    let batch = executor.execute(&query).expect("PROFILE should execute");
+    assert_eq!(batch.records.len(), 1, "PROFILE returns one row of plan text");
+    match batch.records[0].get("plan") {
+        Some(samyama::query::executor::Value::Property(PropertyValue::String(text))) => text.clone(),
+        other => panic!("expected a plan string, got {other:?}"),
+    }
+}
+
+#[test]
+fn the_profile_names_every_operator_in_the_plan() {
+    let store = fixture();
+    let text = profile_text(
+        &store,
+        "PROFILE MATCH (p:Person)-[:KNOWS]->(f:Person) WHERE p.age > 20 \
+         RETURN f.name, count(p) AS c ORDER BY c DESC LIMIT 10",
+    );
+
+    assert!(text.contains("--- Profile (per operator) ---"), "{text}");
+    for operator in ["Scan", "Expand", "Filter"] {
+        assert!(
+            text.contains(operator),
+            "the plan tree should name {operator}:\n{text}"
+        );
+    }
+}
+
+#[test]
+fn the_report_states_how_much_of_the_wall_clock_it_attributed() {
+    // Without this line the report cannot be checked against the gate, which
+    // is written as a percentage rather than as a list of operators.
+    let store = fixture();
+    let text = profile_text(&store, "PROFILE MATCH (p:Person)-[:KNOWS]->(f:Person) RETURN f.name LIMIT 50");
+
+    assert!(text.contains("attributed to operators"), "{text}");
+    assert!(text.contains("Hottest operators by exclusive time"), "{text}");
+
+    let line = text
+        .lines()
+        .find(|l| l.contains("attributed to operators"))
+        .expect("attribution line");
+    let pct: f64 = line
+        .rsplit('(')
+        .next()
+        .and_then(|s| s.split('%').next())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| panic!("could not read a percentage from {line:?}"));
+    assert!(
+        (0.0..=101.0).contains(&pct),
+        "attributed fraction {pct} is not a percentage: {line}"
+    );
+}
+
+#[test]
+fn profiling_reports_the_same_rows_the_plain_query_returns() {
+    // A profile of a plan that answers differently from the real one is worse
+    // than no profile: it sends the reader to the wrong operator.
+    let store = fixture();
+    let cypher = "MATCH (p:Person)-[:KNOWS]->(f:Person) WHERE p.age > 30 RETURN f.name LIMIT 25";
+
+    let plain = {
+        let query = parse_query(cypher).unwrap();
+        QueryExecutor::new(&store).execute(&query).unwrap().records.len()
+    };
+
+    let text = profile_text(&store, &format!("PROFILE {cypher}"));
+    let rows_line = text
+        .lines()
+        .find(|l| l.starts_with("Rows: "))
+        .expect("the profile states its row count");
+    assert!(
+        rows_line.contains(&format!("Rows: {plain},")),
+        "profile reported {rows_line:?} but the plain query returned {plain} rows"
+    );
+}
+
+#[test]
+fn the_instrumentation_cost_is_reported_rather_than_hidden() {
+    // Two Instant::now() per next() is not free on a row-at-a-time plan. A
+    // profile that presents its own inflated total as the query's latency is
+    // how an optimisation gets chosen against a number that does not exist.
+    let store = fixture();
+    let text = profile_text(&store, "PROFILE MATCH (p:Person)-[:KNOWS]->(f:Person) RETURN f.name");
+
+    assert!(
+        text.contains("Uninstrumented execution of the same plan"),
+        "the plain total must be printed alongside the instrumented one:\n{text}"
+    );
+    assert!(
+        text.contains("take absolute latency from the benchmark"),
+        "and the reader must be told which number to quote:\n{text}"
+    );
+}
+
+#[test]
+fn explain_is_unchanged_by_the_profiling_work() {
+    // EXPLAIN must not start reporting times it did not measure.
+    let store = fixture();
+    let query = parse_query("EXPLAIN MATCH (p:Person)-[:KNOWS]->(f:Person) RETURN f.name").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    let text = match batch.records[0].get("plan") {
+        Some(samyama::query::executor::Value::Property(PropertyValue::String(t))) => t.clone(),
+        other => panic!("expected a plan string, got {other:?}"),
+    };
+    assert!(!text.contains("--- Profile (per operator) ---"), "{text}");
+    assert!(text.contains("Expand"), "{text}");
+}
+
+#[test]
+fn a_plan_with_one_operator_still_profiles() {
+    let store = fixture();
+    let text = profile_text(&store, "PROFILE MATCH (p:Person) RETURN p LIMIT 1");
+    assert!(text.contains("--- Profile (per operator) ---"), "{text}");
+    assert!(!text.contains("no operators instrumented"), "{text}");
+}


### PR DESCRIPTION
`CH-PROFILE-01`. Part of #296.

## The gap

`PROFILE` reported one number — total execution time — which is what the client already had. The first question anyone asks about a 3.5-second complex read, *where did the three and a half seconds go?*, had no answer inside the engine; the only way to get one was a sampling profiler on a debug build.

The H1 gate is stated as a fraction: **≥90% of wall-clock attributed** for IC1/IC6/IC9/BI-6/CR-7. A single total attributes nothing.

## What it produces

LDBC SF1, IC9 `Recent FoF Posts`, parameters derived at p50 (#505):

```
operator                                     self      total  self %         rows      calls
Distinct                                    0.06ms   3416.33ms    0.0%           20          2
  Limit (20)                                0.00ms   3416.27ms    0.0%           20         22
    Project (friend.id, friend.firstN)      0.08ms   3416.27ms    0.0%           20         20
      Sort (m.creationDate DESC)         2436.73ms   3416.19ms   68.6%           20         20
        Filter (friend.id <> Integer(3     54.40ms    979.46ms    1.5%       389461          5
          Filter (friend.id <> Integer     77.60ms    925.06ms    2.2%       389461          6
            Expand ((friend)<-[:HAS_CR    820.64ms    847.46ms   23.1%       409960         10
              VarLengthExpand ((p)-[:K     26.81ms     26.82ms    0.8%         3272       3276
                IndexScan (var=p, Pers      0.01ms      0.01ms    0.0%            1          5

Instrumented execution: 3552.50ms; attributed to operators: 3416.33ms (96.2%)
Outside the operator tree: 136.17ms (planning, result assembly, deadline checks)
Uninstrumented execution of the same plan: 3469.13ms — instrumentation costs 1.0x.
```

**96.2% attributed**, against a 90% gate.

Two findings fall straight out of that table, both filed separately rather than fixed here — this PR is the instrument, not the repair:

- `ORDER BY m.creationDate DESC LIMIT 20` **sorts 389,461 rows to return twenty**, and that sort is 68.6% of the query. #304 predicted an unbounded top-N would matter at scale; this is the number.
- The **same `Filter` predicate appears twice**, stacked, both producing 389,461 rows. The second removes nothing and costs ~130 ms.

That is the point of the exercise: #296's last comment narrowed the problem to *"does the engine materialise where competitors stream?"* on reasoning rather than evidence. Now there is evidence, and it says the materialisation is in `Sort`, not in the traversal — `VarLengthExpand` is 0.8%.

## How

Every node of the Volcano tree is wrapped in a timer that counts rows and pull calls. A parent's `next()` calls its children's, so a node's measured time **includes** its children; exclusive time is that total minus the children's totals, and the report ranks by it.

Three mechanics that are load-bearing:

**The plan is run twice** — instrumented for the breakdown, plain for a total that instrumenting did not inflate. Instrumented **first**, deliberately: the second run reads a warm cache, so the reported instrumentation overhead is if anything too high. Flattering our own tooling inside a measurement whose entire purpose is deciding what to optimise is the failure mode worth designing against.

**Nothing is instrumented unless `PROFILE` was asked for.** The ordinary execution path does not allocate the wrapper, branch on it, or touch a counter.

**The wrapper forwards rather than reimplements.** `try_push_limit` must still reach the scan underneath and `next_batch` must keep an operator's vectorised override, or instrumenting a query would change the plan it measures.

## API

`children_mut()` is new on `PhysicalOperator` — the mutable counterpart of the children `describe()` already returns for EXPLAIN, defaulted to none so every leaf is unchanged. Implemented for the 25 operators that hold an input.

`--profile` on the LDBC bench runs the selected queries under `PROFILE` and prints the breakdown instead of a timing table:

```
cargo bench --bench ldbc_benchmark -- --profile --derive-params 50 --query IC9
```

## Testing

13 new tests, all green.

`src/query/executor/profile.rs` (7): the walk finds every node; instrumentation does not change the answer; rows are counted per operator; a parent's total includes its child; self-time never goes negative; the report names the hottest operator and states the attributed fraction; an empty tree reports rather than panics.

`tests/profile_attribution.rs` (6): the profile names every operator in a real plan; the attributed percentage is present and is a percentage; the row count matches the plain query's; the instrumentation cost is printed rather than hidden; EXPLAIN is unchanged; a one-operator plan still profiles.