### PR TITLE
Evaluate each ORDER BY key once, and keep only the rows a LIMIT can reach

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -4730,6 +4730,14 @@ pub struct SortOperator {
     records: Vec<Record>,
     current: usize,
     executed: bool,
+    /// Upper bound on the rows anything above this operator can observe, from
+    /// a `LIMIT` (plus any `SKIP`) pushed down through `try_push_limit`.
+    ///
+    /// `None` means every row is observable and the whole input must be
+    /// sorted. When it is set, only the first `k` rows in sort order can ever
+    /// be read, so the rest are discarded as they arrive instead of being
+    /// sorted and then thrown away (#518).
+    limit_hint: Option<usize>,
 }
 
 impl SortOperator {
@@ -4740,7 +4748,66 @@ impl SortOperator {
             records: Vec::new(),
             current: 0,
             executed: false,
+            limit_hint: None,
         }
+    }
+
+    /// The sort key for one record: each `ORDER BY` expression evaluated once.
+    ///
+    /// This is the whole of the fix in #518. The comparator used to evaluate
+    /// both sides' expressions on **every comparison**, so a sort of n rows
+    /// performed ~2·n·log₂(n) evaluations rather than n. On LDBC IC9 that was
+    /// 389,461 rows -> ~14.5 million property resolutions where 389,461 would
+    /// do, and `Sort` was 68.6% of the query.
+    fn key_of(&self, record: &Record, store: &GraphStore) -> Vec<PropertyValue> {
+        self.sort_items
+            .iter()
+            .map(|(expr, _)| {
+                // Errors are folded to Null, which is what the comparator did
+                // before and what ORDER BY over a missing property means.
+                Self::evaluate_expression(expr, record, store)
+                    .unwrap_or(Value::Null)
+                    .as_property()
+                    .cloned()
+                    .unwrap_or(PropertyValue::Null)
+            })
+            .collect()
+    }
+
+    /// Compare two precomputed keys under the per-column sort directions.
+    fn cmp_keys(a: &[PropertyValue], b: &[PropertyValue], items: &[(Expression, bool)]) -> std::cmp::Ordering {
+        for (i, (_, ascending)) in items.iter().enumerate() {
+            let (Some(x), Some(y)) = (a.get(i), b.get(i)) else {
+                continue;
+            };
+            let ord = x.cmp(y);
+            if ord != std::cmp::Ordering::Equal {
+                return if *ascending { ord } else { ord.reverse() };
+            }
+        }
+        std::cmp::Ordering::Equal
+    }
+
+    /// Keep only the `k` smallest rows under the sort order, discarding the
+    /// rest.
+    ///
+    /// `select_nth_unstable_by` partitions in O(n) rather than sorting, so
+    /// trimming a buffer is cheaper than sorting it and is done repeatedly as
+    /// the input streams in. Rows tied with the k-th are dropped along with
+    /// the rest of the tail; Cypher does not define a tie-break for
+    /// `ORDER BY … LIMIT`, so any k of a tied set is a valid answer, but two
+    /// runs may therefore disagree about *which* — the same latitude the
+    /// unstable sort below already takes.
+    fn trim_to(keyed: &mut Vec<(Vec<PropertyValue>, Record)>, k: usize, items: &[(Expression, bool)]) {
+        if k == 0 {
+            keyed.clear();
+            return;
+        }
+        if keyed.len() <= k {
+            return;
+        }
+        keyed.select_nth_unstable_by(k - 1, |a, b| Self::cmp_keys(&a.0, &b.0, items));
+        keyed.truncate(k);
     }
 
     fn evaluate_expression(expr: &Expression, record: &Record, store: &GraphStore) -> ExecutionResult<Value> {
@@ -4819,6 +4886,23 @@ impl PhysicalOperator for SortOperator {
         vec![&mut self.input]
     }
 
+    /// Accept the hint, and stop it here.
+    ///
+    /// A sort does not change cardinality, so it is safe for it to know that
+    /// only the first `n` rows will ever be read -- that is exactly a top-N.
+    /// It is *not* safe to pass the hint further down: the input must still
+    /// produce every row, or the sort would be ordering an arbitrary prefix.
+    ///
+    /// Returning `true` records that the hint was consumed rather than
+    /// ignored, which is what the contract on this method means.
+    fn try_push_limit(&mut self, n: usize) -> bool {
+        self.limit_hint = Some(match self.limit_hint {
+            Some(existing) => existing.min(n),
+            None => n,
+        });
+        true
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         if !self.executed {
             self.execute_all(store)?;
@@ -4854,6 +4938,8 @@ impl PhysicalOperator for SortOperator {
         self.records.clear();
         self.current = 0;
         self.executed = false;
+        // `limit_hint` is deliberately kept: it is a property of the plan the
+        // planner built, not state from a previous execution.
     }
 
     fn describe(&self) -> OperatorDescription {
@@ -4870,30 +4956,40 @@ impl PhysicalOperator for SortOperator {
 
 impl SortOperator {
     fn execute_all(&mut self, store: &GraphStore) -> ExecutionResult<()> {
-        // Materialize all records in batches
+        // Decorate-sort-undecorate: evaluate each ORDER BY expression once per
+        // row and sort the resulting keys, rather than re-evaluating both
+        // sides inside the comparator on every one of the ~n·log₂(n)
+        // comparisons (#518).
         let batch_size = 65536;
+        let bound = self.limit_hint;
+
+        // With a bound, the buffer is trimmed back to k whenever it grows
+        // past a working size, so peak memory is O(k) rather than O(n). The
+        // floor keeps the trimming amortised: for a small k the partition
+        // would otherwise run on nearly every batch.
+        let trim_at = bound.map(|k| k.saturating_mul(2).max(4096));
+
+        let mut keyed: Vec<(Vec<PropertyValue>, Record)> = Vec::new();
         while let Some(batch) = self.input.next_batch(store, batch_size)? {
-            self.records.extend(batch.records);
-        }
-
-        // Sort
-        let sort_items = &self.sort_items;
-        self.records.sort_by(|a, b| {
-            for (expr, ascending) in sort_items {
-                let val_a = Self::evaluate_expression(expr, a, store).unwrap_or(Value::Null);
-                let val_b = Self::evaluate_expression(expr, b, store).unwrap_or(Value::Null);
-
-                let prop_a = val_a.as_property().unwrap_or(&PropertyValue::Null);
-                let prop_b = val_b.as_property().unwrap_or(&PropertyValue::Null);
-
-                let ord = prop_a.cmp(prop_b);
-                if ord != std::cmp::Ordering::Equal {
-                    return if *ascending { ord } else { ord.reverse() };
+            keyed.reserve(batch.records.len());
+            for record in batch.records {
+                let key = self.key_of(&record, store);
+                keyed.push((key, record));
+            }
+            if let (Some(k), Some(threshold)) = (bound, trim_at) {
+                if keyed.len() >= threshold {
+                    Self::trim_to(&mut keyed, k, &self.sort_items);
                 }
             }
-            std::cmp::Ordering::Equal
-        });
+        }
+        if let Some(k) = bound {
+            Self::trim_to(&mut keyed, k, &self.sort_items);
+        }
 
+        let sort_items = &self.sort_items;
+        keyed.sort_by(|a, b| Self::cmp_keys(&a.0, &b.0, sort_items));
+
+        self.records = keyed.into_iter().map(|(_, record)| record).collect();
         self.executed = true;
         Ok(())
     }
@@ -7685,6 +7781,19 @@ impl SkipOperator {
 impl PhysicalOperator for SkipOperator {
     fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
         vec![&mut self.input]
+    }
+
+    /// Widen the hint by this operator's own skip before passing it on.
+    ///
+    /// If something above needs `n` rows and this operator discards the first
+    /// `k`, the subtree has to produce `n + k`. Forwarding `n` unchanged would
+    /// make a bounded sort below keep too few rows and silently lose the tail
+    /// of the page (#518).
+    ///
+    /// Before this, `SkipOperator` used the default and blocked the hint
+    /// entirely, so nothing below a SKIP ever terminated early.
+    fn try_push_limit(&mut self, n: usize) -> bool {
+        self.input.try_push_limit(n.saturating_add(self.skip))
     }
 
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {

--- a/tests/order_by_limit_topn.rs
+++ b/tests/order_by_limit_topn.rs
@@ -1,0 +1,196 @@
+//! `ORDER BY … LIMIT k` keeps k rows, not n (#518).
+//!
+//! The correctness bar for a bounded sort is higher than for an unbounded one,
+//! because every way of getting it wrong loses rows silently: an off-by-one in
+//! the bound, a `SKIP` that is not added to it, or a cardinality-changing
+//! operator between the sort and the limit that the bound was not allowed to
+//! cross. Each of those has a test here.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// `n` nodes with `v` counting up, inserted in an order that is *not* the sort
+/// order — so a bounded sort that trimmed on arrival order rather than on key
+/// order would fail.
+fn shuffled(n: i64) -> GraphStore {
+    let mut store = GraphStore::new();
+    // A stride coprime with n visits every value exactly once in a scrambled
+    // order, deterministically.
+    let stride = 7;
+    for i in 0..n {
+        let v = (i * stride) % n;
+        let id = store.create_node("N");
+        let _ = store.set_node_property("default", id, "v".to_string(), PropertyValue::Integer(v));
+        let _ = store.set_node_property(
+            "default",
+            id,
+            "band".to_string(),
+            PropertyValue::Integer(v % 3),
+        );
+    }
+    store
+}
+
+fn values(store: &GraphStore, cypher: &str) -> Vec<i64> {
+    let query = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&query).expect("query should execute");
+    batch
+        .records
+        .iter()
+        .map(|r| match r.get("c") {
+            Some(Value::Property(PropertyValue::Integer(i))) => *i,
+            other => panic!("expected an integer, got {other:?}"),
+        })
+        .collect()
+}
+
+#[test]
+fn ascending_top_k_is_the_k_smallest_in_order() {
+    let store = shuffled(5000);
+    assert_eq!(
+        values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c LIMIT 5"),
+        vec![0, 1, 2, 3, 4]
+    );
+}
+
+#[test]
+fn descending_top_k_is_the_k_largest_in_order() {
+    let store = shuffled(5000);
+    assert_eq!(
+        values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c DESC LIMIT 5"),
+        vec![4999, 4998, 4997, 4996, 4995]
+    );
+}
+
+#[test]
+fn skip_is_added_to_the_bound() {
+    // The bound a sort may apply is SKIP + LIMIT. If only LIMIT reaches it,
+    // the sort keeps 5 rows, SKIP throws away 3 of them, and the page comes
+    // back short.
+    let store = shuffled(5000);
+    assert_eq!(
+        values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c SKIP 3 LIMIT 5"),
+        vec![3, 4, 5, 6, 7]
+    );
+}
+
+#[test]
+fn a_large_skip_past_several_trim_thresholds_still_pages_correctly() {
+    let store = shuffled(5000);
+    let rows = values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c SKIP 4990 LIMIT 10");
+    assert_eq!(rows, (4990..5000).collect::<Vec<_>>());
+}
+
+#[test]
+fn every_page_of_a_full_scan_is_correct() {
+    // Paging all the way through catches a bound that is right at the start
+    // and drifts, which a single spot-check does not.
+    let store = shuffled(200);
+    let mut seen = Vec::new();
+    for page in 0..10 {
+        let rows = values(
+            &store,
+            &format!("MATCH (n:N) RETURN n.v AS c ORDER BY c SKIP {} LIMIT 20", page * 20),
+        );
+        assert_eq!(rows.len(), 20, "page {page} was short: {rows:?}");
+        seen.extend(rows);
+    }
+    assert_eq!(seen, (0..200).collect::<Vec<_>>());
+}
+
+#[test]
+fn a_limit_larger_than_the_input_returns_everything() {
+    let store = shuffled(50);
+    let rows = values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c LIMIT 1000");
+    assert_eq!(rows, (0..50).collect::<Vec<_>>());
+}
+
+#[test]
+fn a_limit_of_zero_returns_nothing() {
+    let store = shuffled(50);
+    assert!(values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c LIMIT 0").is_empty());
+}
+
+#[test]
+fn without_a_limit_every_row_survives_in_order() {
+    let store = shuffled(300);
+    let rows = values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c");
+    assert_eq!(rows, (0..300).collect::<Vec<_>>());
+}
+
+#[test]
+fn a_multi_key_sort_orders_by_every_key() {
+    let store = shuffled(300);
+    let query = parse_query(
+        "MATCH (n:N) RETURN n.band AS b, n.v AS c ORDER BY b ASC, c DESC LIMIT 4",
+    )
+    .unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    let rows: Vec<(i64, i64)> = batch
+        .records
+        .iter()
+        .map(|r| {
+            let get = |k: &str| match r.get(k) {
+                Some(Value::Property(PropertyValue::Integer(i))) => *i,
+                other => panic!("{other:?}"),
+            };
+            (get("b"), get("c"))
+        })
+        .collect();
+    // band 0 holds 0, 3, 6, … 297; descending within the band.
+    assert_eq!(rows, vec![(0, 297), (0, 294), (0, 291), (0, 288)]);
+}
+
+#[test]
+fn distinct_between_the_sort_and_the_limit_does_not_lose_rows() {
+    // The hazard the bound must not cross. DISTINCT can discard rows, so a
+    // LIMIT above it may need more than `limit` rows from below; a sort that
+    // accepted the bound through a DISTINCT would return short.
+    let mut store = GraphStore::new();
+    for i in 0..300 {
+        let id = store.create_node("N");
+        // Ten distinct values, each repeated thirty times.
+        let _ = store.set_node_property("default", id, "v".to_string(), PropertyValue::Integer(i % 10));
+    }
+    let rows = values(&store, "MATCH (n:N) RETURN DISTINCT n.v AS c ORDER BY c LIMIT 10");
+    assert_eq!(rows, (0..10).collect::<Vec<_>>());
+}
+
+#[test]
+fn a_filter_between_the_sort_and_the_limit_does_not_lose_rows() {
+    let store = shuffled(500);
+    let rows = values(
+        &store,
+        "MATCH (n:N) WHERE n.v > 100 RETURN n.v AS c ORDER BY c LIMIT 5",
+    );
+    assert_eq!(rows, vec![101, 102, 103, 104, 105]);
+}
+
+#[test]
+fn nulls_sort_consistently_under_a_bound() {
+    // ORDER BY over a property some nodes lack must place the missing ones the
+    // same way whether or not a bound is applied, or a LIMIT would change the
+    // membership of the answer rather than only its length.
+    let mut store = GraphStore::new();
+    for i in 0..100 {
+        let id = store.create_node("N");
+        if i % 2 == 0 {
+            let _ = store.set_node_property("default", id, "v".to_string(), PropertyValue::Integer(i));
+        }
+    }
+    let query = parse_query("MATCH (n:N) RETURN n.v AS c ORDER BY c").unwrap();
+    let unbounded = QueryExecutor::new(&store).execute(&query).unwrap();
+    let first_ten: Vec<String> = unbounded
+        .records
+        .iter()
+        .take(10)
+        .map(|r| format!("{:?}", r.get("c")))
+        .collect();
+
+    let query = parse_query("MATCH (n:N) RETURN n.v AS c ORDER BY c LIMIT 10").unwrap();
+    let bounded = QueryExecutor::new(&store).execute(&query).unwrap();
+    let bounded_ten: Vec<String> = bounded.records.iter().map(|r| format!("{:?}", r.get("c"))).collect();
+
+    assert_eq!(bounded_ten, first_ten, "a bound must not change which rows win");
+}


### PR DESCRIPTION
Closes #518. Part of #296.

## The measurement

`CH-PROFILE-01` put 68.6% of LDBC IC9 in `Sort`: 2,437 ms of a 3,469 ms query, consuming 389,461 rows to return twenty.

Reading the operator explained most of it. The comparator evaluated **both sides' `ORDER BY` expressions on every comparison**:

```rust
self.records.sort_by(|a, b| {
    for (expr, ascending) in sort_items {
        let val_a = Self::evaluate_expression(expr, a, store)…   // per comparison
        let val_b = Self::evaluate_expression(expr, b, store)…   // per comparison
```

Sorting n rows makes ~n·log₂(n) comparisons, so that is ~2·n·log₂(n) evaluations where n would do. For IC9: **~14.5 million property resolutions to order a list of 389,461**.

## The change

**Decorate-sort-undecorate.** Each key is evaluated once per row and the keys are sorted:

```
Sort (m.creationDate DESC)   2436.73ms  →  279.08ms      8.7×
IC9 median                      2822ms  →     1249ms     2.3×
```

**Bounded top-N.** A sort under a `LIMIT` only needs the rows the limit can reach. `SortOperator` now accepts the pushed-down hint, trims its buffer back to k with `select_nth_unstable_by` as the input streams in, and peak memory becomes O(k) rather than O(n).

It does **not** forward the hint further down — the input must still produce every row, or the sort would be ordering an arbitrary prefix.

`SkipOperator` now widens the hint by its own skip before passing it on: if something above needs n rows and this operator discards the first k, the subtree has to produce n + k. It previously used the default and blocked the hint entirely, so nothing below a `SKIP` ever terminated early.

## The hazard, and why two tests exist for it

The bound must not cross an operator that can discard rows. A `LIMIT 10` above a `DISTINCT` may need far more than ten rows from underneath.

`DistinctOperator` and `FilterOperator` both use the default `try_push_limit` and return `false`, so the hint stops there and the sort below stays unbounded. That is the existing convention doing its job rather than anything new — but it is the thing that would silently lose rows if it were ever wrong, so `distinct_between_the_sort_and_the_limit_does_not_lose_rows` and `a_filter_between_the_sort_and_the_limit_does_not_lose_rows` assert it directly. Both failed against an earlier draft of this branch and caught a real defect in the `SKIP` interaction.

## After: IC9's profile

```
operator                                     self      total  self %         rows      calls
Limit (20)                                  0.00ms   1142.60ms    0.0%           20          2
  Distinct                                  0.05ms   1142.60ms    0.0%           20          1
    Project (friend.id, friend.firstN)     15.19ms   1142.54ms    1.2%           20         20
      Sort (m.creationDate DESC)          279.08ms   1127.36ms   22.2%           20         20
        Filter                             69.68ms    848.28ms    5.5%       389461          5
          Filter                           64.65ms    778.60ms    5.1%       389461          6
            Expand ((friend)<-[:HAS_CR    690.54ms    713.95ms   55.0%       409960         10
              VarLengthExpand              23.40ms     23.41ms    1.9%         3272       3276
```

`Expand` is now the largest share at 55%, which is #328's territory — expanding to 409,960 posts to keep 20. `Sort` at 279 ms for 389,461 rows is ~0.7 µs/row, which is a reasonable place to stop for now.

The two stacked `Filter`s carrying the same predicate are #519, unaddressed here.

## A determinism note

Rows tied with the k-th are dropped along with the rest of the tail. Cypher does not define a tie-break for `ORDER BY … LIMIT`, so any k of a tied set is a valid answer — the same latitude the unstable sort already took — but two runs may disagree about *which*. That is called out in the code rather than left to be discovered by a golden-file test.

## Testing

12 new tests in `tests/order_by_limit_topn.rs`. Full suite: **2,635 passing, 0 failures.**

The fixture inserts values in a scrambled order rather than sorted order, so a bound that trimmed on arrival order instead of key order fails. Covered: ascending and descending top-k; `SKIP` added to the bound; a large skip crossing several trim thresholds; **every page of a full 200-row scan**, so a bound that is right at the start and drifts is caught; a limit larger than the input; `LIMIT 0`; no limit at all; multi-key sort with mixed directions; `DISTINCT` and `Filter` between the sort and the limit; and nulls placing identically with and without a bound, so a limit changes only the length of the answer and never its membership.