### PR TITLE
Stop hashing row indices with SipHash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,14 @@ samyama-sdk = { path = "crates/samyama-sdk", version = "1.7.0" }
 http-body-util = "0.1"
 
 [[bench]]
+name = "aggregate_throughput"
+harness = false
+
+[[bench]]
+name = "property_access"
+harness = false
+
+[[bench]]
 name = "ingest_profile"
 harness = false
 

--- a/benches/aggregate_throughput.rs
+++ b/benches/aggregate_throughput.rs
@@ -1,0 +1,178 @@
+//! Hash-aggregation throughput, in nanoseconds per input row (#521).
+//!
+//! `CH-PROFILE-01` put **60.1% of LDBC IC5 in `Aggregate`** — 1,947 ms to fold
+//! 1,678,980 rows into 96,862 groups, about 1.16 µs per input row. For
+//! contrast the `Expand` that produced those rows managed 0.55 µs each, so the
+//! aggregate cost more than twice as much per row as the traversal, while
+//! doing strictly less work per row.
+//!
+//! That is a constant, not an algorithm, and a constant needs a reproducer
+//! that does not require a 21M-edge dataset to observe. This isolates the four
+//! shapes the operator actually implements, so the next change has a number to
+//! move rather than a hypothesis to act on:
+//!
+//! | shape | path in `AggregateOperator` |
+//! |---|---|
+//! | no `GROUP BY` | `execute_all_no_group` — no map at all |
+//! | one key | `execute_all_single_key` — `FxHashMap<Value, _>` |
+//! | two integer keys | `execute_all` — `FxHashMap<Vec<Value>, _>` |
+//! | integer + string keys | `execute_all` — IC5's shape |
+//!
+//! The differences between rows of that table are the whole point. The gap
+//! between one key and two says what the per-row `Vec` costs; the gap between
+//! two integers and integer-plus-string says what resolving and cloning a
+//! `String` property per row costs; and the gap between "no group by" and "one
+//! key" says what the hashing itself costs.
+//!
+//!   cargo bench --bench aggregate_throughput
+//!   cargo bench --bench aggregate_throughput -- --rows 2000000 --groups 100000
+
+use std::time::Instant;
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+
+#[path = "common/bench_setup.rs"]
+mod bench_setup;
+
+/// `rows` nodes spread over `groups` distinct values, which is the shape that
+/// matters: a group-by whose every row is its own group measures allocation,
+/// and one with a single group measures nothing.
+fn fixture(rows: usize, groups: usize) -> GraphStore {
+    let mut store = GraphStore::new();
+    for i in 0..rows {
+        let id = store.create_node("Row");
+        let group = (i % groups) as i64;
+        store.set_column_property(id, "gid", PropertyValue::Integer(group));
+        // A second integer key **functionally determined by the first**, so
+        // the two-key shape produces exactly as many groups as the one-key
+        // shape. An independent second key would multiply the group count and
+        // the comparison would be measuring map growth rather than the cost of
+        // building a composite key -- which is what a first draft of this
+        // bench did, reporting 500,000 groups against 25,000 and a 3.8x
+        // difference that was mostly the extra groups.
+        store.set_column_property(id, "gid2", PropertyValue::Integer(group * 2));
+        // A string key of a realistic width -- LDBC's `forum.title` is a short
+        // phrase, not a single character, and the clone cost scales with it.
+        store.set_column_property(
+            id,
+            "gname",
+            PropertyValue::String(format!("group-{group:08}")),
+        );
+        store.set_column_property(id, "weight", PropertyValue::Integer((i % 97) as i64));
+    }
+    store
+}
+
+/// Exclusive time in the `Aggregate` operator, from `PROFILE` (#517).
+///
+/// Timing the whole query would fold in the scan that feeds it, which on these
+/// shapes is a large and varying share. The per-operator attribution exists
+/// precisely so a constant like this can be isolated.
+fn aggregate_self_ms(store: &GraphStore, cypher: &str) -> Option<f64> {
+    let query = parse_query(&format!("PROFILE {cypher}")).ok()?;
+    let batch = QueryExecutor::new(store).execute(&query).ok()?;
+    let text = match batch.records.first()?.get("plan")? {
+        samyama::query::executor::Value::Property(PropertyValue::String(t)) => t.clone(),
+        _ => return None,
+    };
+    // The ranked section prints `  1. Aggregate   1946.54ms   60.1%  ...`.
+    text.lines()
+        .skip_while(|l| !l.contains("Hottest operators"))
+        .find(|l| l.contains("Aggregate"))
+        .and_then(|l| l.split_whitespace().find(|w| w.ends_with("ms")))
+        .and_then(|w| w.trim_end_matches("ms").parse().ok())
+}
+
+fn time_query(store: &GraphStore, cypher: &str, rows: usize) -> (f64, usize) {
+    let query = parse_query(cypher).expect("query should parse");
+    // Warm once: the first run pays for statistics and any lazy index work,
+    // which is not what this is measuring.
+    let _ = QueryExecutor::new(store).execute(&query).expect("query should run");
+
+    let started = Instant::now();
+    let batch = QueryExecutor::new(store).execute(&query).expect("query should run");
+    let elapsed = started.elapsed();
+
+    let ns_per_row = elapsed.as_secs_f64() * 1e9 / rows as f64;
+    (ns_per_row, batch.records.len())
+}
+
+fn main() {
+    bench_setup::init();
+    let calibration = bench_setup::report_calibration();
+
+    let args: Vec<String> = std::env::args().collect();
+    let arg = |flag: &str| -> Option<usize> {
+        args.iter()
+            .position(|a| a == flag)
+            .and_then(|i| args.get(i + 1))
+            .and_then(|v| v.parse().ok())
+    };
+    let rows = arg("--rows").unwrap_or(1_000_000);
+    let groups = arg("--groups").unwrap_or(50_000);
+
+    eprintln!("Building {rows} rows over {groups} groups…");
+    let build_start = Instant::now();
+    let store = fixture(rows, groups);
+    eprintln!("built in {:.1}s\n", build_start.elapsed().as_secs_f64());
+
+    let cases: Vec<(&str, &str)> = vec![
+        (
+            "no GROUP BY, scanning (global sum)",
+            "MATCH (r:Row) RETURN sum(r.weight) AS s",
+        ),
+        (
+            "one integer key",
+            "MATCH (r:Row) RETURN r.gid AS g, count(r) AS c",
+        ),
+        (
+            "two integer keys, same group count",
+            "MATCH (r:Row) RETURN r.gid AS g, r.gid2 AS g2, count(r) AS c",
+        ),
+        (
+            "integer + string keys (IC5's shape)",
+            "MATCH (r:Row) RETURN r.gid AS g, r.gname AS n, count(r) AS c",
+        ),
+        (
+            "one integer key, sum over a property",
+            "MATCH (r:Row) RETURN r.gid AS g, sum(r.weight) AS s",
+        ),
+    ];
+
+    println!(
+        "{:<42} {:>10} {:>12} {:>10} {:>10}",
+        "shape", "ns/row", "agg ns/row", "query ms", "groups"
+    );
+    println!("{:-<42} {:->10} {:->12} {:->10} {:->10}", "", "", "", "", "");
+    for (name, cypher) in &cases {
+        let (ns_per_row, out_rows) = time_query(&store, cypher, rows);
+        // `agg ns/row` is the operator alone; `ns/row` is the whole query,
+        // scan included. The gap between them is what the aggregate is *not*
+        // responsible for.
+        let agg = aggregate_self_ms(&store, cypher)
+            .map(|ms| ms * 1e6 / rows as f64)
+            .unwrap_or(f64::NAN);
+        println!(
+            "{:<42} {:>10.1} {:>12.1} {:>10.0} {:>10}",
+            name,
+            ns_per_row,
+            agg,
+            ns_per_row * rows as f64 / 1e6,
+            out_rows
+        );
+    }
+
+    println!();
+    println!("Read the differences, not the absolutes:");
+    println!("  one key   - no group by  = hashing and the map");
+    println!("  two keys  - one key      = the per-row Vec<Value> the general path builds");
+    println!("  int+str   - two ints     = resolving and cloning a String property per row");
+    println!("  count     - sum          = evaluating the aggregate's argument per row");
+    println!();
+    println!("LDBC IC5 measured 1,160 ns/row over 1,678,980 rows into 96,862 groups (#521),");
+    println!("against an Expand feeding it at 550 ns/row.");
+
+    bench_setup::report_drift(calibration);
+}

