### PR TITLE
Say whether the host held still, so a slow machine is not read as a change

### DIFF
--- a/benches/common/bench_setup.rs
+++ b/benches/common/bench_setup.rs
@@ -26,3 +26,136 @@ pub fn init() {
         println!("[bench] Rebuild with `--features gpu` for GPU-accelerated benchmarks.");
     }
 }
+
+// ---------------------------------------------------------------- host state
+//
+// A benchmark that reports absolute milliseconds and nothing else cannot tell
+// a code change from a slower host. On this workstation the *same binary* ran
+// LDBC IC9 in 2,822 ms in the morning and 4,912 ms the same evening -- 1.74x,
+// no code change, nothing else on the CPU -- and two consecutive runs of one
+// binary differed by 24% (#529).
+//
+// That is not a curiosity. `SLT-2` is a ratio against a competitor, and a
+// ratio between numbers taken on a drifting host is not a ratio; a nightly
+// regression gate set below that drift pages on noise, and one set above it
+// misses real regressions. The fix is not to make the host stable -- it is to
+// report enough that a reader can see when it was not.
+
+use std::time::{Duration, Instant};
+
+/// A fixed, CPU-bound unit of work, timed. Touches no memory beyond a register
+/// and no I/O, so it measures core throughput and nothing else.
+///
+/// The point is comparability, not realism: two runs whose calibration differs
+/// materially were taken on hosts of different speed, whatever their timings
+/// say. Compare this figure before comparing anything else.
+pub fn calibrate() -> Duration {
+    // `black_box` on the accumulator stops LLVM folding the loop away, which
+    // it will otherwise do -- a calibration that optimises to nothing reports
+    // a stable zero and hides exactly what it exists to reveal.
+    let started = Instant::now();
+    let mut acc: u64 = 0x9E3779B97F4A7C15;
+    for i in 0..20_000_000u64 {
+        acc = acc.wrapping_mul(6364136223846793005).wrapping_add(i | 1);
+        acc ^= acc >> 29;
+    }
+    std::hint::black_box(acc);
+    started.elapsed()
+}
+
+/// What the machine was doing, as far as it will say.
+///
+/// Linux-only in the parts that need `/proc`; elsewhere the fields it cannot
+/// answer are reported as unknown rather than guessed.
+pub struct HostState {
+    pub load_average: Option<f64>,
+    pub cpu_mhz: Option<f64>,
+}
+
+impl HostState {
+    pub fn read() -> Self {
+        let load_average = std::fs::read_to_string("/proc/loadavg")
+            .ok()
+            .and_then(|s| s.split_whitespace().next()?.parse().ok());
+
+        // Mean current frequency across all cores.
+        //
+        // Not the first core's: `/proc/cpuinfo` reports an instantaneous
+        // value, and an idle core reads a few hundred MHz while the core
+        // actually running the benchmark is at full speed. Reading core 0
+        // alone produced 2,235 MHz at the start of a run and 400 MHz at the
+        // end of the same run, which says nothing about the machine.
+        //
+        // Even averaged this is a weak signal next to `calibrate()`. It is
+        // here because a host that has thermally capped shows it here first.
+        let cpu_mhz = std::fs::read_to_string("/proc/cpuinfo").ok().and_then(|s| {
+            let readings: Vec<f64> = s
+                .lines()
+                .filter(|l| l.starts_with("cpu MHz"))
+                .filter_map(|l| l.split(':').nth(1)?.trim().parse().ok())
+                .collect();
+            (!readings.is_empty()).then(|| readings.iter().sum::<f64>() / readings.len() as f64)
+        });
+
+        HostState { load_average, cpu_mhz }
+    }
+
+    pub fn format(&self) -> String {
+        let load = self
+            .load_average
+            .map(|l| format!("{:.2}", l))
+            .unwrap_or_else(|| "unknown".into());
+        let mhz = self
+            .cpu_mhz
+            .map(|m| format!("{:.0} MHz mean", m))
+            .unwrap_or_else(|| "unknown".into());
+        format!("load {load}, cpu {mhz}")
+    }
+}
+
+/// Print the calibration and host state that a reader needs before believing
+/// any absolute figure in the run.
+///
+/// Called at the start of a suite; call [`report_drift`] at the end with the
+/// value returned here.
+pub fn report_calibration() -> Duration {
+    let host = HostState::read();
+    let calibration = calibrate();
+    eprintln!(
+        "Host calibration: {:.0} ms for a fixed CPU-bound loop ({})",
+        calibration.as_secs_f64() * 1000.0,
+        host.format()
+    );
+    eprintln!(
+        "  Compare this before comparing timings: two runs whose calibration differs\n  \
+         were taken on hosts of different speed, whatever their milliseconds say (#529)."
+    );
+    calibration
+}
+
+/// Re-measure at the end of a suite and say whether the host held still.
+pub fn report_drift(before: Duration) {
+    let host = HostState::read();
+    let after = calibrate();
+    let ratio = if before.is_zero() {
+        1.0
+    } else {
+        after.as_secs_f64() / before.as_secs_f64()
+    };
+    eprintln!(
+        "Host calibration after the suite: {:.0} ms ({}) — {:.2}x the opening figure",
+        after.as_secs_f64() * 1000.0,
+        host.format(),
+        ratio
+    );
+    // 10% is well inside what this box does when it is behaving and well
+    // outside what a stable one should do across a two-minute suite.
+    if !(0.9..=1.1).contains(&ratio) {
+        eprintln!(
+            "  WARNING: the host changed speed by {:.0}% during the run. Timings from the\n  \
+             start and the end of this suite are not comparable with each other, and none\n  \
+             of them is comparable with another session (#529).",
+            (ratio - 1.0).abs() * 100.0
+        );
+    }
+}

