### PR TITLE
Apply only the WHERE conjuncts the plan below is not already applying

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2102,6 +2102,16 @@ pub trait PhysicalOperator: Send {
     /// Reset the operator to start from the beginning
     fn reset(&mut self);
 
+    /// The predicate this operator filters on, if it is a filter.
+    ///
+    /// Exists so the planner can tell whether a filter it is about to add is
+    /// the one already sitting underneath. `x AND x` is idempotent, so the
+    /// second evaluation is pure cost -- ~130 ms on LDBC IC9, where the same
+    /// compound predicate was evaluated 389,461 times twice over (#519).
+    fn filter_predicate(&self) -> Option<&Expression> {
+        None
+    }
+
     /// The operators this one pulls from, in the order `describe()` lists
     /// them.
     ///
@@ -2998,6 +3008,10 @@ impl FilterOperator {
 impl PhysicalOperator for FilterOperator {
     fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
         vec![&mut self.input]
+    }
+
+    fn filter_predicate(&self) -> Option<&Expression> {
+        Some(&self.predicate)
     }
 
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -4730,6 +4730,14 @@ pub struct SortOperator {
     records: Vec<Record>,
     current: usize,
     executed: bool,
+    /// Upper bound on the rows anything above this operator can observe, from
+    /// a `LIMIT` (plus any `SKIP`) pushed down through `try_push_limit`.
+    ///
+    /// `None` means every row is observable and the whole input must be
+    /// sorted. When it is set, only the first `k` rows in sort order can ever
+    /// be read, so the rest are discarded as they arrive instead of being
+    /// sorted and then thrown away (#518).
+    limit_hint: Option<usize>,
 }
 
 impl SortOperator {
@@ -4740,7 +4748,66 @@ impl SortOperator {
             records: Vec::new(),
             current: 0,
             executed: false,
+            limit_hint: None,
         }
+    }
+
+    /// The sort key for one record: each `ORDER BY` expression evaluated once.
+    ///
+    /// This is the whole of the fix in #518. The comparator used to evaluate
+    /// both sides' expressions on **every comparison**, so a sort of n rows
+    /// performed ~2·n·log₂(n) evaluations rather than n. On LDBC IC9 that was
+    /// 389,461 rows -> ~14.5 million property resolutions where 389,461 would
+    /// do, and `Sort` was 68.6% of the query.
+    fn key_of(&self, record: &Record, store: &GraphStore) -> Vec<PropertyValue> {
+        self.sort_items
+            .iter()
+            .map(|(expr, _)| {
+                // Errors are folded to Null, which is what the comparator did
+                // before and what ORDER BY over a missing property means.
+                Self::evaluate_expression(expr, record, store)
+                    .unwrap_or(Value::Null)
+                    .as_property()
+                    .cloned()
+                    .unwrap_or(PropertyValue::Null)
+            })
+            .collect()
+    }
+
+    /// Compare two precomputed keys under the per-column sort directions.
+    fn cmp_keys(a: &[PropertyValue], b: &[PropertyValue], items: &[(Expression, bool)]) -> std::cmp::Ordering {
+        for (i, (_, ascending)) in items.iter().enumerate() {
+            let (Some(x), Some(y)) = (a.get(i), b.get(i)) else {
+                continue;
+            };
+            let ord = x.cmp(y);
+            if ord != std::cmp::Ordering::Equal {
+                return if *ascending { ord } else { ord.reverse() };
+            }
+        }
+        std::cmp::Ordering::Equal
+    }
+
+    /// Keep only the `k` smallest rows under the sort order, discarding the
+    /// rest.
+    ///
+    /// `select_nth_unstable_by` partitions in O(n) rather than sorting, so
+    /// trimming a buffer is cheaper than sorting it and is done repeatedly as
+    /// the input streams in. Rows tied with the k-th are dropped along with
+    /// the rest of the tail; Cypher does not define a tie-break for
+    /// `ORDER BY … LIMIT`, so any k of a tied set is a valid answer, but two
+    /// runs may therefore disagree about *which* — the same latitude the
+    /// unstable sort below already takes.
+    fn trim_to(keyed: &mut Vec<(Vec<PropertyValue>, Record)>, k: usize, items: &[(Expression, bool)]) {
+        if k == 0 {
+            keyed.clear();
+            return;
+        }
+        if keyed.len() <= k {
+            return;
+        }
+        keyed.select_nth_unstable_by(k - 1, |a, b| Self::cmp_keys(&a.0, &b.0, items));
+        keyed.truncate(k);
     }
 
     fn evaluate_expression(expr: &Expression, record: &Record, store: &GraphStore) -> ExecutionResult<Value> {
@@ -4819,6 +4886,23 @@ impl PhysicalOperator for SortOperator {
         vec![&mut self.input]
     }
 
+    /// Accept the hint, and stop it here.
+    ///
+    /// A sort does not change cardinality, so it is safe for it to know that
+    /// only the first `n` rows will ever be read -- that is exactly a top-N.
+    /// It is *not* safe to pass the hint further down: the input must still
+    /// produce every row, or the sort would be ordering an arbitrary prefix.
+    ///
+    /// Returning `true` records that the hint was consumed rather than
+    /// ignored, which is what the contract on this method means.
+    fn try_push_limit(&mut self, n: usize) -> bool {
+        self.limit_hint = Some(match self.limit_hint {
+            Some(existing) => existing.min(n),
+            None => n,
+        });
+        true
+    }
+
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         if !self.executed {
             self.execute_all(store)?;
@@ -4854,6 +4938,8 @@ impl PhysicalOperator for SortOperator {
         self.records.clear();
         self.current = 0;
         self.executed = false;
+        // `limit_hint` is deliberately kept: it is a property of the plan the
+        // planner built, not state from a previous execution.
     }
 
     fn describe(&self) -> OperatorDescription {
@@ -4870,30 +4956,40 @@ impl PhysicalOperator for SortOperator {
 
 impl SortOperator {
     fn execute_all(&mut self, store: &GraphStore) -> ExecutionResult<()> {
-        // Materialize all records in batches
+        // Decorate-sort-undecorate: evaluate each ORDER BY expression once per
+        // row and sort the resulting keys, rather than re-evaluating both
+        // sides inside the comparator on every one of the ~n·log₂(n)
+        // comparisons (#518).
         let batch_size = 65536;
+        let bound = self.limit_hint;
+
+        // With a bound, the buffer is trimmed back to k whenever it grows
+        // past a working size, so peak memory is O(k) rather than O(n). The
+        // floor keeps the trimming amortised: for a small k the partition
+        // would otherwise run on nearly every batch.
+        let trim_at = bound.map(|k| k.saturating_mul(2).max(4096));
+
+        let mut keyed: Vec<(Vec<PropertyValue>, Record)> = Vec::new();
         while let Some(batch) = self.input.next_batch(store, batch_size)? {
-            self.records.extend(batch.records);
-        }
-
-        // Sort
-        let sort_items = &self.sort_items;
-        self.records.sort_by(|a, b| {
-            for (expr, ascending) in sort_items {
-                let val_a = Self::evaluate_expression(expr, a, store).unwrap_or(Value::Null);
-                let val_b = Self::evaluate_expression(expr, b, store).unwrap_or(Value::Null);
-
-                let prop_a = val_a.as_property().unwrap_or(&PropertyValue::Null);
-                let prop_b = val_b.as_property().unwrap_or(&PropertyValue::Null);
-
-                let ord = prop_a.cmp(prop_b);
-                if ord != std::cmp::Ordering::Equal {
-                    return if *ascending { ord } else { ord.reverse() };
+            keyed.reserve(batch.records.len());
+            for record in batch.records {
+                let key = self.key_of(&record, store);
+                keyed.push((key, record));
+            }
+            if let (Some(k), Some(threshold)) = (bound, trim_at) {
+                if keyed.len() >= threshold {
+                    Self::trim_to(&mut keyed, k, &self.sort_items);
                 }
             }
-            std::cmp::Ordering::Equal
-        });
+        }
+        if let Some(k) = bound {
+            Self::trim_to(&mut keyed, k, &self.sort_items);
+        }
 
+        let sort_items = &self.sort_items;
+        keyed.sort_by(|a, b| Self::cmp_keys(&a.0, &b.0, sort_items));
+
+        self.records = keyed.into_iter().map(|(_, record)| record).collect();
         self.executed = true;
         Ok(())
     }
@@ -7685,6 +7781,19 @@ impl SkipOperator {
 impl PhysicalOperator for SkipOperator {
     fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
         vec![&mut self.input]
+    }
+
+    /// Widen the hint by this operator's own skip before passing it on.
+    ///
+    /// If something above needs `n` rows and this operator discards the first
+    /// `k`, the subtree has to produce `n + k`. Forwarding `n` unchanged would
+    /// make a bounded sort below keep too few rows and silently lose the tail
+    /// of the page (#518).
+    ///
+    /// Before this, `SkipOperator` used the default and blocked the hint
+    /// entirely, so nothing below a SKIP ever terminated early.
+    fn try_push_limit(&mut self, n: usize) -> bool {
+        self.input.try_push_limit(n.saturating_add(self.skip))
     }
 
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1365,7 +1365,72 @@ impl QueryPlanner {
         // would fail because the WithBarrier projects away referenced variables.
         if query.with_clause.is_none() {
             if let Some(where_clause) = &query.where_clause {
-                operator = Box::new(FilterOperator::new(operator, where_clause.predicate.clone()));
+                // Apply only the conjuncts the plan below is not already
+                // applying.
+                //
+                // The decomposition above hands each MATCH the conjuncts that
+                // reference only its own variables, and the match planners
+                // attach them as filters inside the subplan -- often at the
+                // scan, which is the whole point of pushing them down. This
+                // line then re-applied the *entire* WHERE on top. For
+                // `WHERE p.age > 10 AND f.age < 40` over `(p)-[:KNOWS]->(f)`
+                // the result was three evaluations of the same work:
+                //
+                //     Filter (p.age > 10 AND f.age < 40)     <- here
+                //       Filter (f.age < 40)
+                //         Expand
+                //           Filter (p.age > 10)
+                //             NodeScan
+                //
+                // On LDBC IC9 the redundant pass cost ~130 ms over 389,461
+                // rows and removed nothing (#519).
+                //
+                // What is dropped is decided by reading the plan that was
+                // actually built, not by trusting that the planner pushed what
+                // it was given: there are several planning paths and none of
+                // them promises to attach every predicate it receives.
+                //
+                // Two shapes make re-application load-bearing rather than
+                // redundant, and both are excluded rather than reasoned about:
+                //
+                //   * OPTIONAL MATCH -- a left outer join can leave a variable
+                //     NULL for unmatched rows. A filter pushed inside the
+                //     optional side never sees those rows; the top-level one
+                //     does, and rejects them. Dropping it would admit rows
+                //     that should have been excluded.
+                //   * a leading UNWIND -- predicates on its variable are
+                //     deliberately left out of the decomposition, because the
+                //     Unwind that binds them sits above the matches. They are
+                //     not in any descendant filter, so they survive the
+                //     subtraction anyway; excluding the case as well makes the
+                //     reasoning independent of that.
+                //
+                // With those excluded, every operator between a pushed filter
+                // and this point only *adds* bindings -- Expand, ExpandInto,
+                // Join on shared equal values, CartesianProduct -- so a
+                // conjunct proved below stays true here.
+                let has_optional = query.match_clauses.iter().any(|mc| mc.optional);
+                let has_late_bound = !Self::late_bound_variables(query).is_empty();
+
+                let predicate = if has_optional || has_late_bound {
+                    Some(where_clause.predicate.clone())
+                } else {
+                    let mut applied = Vec::new();
+                    Self::collect_applied_predicates(&mut operator, &mut applied);
+                    let remaining: Vec<Expression> = flatten_and_predicates(&where_clause.predicate)
+                        .into_iter()
+                        .filter(|conjunct| !applied.contains(conjunct))
+                        .collect();
+                    remaining.into_iter().reduce(|acc, pred| Expression::Binary {
+                        left: Box::new(acc),
+                        op: BinaryOp::And,
+                        right: Box::new(pred),
+                    })
+                };
+
+                if let Some(predicate) = predicate {
+                    operator = Box::new(FilterOperator::new(operator, predicate));
+                }
             }
         }
 
@@ -1987,6 +2052,20 @@ impl QueryPlanner {
 
     /// Dispatch to graph-native or legacy planner based on configuration.
     /// Falls back to legacy planner if graph-native fails (e.g., label-free patterns).
+    /// Every conjunct any `Filter` in this subtree is already applying.
+    ///
+    /// Read off the built plan rather than tracked during construction: the
+    /// planner has several paths into a match subplan and the question here is
+    /// what the chosen one *did*, not what it was asked to do.
+    fn collect_applied_predicates(op: &mut OperatorBox, out: &mut Vec<Expression>) {
+        if let Some(predicate) = op.filter_predicate() {
+            out.extend(flatten_and_predicates(predicate));
+        }
+        for child in op.children_mut() {
+            Self::collect_applied_predicates(child, out);
+        }
+    }
+
     fn dispatch_plan_match(&self, match_clause: &MatchClause, where_clause: Option<&WhereClause>, store: &GraphStore) -> ExecutionResult<OperatorBox> {
         if self.config.graph_native {
             match self.plan_match_native(match_clause, where_clause, store) {

--- a/tests/duplicate_filter_plan.rs
+++ b/tests/duplicate_filter_plan.rs
@@ -1,0 +1,182 @@
+//! A single `WHERE` produces a single `Filter` (#519).
+//!
+//! The predicate decomposition hands each MATCH the conjuncts that reference
+//! only its own variables, and the match planner attaches them inside the
+//! subplan. The top-level `WHERE` filter then applied the whole predicate
+//! again, so a one-MATCH query with a compound `WHERE` evaluated it twice per
+//! row — on LDBC IC9, 389,461 rows through two identical `Filter`s, the upper
+//! one removing nothing.
+//!
+//! These assert on `EXPLAIN` rather than on timings: the defect is a plan
+//! shape, and a plan shape is checkable without a profiler.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn fixture() -> GraphStore {
+    let mut store = GraphStore::new();
+    let people: Vec<_> = (0..60)
+        .map(|i| {
+            let id = store.create_node("Person");
+            let _ = store.set_node_property("default", id, "age".to_string(), PropertyValue::Integer(i % 50));
+            let _ = store.set_node_property(
+                "default",
+                id,
+                "name".to_string(),
+                PropertyValue::String(format!("p{i}")),
+            );
+            id
+        })
+        .collect();
+    for (i, &src) in people.iter().enumerate() {
+        let _ = store.create_edge(src, people[(i + 3) % people.len()], "KNOWS");
+    }
+    store
+}
+
+fn plan(store: &GraphStore, cypher: &str) -> String {
+    let query = parse_query(&format!("EXPLAIN {cypher}")).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&query).expect("EXPLAIN should run");
+    match batch.records[0].get("plan") {
+        Some(Value::Property(PropertyValue::String(t))) => t.clone(),
+        other => panic!("expected a plan string, got {other:?}"),
+    }
+}
+
+/// `Filter` operators in the plan tree.
+///
+/// EXPLAIN appends planner diagnostics and graph statistics below the tree,
+/// and the diagnostics list every *candidate* plan -- which contain filters of
+/// their own. Counting the whole output would count plans that were considered
+/// and rejected.
+fn count_filters(plan: &str) -> usize {
+    plan.lines()
+        .take_while(|l| !l.starts_with("---"))
+        .filter(|l| l.trim_start().trim_start_matches("+- ").starts_with("Filter"))
+        .count()
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> usize {
+    let query = parse_query(cypher).expect("query should parse");
+    QueryExecutor::new(store).execute(&query).expect("query should run").records.len()
+}
+
+#[test]
+fn a_compound_where_on_one_match_plans_one_filter() {
+    let store = fixture();
+    let text = plan(
+        &store,
+        "MATCH (p:Person)-[:KNOWS]->(f:Person) WHERE p.age > 10 AND p.age < 40 RETURN f.name",
+    );
+    assert_eq!(
+        count_filters(&text),
+        1,
+        "the same predicate was planted twice:\n{text}"
+    );
+}
+
+#[test]
+fn a_query_with_no_where_plans_no_filter() {
+    let store = fixture();
+    let text = plan(&store, "MATCH (p:Person)-[:KNOWS]->(f:Person) RETURN f.name");
+    assert_eq!(count_filters(&text), 0, "{text}");
+}
+
+#[test]
+fn a_single_predicate_plans_one_filter() {
+    let store = fixture();
+    let text = plan(&store, "MATCH (p:Person) WHERE p.age > 10 RETURN p.name");
+    assert!(count_filters(&text) <= 1, "{text}");
+}
+
+#[test]
+fn deduplicating_does_not_change_the_answer() {
+    // `x AND x` is idempotent, so dropping the second evaluation cannot change
+    // the result -- but the whole point of the guard is that it only fires when
+    // the predicates are genuinely equal, so this is worth asserting rather
+    // than assuming.
+    let store = fixture();
+    assert_eq!(
+        rows(&store, "MATCH (p:Person) WHERE p.age > 10 AND p.age < 40 RETURN p.name"),
+        rows(&store, "MATCH (p:Person) WHERE p.age > 10 AND p.age < 40 RETURN p.name"),
+    );
+
+    let expected = (0..60).filter(|i| (i % 50) > 10 && (i % 50) < 40).count();
+    assert_eq!(
+        rows(&store, "MATCH (p:Person) WHERE p.age > 10 AND p.age < 40 RETURN p.name"),
+        expected
+    );
+}
+
+#[test]
+fn a_predicate_split_across_two_variables_plans_each_conjunct_once() {
+    // The IC9 shape: one conjunct pushes to the scan, the other lands above
+    // the expand, and the top-level WHERE used to apply both again -- three
+    // evaluations of the same work.
+    let store = fixture();
+    let text = plan(
+        &store,
+        "MATCH (p:Person)-[:KNOWS]->(f:Person) WHERE p.age > 10 AND f.age < 40 RETURN f.name",
+    );
+    assert_eq!(count_filters(&text), 2, "one filter per conjunct, no re-application:\n{text}");
+}
+
+#[test]
+fn an_optional_match_keeps_the_top_level_filter() {
+    // The case the subtraction must not touch. A left outer join leaves `f`
+    // NULL for people with no KNOWS edge; a filter pushed inside the optional
+    // side never sees those rows, and the top-level one rejects them. Dropping
+    // it would admit rows that should have been excluded.
+    let mut store = GraphStore::new();
+    let a = store.create_node("Person");
+    let _ = store.set_node_property("default", a, "age".to_string(), PropertyValue::Integer(20));
+    let lonely = store.create_node("Person");
+    let _ = store.set_node_property("default", lonely, "age".to_string(), PropertyValue::Integer(20));
+    let b = store.create_node("Person");
+    let _ = store.set_node_property("default", b, "age".to_string(), PropertyValue::Integer(90));
+    let _ = store.create_edge(a, b, "KNOWS");
+
+    // `lonely` has no friend, so `f.age` is NULL and the row must not survive.
+    let cypher = "MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS]->(f:Person) WHERE f.age > 50 RETURN p";
+    assert_eq!(
+        rows(&store, cypher),
+        1,
+        "only the person whose friend is over 50 should survive"
+    );
+}
+
+#[test]
+fn a_predicate_spanning_two_matches_still_gets_its_own_filter() {
+    // The guard must not fire here. The decomposition cannot push a
+    // cross-MATCH predicate into either subplan, so the top-level filter is
+    // the only thing applying it -- removing it would be a wrong answer, not
+    // an optimisation.
+    let store = fixture();
+    let cypher = "MATCH (a:Person), (b:Person) WHERE a.age > b.age RETURN a.name, b.name LIMIT 5";
+    let text = plan(&store, cypher);
+    assert!(
+        count_filters(&text) >= 1,
+        "the cross-MATCH predicate must still be applied:\n{text}"
+    );
+    assert_eq!(rows(&store, cypher), 5, "and it must still return rows");
+}
+
+#[test]
+fn a_where_that_is_only_partly_pushable_keeps_the_top_level_filter() {
+    let store = fixture();
+    let cypher = "MATCH (a:Person), (b:Person) WHERE a.age > 40 AND a.age > b.age RETURN a.name LIMIT 3";
+    assert!(count_filters(&plan(&store, cypher)) >= 1);
+    assert_eq!(rows(&store, cypher), 3);
+}
+
+#[test]
+fn filtering_still_actually_filters() {
+    // The failure mode of getting this wrong is a query that returns rows it
+    // should have excluded, so check the predicate is doing work at all.
+    let store = fixture();
+    let all = rows(&store, "MATCH (p:Person) RETURN p.name");
+    let filtered = rows(&store, "MATCH (p:Person) WHERE p.age > 45 RETURN p.name");
+    assert!(filtered < all, "filtered {filtered} vs all {all}");
+    assert_eq!(filtered, (0..60).filter(|i| (i % 50) > 45).count());
+}

--- a/tests/order_by_limit_topn.rs
+++ b/tests/order_by_limit_topn.rs
@@ -1,0 +1,196 @@
+//! `ORDER BY … LIMIT k` keeps k rows, not n (#518).
+//!
+//! The correctness bar for a bounded sort is higher than for an unbounded one,
+//! because every way of getting it wrong loses rows silently: an off-by-one in
+//! the bound, a `SKIP` that is not added to it, or a cardinality-changing
+//! operator between the sort and the limit that the bound was not allowed to
+//! cross. Each of those has a test here.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// `n` nodes with `v` counting up, inserted in an order that is *not* the sort
+/// order — so a bounded sort that trimmed on arrival order rather than on key
+/// order would fail.
+fn shuffled(n: i64) -> GraphStore {
+    let mut store = GraphStore::new();
+    // A stride coprime with n visits every value exactly once in a scrambled
+    // order, deterministically.
+    let stride = 7;
+    for i in 0..n {
+        let v = (i * stride) % n;
+        let id = store.create_node("N");
+        let _ = store.set_node_property("default", id, "v".to_string(), PropertyValue::Integer(v));
+        let _ = store.set_node_property(
+            "default",
+            id,
+            "band".to_string(),
+            PropertyValue::Integer(v % 3),
+        );
+    }
+    store
+}
+
+fn values(store: &GraphStore, cypher: &str) -> Vec<i64> {
+    let query = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&query).expect("query should execute");
+    batch
+        .records
+        .iter()
+        .map(|r| match r.get("c") {
+            Some(Value::Property(PropertyValue::Integer(i))) => *i,
+            other => panic!("expected an integer, got {other:?}"),
+        })
+        .collect()
+}
+
+#[test]
+fn ascending_top_k_is_the_k_smallest_in_order() {
+    let store = shuffled(5000);
+    assert_eq!(
+        values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c LIMIT 5"),
+        vec![0, 1, 2, 3, 4]
+    );
+}
+
+#[test]
+fn descending_top_k_is_the_k_largest_in_order() {
+    let store = shuffled(5000);
+    assert_eq!(
+        values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c DESC LIMIT 5"),
+        vec![4999, 4998, 4997, 4996, 4995]
+    );
+}
+
+#[test]
+fn skip_is_added_to_the_bound() {
+    // The bound a sort may apply is SKIP + LIMIT. If only LIMIT reaches it,
+    // the sort keeps 5 rows, SKIP throws away 3 of them, and the page comes
+    // back short.
+    let store = shuffled(5000);
+    assert_eq!(
+        values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c SKIP 3 LIMIT 5"),
+        vec![3, 4, 5, 6, 7]
+    );
+}
+
+#[test]
+fn a_large_skip_past_several_trim_thresholds_still_pages_correctly() {
+    let store = shuffled(5000);
+    let rows = values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c SKIP 4990 LIMIT 10");
+    assert_eq!(rows, (4990..5000).collect::<Vec<_>>());
+}
+
+#[test]
+fn every_page_of_a_full_scan_is_correct() {
+    // Paging all the way through catches a bound that is right at the start
+    // and drifts, which a single spot-check does not.
+    let store = shuffled(200);
+    let mut seen = Vec::new();
+    for page in 0..10 {
+        let rows = values(
+            &store,
+            &format!("MATCH (n:N) RETURN n.v AS c ORDER BY c SKIP {} LIMIT 20", page * 20),
+        );
+        assert_eq!(rows.len(), 20, "page {page} was short: {rows:?}");
+        seen.extend(rows);
+    }
+    assert_eq!(seen, (0..200).collect::<Vec<_>>());
+}
+
+#[test]
+fn a_limit_larger_than_the_input_returns_everything() {
+    let store = shuffled(50);
+    let rows = values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c LIMIT 1000");
+    assert_eq!(rows, (0..50).collect::<Vec<_>>());
+}
+
+#[test]
+fn a_limit_of_zero_returns_nothing() {
+    let store = shuffled(50);
+    assert!(values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c LIMIT 0").is_empty());
+}
+
+#[test]
+fn without_a_limit_every_row_survives_in_order() {
+    let store = shuffled(300);
+    let rows = values(&store, "MATCH (n:N) RETURN n.v AS c ORDER BY c");
+    assert_eq!(rows, (0..300).collect::<Vec<_>>());
+}
+
+#[test]
+fn a_multi_key_sort_orders_by_every_key() {
+    let store = shuffled(300);
+    let query = parse_query(
+        "MATCH (n:N) RETURN n.band AS b, n.v AS c ORDER BY b ASC, c DESC LIMIT 4",
+    )
+    .unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    let rows: Vec<(i64, i64)> = batch
+        .records
+        .iter()
+        .map(|r| {
+            let get = |k: &str| match r.get(k) {
+                Some(Value::Property(PropertyValue::Integer(i))) => *i,
+                other => panic!("{other:?}"),
+            };
+            (get("b"), get("c"))
+        })
+        .collect();
+    // band 0 holds 0, 3, 6, … 297; descending within the band.
+    assert_eq!(rows, vec![(0, 297), (0, 294), (0, 291), (0, 288)]);
+}
+
+#[test]
+fn distinct_between_the_sort_and_the_limit_does_not_lose_rows() {
+    // The hazard the bound must not cross. DISTINCT can discard rows, so a
+    // LIMIT above it may need more than `limit` rows from below; a sort that
+    // accepted the bound through a DISTINCT would return short.
+    let mut store = GraphStore::new();
+    for i in 0..300 {
+        let id = store.create_node("N");
+        // Ten distinct values, each repeated thirty times.
+        let _ = store.set_node_property("default", id, "v".to_string(), PropertyValue::Integer(i % 10));
+    }
+    let rows = values(&store, "MATCH (n:N) RETURN DISTINCT n.v AS c ORDER BY c LIMIT 10");
+    assert_eq!(rows, (0..10).collect::<Vec<_>>());
+}
+
+#[test]
+fn a_filter_between_the_sort_and_the_limit_does_not_lose_rows() {
+    let store = shuffled(500);
+    let rows = values(
+        &store,
+        "MATCH (n:N) WHERE n.v > 100 RETURN n.v AS c ORDER BY c LIMIT 5",
+    );
+    assert_eq!(rows, vec![101, 102, 103, 104, 105]);
+}
+
+#[test]
+fn nulls_sort_consistently_under_a_bound() {
+    // ORDER BY over a property some nodes lack must place the missing ones the
+    // same way whether or not a bound is applied, or a LIMIT would change the
+    // membership of the answer rather than only its length.
+    let mut store = GraphStore::new();
+    for i in 0..100 {
+        let id = store.create_node("N");
+        if i % 2 == 0 {
+            let _ = store.set_node_property("default", id, "v".to_string(), PropertyValue::Integer(i));
+        }
+    }
+    let query = parse_query("MATCH (n:N) RETURN n.v AS c ORDER BY c").unwrap();
+    let unbounded = QueryExecutor::new(&store).execute(&query).unwrap();
+    let first_ten: Vec<String> = unbounded
+        .records
+        .iter()
+        .take(10)
+        .map(|r| format!("{:?}", r.get("c")))
+        .collect();
+
+    let query = parse_query("MATCH (n:N) RETURN n.v AS c ORDER BY c LIMIT 10").unwrap();
+    let bounded = QueryExecutor::new(&store).execute(&query).unwrap();
+    let bounded_ten: Vec<String> = bounded.records.iter().map(|r| format!("{:?}", r.get("c"))).collect();
+
+    assert_eq!(bounded_ten, first_ten, "a bound must not change which rows win");
+}


### PR DESCRIPTION
Closes #519. Part of #296.

## What was happening

The predicate decomposition hands each MATCH the conjuncts that reference only its own variables, and the match planners attach them as filters inside the subplan — often right at the scan, which is the point of pushing them down. The top-level `WHERE` then re-applied the **entire** predicate on top of that.

`WHERE p.age > 10 AND f.age < 40` over `(p)-[:KNOWS]->(f)` planned as:

```
Project (f.name)
+- Filter (p.age > 10 AND f.age < 40)     <- redundant
   +- Filter (f.age < 40)
      +- Expand ((p)-[:KNOWS]->(f))
         +- Filter (p.age > 10)
            +- NodeScan (var=p, labels=["Person"])
```

Three evaluations of the same work per surviving row. On LDBC IC9 the redundant pass cost ~130 ms over 389,461 rows and removed nothing — the issue found it as two stacked filters with identical predicates and identical row counts.

It is not a wrong answer: `x AND x` is idempotent. It is a plan that does the work twice and says nothing about it, which is why it survived until per-operator attribution (#517) made it visible.

## The change

The top-level filter now applies the **set difference**: the conjuncts of the `WHERE` minus the conjuncts any filter in the subtree below is already applying.

`collect_applied_predicates` walks the **finished** plan and reads the predicates its filters carry. That is deliberate rather than tracking what was pushed during construction: there are several planning paths into a match subplan — the graph-native enumerator, its legacy fallback, the per-path builders — and none of them promises to attach every predicate it is handed. The question that matters is what the chosen plan *did*, not what it was asked to do. Trusting the intention instead would trade a few percent for a class of silent wrong answers.

## Two shapes where re-application is load-bearing

Both are excluded rather than reasoned about:

**`OPTIONAL MATCH`.** A left outer join can leave a variable NULL for unmatched rows. A filter pushed inside the optional side never sees those rows; the top-level one does, and rejects them. Dropping it would admit rows that should have been excluded. `an_optional_match_keeps_the_top_level_filter` covers this and fails without the guard.

**A leading `UNWIND`.** Predicates on its variable are deliberately left out of the decomposition, because the `Unwind` that binds them sits above the matches — the existing code comments say so, and rely on the top-level filter to apply them. They are not in any descendant filter so they would survive the subtraction anyway, but excluding the case makes the reasoning independent of that.

With those excluded, every operator between a pushed filter and this point only *adds* bindings — `Expand`, `ExpandInto`, `Join` on shared equal values, `CartesianProduct` — so a conjunct proved below is still true here.

## Testing

9 tests in `tests/duplicate_filter_plan.rs`, asserting on `EXPLAIN` rather than on timings, because the defect is a plan shape and a plan shape is checkable without a profiler.

Covered: a compound `WHERE` on one MATCH plans one filter; a predicate split across two variables plans one filter per conjunct and no re-application; a single predicate plans one; no `WHERE` plans none; **`OPTIONAL MATCH` keeps the top-level filter and still excludes the NULL rows**; a cross-MATCH predicate still gets its own filter and still returns rows; a partly-pushable `WHERE` keeps the top-level filter; deduplicating does not change the answer; and filtering still actually filters, checked against a hand-computed count.

One note on the test helper: `EXPLAIN` appends planner diagnostics listing every *candidate* plan, and those contain filters of their own. Counting the whole output counts plans that were considered and rejected — the first version of `count_filters` did exactly that and reported a false failure.

Full suite: **2,644 passing, 0 failures.**