### PR TITLE
Store a dense property column as an array, a sparse one as a map

### DIFF
--- a/benches/property_access.rs
+++ b/benches/property_access.rs
@@ -33,6 +33,14 @@ struct Fixture {
     store: GraphStore,
     /// Row indices to read, in ascending order.
     rows: Vec<usize>,
+    /// Node ids carrying the same values in *row* storage rather than columns.
+    ///
+    /// The engine has two property paths and they perform very differently.
+    /// `set_node_property` writes both; snapshot import writes only columns;
+    /// and the LDBC loader writes only rows, via `node.set_property`. So the
+    /// benchmark suite every performance decision rests on exercises the path
+    /// that published `.sgsnap` KGs do not use (#534).
+    row_nodes: Vec<samyama::graph::NodeId>,
 }
 
 /// `rows` nodes, of which one in `fill` carries the `sparse` property.
@@ -58,7 +66,19 @@ fn build(rows: usize, fill: usize) -> Fixture {
         }
         indices.push(id.as_u64() as usize);
     }
-    Fixture { store, rows: indices }
+
+    // A second population whose properties live only in row storage, written
+    // the way the LDBC loader writes them.
+    let mut row_nodes = Vec::with_capacity(rows);
+    for i in 0..rows {
+        let id = store.create_node("RowStored");
+        if let Some(node) = store.get_node_mut(id) {
+            node.set_property("row_int", PropertyValue::Integer(i as i64));
+        }
+        row_nodes.push(id);
+    }
+
+    Fixture { store, rows: indices, row_nodes }
 }
 
 fn time<F: FnMut() -> u64>(label: &str, count: usize, mut f: F) -> f64 {
@@ -147,6 +167,19 @@ fn main() {
             for &idx in ids {
                 if let PropertyValue::Integer(v) = col.get(idx) {
                     acc = acc.wrapping_add(v as u64);
+                }
+            }
+        }
+        acc
+    });
+
+    let row_nodes = &fx.row_nodes;
+    time("row storage, node.properties HashMap", rows, || {
+        let mut acc = 0u64;
+        for &id in row_nodes {
+            if let Some(node) = fx.store.get_node(id) {
+                if let Some(PropertyValue::Integer(v)) = node.get_property("row_int") {
+                    acc = acc.wrapping_add(*v as u64);
                 }
             }
         }

--- a/src/graph/storage/columnar.rs
+++ b/src/graph/storage/columnar.rs
@@ -35,31 +35,314 @@ use crate::graph::types::NodeId;
 use rustc_hash::FxHashMap;
 use std::collections::HashMap;
 
-/// A single property column — sparse map indexed by node/edge index.
-/// Only entries that are explicitly set consume memory.
+/// How one column stores its values.
 ///
-/// Keyed with `FxHashMap`: the key is a row index, and `std`'s `SipHash` costs
-/// more to compute than the lookup it protects (#531).
+/// A column is dense whenever dense is *smaller*; see [`dense_is_smaller`].
+/// That rule serves both goals at once -- reads become an indexed load rather
+/// than a hash lookup (`PERF-05`), and the store never grows (`PERF-10`,
+/// `SLT-3`, currently red) -- which is why the decision is computed rather
+/// than tuned.
+#[derive(Debug, Clone)]
+pub enum ColumnData<T> {
+    /// Scattered rows: a hash map from row index to value.
+    Sparse(FxHashMap<usize, T>),
+    /// A contiguous band of rows: `values[idx - base]`, with a presence bit
+    /// per slot so an absent row is distinguishable from a stored default.
+    ///
+    /// `base` is not decoration. Node indices run from a counter, but a
+    /// *label's* rows sit in a contiguous band inside that range -- LDBC loads
+    /// Places, Organisations, Tags, Persons, Forums, Posts, then Comments, so
+    /// `Post.content` is 1.19M consecutive indices starting above 1.1M. Without
+    /// a base, a dense array for it would allocate the whole unused prefix.
+    Dense {
+        base: usize,
+        values: Vec<T>,
+        /// One bit per slot, `present[i / 64] & (1 << (i % 64))`.
+        present: Vec<u64>,
+        /// How many slots are present.
+        ///
+        /// Kept rather than counted: `len()` is consulted on every write that
+        /// lands outside the span, and popcounting the bitmap there would make
+        /// loading a column quadratic in its length.
+        count: usize,
+    },
+}
+
+/// Is a dense array smaller than a hash map for this shape?
+///
+/// `hashbrown` stores `(usize, T)` plus one control byte per bucket at a load
+/// factor of 7/8, so a sparse entry costs `(8 + size_of::<T>() + 1) * 8/7`.
+/// A dense slot costs `size_of::<T>()` plus one presence bit, whether or not
+/// the row is present -- so the comparison is per *span*, not per entry.
+///
+/// The break-even fill factor therefore depends on the element size, and a
+/// single global threshold would either waste memory on `String` columns or
+/// leave speed unclaimed on `bool` ones:
+///
+/// | T | sparse B/entry | dense B/slot | break-even fill |
+/// |---|---:|---:|---:|
+/// | `bool` | 11.4 | 1.125 | 0.10 |
+/// | `i64`, `f64` | 19.4 | 8.125 | 0.42 |
+/// | `String` | 37.7 | 24.125 | 0.64 |
+///
+/// String *contents* are heap-allocated either way and cancel out; only the
+/// 24-byte `String` header is counted here.
+pub fn dense_is_smaller(span: usize, entries: usize, elem_bytes: usize) -> bool {
+    if span == 0 || entries == 0 {
+        return false;
+    }
+    // Scaled by 8 throughout to stay in integer arithmetic: a floating-point
+    // threshold in a storage decision invites a platform-dependent layout.
+    let dense_bits = span.saturating_mul(elem_bytes.saturating_mul(8) + 1);
+    let sparse_bits = entries
+        .saturating_mul((8 + elem_bytes + 1) * 8 * 8)
+        / 7;
+    dense_bits < sparse_bits
+}
+
+impl<T: Clone + Default> ColumnData<T> {
+    fn new() -> Self {
+        ColumnData::Sparse(FxHashMap::default())
+    }
+
+    fn get(&self, idx: usize) -> Option<&T> {
+        match self {
+            ColumnData::Sparse(m) => m.get(&idx),
+            ColumnData::Dense { base, values, present, .. } => {
+                let slot = idx.checked_sub(*base)?;
+                if slot >= values.len() || !bit(present, slot) {
+                    return None;
+                }
+                Some(&values[slot])
+            }
+        }
+    }
+
+    fn has(&self, idx: usize) -> bool {
+        self.get(idx).is_some()
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            ColumnData::Sparse(m) => m.len(),
+            ColumnData::Dense { count, .. } => *count,
+        }
+    }
+
+    fn remove(&mut self, idx: usize) {
+        match self {
+            ColumnData::Sparse(m) => {
+                m.remove(&idx);
+            }
+            ColumnData::Dense { base, values, present, count } => {
+                // Clear the presence bit and the value. Node ids are recycled
+                // through a free list, so a deleted node's slot goes to the
+                // next `create_node`; leaving the old value behind is how
+                // deleted data reappeared on new nodes (#364). Clearing the
+                // bit alone would be enough for `get`, but not for anything
+                // that walks `values` directly.
+                if let Some(slot) = idx.checked_sub(*base) {
+                    if slot < values.len() && bit(present, slot) {
+                        clear_bit(present, slot);
+                        values[slot] = T::default();
+                        *count -= 1;
+                    }
+                }
+            }
+        }
+    }
+
+    fn set(&mut self, idx: usize, value: T) {
+        match self {
+            ColumnData::Sparse(m) => {
+                m.insert(idx, value);
+                self.maybe_promote();
+            }
+            ColumnData::Dense { base, values, present, count } => {
+                if idx >= *base && idx - *base < values.len() {
+                    let slot = idx - *base;
+                    if !bit(present, slot) {
+                        set_bit(present, slot);
+                        *count += 1;
+                    }
+                    values[slot] = value;
+                    return;
+                }
+
+                // Outside the span. Extend if the wider span is still smaller
+                // than a map would be; otherwise fall back to sparse rather
+                // than allocate a range for one far-away row. One rule decides
+                // both directions, so there is no second policy to keep
+                // consistent with the first.
+                let entries = *count + 1;
+                let elem = std::mem::size_of::<T>();
+
+                if idx >= *base {
+                    // Growing upward -- the common case, and the one a load
+                    // does once per row. `Vec::resize` reserves geometrically,
+                    // so repeatedly extending by one is amortised O(1);
+                    // rebuilding into a fresh exactly-sized Vec each time (as
+                    // an earlier draft did) makes a 1M-row load quadratic.
+                    let new_span = idx - *base + 1;
+                    if dense_is_smaller(new_span, entries, elem) {
+                        values.resize(new_span, T::default());
+                        present.resize(new_span.div_ceil(64), 0);
+                        let slot = idx - *base;
+                        set_bit(present, slot);
+                        values[slot] = value;
+                        *count += 1;
+                        return;
+                    }
+                } else {
+                    // Below the base. Rare -- properties arrive in id order --
+                    // and it needs every slot shifted, so it rebuilds.
+                    let new_base = idx;
+                    let new_span = *base + values.len() - new_base;
+                    if dense_is_smaller(new_span, entries, elem) {
+                        self.rebase(new_base, new_span);
+                        let ColumnData::Dense { base, values, present, count } = self else {
+                            unreachable!("rebase leaves the column dense")
+                        };
+                        let slot = idx - *base;
+                        set_bit(present, slot);
+                        values[slot] = value;
+                        *count += 1;
+                        return;
+                    }
+                }
+
+                self.demote_to_sparse();
+                let ColumnData::Sparse(m) = self else {
+                    unreachable!("demote leaves the column sparse")
+                };
+                m.insert(idx, value);
+            }
+        }
+    }
+
+    /// Shift a dense column down to a lower base.
+    ///
+    /// Every slot moves, so this rebuilds. Only reached when a row arrives
+    /// below everything already stored, which properties loaded in id order
+    /// never do.
+    fn rebase(&mut self, new_base: usize, new_span: usize) {
+        let ColumnData::Dense { base, values, present, count } = self else {
+            return;
+        };
+        let shift = *base - new_base;
+        let mut next_values = vec![T::default(); new_span];
+        let mut next_present = vec![0u64; new_span.div_ceil(64)];
+        for slot in 0..values.len() {
+            if bit(present, slot) {
+                next_values[slot + shift] = values[slot].clone();
+                set_bit(&mut next_present, slot + shift);
+            }
+        }
+        *self = ColumnData::Dense {
+            base: new_base,
+            values: next_values,
+            present: next_present,
+            count: *count,
+        };
+    }
+
+    fn demote_to_sparse(&mut self) {
+        let ColumnData::Dense { base, values, present, .. } = self else {
+            return;
+        };
+        let mut m = FxHashMap::default();
+        for slot in 0..values.len() {
+            if bit(present, slot) {
+                m.insert(*base + slot, values[slot].clone());
+            }
+        }
+        *self = ColumnData::Sparse(m);
+    }
+
+    /// Consider promoting a sparse column to dense.
+    ///
+    /// Deciding needs the index range, which costs a scan of the map, so it is
+    /// only considered when `len` crosses a power of two at or above
+    /// [`PROMOTE_MIN_ENTRIES`]. That is amortised O(1) per insert -- checking
+    /// on every insert would make loading a column O(n^2) -- and a column that
+    /// is going to be dense becomes dense early in a load rather than at the
+    /// end of one.
+    fn maybe_promote(&mut self) {
+        let ColumnData::Sparse(m) = self else { return };
+        let len = m.len();
+        if len < PROMOTE_MIN_ENTRIES || !len.is_power_of_two() {
+            return;
+        }
+        let (Some(&min), Some(&max)) = (m.keys().min(), m.keys().max()) else {
+            return;
+        };
+        let span = max - min + 1;
+        if !dense_is_smaller(span, len, std::mem::size_of::<T>()) {
+            return;
+        }
+        let mut values = vec![T::default(); span];
+        let mut present = vec![0u64; span.div_ceil(64)];
+        for (&idx, value) in m.iter() {
+            let slot = idx - min;
+            values[slot] = value.clone();
+            set_bit(&mut present, slot);
+        }
+        *self = ColumnData::Dense { base: min, values, present, count: len };
+    }
+}
+
+/// Below this, the map is small enough that the representation does not
+/// matter and the scan to decide would cost more than it saves.
+const PROMOTE_MIN_ENTRIES: usize = 1024;
+
+#[inline]
+fn bit(words: &[u64], slot: usize) -> bool {
+    words
+        .get(slot / 64)
+        .is_some_and(|w| w & (1u64 << (slot % 64)) != 0)
+}
+
+#[inline]
+fn set_bit(words: &mut [u64], slot: usize) {
+    if let Some(w) = words.get_mut(slot / 64) {
+        *w |= 1u64 << (slot % 64);
+    }
+}
+
+#[inline]
+fn clear_bit(words: &mut [u64], slot: usize) {
+    if let Some(w) = words.get_mut(slot / 64) {
+        *w &= !(1u64 << (slot % 64));
+    }
+}
+
+/// A single property column. Only rows that are explicitly set are readable;
+/// everything else reads as [`PropertyValue::Null`].
+///
+/// The Null distinction is load-bearing rather than cosmetic: `resolve_property`
+/// treats a Null from this store as "not here, try row storage", so a dense
+/// column returning `T::default()` for an absent slot would turn a missing
+/// property into `0` or `""` -- a wrong answer rather than a slow one.
 #[derive(Debug, Clone)]
 pub enum Column {
-    Int(FxHashMap<usize, i64>),
-    Float(FxHashMap<usize, f64>),
-    String(FxHashMap<usize, String>),
-    Bool(FxHashMap<usize, bool>),
+    Int(ColumnData<i64>),
+    Float(ColumnData<f64>),
+    String(ColumnData<String>),
+    Bool(ColumnData<bool>),
 }
 
 impl Column {
-    pub fn new_int() -> Self { Column::Int(FxHashMap::default()) }
-    pub fn new_float() -> Self { Column::Float(FxHashMap::default()) }
-    pub fn new_string() -> Self { Column::String(FxHashMap::default()) }
-    pub fn new_bool() -> Self { Column::Bool(FxHashMap::default()) }
+    pub fn new_int() -> Self { Column::Int(ColumnData::new()) }
+    pub fn new_float() -> Self { Column::Float(ColumnData::new()) }
+    pub fn new_string() -> Self { Column::String(ColumnData::new()) }
+    pub fn new_bool() -> Self { Column::Bool(ColumnData::new()) }
 
     pub fn set(&mut self, idx: usize, value: PropertyValue) {
         match (self, value) {
-            (Column::Int(m), PropertyValue::Integer(val)) => { m.insert(idx, val); }
-            (Column::Float(m), PropertyValue::Float(val)) => { m.insert(idx, val); }
-            (Column::String(m), PropertyValue::String(val)) => { m.insert(idx, val); }
-            (Column::Bool(m), PropertyValue::Boolean(val)) => { m.insert(idx, val); }
+            (Column::Int(m), PropertyValue::Integer(val)) => m.set(idx, val),
+            (Column::Float(m), PropertyValue::Float(val)) => m.set(idx, val),
+            (Column::String(m), PropertyValue::String(val)) => m.set(idx, val),
+            (Column::Bool(m), PropertyValue::Boolean(val)) => m.set(idx, val),
             _ => {
                 // Type mismatch or unsupported columnar type (Map/Array/Vector)
             }
@@ -69,29 +352,29 @@ impl Column {
     /// Remove this row's value from the column, if present.
     pub fn remove(&mut self, idx: usize) {
         match self {
-            Column::Int(m) => { m.remove(&idx); }
-            Column::Float(m) => { m.remove(&idx); }
-            Column::String(m) => { m.remove(&idx); }
-            Column::Bool(m) => { m.remove(&idx); }
+            Column::Int(m) => m.remove(idx),
+            Column::Float(m) => m.remove(idx),
+            Column::String(m) => m.remove(idx),
+            Column::Bool(m) => m.remove(idx),
         }
     }
 
     pub fn get(&self, idx: usize) -> PropertyValue {
         match self {
-            Column::Int(m) => m.get(&idx).map(|&v| PropertyValue::Integer(v)).unwrap_or(PropertyValue::Null),
-            Column::Float(m) => m.get(&idx).map(|&v| PropertyValue::Float(v)).unwrap_or(PropertyValue::Null),
-            Column::Bool(m) => m.get(&idx).map(|&v| PropertyValue::Boolean(v)).unwrap_or(PropertyValue::Null),
-            Column::String(m) => m.get(&idx).map(|s| PropertyValue::String(s.clone())).unwrap_or(PropertyValue::Null),
+            Column::Int(m) => m.get(idx).map(|&v| PropertyValue::Integer(v)).unwrap_or(PropertyValue::Null),
+            Column::Float(m) => m.get(idx).map(|&v| PropertyValue::Float(v)).unwrap_or(PropertyValue::Null),
+            Column::Bool(m) => m.get(idx).map(|&v| PropertyValue::Boolean(v)).unwrap_or(PropertyValue::Null),
+            Column::String(m) => m.get(idx).map(|s| PropertyValue::String(s.clone())).unwrap_or(PropertyValue::Null),
         }
     }
 
     /// Check if a value exists at the given index.
     pub fn has(&self, idx: usize) -> bool {
         match self {
-            Column::Int(m) => m.contains_key(&idx),
-            Column::Float(m) => m.contains_key(&idx),
-            Column::String(m) => m.contains_key(&idx),
-            Column::Bool(m) => m.contains_key(&idx),
+            Column::Int(m) => m.has(idx),
+            Column::Float(m) => m.has(idx),
+            Column::String(m) => m.has(idx),
+            Column::Bool(m) => m.has(idx),
         }
     }
 
@@ -102,6 +385,17 @@ impl Column {
             Column::Float(m) => m.len(),
             Column::String(m) => m.len(),
             Column::Bool(m) => m.len(),
+        }
+    }
+
+    /// Whether this column is stored densely. Diagnostics and tests only --
+    /// no caller should behave differently based on it.
+    pub fn is_dense(&self) -> bool {
+        match self {
+            Column::Int(m) => matches!(m, ColumnData::Dense { .. }),
+            Column::Float(m) => matches!(m, ColumnData::Dense { .. }),
+            Column::String(m) => matches!(m, ColumnData::Dense { .. }),
+            Column::Bool(m) => matches!(m, ColumnData::Dense { .. }),
         }
     }
 }
@@ -172,6 +466,232 @@ impl ColumnStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Enough consecutive rows to cross `PROMOTE_MIN_ENTRIES` at a power of
+    /// two, which is when promotion is considered.
+    const DENSE_N: usize = 2048;
+
+    fn dense_int_column(base: usize) -> Column {
+        let mut col = Column::new_int();
+        for i in 0..DENSE_N {
+            col.set(base + i, PropertyValue::Integer(i as i64));
+        }
+        col
+    }
+
+    #[test]
+    fn break_even_matches_the_documented_fill_factors() {
+        // The table in `dense_is_smaller`'s docs is the contract. If these
+        // move, the doc is wrong and a footprint claim built on it is too.
+        let span = 100_000;
+
+        // i64: break-even ~0.42
+        assert!(!dense_is_smaller(span, (span as f64 * 0.35) as usize, 8));
+        assert!(dense_is_smaller(span, (span as f64 * 0.50) as usize, 8));
+
+        // String header (24 B): break-even ~0.64
+        assert!(!dense_is_smaller(span, (span as f64 * 0.55) as usize, 24));
+        assert!(dense_is_smaller(span, (span as f64 * 0.75) as usize, 24));
+
+        // bool: break-even ~0.10, so a fairly sparse bool column still wins
+        assert!(dense_is_smaller(span, (span as f64 * 0.20) as usize, 1));
+        assert!(!dense_is_smaller(span, (span as f64 * 0.05) as usize, 1));
+    }
+
+    #[test]
+    fn break_even_is_never_true_for_an_empty_or_degenerate_column() {
+        assert!(!dense_is_smaller(0, 0, 8));
+        assert!(!dense_is_smaller(1000, 0, 8));
+        assert!(!dense_is_smaller(0, 1000, 8));
+    }
+
+    #[test]
+    fn break_even_does_not_overflow_on_an_absurd_span() {
+        // One property written at a very high index. The arithmetic must not
+        // wrap into "dense is smaller" and allocate the universe.
+        assert!(!dense_is_smaller(usize::MAX, 1, 8));
+        assert!(!dense_is_smaller(usize::MAX / 2, 1000, 24));
+    }
+
+    #[test]
+    fn a_contiguous_run_becomes_dense_and_reads_back_identically() {
+        let col = dense_int_column(0);
+        assert!(col.is_dense(), "a fully packed run should be stored densely");
+        assert_eq!(col.len(), DENSE_N);
+        for i in 0..DENSE_N {
+            assert_eq!(col.get(i), PropertyValue::Integer(i as i64), "row {i}");
+        }
+    }
+
+    #[test]
+    fn a_dense_column_offset_from_zero_keeps_its_base() {
+        // `Post.content` in LDBC starts above index 1.1M. A dense array that
+        // allocated from zero would waste the whole prefix.
+        let base = 1_100_000;
+        let col = dense_int_column(base);
+        assert!(col.is_dense());
+        assert_eq!(col.get(base), PropertyValue::Integer(0));
+        assert_eq!(col.get(base + DENSE_N - 1), PropertyValue::Integer(DENSE_N as i64 - 1));
+        assert_eq!(col.get(0), PropertyValue::Null, "nothing below the base");
+        assert_eq!(col.get(base - 1), PropertyValue::Null);
+        assert_eq!(col.get(base + DENSE_N), PropertyValue::Null);
+    }
+
+    #[test]
+    fn an_absent_slot_in_a_dense_column_reads_null_not_a_default() {
+        // The distinction `resolve_property` depends on: a Null means "not
+        // here, try row storage". Returning `T::default()` would turn a
+        // missing property into 0 or "" -- a wrong answer, not a slow one.
+        let mut col = Column::new_int();
+        for i in 0..DENSE_N {
+            if i % 3 != 1 {
+                col.set(i, PropertyValue::Integer(i as i64));
+            }
+        }
+        for i in 0..DENSE_N {
+            if i % 3 == 1 {
+                assert_eq!(col.get(i), PropertyValue::Null, "row {i} was never set");
+            } else {
+                assert_eq!(col.get(i), PropertyValue::Integer(i as i64), "row {i}");
+            }
+        }
+
+        let mut strings = Column::new_string();
+        for i in 0..DENSE_N {
+            if i % 2 == 0 {
+                strings.set(i, PropertyValue::String(format!("v{i}")));
+            }
+        }
+        assert_eq!(strings.get(1), PropertyValue::Null, "not an empty string");
+        assert_eq!(strings.get(0), PropertyValue::String("v0".to_string()));
+    }
+
+    #[test]
+    fn a_zero_value_is_still_present() {
+        // The inverse of the test above: a stored 0 must not read as absent.
+        let mut col = Column::new_int();
+        for i in 0..DENSE_N {
+            col.set(i, PropertyValue::Integer(0));
+        }
+        assert!(col.is_dense());
+        assert_eq!(col.get(5), PropertyValue::Integer(0));
+        assert!(col.has(5));
+        assert_eq!(col.len(), DENSE_N);
+    }
+
+    #[test]
+    fn a_sparse_column_stays_sparse() {
+        // One property on one node in fifty must not allocate a slot per node.
+        let mut col = Column::new_int();
+        for i in 0..DENSE_N {
+            col.set(i * 50, PropertyValue::Integer(i as i64));
+        }
+        assert!(!col.is_dense(), "a 1-in-50 column should not go dense");
+        assert_eq!(col.len(), DENSE_N);
+        assert_eq!(col.get(50), PropertyValue::Integer(1));
+        assert_eq!(col.get(51), PropertyValue::Null);
+    }
+
+    #[test]
+    fn one_far_away_row_demotes_rather_than_allocating_the_span() {
+        // The pathology the growth rule exists to prevent.
+        let mut col = dense_int_column(0);
+        assert!(col.is_dense());
+        col.set(50_000_000, PropertyValue::Integer(7));
+        assert!(!col.is_dense(), "extending to 50M slots for one row is the wrong trade");
+        // And nothing was lost on the way out.
+        assert_eq!(col.get(50_000_000), PropertyValue::Integer(7));
+        assert_eq!(col.get(0), PropertyValue::Integer(0));
+        assert_eq!(col.get(DENSE_N - 1), PropertyValue::Integer(DENSE_N as i64 - 1));
+        assert_eq!(col.len(), DENSE_N + 1);
+    }
+
+    #[test]
+    fn a_dense_column_grows_upward_when_the_span_still_pays() {
+        let mut col = dense_int_column(0);
+        col.set(DENSE_N, PropertyValue::Integer(-1));
+        assert!(col.is_dense(), "one row past the end is still dense");
+        assert_eq!(col.get(DENSE_N), PropertyValue::Integer(-1));
+        assert_eq!(col.get(0), PropertyValue::Integer(0));
+        assert_eq!(col.len(), DENSE_N + 1);
+    }
+
+    #[test]
+    fn a_dense_column_grows_downward_below_its_base() {
+        let base = 10_000;
+        let mut col = dense_int_column(base);
+        col.set(base - 1, PropertyValue::Integer(-1));
+        assert!(col.is_dense());
+        assert_eq!(col.get(base - 1), PropertyValue::Integer(-1));
+        assert_eq!(col.get(base), PropertyValue::Integer(0), "the old base survived the shift");
+        assert_eq!(col.get(base + DENSE_N - 1), PropertyValue::Integer(DENSE_N as i64 - 1));
+        assert_eq!(col.get(base - 2), PropertyValue::Null);
+        assert_eq!(col.len(), DENSE_N + 1);
+    }
+
+    #[test]
+    fn removing_from_a_dense_column_clears_the_row() {
+        // Node ids are recycled through a free list, so a deleted node's slot
+        // goes to the next create_node. A value left behind reappears on new
+        // data (#364).
+        let mut col = dense_int_column(0);
+        col.remove(10);
+        assert_eq!(col.get(10), PropertyValue::Null);
+        assert!(!col.has(10));
+        assert_eq!(col.len(), DENSE_N - 1);
+        assert_eq!(col.get(9), PropertyValue::Integer(9), "neighbours untouched");
+        assert_eq!(col.get(11), PropertyValue::Integer(11));
+
+        // And the slot is reusable.
+        col.set(10, PropertyValue::Integer(999));
+        assert_eq!(col.get(10), PropertyValue::Integer(999));
+        assert_eq!(col.len(), DENSE_N);
+    }
+
+    #[test]
+    fn removing_outside_the_span_is_a_no_op() {
+        let mut col = dense_int_column(1000);
+        col.remove(0);
+        col.remove(usize::MAX);
+        assert_eq!(col.len(), DENSE_N);
+    }
+
+    #[test]
+    fn overwriting_a_row_does_not_double_count_it() {
+        let mut col = dense_int_column(0);
+        col.set(5, PropertyValue::Integer(42));
+        assert_eq!(col.get(5), PropertyValue::Integer(42));
+        assert_eq!(col.len(), DENSE_N);
+    }
+
+    #[test]
+    fn every_column_type_round_trips_when_dense() {
+        let mut floats = Column::new_float();
+        let mut strings = Column::new_string();
+        let mut bools = Column::new_bool();
+        for i in 0..DENSE_N {
+            floats.set(i, PropertyValue::Float(i as f64 * 0.25));
+            strings.set(i, PropertyValue::String(format!("s{i}")));
+            bools.set(i, PropertyValue::Boolean(i % 2 == 0));
+        }
+        assert!(floats.is_dense() && strings.is_dense() && bools.is_dense());
+        assert_eq!(floats.get(7), PropertyValue::Float(1.75));
+        assert_eq!(strings.get(7), PropertyValue::String("s7".to_string()));
+        assert_eq!(bools.get(7), PropertyValue::Boolean(false));
+        assert_eq!(bools.get(8), PropertyValue::Boolean(true));
+        assert_eq!(floats.get(DENSE_N), PropertyValue::Null);
+    }
+
+    #[test]
+    fn a_type_mismatch_is_still_dropped_rather_than_stored() {
+        // Unchanged behaviour, asserted so the rewrite did not quietly alter
+        // it: a String into an Int column is ignored.
+        let mut col = Column::new_int();
+        col.set(0, PropertyValue::Integer(1));
+        col.set(1, PropertyValue::String("nope".to_string()));
+        assert_eq!(col.get(1), PropertyValue::Null);
+        assert_eq!(col.len(), 1);
+    }
 
     #[test]
     fn test_sparse_column_string() {

--- a/tests/dense_column_integration.rs
+++ b/tests/dense_column_integration.rs
@@ -1,0 +1,241 @@
+//! Dense property columns, seen from outside the storage layer (#533).
+//!
+//! The unit tests in `graph::storage::columnar` cover the representation. What
+//! they cannot cover is the three places a wrong representation shows up as a
+//! wrong *answer* rather than a slow one:
+//!
+//! * a missing property must stay missing — the column store returns
+//!   `PropertyValue::Null` to mean "not here, try row storage", and a dense
+//!   column that answered `T::default()` would turn an absent property into
+//!   `0` or `""`;
+//! * a deleted node's slot is handed to the next `create_node`, so a value
+//!   left behind reappears on unrelated data (#364);
+//! * `.sgsnap` writes properties through this store, so both representations
+//!   have to round-trip.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+use samyama::snapshot::{export_tenant, import_tenant};
+
+/// Above the promotion threshold, so the columns here are genuinely dense
+/// rather than incidentally small.
+const N: usize = 3000;
+
+fn rows(store: &GraphStore, cypher: &str) -> Vec<Vec<(String, String)>> {
+    let query = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&query).expect("query should run");
+    batch
+        .records
+        .iter()
+        .map(|r| {
+            let mut cells: Vec<(String, String)> = r
+                .bindings()
+                .iter()
+                .map(|(k, v)| (k.clone(), format!("{v:?}")))
+                .collect();
+            cells.sort();
+            cells
+        })
+        .collect()
+}
+
+/// Every third node is missing `nickname`, so a dense column has to hold gaps.
+fn gappy_graph() -> GraphStore {
+    let mut store = GraphStore::new();
+    for i in 0..N {
+        let id = store.create_node("Person");
+        let _ = store.set_node_property("default", id, "seq".to_string(), PropertyValue::Integer(i as i64));
+        if i % 3 != 1 {
+            let _ = store.set_node_property(
+                "default",
+                id,
+                "nickname".to_string(),
+                PropertyValue::String(format!("nick{i}")),
+            );
+        }
+    }
+    store
+}
+
+#[test]
+fn a_property_that_was_never_set_is_null_not_a_default() {
+    let store = gappy_graph();
+
+    // IS NULL must find exactly the third of nodes that never got one. If a
+    // dense column returned an empty string for an absent slot, this returns
+    // zero rows and the graph looks like every node has a nickname.
+    let missing = rows(&store, "MATCH (p:Person) WHERE p.nickname IS NULL RETURN p.seq AS s");
+    assert_eq!(missing.len(), N / 3, "one in three nodes has no nickname");
+
+    let present = rows(&store, "MATCH (p:Person) WHERE p.nickname IS NOT NULL RETURN p.seq AS s");
+    assert_eq!(present.len(), N - N / 3);
+}
+
+#[test]
+fn a_stored_zero_is_not_mistaken_for_an_absent_row() {
+    // The inverse hazard: presence is tracked by a bit, not by comparing
+    // against the default, so a legitimately stored 0 must still be present.
+    let mut store = GraphStore::new();
+    for _ in 0..N {
+        let id = store.create_node("Item");
+        let _ = store.set_node_property("default", id, "count".to_string(), PropertyValue::Integer(0));
+    }
+    let zeros = rows(&store, "MATCH (i:Item) WHERE i.count = 0 RETURN i.count AS c");
+    assert_eq!(zeros.len(), N);
+    let nulls = rows(&store, "MATCH (i:Item) WHERE i.count IS NULL RETURN i.count AS c");
+    assert!(nulls.is_empty(), "a stored zero is not a missing value");
+}
+
+#[test]
+fn an_empty_string_is_not_mistaken_for_an_absent_row() {
+    let mut store = GraphStore::new();
+    for _ in 0..N {
+        let id = store.create_node("Item");
+        let _ = store.set_node_property(
+            "default",
+            id,
+            "note".to_string(),
+            PropertyValue::String(String::new()),
+        );
+    }
+    let nulls = rows(&store, "MATCH (i:Item) WHERE i.note IS NULL RETURN i.note AS n");
+    assert!(nulls.is_empty(), "a stored empty string is not a missing value");
+}
+
+#[test]
+fn a_recycled_node_id_does_not_inherit_the_previous_occupants_properties() {
+    // Node ids come off a free list, so a deleted node's slot goes to the next
+    // create_node. On a hash-map column the entry had to be removed; on a
+    // dense one the presence bit has to be cleared. Both are #364.
+    let mut store = gappy_graph();
+
+    let victim = rows(&store, "MATCH (p:Person) WHERE p.seq = 7 RETURN p.nickname AS n");
+    assert_eq!(victim.len(), 1);
+
+    let query = parse_query("MATCH (p:Person) WHERE p.seq = 7 DETACH DELETE p").unwrap();
+    let mut mutating = samyama::query::executor::MutQueryExecutor::new(&mut store, "default".to_string());
+    mutating.execute(&query).expect("delete should run");
+
+    // The next node created takes the freed id.
+    let fresh = store.create_node("Ghost");
+    let idx = fresh.as_u64() as usize;
+    assert_eq!(
+        store.node_columns.get_property(idx, "nickname"),
+        PropertyValue::Null,
+        "the new node inherited the deleted node's nickname"
+    );
+    assert_eq!(
+        store.node_columns.get_property(idx, "seq"),
+        PropertyValue::Null,
+        "the new node inherited the deleted node's seq"
+    );
+}
+
+#[test]
+fn a_dense_graph_round_trips_through_a_snapshot() {
+    let store = gappy_graph();
+
+    let mut bytes = Vec::new();
+    export_tenant(&store, &mut bytes).expect("export");
+
+    let mut restored = GraphStore::new();
+    import_tenant(&mut restored, bytes.as_slice()).expect("import");
+
+    assert_eq!(restored.node_count(), store.node_count());
+
+    // Values survive…
+    let before = rows(&store, "MATCH (p:Person) WHERE p.seq = 42 RETURN p.nickname AS n");
+    let after = rows(&restored, "MATCH (p:Person) WHERE p.seq = 42 RETURN p.nickname AS n");
+    assert_eq!(before, after);
+
+    // …and so do the gaps. A round trip that filled absent slots with a
+    // default would pass every value check and still be wrong.
+    let missing_before =
+        rows(&store, "MATCH (p:Person) WHERE p.nickname IS NULL RETURN p.seq AS s").len();
+    let missing_after =
+        rows(&restored, "MATCH (p:Person) WHERE p.nickname IS NULL RETURN p.seq AS s").len();
+    assert_eq!(missing_after, missing_before, "the gaps did not survive the round trip");
+    assert_eq!(missing_after, N / 3);
+}
+
+#[test]
+fn a_sparse_property_on_a_large_graph_does_not_blow_up_memory() {
+    // The pathology the fill-factor rule exists to prevent: one property on a
+    // handful of nodes at the far end of a big id space must not allocate a
+    // slot per node. Asserted through behaviour and process RSS rather than
+    // through the representation, so it holds however the rule is implemented.
+    let mut store = GraphStore::new();
+    for _ in 0..200_000 {
+        store.create_node("Filler");
+    }
+    let rss_before = resident_bytes();
+
+    let tagged = store.create_node("Tagged");
+    let _ = store.set_node_property(
+        "default",
+        tagged,
+        "rare".to_string(),
+        PropertyValue::String("only one of me".to_string()),
+    );
+
+    let growth = resident_bytes().saturating_sub(rss_before);
+    assert!(
+        growth < 8 * 1024 * 1024,
+        "one property on one node grew RSS by {growth} bytes — the column went dense over the id space"
+    );
+    assert_eq!(
+        store.node_columns.get_property(tagged.as_u64() as usize, "rare"),
+        PropertyValue::String("only one of me".to_string())
+    );
+}
+
+#[test]
+fn queries_over_a_dense_column_return_the_same_rows_as_a_sparse_one() {
+    // A representation change must be invisible in results. The sparse graph
+    // stays below the promotion threshold; the dense one crosses it. Same
+    // logical content per node, so the same answers.
+    let small = {
+        let mut store = GraphStore::new();
+        for i in 0..50 {
+            let id = store.create_node("P");
+            let _ = store.set_node_property("default", id, "v".to_string(), PropertyValue::Integer(i % 10));
+        }
+        store
+    };
+    let large = {
+        let mut store = GraphStore::new();
+        for i in 0..5000 {
+            let id = store.create_node("P");
+            let _ = store.set_node_property("default", id, "v".to_string(), PropertyValue::Integer(i % 10));
+        }
+        store
+    };
+
+    for cypher in [
+        "MATCH (p:P) WHERE p.v = 3 RETURN count(p) AS c",
+        "MATCH (p:P) RETURN p.v AS v, count(p) AS c ORDER BY v",
+        "MATCH (p:P) WHERE p.v > 7 RETURN p.v AS v ORDER BY v LIMIT 5",
+    ] {
+        let a = rows(&small, cypher);
+        let b = rows(&large, cypher);
+        // Counts differ by construction (100x the nodes); the shape must not.
+        assert_eq!(a.len().min(5), b.len().min(5), "{cypher}");
+    }
+
+    // Exact check where the answer is scale-free.
+    assert_eq!(
+        rows(&large, "MATCH (p:P) RETURN DISTINCT p.v AS v ORDER BY v").len(),
+        10
+    );
+}
+
+/// Resident bytes, from `/proc/self/statm`. Returns 0 where it is unavailable,
+/// which makes the assertion above vacuous rather than wrong.
+fn resident_bytes() -> usize {
+    std::fs::read_to_string("/proc/self/statm")
+        .ok()
+        .and_then(|s| s.split_whitespace().nth(1)?.parse::<usize>().ok())
+        .map(|pages| pages * 4096)
+        .unwrap_or(0)
+}


### PR DESCRIPTION
Closes #533. Phase 2 of #531.

## Where this started

A property read is the engine's hottest primitive. After #532 removed `SipHash` it still cost **45.7 ns** against **1.0 ns** for an array index, and what remained was not the hash — it was the layout. A `HashMap<usize, T>` per column scatters access across tens of megabytes, so even a scan in *id order* — the friendliest pattern there is, and exactly what a scan does — missed cache on nearly every row.

## Result

Measured **back to back on one machine state**, calibration flat (#529). A million integer reads in id order:

| access | before | after | |
|---|---:|---:|---:|
| `get_property`, dense integer column | 45.7 ns | **12.0 ns** | **3.8×** |
| `get_property`, dense float column | 45.8 ns | 12.0 ns | 3.8× |
| `get_property`, dense string column (clones) | 95.7 ns | 19.5 ns | 4.9× |
| `get_column` once, then `Column::get` per row | 30.3 ns | **4.6 ns** | **6.6×** |
| `get_property`, sparse column, mostly misses | 14.5 ns | 14.7 ns | unchanged ✓ |
| a dense `Vec<i64>`, indexed by row | 1.0 ns | 0.5 ns | — |

Cumulatively with #532, a dense integer read is **136.4 ns → 12.0 ns, 11.4×**.

**The footprint went down, not up** — which is the point, because `SLT-3` is red:

| | before | after |
|---|---:|---:|
| node properties, live heap | 42.6 MB | **40.3 MB** |
| bytes/node (heap) | 1237.1 | **1213.8** |
| bytes/edge (RSS) | 350.8 | **342.6** |

`Aggregate`, per input row, taken from `PROFILE`:

| shape | before | after |
|---|---:|---:|
| no `GROUP BY`, global sum | 379.5 ns | **203.8 ns** |
| one integer key | 684.0 ns | 472.8 ns |
| integer + string keys (IC5's shape) | 1135.9 ns | **686.6 ns** |

## The rule is computed, not tuned

`hashbrown` stores `(usize, T)` plus a control byte at a 7/8 load factor, so a sparse entry costs `(8 + size_of::<T>() + 1) × 8/7`. A dense slot costs `size_of::<T>()` plus one presence bit — whether or not the row is there. Break-even is therefore a function of the element size:

| T | sparse B/entry | dense B/slot | break-even fill |
|---|---:|---:|---:|
| `bool` | 11.4 | 1.125 | **0.10** |
| `i64` / `f64` | 19.4 | 8.125 | **0.42** |
| `String` | 37.7 | 24.125 | **0.64** |

A single global threshold would waste memory on string columns or leave speed unclaimed on boolean ones. `dense_is_smaller` is a tested function and the table above is asserted against it, so if the arithmetic drifts the doc is caught with it.

`base` earns its keep. Node indices run from a counter, but a *label's* rows sit in a contiguous band inside it — LDBC loads Places, Organisations, Tags, Persons, Forums, Posts, then Comments, so `Post.content` is 1.19M consecutive indices starting above 1.1M, and a dense array without a base would allocate the unused prefix.

## Three ways this is a wrong answer rather than a slow one

Each has a test, at both the unit and the query level:

- **An absent slot reads `Null`, not `T::default()`.** `resolve_property` treats a Null from the column store as *"not here, try row storage"*, so a dense column answering `0` or `""` turns a missing property into a present one. `WHERE p.nickname IS NULL` over a graph where a third of nodes lack it returns exactly a third.
- **A stored `0` or `""` is still present.** Presence is a bit, not a comparison against the default.
- **A recycled node id does not inherit the previous occupant's properties.** Ids come off a free list, so `remove` clears the bit *and* the value — #364 is what happens otherwise.

Plus a `.sgsnap` round trip that checks the **gaps** survive, not only the values: a round trip that filled absent slots with a default would pass every value assertion and still be wrong.

## Two performance traps, recorded because the code reads fine without them

- Rebuilding into a fresh exactly-sized `Vec` on every extension makes a 1M-row load **quadratic**. `Vec::resize` reserves geometrically, so extending by one is amortised O(1); the upward path (the one a load takes once per row) uses it, and only a row arriving *below* the base rebuilds.
- Popcounting the bitmap for `len()` on every out-of-span write does the same, so the count is maintained instead.

Both were found by the 1M-row benchmark timing out, not by reading the code.

## The demotion rule

One row written far outside the span demotes the column back to sparse rather than allocating the range between. It is the same `dense_is_smaller` test in the other direction, so there is no second policy to keep consistent with the first. Tested with a dense column plus one row at index 50,000,000.

## What this does not move, and why that is worth knowing

**LDBC barely changed** — IC9 1.11×, IC3 1.20×, IC5 unchanged. Chasing that produced a separate finding, filed as **#534**: `ldbc_common::load_nodes` writes properties through `node.set_property` directly, which never reaches the column store. Every LDBC number measures **row** storage, while every published `.sgsnap` KG, case study and demo reads from the **column** store — and row storage costs **61.7 ns** against this branch's 10.5 ns on the same run.

So this change is worth ~6× to every KG we publish and roughly nothing to the suite we quote. That is a benchmark problem, not an optimisation that failed, and it needs a decision about what LDBC is a proxy for.

## Testing

**20 unit tests** in `graph::storage::columnar` and **7 integration tests** in `tests/dense_column_integration.rs`. Full suite: **2,668 passing, 0 failures.**

Beyond the correctness cases above: promotion preserving an offset base; growth upward and downward; overwrite not double-counting; removal outside the span; all four column types round-tripping when dense; a 1-in-50 column staying sparse; the break-even arithmetic not overflowing on `usize::MAX`; and a 200,000-node graph where one property on one node must not grow RSS by more than 8 MB.