--- a/benches/ldbc_benchmark.rs
+++ b/benches/ldbc_benchmark.rs
@@ -669,6 +669,10 @@ async fn run_benchmark(
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     bench_setup::init();
+    // Opening calibration, before anything else competes for the CPU. Closed
+    // out at the end of the suite so a host that changed speed mid-run says so
+    // rather than being read as a code change (#529).
+    let calibration = bench_setup::report_calibration();
 
     let args: Vec<String> = std::env::args().collect();
 
@@ -951,6 +955,7 @@ async fn main() -> Result<(), Error> {
     if profile_mode {
         println!();
         println!("Profiled {} query/queries in {}.", queries.len(), format_duration(bench_time));
+        bench_setup::report_drift(calibration);
         if errors > 0 {
             std::process::exit(1);
         }
@@ -977,6 +982,8 @@ async fn main() -> Result<(), Error> {
     // Cache stats
     let stats = client.cache_stats();
     println!("AST cache: {} hits, {} misses", stats.hits(), stats.misses());
+
+    bench_setup::report_drift(calibration);
 
     // Any empty read is a configuration failure, not a pass. A run with 17 of 21 reads
     // returning nothing measured nothing, and exiting 0 on it is how "21/21 passed in 32 ms"

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -27,6 +27,32 @@ The split follows from where a reader can act: a number you can reproduce
 belongs next to the code that produces it; a number that required another
 vendor's licensed software to obtain does not.
 
+## Comparing two numbers
+
+**A before/after claim requires both figures from one back-to-back session on
+one machine.** Not "the same machine" — the same *sitting*.
+
+This is not caution for its own sake. On a 16-core workstation, the same
+binary at the same commit ran LDBC IC9 in **2,822 ms in the morning and
+4,912 ms the same evening**, with nothing else on the CPU; two consecutive
+runs of one binary differed by **24%** (#529). Comparing an evening run
+against a morning baseline produced apparent 2–4x regressions in three
+queries, none of which existed.
+
+So:
+
+- **Check the calibration line first.** Every run prints a fixed CPU-bound
+  loop's duration at the start and again at the end, with the load average
+  and mean core frequency. Two runs whose calibration differs were taken on
+  hosts of different speed, whatever their milliseconds say. If the closing
+  figure differs from the opening one by more than 10%, the run says so and
+  its own numbers are not internally comparable either.
+- **Quote the ratio, not the milliseconds**, when the point is an
+  improvement. A ratio measured back to back survives a slow host; an
+  absolute figure does not survive being read next to one taken elsewhere.
+- **`SLT-2` is a ratio against a competitor.** A competitor figure measured
+  in a different session is not a baseline for one of ours.
+
 
 Two suites are documented here: the LDBC SNB Interactive results below, and **HIER**, the
 hierarchy category introduced with ADR-035.

--- a/tests/bench_host_calibration.rs
+++ b/tests/bench_host_calibration.rs
@@ -1,0 +1,114 @@
+//! The benchmark harness reports whether the host held still (#529).
+//!
+//! Every `[[bench]]` sets `harness = false`, so `cargo test --bench` runs the
+//! benchmark's `main` rather than its `#[test]` functions. Pulling the module
+//! into a normal test target is what makes these run.
+//!
+//! What is worth testing here is narrow but load-bearing: the calibration must
+//! not be optimised away, it must be stable enough that a real change in host
+//! speed stands out from its own noise, and the drift report must fire when
+//! the two figures disagree. A calibration that silently folds to zero reports
+//! a perfectly stable host forever.
+
+#[path = "../benches/common/bench_setup.rs"]
+mod bench_setup;
+
+use std::time::Duration;
+
+#[test]
+fn the_calibration_loop_is_not_optimised_away() {
+    // The failure this guards: LLVM folds the loop, `calibrate()` returns
+    // ~0 ns, every run looks identical, and the one thing the figure exists to
+    // detect becomes invisible.
+    let elapsed = bench_setup::calibrate();
+    assert!(
+        elapsed > Duration::from_micros(500),
+        "calibration took {elapsed:?} — the loop was almost certainly folded away"
+    );
+    // And it must not be so slow that adding it to every benchmark is a cost
+    // of its own.
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "calibration took {elapsed:?}, which is too slow to run at the start and end of every suite"
+    );
+}
+
+#[test]
+fn the_calibration_is_repeatable_enough_to_be_a_signal() {
+    // It only has to separate a real change in host speed from its own noise.
+    // The drift it exists to catch was 1.74x; the threshold that warns is 10%.
+    // So the spread across consecutive calls must be well under that, or the
+    // warning fires on itself.
+    let samples: Vec<Duration> = (0..5).map(|_| bench_setup::calibrate()).collect();
+    let fastest = samples.iter().min().unwrap().as_secs_f64();
+    let slowest = samples.iter().max().unwrap().as_secs_f64();
+
+    assert!(fastest > 0.0, "calibration returned zero: {samples:?}");
+    let spread = slowest / fastest;
+    assert!(
+        spread < 2.0,
+        "calibration varied {spread:.2}x across five consecutive calls ({samples:?}); \
+         it cannot distinguish a slower host from its own noise"
+    );
+}
+
+#[test]
+fn host_state_reports_what_it_can_and_says_so_when_it_cannot() {
+    let state = bench_setup::HostState::read();
+    let text = state.format();
+
+    assert!(text.contains("load"), "{text}");
+    assert!(text.contains("cpu"), "{text}");
+
+    // On Linux both should resolve. Elsewhere they must read as unknown
+    // rather than as a fabricated zero.
+    #[cfg(target_os = "linux")]
+    {
+        assert!(state.load_average.is_some(), "load average should be readable on Linux");
+        assert!(state.cpu_mhz.is_some(), "cpu MHz should be readable on Linux");
+        assert!(!text.contains("unknown"), "{text}");
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        assert!(text.contains("unknown"), "{text}");
+    }
+}
+
+#[test]
+fn the_mean_frequency_is_not_a_single_cores_idle_reading() {
+    // Reading core 0 alone gave 2,235 MHz at the start of a run and 400 MHz at
+    // the end of the same run: an idle core, not a throttled machine. The mean
+    // across cores should sit in a plausible band rather than at either
+    // extreme.
+    #[cfg(target_os = "linux")]
+    {
+        let Some(mhz) = bench_setup::HostState::read().cpu_mhz else {
+            eprintln!("SKIP: no cpu MHz reported");
+            return;
+        };
+        assert!(
+            (100.0..10_000.0).contains(&mhz),
+            "mean cpu frequency {mhz} MHz is outside any plausible range"
+        );
+    }
+}
+
+#[test]
+fn reporting_calibration_returns_the_figure_it_printed() {
+    // `report_calibration` hands its measurement back so the end of the suite
+    // can compare against it. Returning something else would make the drift
+    // report meaningless while still looking right.
+    let reported = bench_setup::report_calibration();
+    assert!(reported > Duration::ZERO);
+    // Exercises the closing path too: it must not panic when the host held
+    // still, which is the overwhelmingly common case.
+    bench_setup::report_drift(reported);
+}
+
+#[test]
+fn drift_reporting_survives_a_zero_baseline() {
+    // A pathological input rather than a realistic one: the ratio divides by
+    // the opening figure, and a panic inside the *reporting* of a benchmark
+    // would lose the whole run's results.
+    bench_setup::report_drift(Duration::ZERO);
+}


### PR DESCRIPTION
Part of #529.

## What happened

While measuring #518 I recorded the **same binary at the same commit**, same dataset, same machine, four hours apart:

| when | IC9 median |
|---|---:|
| morning | 2,822 ms |
| evening | 4,912 ms |

1.74×, with nothing else on the CPU. Two consecutive runs of one binary differed by **24%**.

Comparing an evening run of `main` against the morning baseline showed IC10 2×, IC11 4× and IC12 3× **slower**. None of those regressions existed — a back-to-back A/B showed IC9 1.97× faster and IC10–IC12 unchanged. They were caught only because they looked implausible enough to re-measure. A smaller false regression would have been believed, and a real one of that size would have been dismissed as noise.

The benchmark reported a median in absolute milliseconds and nothing that distinguishes a code change from a slower host.

## What this adds

Every run opens and closes with a fixed CPU-bound loop, timed, next to the load average and mean core frequency:

```
Host calibration: 37 ms for a fixed CPU-bound loop (load 2.08, cpu 2235 MHz mean)
  Compare this before comparing timings: two runs whose calibration differs
  were taken on hosts of different speed, whatever their milliseconds say (#529).
...
Host calibration after the suite: 37 ms (load 2.91, cpu 2210 MHz mean) — 1.00x the opening figure
```

A host that changed speed by more than 10% during the suite gets a warning saying its own numbers are not internally comparable, let alone comparable with another session.

**The frequency is a mean across cores, not core 0's.** `/proc/cpuinfo` reports an instantaneous value, and reading one core gave 2,235 MHz at the start of a run and 400 MHz at the end of the *same* run — an idle core, not a throttled machine. That reading would have been worse than none.

## And the protocol, written down

`docs/BENCHMARKS.md` gains a "Comparing two numbers" section stating the rule rather than leaving it as folklore:

- a before/after claim needs both figures from **one back-to-back sitting** — not "the same machine", the same *session*;
- quote the **ratio**, not the milliseconds, when the point is an improvement;
- `SLT-2` is a ratio against a competitor, so a competitor figure from another session is not a baseline for one of ours.

## What this does not do

The rest of #529 stays open: the calibration is not yet in the JSON result envelope, and the regression gate does not yet normalise against it or refuse a comparison when it moved. This is the part that makes the drift visible; making it *actionable* is the follow-up.

## Testing

6 tests in `tests/bench_host_calibration.rs`, guarding the two ways a calibration becomes useless:

- **it must not be optimised away.** LLVM will happily fold the loop, and a calibration that returns ~0 ns reports a perfectly stable host forever — the one thing it exists to detect becomes invisible. Also bounded above, so running it twice per suite is not a cost of its own.
- **it must be quieter than the drift it measures.** Five consecutive calls must agree well inside the 10% warning threshold, or the warning fires on itself.

Plus: host state resolves on Linux and reads as `unknown` rather than a fabricated zero elsewhere; the mean frequency sits in a plausible band rather than at an idle core's extreme; `report_calibration` returns the figure it printed, so the closing comparison is against the right number; and `report_drift` survives a zero baseline, because a panic inside the *reporting* of a benchmark loses the whole run.

The tests live in `tests/` because every `[[bench]]` here sets `harness = false` — `cargo test --bench` runs `main`, so a `#[test]` inside a bench never executes.