--- a/benches/common/bench_setup.rs
+++ b/benches/common/bench_setup.rs
@@ -26,3 +26,136 @@ pub fn init() {
         println!("[bench] Rebuild with `--features gpu` for GPU-accelerated benchmarks.");
     }
 }
+
+// ---------------------------------------------------------------- host state
+//
+// A benchmark that reports absolute milliseconds and nothing else cannot tell
+// a code change from a slower host. On this workstation the *same binary* ran
+// LDBC IC9 in 2,822 ms in the morning and 4,912 ms the same evening -- 1.74x,
+// no code change, nothing else on the CPU -- and two consecutive runs of one
+// binary differed by 24% (#529).
+//
+// That is not a curiosity. `SLT-2` is a ratio against a competitor, and a
+// ratio between numbers taken on a drifting host is not a ratio; a nightly
+// regression gate set below that drift pages on noise, and one set above it
+// misses real regressions. The fix is not to make the host stable -- it is to
+// report enough that a reader can see when it was not.
+
+use std::time::{Duration, Instant};
+
+/// A fixed, CPU-bound unit of work, timed. Touches no memory beyond a register
+/// and no I/O, so it measures core throughput and nothing else.
+///
+/// The point is comparability, not realism: two runs whose calibration differs
+/// materially were taken on hosts of different speed, whatever their timings
+/// say. Compare this figure before comparing anything else.
+pub fn calibrate() -> Duration {
+    // `black_box` on the accumulator stops LLVM folding the loop away, which
+    // it will otherwise do -- a calibration that optimises to nothing reports
+    // a stable zero and hides exactly what it exists to reveal.
+    let started = Instant::now();
+    let mut acc: u64 = 0x9E3779B97F4A7C15;
+    for i in 0..20_000_000u64 {
+        acc = acc.wrapping_mul(6364136223846793005).wrapping_add(i | 1);
+        acc ^= acc >> 29;
+    }
+    std::hint::black_box(acc);
+    started.elapsed()
+}
+
+/// What the machine was doing, as far as it will say.
+///
+/// Linux-only in the parts that need `/proc`; elsewhere the fields it cannot
+/// answer are reported as unknown rather than guessed.
+pub struct HostState {
+    pub load_average: Option<f64>,
+    pub cpu_mhz: Option<f64>,
+}
+
+impl HostState {
+    pub fn read() -> Self {
+        let load_average = std::fs::read_to_string("/proc/loadavg")
+            .ok()
+            .and_then(|s| s.split_whitespace().next()?.parse().ok());
+
+        // Mean current frequency across all cores.
+        //
+        // Not the first core's: `/proc/cpuinfo` reports an instantaneous
+        // value, and an idle core reads a few hundred MHz while the core
+        // actually running the benchmark is at full speed. Reading core 0
+        // alone produced 2,235 MHz at the start of a run and 400 MHz at the
+        // end of the same run, which says nothing about the machine.
+        //
+        // Even averaged this is a weak signal next to `calibrate()`. It is
+        // here because a host that has thermally capped shows it here first.
+        let cpu_mhz = std::fs::read_to_string("/proc/cpuinfo").ok().and_then(|s| {
+            let readings: Vec<f64> = s
+                .lines()
+                .filter(|l| l.starts_with("cpu MHz"))
+                .filter_map(|l| l.split(':').nth(1)?.trim().parse().ok())
+                .collect();
+            (!readings.is_empty()).then(|| readings.iter().sum::<f64>() / readings.len() as f64)
+        });
+
+        HostState { load_average, cpu_mhz }
+    }
+
+    pub fn format(&self) -> String {
+        let load = self
+            .load_average
+            .map(|l| format!("{:.2}", l))
+            .unwrap_or_else(|| "unknown".into());
+        let mhz = self
+            .cpu_mhz
+            .map(|m| format!("{:.0} MHz mean", m))
+            .unwrap_or_else(|| "unknown".into());
+        format!("load {load}, cpu {mhz}")
+    }
+}
+
+/// Print the calibration and host state that a reader needs before believing
+/// any absolute figure in the run.
+///
+/// Called at the start of a suite; call [`report_drift`] at the end with the
+/// value returned here.
+pub fn report_calibration() -> Duration {
+    let host = HostState::read();
+    let calibration = calibrate();
+    eprintln!(
+        "Host calibration: {:.0} ms for a fixed CPU-bound loop ({})",
+        calibration.as_secs_f64() * 1000.0,
+        host.format()
+    );
+    eprintln!(
+        "  Compare this before comparing timings: two runs whose calibration differs\n  \
+         were taken on hosts of different speed, whatever their milliseconds say (#529)."
+    );
+    calibration
+}
+
+/// Re-measure at the end of a suite and say whether the host held still.
+pub fn report_drift(before: Duration) {
+    let host = HostState::read();
+    let after = calibrate();
+    let ratio = if before.is_zero() {
+        1.0
+    } else {
+        after.as_secs_f64() / before.as_secs_f64()
+    };
+    eprintln!(
+        "Host calibration after the suite: {:.0} ms ({}) — {:.2}x the opening figure",
+        after.as_secs_f64() * 1000.0,
+        host.format(),
+        ratio
+    );
+    // 10% is well inside what this box does when it is behaving and well
+    // outside what a stable one should do across a two-minute suite.
+    if !(0.9..=1.1).contains(&ratio) {
+        eprintln!(
+            "  WARNING: the host changed speed by {:.0}% during the run. Timings from the\n  \
+             start and the end of this suite are not comparable with each other, and none\n  \
+             of them is comparable with another session (#529).",
+            (ratio - 1.0).abs() * 100.0
+        );
+    }
+}

