### PR TITLE
Apply DISTINCT before SKIP and LIMIT, and stop SKIP eating its own batch

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -7699,27 +7699,39 @@ impl PhysicalOperator for SkipOperator {
     }
 
     fn next_batch(&mut self, store: &GraphStore, batch_size: usize) -> ExecutionResult<Option<RecordBatch>> {
-        while self.skipped < self.skip {
-            if let Some(batch) = self.input.next_batch(store, batch_size)? {
-                for record in batch.records {
-                    self.skipped += 1;
-                    if self.skipped >= self.skip {
-                        // We may have extra records in this batch — collect remaining
-                        let mut remaining = vec![record];
-                        // Continue pulling from current batch not possible since we consumed it,
-                        // but we've finished skipping
-                        break;
-                    }
-                }
-                if self.skipped >= self.skip {
-                    // Start fresh from next batch
-                    break;
-                }
-            } else {
+        // Return the *remainder* of the batch the skip lands in.
+        //
+        // The previous version consumed a whole batch to count off `skip`
+        // records and then discarded it, rows past the boundary included,
+        // before asking the input for another batch it had already exhausted.
+        // `execute_plan` pulls 1024 rows at a time, so any result of 1024 rows
+        // or fewer arrives in one batch and `SKIP n` returned nothing at all
+        // (#523).
+        //
+        // `SKIP … LIMIT` hid it: `LimitOperator` requests exactly as many rows
+        // as remain under its limit, so with `SKIP 2 LIMIT 2` the skip
+        // consumed a 2-row batch and the next request returned the right two.
+        // The boundary aligning with the batch size is not a partial fix.
+        loop {
+            let Some(batch) = self.input.next_batch(store, batch_size)? else {
                 return Ok(None);
+            };
+
+            let available = batch.records.len();
+            if self.skipped + available <= self.skip {
+                // The whole batch falls inside the skip.
+                self.skipped += available;
+                continue;
             }
+
+            let drop = self.skip - self.skipped;
+            self.skipped += drop;
+            let records: Vec<Record> = batch.records.into_iter().skip(drop).collect();
+            if records.is_empty() {
+                continue;
+            }
+            return Ok(Some(RecordBatch { records, columns: batch.columns }));
         }
-        self.input.next_batch(store, batch_size)
     }
 
     fn reset(&mut self) {

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -581,11 +581,11 @@ impl QueryPlanner {
 
     pub fn plan(&self, query: &Query, store: &GraphStore) -> ExecutionResult<ExecutionPlan> {
         Self::reject_unevaluated_property_exprs(query)?;
-        let mut plan = self.plan_inner(query, store)?;
-        if query.return_clause.as_ref().is_some_and(|r| r.distinct) {
-            plan.root = Box::new(DistinctOperator::new(plan.root));
-        }
-        Ok(plan)
+        // `DISTINCT` is inserted inside `plan_inner`, below SKIP and LIMIT.
+        // Wrapping the finished plan here put it *above* them, so `LIMIT n`
+        // took n duplicate-bearing rows and DISTINCT then collapsed them --
+        // `RETURN DISTINCT p.city LIMIT 3` returned one row (#522).
+        self.plan_inner(query, store)
     }
 
     fn plan_inner(&self, query: &Query, store: &GraphStore) -> ExecutionResult<ExecutionPlan> {
@@ -1853,6 +1853,25 @@ impl QueryPlanner {
                     output_columns.push(item.alias.clone().unwrap_or_else(|| item.name.clone()));
                 }
             }
+        }
+
+        // DISTINCT, before SKIP and LIMIT.
+        //
+        // openCypher evaluates `RETURN DISTINCT` ahead of `ORDER BY`, `SKIP`
+        // and `LIMIT`: the projection is deduplicated, and only then is the
+        // result ordered and sliced. Deduplicating afterwards means `LIMIT n`
+        // slices a list that still contains duplicates, so fewer than n rows
+        // survive -- and `SKIP k` skips raw rows rather than distinct ones,
+        // which can leave the row it was meant to skip in the output (#522).
+        //
+        // `DistinctOperator` is a streaming, first-occurrence-wins filter, so
+        // placing it above the sort preserves the ordering the sort produced;
+        // no second sort is needed. Both plan shapes reach here with the
+        // projection already on top -- `Sort -> Project` when there is no
+        // aggregation, `Aggregate -> Project -> Sort` when there is -- so one
+        // insertion point covers both.
+        if query.return_clause.as_ref().is_some_and(|r| r.distinct) {
+            operator = Box::new(DistinctOperator::new(operator));
         }
 
         // Add SKIP if present

--- a/tests/distinct_ordering_semantics.rs
+++ b/tests/distinct_ordering_semantics.rs
@@ -1,0 +1,168 @@
+//! `RETURN DISTINCT` is evaluated before `ORDER BY`, `SKIP` and `LIMIT` (#522).
+//!
+//! openCypher's clause order for a `RETURN` is: project → deduplicate → order →
+//! skip → limit. Deduplicating *after* the slice is a silent wrong answer: the
+//! query succeeds, every row it returns is a valid row, and only the count is
+//! wrong — which reads as sparse data rather than as a bug.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// Ten people, eight of them in the same city.
+///
+/// The skew is the point: a fixture where distinct values are evenly spread
+/// hides this bug, because the first n rows happen to contain n distinct
+/// values. The original manual check passed for exactly that reason.
+fn skewed_cities() -> GraphStore {
+    let mut store = GraphStore::new();
+    for i in 0..10 {
+        let id = store.create_node("Person");
+        let city = if i < 8 {
+            "Amsterdam"
+        } else if i == 8 {
+            "Berlin"
+        } else {
+            "Cairo"
+        };
+        let _ = store.set_node_property(
+            "default",
+            id,
+            "city".to_string(),
+            PropertyValue::String(city.to_string()),
+        );
+    }
+    store
+}
+
+fn column(store: &GraphStore, cypher: &str, name: &str) -> Vec<String> {
+    let query = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&query).expect("query should execute");
+    batch
+        .records
+        .iter()
+        .map(|r| match r.get(name) {
+            Some(Value::Property(PropertyValue::String(s))) => s.clone(),
+            Some(Value::Property(PropertyValue::Integer(i))) => i.to_string(),
+            other => format!("{other:?}"),
+        })
+        .collect()
+}
+
+#[test]
+fn limit_counts_distinct_rows() {
+    // Was `[Amsterdam]`: LIMIT 3 took three of the eight Amsterdams and
+    // DISTINCT collapsed them to one.
+    let rows = column(
+        &skewed_cities(),
+        "MATCH (p:Person) RETURN DISTINCT p.city AS c ORDER BY c LIMIT 3",
+        "c",
+    );
+    assert_eq!(rows, vec!["Amsterdam", "Berlin", "Cairo"]);
+}
+
+#[test]
+fn limit_smaller_than_the_distinct_count_still_returns_exactly_limit() {
+    let rows = column(
+        &skewed_cities(),
+        "MATCH (p:Person) RETURN DISTINCT p.city AS c ORDER BY c LIMIT 2",
+        "c",
+    );
+    assert_eq!(rows, vec!["Amsterdam", "Berlin"]);
+}
+
+#[test]
+fn skip_counts_distinct_rows() {
+    // Was `[Amsterdam, Berlin, Cairo]`: SKIP 1 dropped one raw Amsterdam, the
+    // other seven deduplicated to one, and nothing was skipped at all.
+    let rows = column(
+        &skewed_cities(),
+        "MATCH (p:Person) RETURN DISTINCT p.city AS c ORDER BY c SKIP 1",
+        "c",
+    );
+    assert_eq!(rows, vec!["Berlin", "Cairo"]);
+}
+
+#[test]
+fn skip_and_limit_together_count_distinct_rows() {
+    let rows = column(
+        &skewed_cities(),
+        "MATCH (p:Person) RETURN DISTINCT p.city AS c ORDER BY c SKIP 1 LIMIT 1",
+        "c",
+    );
+    assert_eq!(rows, vec!["Berlin"]);
+}
+
+#[test]
+fn distinct_without_a_slice_is_unchanged() {
+    let mut rows = column(&skewed_cities(), "MATCH (p:Person) RETURN DISTINCT p.city AS c", "c");
+    rows.sort();
+    assert_eq!(rows, vec!["Amsterdam", "Berlin", "Cairo"]);
+}
+
+#[test]
+fn ordering_survives_deduplication() {
+    // DistinctOperator is first-occurrence-wins and streaming, so it must not
+    // disturb the order the sort produced. Descending, so a stable-but-wrong
+    // implementation that re-sorted ascending would be caught.
+    let rows = column(
+        &skewed_cities(),
+        "MATCH (p:Person) RETURN DISTINCT p.city AS c ORDER BY c DESC",
+        "c",
+    );
+    assert_eq!(rows, vec!["Cairo", "Berlin", "Amsterdam"]);
+}
+
+#[test]
+fn limit_without_distinct_is_unaffected() {
+    let rows = column(&skewed_cities(), "MATCH (p:Person) RETURN p.city AS c LIMIT 3", "c");
+    assert_eq!(rows.len(), 3, "a plain LIMIT still returns raw rows: {rows:?}");
+}
+
+#[test]
+fn distinct_over_several_columns_deduplicates_on_the_whole_row() {
+    let mut store = GraphStore::new();
+    for i in 0..12 {
+        let id = store.create_node("Person");
+        // 3 distinct (city, band) pairs, heavily skewed towards the first.
+        let (city, band) = if i < 9 {
+            ("Amsterdam", 1)
+        } else if i < 11 {
+            ("Amsterdam", 2)
+        } else {
+            ("Berlin", 1)
+        };
+        let _ = store.set_node_property(
+            "default",
+            id,
+            "city".to_string(),
+            PropertyValue::String(city.to_string()),
+        );
+        let _ = store.set_node_property("default", id, "band".to_string(), PropertyValue::Integer(band));
+    }
+
+    let query = parse_query("MATCH (p:Person) RETURN DISTINCT p.city AS c, p.band AS b LIMIT 3").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    assert_eq!(batch.records.len(), 3, "three distinct (city, band) pairs exist");
+}
+
+#[test]
+fn the_plan_puts_distinct_below_the_limit() {
+    // The property, not just the symptom: if a later change moves DISTINCT
+    // back above the slice, this fails without needing a fixture skewed the
+    // right way to expose it.
+    let store = skewed_cities();
+    let query = parse_query("EXPLAIN MATCH (p:Person) RETURN DISTINCT p.city AS c LIMIT 3").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    let plan = match batch.records[0].get("plan") {
+        Some(Value::Property(PropertyValue::String(t))) => t.clone(),
+        other => panic!("expected a plan string, got {other:?}"),
+    };
+
+    let limit_at = plan.find("Limit").expect("plan should contain a Limit");
+    let distinct_at = plan.find("Distinct").expect("plan should contain a Distinct");
+    assert!(
+        limit_at < distinct_at,
+        "Limit must sit above Distinct in the tree, so Distinct runs first:\n{plan}"
+    );
+}

--- a/tests/skip_batching.rs
+++ b/tests/skip_batching.rs
@@ -1,0 +1,115 @@
+//! `SKIP` returns everything after the first n rows, batched or not (#523).
+//!
+//! The executor pulls results with `next_batch(store, 1024)`, so `SkipOperator`
+//! is exercised through its batched path and almost never through `next`. The
+//! batched path consumed a whole batch to count off the skip and discarded the
+//! rows past the boundary, which made `SKIP n` alone return an empty result —
+//! a well-formed empty result, from a query that succeeded.
+//!
+//! Every test here therefore goes through `QueryExecutor`, which is the batched
+//! path. A test that drove the operator row-at-a-time would have passed
+//! throughout.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn numbered(n: i64) -> GraphStore {
+    let mut store = GraphStore::new();
+    for i in 0..n {
+        let id = store.create_node("N");
+        let _ = store.set_node_property("default", id, "v".to_string(), PropertyValue::Integer(i));
+    }
+    store
+}
+
+fn values(store: &GraphStore, cypher: &str) -> Vec<i64> {
+    let query = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&query).expect("query should execute");
+    batch
+        .records
+        .iter()
+        .map(|r| match r.get("c") {
+            Some(Value::Property(PropertyValue::Integer(i))) => *i,
+            other => panic!("expected an integer, got {other:?}"),
+        })
+        .collect()
+}
+
+#[test]
+fn skip_alone_returns_the_tail() {
+    // Was `[]`.
+    let store = numbered(5);
+    assert_eq!(values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c SKIP 2"), vec![2, 3, 4]);
+}
+
+#[test]
+fn skip_of_zero_returns_everything() {
+    let store = numbered(5);
+    assert_eq!(
+        values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c SKIP 0"),
+        vec![0, 1, 2, 3, 4]
+    );
+}
+
+#[test]
+fn skip_past_the_end_returns_nothing() {
+    let store = numbered(5);
+    assert!(values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c SKIP 99").is_empty());
+}
+
+#[test]
+fn skip_of_exactly_the_row_count_returns_nothing() {
+    let store = numbered(5);
+    assert!(values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c SKIP 5").is_empty());
+}
+
+#[test]
+fn skip_with_limit_is_correct_when_the_boundary_does_not_align() {
+    // `SKIP 2 LIMIT 2` passed even while the operator was broken, because the
+    // limit made the request size equal the skip. A skip that does not divide
+    // evenly into the requested batch is the case that actually tests it.
+    let store = numbered(10);
+    assert_eq!(
+        values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c SKIP 3 LIMIT 4"),
+        vec![3, 4, 5, 6]
+    );
+    assert_eq!(
+        values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c SKIP 1 LIMIT 7"),
+        vec![1, 2, 3, 4, 5, 6, 7]
+    );
+}
+
+#[test]
+fn skip_spans_more_than_one_batch() {
+    // The executor pulls 1024 rows at a time, so a skip larger than that has
+    // to consume whole batches and then return the remainder of the one it
+    // lands in.
+    let store = numbered(2500);
+    let rows = values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c SKIP 1500");
+    assert_eq!(rows.len(), 1000);
+    assert_eq!(rows.first(), Some(&1500));
+    assert_eq!(rows.last(), Some(&2499));
+}
+
+#[test]
+fn a_skip_landing_exactly_on_a_batch_boundary_loses_nothing() {
+    let store = numbered(2048);
+    let rows = values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c SKIP 1024");
+    assert_eq!(rows.len(), 1024);
+    assert_eq!(rows.first(), Some(&1024));
+}
+
+#[test]
+fn every_prefix_length_is_skippable() {
+    // Sweeping the skip catches an off-by-one at either end of the boundary
+    // arithmetic, which a single hand-picked value does not.
+    let store = numbered(37);
+    for skip in 0..=37usize {
+        let rows = values(&store, &format!("MATCH (n:N) RETURN n.v AS c ORDER BY c SKIP {skip}"));
+        assert_eq!(rows.len(), 37 - skip, "SKIP {skip} returned {} rows", rows.len());
+        if let Some(first) = rows.first() {
+            assert_eq!(*first, skip as i64, "SKIP {skip} started at {first}");
+        }
+    }
+}


### PR DESCRIPTION
Closes #522. Closes #523.

Two wrong answers, both silent, both found while reading the IC9 plan for #296.

## 1 — `DISTINCT` ran after `LIMIT`

`DistinctOperator` was wrapped around the **root of the finished plan**, which put it above `SKIP` and `LIMIT`. openCypher deduplicates before ordering and slicing, so `LIMIT n` was taking n duplicate-bearing rows and `DISTINCT` was collapsing them afterwards.

Ten `:Person`, eight of them in the same city:

| query | expected | before |
|---|---|---|
| `RETURN DISTINCT p.city AS c ORDER BY c LIMIT 3` | `[Amsterdam, Berlin, Cairo]` | **`[Amsterdam]`** |
| `RETURN DISTINCT p.city AS c ORDER BY c SKIP 1` | `[Berlin, Cairo]` | **`[Amsterdam, Berlin, Cairo]`** |

The `SKIP` case is the worse one: it dropped one *raw* Amsterdam, the remaining seven deduplicated to one, and the row it was meant to skip is still in the output — so `SKIP 1` skipped nothing.

`DistinctOperator` is a streaming, first-occurrence-wins filter, so inserting it above the sort preserves the order the sort produced; no second sort is needed. Both plan shapes reach the insertion point with the projection already on top — `Sort -> Project` without aggregation, `Aggregate -> Project -> Sort` with — so one site covers both.

## 2 — `SKIP` without `LIMIT` returned nothing at all

`SkipOperator::next_batch` consumed a whole batch to count off the skip and then **discarded it**, rows past the boundary included, before asking the input for another batch it had already exhausted. The old code said so and proceeded anyway:

```rust
let mut remaining = vec![record];
// Continue pulling from current batch not possible since we consumed it,
// but we've finished skipping
break;                       // <- `remaining` dropped here
```

`execute_plan` pulls 1024 rows at a time, so **any result of 1024 rows or fewer arrives in one batch**:

```cypher
MATCH (n:N) RETURN n.v AS c ORDER BY c SKIP 2     -- over 5 rows -> []   (expected [2,3,4])
```

`SKIP … LIMIT` masked it: `LimitOperator` requests exactly as many rows as remain under its limit, so with `SKIP 2 LIMIT 2` the skip consumed a two-row batch and the next request returned the right two. The skip boundary happening to align with the request size is not a partial fix — so the tests here use skips that do **not** align (`SKIP 3 LIMIT 4`), a skip spanning several 1024-row batches, and a sweep over every prefix length from 0 to n.

`SkipOperator::next` was always correct. Nothing reaches it, because the executor is batched — which is why every new test goes through `QueryExecutor` rather than driving the operator directly. A row-at-a-time test would have passed throughout.

## Why these are P0

`SLT-1` requires zero known wrong-answer bugs, and Axiom 1 puts the right answer first among the six things a customer buys. Beyond that, both are invisible: the query succeeds, returns a well-formed result, and every row in it is individually valid. Under-returning reads as sparse data, and an empty page-2 reads as the end of the data — so the caller's most likely response is to stop paginating.

`SKIP` is pagination. It has been returning nothing for every unbounded use.

## Testing

17 new tests. Full suite: **2,426 passing, 0 failures.**

`tests/distinct_ordering_semantics.rs` (9) — limit counts distinct rows; a limit below the distinct count returns exactly the limit; skip counts distinct rows; skip and limit together; distinct without a slice unchanged; ordering survives deduplication (descending, so a re-sorting implementation is caught); limit without distinct unaffected; multi-column distinct dedupes on the whole row; and a **plan-shape assertion** — `Distinct` must sit below `Limit` in `EXPLAIN`, so a future change that moves it back is caught without needing a fixture skewed the right way to expose it.

`tests/skip_batching.rs` (8) — skip alone returns the tail; skip 0; skip past the end; skip equal to the row count; skip with limit on a non-aligned boundary; a skip spanning several batches (2,500 rows, `SKIP 1500`); a skip landing exactly on a batch boundary; and a sweep asserting every prefix length from 0 to 37 returns the right count *and* starts at the right value.

The fixture skew is deliberate. My first manual check of the `DISTINCT` bug used ten people evenly spread across three cities and **passed**, because the first three rows happened to hold three distinct values. A fixture that hides the bug is worse than no fixture.

## Note

That an entire clause has been broken for every unbounded use is an argument for #434 — the openCypher TCK would have caught `SKIP` on day one.