--- a/benches/ldbc_benchmark.rs
+++ b/benches/ldbc_benchmark.rs
@@ -669,6 +669,10 @@ async fn run_benchmark(
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     bench_setup::init();
+    // Opening calibration, before anything else competes for the CPU. Closed
+    // out at the end of the suite so a host that changed speed mid-run says so
+    // rather than being read as a code change (#529).
+    let calibration = bench_setup::report_calibration();
 
     let args: Vec<String> = std::env::args().collect();
 
@@ -951,6 +955,7 @@ async fn main() -> Result<(), Error> {
     if profile_mode {
         println!();
         println!("Profiled {} query/queries in {}.", queries.len(), format_duration(bench_time));
+        bench_setup::report_drift(calibration);
         if errors > 0 {
             std::process::exit(1);
         }
@@ -977,6 +982,8 @@ async fn main() -> Result<(), Error> {
     // Cache stats
     let stats = client.cache_stats();
     println!("AST cache: {} hits, {} misses", stats.hits(), stats.misses());
+
+    bench_setup::report_drift(calibration);
 
     // Any empty read is a configuration failure, not a pass. A run with 17 of 21 reads
     // returning nothing measured nothing, and exiting 0 on it is how "21/21 passed in 32 ms"

--- a/benches/property_access.rs
+++ b/benches/property_access.rs
@@ -1,0 +1,176 @@
+//! What one property read costs (#531).
+//!
+//! `CH-PROFILE-01` traced LDBC IC5's `Aggregate` cost to something more basic
+//! than aggregation: an aggregate with **no grouping at all** — a global
+//! `sum(r.weight)` — costs 427 ns per row, and almost all of that is reading
+//! one property. The same constant is paid by `Filter` on every row it tests,
+//! by `Sort` on every key it evaluates, and by `Project` on every column it
+//! emits, so it is worth a reproducer of its own rather than being rediscovered
+//! inside whichever operator is being looked at that week.
+//!
+//! The comparison that matters is against a dense array, because that is what
+//! "columnar" normally means and what the cost *should* be:
+//!
+//!   * `ColumnStore::get_property` — the engine's path: property name to a
+//!     column, then row index to a value, two hash lookups
+//!   * a `Vec<i64>` indexed by row — one load, prefetchable
+//!
+//! Rows are visited **in id order**, which is the friendliest possible pattern
+//! for both. A scan does exactly this, and the hash map still misses cache on
+//! nearly every row because the hash scatters the access.
+//!
+//!   cargo bench --bench property_access
+//!   cargo bench --bench property_access -- --rows 2000000 --fill 10
+
+use std::time::Instant;
+
+use samyama::graph::{GraphStore, PropertyValue};
+
+#[path = "common/bench_setup.rs"]
+mod bench_setup;
+
+struct Fixture {
+    store: GraphStore,
+    /// Row indices to read, in ascending order.
+    rows: Vec<usize>,
+}
+
+/// `rows` nodes, of which one in `fill` carries the `sparse` property.
+///
+/// The fill factor is the parameter the design question turns on: a dense
+/// array beats a hash map on a common property and loses on a rare one in a
+/// large graph, so any decision to change the representation needs both
+/// numbers rather than one.
+fn build(rows: usize, fill: usize) -> Fixture {
+    let mut store = GraphStore::new();
+    let mut indices = Vec::with_capacity(rows);
+    for i in 0..rows {
+        let id = store.create_node("Row");
+        store.set_column_property(id, "dense_int", PropertyValue::Integer(i as i64));
+        store.set_column_property(id, "dense_float", PropertyValue::Float(i as f64 * 0.5));
+        store.set_column_property(
+            id,
+            "dense_str",
+            PropertyValue::String(format!("row-{i:09}")),
+        );
+        if i % fill == 0 {
+            store.set_column_property(id, "sparse_int", PropertyValue::Integer(i as i64));
+        }
+        indices.push(id.as_u64() as usize);
+    }
+    Fixture { store, rows: indices }
+}
+
+fn time<F: FnMut() -> u64>(label: &str, count: usize, mut f: F) -> f64 {
+    // Warm, so the first pass does not pay for page faults the others avoid.
+    std::hint::black_box(f());
+    let started = Instant::now();
+    let sink = f();
+    let ns = started.elapsed().as_secs_f64() * 1e9 / count as f64;
+    std::hint::black_box(sink);
+    println!("{label:<46} {ns:>10.1}");
+    ns
+}
+
+fn main() {
+    bench_setup::init();
+    let calibration = bench_setup::report_calibration();
+
+    let args: Vec<String> = std::env::args().collect();
+    let arg = |flag: &str| -> Option<usize> {
+        args.iter()
+            .position(|a| a == flag)
+            .and_then(|i| args.get(i + 1))
+            .and_then(|v| v.parse().ok())
+    };
+    let rows = arg("--rows").unwrap_or(1_000_000);
+    let fill = arg("--fill").unwrap_or(20);
+
+    eprintln!("Building {rows} rows (sparse property on one in {fill})…");
+    let started = Instant::now();
+    let fx = build(rows, fill);
+    eprintln!("built in {:.1}s\n", started.elapsed().as_secs_f64());
+
+    let columns = &fx.store.node_columns;
+    let ids = &fx.rows;
+
+    println!("{:<46} {:>10}", "access", "ns");
+    println!("{:-<46} {:->10}", "", "");
+
+    let dense_int = time("get_property, dense integer column", rows, || {
+        let mut acc = 0u64;
+        for &idx in ids {
+            if let PropertyValue::Integer(v) = columns.get_property(idx, "dense_int") {
+                acc = acc.wrapping_add(v as u64);
+            }
+        }
+        acc
+    });
+
+    time("get_property, dense float column", rows, || {
+        let mut acc = 0u64;
+        for &idx in ids {
+            if let PropertyValue::Float(v) = columns.get_property(idx, "dense_float") {
+                acc = acc.wrapping_add(v as u64);
+            }
+        }
+        acc
+    });
+
+    time("get_property, dense string column (clones)", rows, || {
+        let mut acc = 0u64;
+        for &idx in ids {
+            if let PropertyValue::String(s) = columns.get_property(idx, "dense_str") {
+                acc = acc.wrapping_add(s.len() as u64);
+            }
+        }
+        acc
+    });
+
+    time("get_property, sparse column, mostly misses", rows, || {
+        let mut acc = 0u64;
+        for &idx in ids {
+            if let PropertyValue::Integer(v) = columns.get_property(idx, "sparse_int") {
+                acc = acc.wrapping_add(v as u64);
+            }
+        }
+        acc
+    });
+
+    time("get_column once, then Column::get per row", rows, || {
+        let mut acc = 0u64;
+        // Hoisting the name lookup out of the loop is available to any
+        // operator that reads the same property for every row -- which is all
+        // of them. If this is much cheaper than the line above, that is a
+        // change an operator can make without touching the storage layout.
+        if let Some(col) = columns.get_column("dense_int") {
+            for &idx in ids {
+                if let PropertyValue::Integer(v) = col.get(idx) {
+                    acc = acc.wrapping_add(v as u64);
+                }
+            }
+        }
+        acc
+    });
+
+    let plain: Vec<i64> = (0..rows as i64).collect();
+    let vec_ns = time("a dense Vec<i64>, indexed by row", rows, || {
+        let mut acc = 0u64;
+        for &idx in ids {
+            acc = acc.wrapping_add(plain[idx - 1] as u64);
+        }
+        acc
+    });
+
+    println!();
+    println!(
+        "A dense integer read costs {:.0}x an array index ({:.1} ns vs {:.1} ns).",
+        dense_int / vec_ns.max(0.01),
+        dense_int,
+        vec_ns
+    );
+    println!("Most of that is cache, not hashing: at {rows} rows the inner table is tens of");
+    println!("megabytes and the hash scatters access, so even a scan in id order misses.");
+
+    bench_setup::report_drift(calibration);
+}

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -27,6 +27,32 @@ The split follows from where a reader can act: a number you can reproduce
 belongs next to the code that produces it; a number that required another
 vendor's licensed software to obtain does not.
 
+## Comparing two numbers
+
+**A before/after claim requires both figures from one back-to-back session on
+one machine.** Not "the same machine" — the same *sitting*.
+
+This is not caution for its own sake. On a 16-core workstation, the same
+binary at the same commit ran LDBC IC9 in **2,822 ms in the morning and
+4,912 ms the same evening**, with nothing else on the CPU; two consecutive
+runs of one binary differed by **24%** (#529). Comparing an evening run
+against a morning baseline produced apparent 2–4x regressions in three
+queries, none of which existed.
+
+So:
+
+- **Check the calibration line first.** Every run prints a fixed CPU-bound
+  loop's duration at the start and again at the end, with the load average
+  and mean core frequency. Two runs whose calibration differs were taken on
+  hosts of different speed, whatever their milliseconds say. If the closing
+  figure differs from the opening one by more than 10%, the run says so and
+  its own numbers are not internally comparable either.
+- **Quote the ratio, not the milliseconds**, when the point is an
+  improvement. A ratio measured back to back survives a slow host; an
+  absolute figure does not survive being read next to one taken elsewhere.
+- **`SLT-2` is a ratio against a competitor.** A competitor figure measured
+  in a different session is not a baseline for one of ours.
+
 
 Two suites are documented here: the LDBC SNB Interactive results below, and **HIER**, the
 hierarchy category introduced with ADR-035.

--- a/src/graph/storage/columnar.rs
+++ b/src/graph/storage/columnar.rs
@@ -1,28 +1,58 @@
 //! Columnar storage implementation for node and edge properties.
 //!
-//! Sparse HashMap-based columns: only entries that exist are stored.
+//! Sparse hash-map-based columns: only entries that exist are stored.
 //! No memory waste for multi-label graphs where properties differ per label.
 //! E.g., "title" only stored for Article nodes, not for Author/MeSH/Chemical nodes.
+//!
+//! # Cost of a read, and what it is not
+//!
+//! A property read is **two hash lookups**: the property name to a column, then
+//! the row index to a value. Measured over a million integer reads in id order
+//! (#531):
+//!
+//! | access | ns |
+//! |---|---:|
+//! | `get_property` with `std::collections::HashMap` | 222.4 |
+//! | `get_property` with `FxHashMap` (this) | see the bench |
+//! | a dense `Vec<i64>` index | 1.3 |
+//!
+//! The hash function is the part this module can cheaply control, and that is
+//! what `FxHashMap` addresses here — `std`'s `SipHash` is a DoS-resistant hash
+//! being asked to hash a `usize`, which is not the threat model of a row index.
+//!
+//! **Most of the remaining cost is not the hash.** At a million rows the inner
+//! table is tens of megabytes and the hash scatters access, so a scan in id
+//! order — the friendliest order there is — still misses cache on nearly every
+//! row. Fixing that means a dense array with a presence bitmap for the columns
+//! that are dense enough to deserve one, which is #531's Phase 2 and a real
+//! design task: the sparsity argument above is genuine, and a dense array over
+//! a rare property in a 66M-node graph would be worse than what is here.
+//!
+//! So: this is the cheap half, it is measured, and it does not close #531.
 
 use crate::graph::PropertyValue;
 use crate::graph::types::NodeId;
+use rustc_hash::FxHashMap;
 use std::collections::HashMap;
 
-/// A single property column — sparse HashMap indexed by node/edge index.
+/// A single property column — sparse map indexed by node/edge index.
 /// Only entries that are explicitly set consume memory.
+///
+/// Keyed with `FxHashMap`: the key is a row index, and `std`'s `SipHash` costs
+/// more to compute than the lookup it protects (#531).
 #[derive(Debug, Clone)]
 pub enum Column {
-    Int(HashMap<usize, i64>),
-    Float(HashMap<usize, f64>),
-    String(HashMap<usize, String>),
-    Bool(HashMap<usize, bool>),
+    Int(FxHashMap<usize, i64>),
+    Float(FxHashMap<usize, f64>),
+    String(FxHashMap<usize, String>),
+    Bool(FxHashMap<usize, bool>),
 }
 
 impl Column {
-    pub fn new_int() -> Self { Column::Int(HashMap::new()) }
-    pub fn new_float() -> Self { Column::Float(HashMap::new()) }
-    pub fn new_string() -> Self { Column::String(HashMap::new()) }
-    pub fn new_bool() -> Self { Column::Bool(HashMap::new()) }
+    pub fn new_int() -> Self { Column::Int(FxHashMap::default()) }
+    pub fn new_float() -> Self { Column::Float(FxHashMap::default()) }
+    pub fn new_string() -> Self { Column::String(FxHashMap::default()) }
+    pub fn new_bool() -> Self { Column::Bool(FxHashMap::default()) }
 
     pub fn set(&mut self, idx: usize, value: PropertyValue) {
         match (self, value) {
@@ -79,8 +109,11 @@ impl Column {
 /// Manages multiple property columns.
 #[derive(Debug, Default, Clone)]
 pub struct ColumnStore {
-    /// Mapping from property key -> Column
-    columns: HashMap<String, Column>,
+    /// Mapping from property key -> Column.
+    ///
+    /// Also `FxHashMap`: property names are short, the set of them is small
+    /// and fixed after load, and this lookup happens on every property read.
+    columns: FxHashMap<String, Column>,
 }
 
 impl ColumnStore {

--- a/tests/bench_host_calibration.rs
+++ b/tests/bench_host_calibration.rs
@@ -1,0 +1,114 @@
+//! The benchmark harness reports whether the host held still (#529).
+//!
+//! Every `[[bench]]` sets `harness = false`, so `cargo test --bench` runs the
+//! benchmark's `main` rather than its `#[test]` functions. Pulling the module
+//! into a normal test target is what makes these run.
+//!
+//! What is worth testing here is narrow but load-bearing: the calibration must
+//! not be optimised away, it must be stable enough that a real change in host
+//! speed stands out from its own noise, and the drift report must fire when
+//! the two figures disagree. A calibration that silently folds to zero reports
+//! a perfectly stable host forever.
+
+#[path = "../benches/common/bench_setup.rs"]
+mod bench_setup;
+
+use std::time::Duration;
+
+#[test]
+fn the_calibration_loop_is_not_optimised_away() {
+    // The failure this guards: LLVM folds the loop, `calibrate()` returns
+    // ~0 ns, every run looks identical, and the one thing the figure exists to
+    // detect becomes invisible.
+    let elapsed = bench_setup::calibrate();
+    assert!(
+        elapsed > Duration::from_micros(500),
+        "calibration took {elapsed:?} — the loop was almost certainly folded away"
+    );
+    // And it must not be so slow that adding it to every benchmark is a cost
+    // of its own.
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "calibration took {elapsed:?}, which is too slow to run at the start and end of every suite"
+    );
+}
+
+#[test]
+fn the_calibration_is_repeatable_enough_to_be_a_signal() {
+    // It only has to separate a real change in host speed from its own noise.
+    // The drift it exists to catch was 1.74x; the threshold that warns is 10%.
+    // So the spread across consecutive calls must be well under that, or the
+    // warning fires on itself.
+    let samples: Vec<Duration> = (0..5).map(|_| bench_setup::calibrate()).collect();
+    let fastest = samples.iter().min().unwrap().as_secs_f64();
+    let slowest = samples.iter().max().unwrap().as_secs_f64();
+
+    assert!(fastest > 0.0, "calibration returned zero: {samples:?}");
+    let spread = slowest / fastest;
+    assert!(
+        spread < 2.0,
+        "calibration varied {spread:.2}x across five consecutive calls ({samples:?}); \
+         it cannot distinguish a slower host from its own noise"
+    );
+}
+
+#[test]
+fn host_state_reports_what_it_can_and_says_so_when_it_cannot() {
+    let state = bench_setup::HostState::read();
+    let text = state.format();
+
+    assert!(text.contains("load"), "{text}");
+    assert!(text.contains("cpu"), "{text}");
+
+    // On Linux both should resolve. Elsewhere they must read as unknown
+    // rather than as a fabricated zero.
+    #[cfg(target_os = "linux")]
+    {
+        assert!(state.load_average.is_some(), "load average should be readable on Linux");
+        assert!(state.cpu_mhz.is_some(), "cpu MHz should be readable on Linux");
+        assert!(!text.contains("unknown"), "{text}");
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        assert!(text.contains("unknown"), "{text}");
+    }
+}
+
+#[test]
+fn the_mean_frequency_is_not_a_single_cores_idle_reading() {
+    // Reading core 0 alone gave 2,235 MHz at the start of a run and 400 MHz at
+    // the end of the same run: an idle core, not a throttled machine. The mean
+    // across cores should sit in a plausible band rather than at either
+    // extreme.
+    #[cfg(target_os = "linux")]
+    {
+        let Some(mhz) = bench_setup::HostState::read().cpu_mhz else {
+            eprintln!("SKIP: no cpu MHz reported");
+            return;
+        };
+        assert!(
+            (100.0..10_000.0).contains(&mhz),
+            "mean cpu frequency {mhz} MHz is outside any plausible range"
+        );
+    }
+}
+
+#[test]
+fn reporting_calibration_returns_the_figure_it_printed() {
+    // `report_calibration` hands its measurement back so the end of the suite
+    // can compare against it. Returning something else would make the drift
+    // report meaningless while still looking right.
+    let reported = bench_setup::report_calibration();
+    assert!(reported > Duration::ZERO);
+    // Exercises the closing path too: it must not panic when the host held
+    // still, which is the overwhelmingly common case.
+    bench_setup::report_drift(reported);
+}
+
+#[test]
+fn drift_reporting_survives_a_zero_baseline() {
+    // A pathological input rather than a realistic one: the ratio divides by
+    // the opening figure, and a panic inside the *reporting* of a benchmark
+    // would lose the whole run's results.
+    bench_setup::report_drift(Duration::ZERO);
+}


### PR DESCRIPTION
Part of #531. Explains most of #521.

## The finding

A property read is **two hash lookups** — the property name to a column, then the row index to a value — and both used `std::collections::HashMap`. `SipHash` is a DoS-resistant hash being asked to hash a `usize`, which is not the threat model of a row index.

Measured **back to back on one machine state**, a million integer reads in id order:

| access | before | after | |
|---|---:|---:|---:|
| `get_property`, dense integer column | 136.4 ns | **44.2 ns** | **3.1×** |
| `get_property`, dense float column | 138.8 ns | 47.2 ns | 2.9× |
| `get_property`, dense string column (clones) | 176.3 ns | 117.1 ns | 1.5× |
| `get_property`, sparse column, mostly misses | 37.4 ns | 14.6 ns | 2.6× |
| `get_column` once, then `Column::get` per row | 68.2 ns | 31.7 ns | 2.2× |
| a dense `Vec<i64>`, indexed by row | 0.7 ns | 0.8 ns | — |

`rustc_hash` was already a dependency and already used for exactly this reason elsewhere in the tree — `AggregateOperator`'s group map carries the comment *"2-3x faster than std HashMap on simple keys"*.

## Why this is the hottest primitive in the engine

`Filter` pays it on every row it tests. `Sort` on every key it evaluates. `Project` on every column it emits. `Aggregate` on every group key — which is how it was found.

`CH-PROFILE-01` put 60.1% of LDBC IC5 in `Aggregate`, so I built `aggregate_throughput` to isolate the constant. The row that mattered was the control:

| shape | `Aggregate` ns/row |
|---|---:|
| **no `GROUP BY` at all, global `sum(r.weight)`** | **427.5** |
| one integer key, `count(r)` | 681.3 |
| two integer keys, same group count | 1136.8 |
| integer + string keys (IC5's shape) | 1248.8 |

An aggregate that does no grouping, adding one integer per row, cost 427 ns/row. Almost all of it was reading one property. #521 is not really about hash aggregation.

## What this does not do

A dense integer read is still **57× an array index**. Most of what remains is cache, not hashing: at a million rows the inner table is tens of megabytes and the hash scatters access, so even a scan in id order misses on nearly every row.

Fixing *that* means a dense array with a presence bitmap — but only for the columns dense enough to deserve one. The sparsity argument in the module's own doc comment is real (*"'title' only stored for Article nodes, not for Author/MeSH/Chemical"*), and a dense array over a rare property in a 66M-node graph would be worse than what is here. So the representation has to be chosen per column from its fill factor, and that is a design task touching the snapshot format, `clear_row`, and the row-store fallback in `resolve_property`.

**This is the cheap half. It does not close #531.**

## Two benches, because the constant was invisible

`benches/property_access.rs` — ns per read for dense int/float/string, a sparse column that mostly misses, the same read with the column lookup hoisted out of the loop, and a plain `Vec<i64>` for scale. Rows are visited in id order, which is the friendliest pattern for both sides and is what a scan actually does.

The hoisted-lookup row is there for a reason: at 31.7 ns against 44.2 ns, an operator that reads the same property for every row — which is all of them — can take a 1.4× without any change to the storage layout. That is a separate, smaller piece of work this measurement makes visible.

`benches/aggregate_throughput.rs` — `Aggregate`'s own time per row across the four shapes the operator implements, taken from `PROFILE` (#517) so the scan feeding it is not folded in. Its fixture derives the second integer key from the first, so the two-key shape produces exactly as many groups as the one-key shape; a first draft used an independent key, got 500,000 groups against 25,000, and reported a 3.8× difference that was mostly the extra groups.

## Testing

Full suite: **2,652 passing, 0 failures.** `FxHashMap` is a drop-in for `HashMap` here — same API, same semantics, different hasher — so the risk is confined to anything depending on iteration order, and nothing does: the store is read by key and written by key.

Host calibration (#529) was flat across both sides of the A/B.