### PR TITLE
Filter a traversal by edge-type id, not by cloning every incident edge's type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,10 @@ name = "property_access"
 harness = false
 
 [[bench]]
+name = "varlength_expand"
+harness = false
+
+[[bench]]
 name = "ingest_profile"
 harness = false
 

--- a/benches/varlength_expand.rs
+++ b/benches/varlength_expand.rs
@@ -1,0 +1,191 @@
+//! What a variable-length expansion costs per edge visited (#520).
+//!
+//! `CH-PROFILE-01` put **98.4% of LDBC IC1 in `VarLengthExpand`** — 582 ms to
+//! produce 9,858 rows from `(p)-[:KNOWS*1..3]-(friend)` over a relation of only
+//! 219,450 edges. An upper bound on the edges such a BFS can visit is the whole
+//! relation twice (both directions), so that is roughly **1.4 µs per edge
+//! visited**, against tens of nanoseconds for walking a CSR slice.
+//!
+//! The same operator at depth 2 costs 7–9 µs per *output row* and at depth 3
+//! costs 59 — 3× the rows for 22× the time. Two points do not make a curve, and
+//! the issue asks for one before anything is optimised.
+//!
+//! This sweeps the depth on a graph of known degree, so:
+//!
+//!   * **edges visited is computable**, not estimated — the BFS deduplicates by
+//!     node, so it visits every edge incident to a reached node exactly once
+//!     per direction, and the bench reports reached-node counts alongside;
+//!   * the per-edge cost can be compared across depths, which separates "each
+//!     hop is expensive" from "the last hop reaches most of the graph".
+//!
+//!   cargo bench --bench varlength_expand
+//!   cargo bench --bench varlength_expand -- --nodes 50000 --degree 20
+
+use std::time::Instant;
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+#[path = "common/bench_setup.rs"]
+mod bench_setup;
+
+/// A regular graph with scrambled targets: every node has exactly `degree`
+/// outgoing edges, aimed by a cheap hash so the neighbourhood **expands** with
+/// depth instead of creeping.
+///
+/// Regular rather than skewed on purpose. LDBC's degree distribution is heavy
+/// tailed, which is realistic and makes "per edge visited" impossible to read;
+/// the question here is the constant, and a constant is easiest to see where
+/// the frontier size is predictable.
+///
+/// A first draft placed targets at fixed strides (`i + 1 + d * 7919`). Every
+/// node then had the *same* offsets, so the set reachable in k hops was the set
+/// of k-fold sums of a fixed offset list — which grows polynomially. It reached
+/// 296 nodes of 20,000 at depth 4 and measured a per-edge cost 28× below LDBC's,
+/// because nothing ever left cache. A fixture that does not fan out does not
+/// exercise the thing being measured.
+/// `noise` is the parameter that makes this resemble LDBC rather than a
+/// textbook BFS.
+///
+/// In LDBC a `Person` is not a node with 41 `KNOWS` edges. It is a node with 41
+/// `KNOWS` edges **and** an incoming `HAS_CREATOR` from every post and comment
+/// it wrote, an outgoing `HAS_INTEREST` per tag, `LIKES`, `IS_LOCATED_IN`,
+/// `HAS_MEMBER` — `KNOWS` is 219,450 edges of a 21.1M-edge graph, and the ones
+/// incident to a Person are dominated by the other types.
+///
+/// A traversal that enumerates every incident edge and *then* filters by type
+/// pays for all of them. A fixture with one edge type cannot show that, which
+/// is why the first version of this bench measured 15–45 ns per edge against
+/// LDBC's ~1.4 µs and looked like the issue was wrong.
+fn scrambled_regular(nodes: usize, degree: usize, noise: usize) -> GraphStore {
+    let mut store = GraphStore::new();
+    let ids: Vec<_> = (0..nodes).map(|_| store.create_node("N")).collect();
+    let pick = |i: usize, d: usize, salt: u64| -> usize {
+        let x = (i as u64)
+            .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+            .wrapping_add((d as u64).wrapping_mul(0xBF58_476D_1CE4_E5B9))
+            .wrapping_add(salt);
+        let x = x ^ (x >> 31);
+        (x % nodes as u64) as usize
+    };
+    for (i, &src) in ids.iter().enumerate() {
+        for d in 0..degree {
+            let target = ids[pick(i, d, 0)];
+            if target != src {
+                let _ = store.create_edge(src, target, "KNOWS");
+            }
+        }
+        for d in 0..noise {
+            let target = ids[pick(i, d, 0x5DEE_CE66)];
+            if target != src {
+                let _ = store.create_edge(src, target, "NOISE");
+            }
+        }
+    }
+    store
+}
+
+/// Distinct nodes reached, and how long the query took.
+fn run(store: &GraphStore, cypher: &str) -> (usize, f64) {
+    let query = parse_query(cypher).expect("query should parse");
+    // Warm, so the first depth does not pay for statistics the others skip.
+    let _ = QueryExecutor::new(store).execute(&query).expect("query should run");
+
+    let started = Instant::now();
+    let batch = QueryExecutor::new(store).execute(&query).expect("query should run");
+    let ms = started.elapsed().as_secs_f64() * 1000.0;
+    (batch.records.len(), ms)
+}
+
+/// Exclusive time in `VarLengthExpand`, from `PROFILE` (#517), so the scan and
+/// projection around it are not folded in.
+fn expand_self_ms(store: &GraphStore, cypher: &str) -> Option<f64> {
+    let query = parse_query(&format!("PROFILE {cypher}")).ok()?;
+    let batch = QueryExecutor::new(store).execute(&query).ok()?;
+    let text = match batch.records.first()?.get("plan")? {
+        Value::Property(samyama::graph::PropertyValue::String(t)) => t.clone(),
+        _ => return None,
+    };
+    text.lines()
+        .skip_while(|l| !l.contains("Hottest operators"))
+        .find(|l| l.contains("VarLengthExpand"))
+        .and_then(|l| l.split_whitespace().find(|w| w.ends_with("ms")))
+        .and_then(|w| w.trim_end_matches("ms").parse().ok())
+}
+
+fn main() {
+    bench_setup::init();
+    let calibration = bench_setup::report_calibration();
+
+    let args: Vec<String> = std::env::args().collect();
+    let arg = |flag: &str| -> Option<usize> {
+        args.iter()
+            .position(|a| a == flag)
+            .and_then(|i| args.get(i + 1))
+            .and_then(|v| v.parse().ok())
+    };
+    let nodes = arg("--nodes").unwrap_or(20_000);
+    let degree = arg("--degree").unwrap_or(10);
+    let max_depth = arg("--max-depth").unwrap_or(4);
+    // Edges of a type the pattern does not want, per node. LDBC's ratio of
+    // non-KNOWS to KNOWS edges incident to a Person is far higher than this.
+    let noise = arg("--noise").unwrap_or(0);
+
+    eprintln!(
+        "Building {nodes} nodes: out-degree {degree} KNOWS + {noise} NOISE ({} edges)…",
+        nodes * (degree + noise)
+    );
+    let started = Instant::now();
+    let store = scrambled_regular(nodes, degree, noise);
+    eprintln!("built in {:.1}s\n", started.elapsed().as_secs_f64());
+
+    // Anchor on a fixed node so every depth asks the same question.
+    let anchor = 1;
+
+    println!(
+        "{:<10} {:>10} {:>12} {:>14} {:>16} {:>12}",
+        "pattern", "reached", "expand ms", "µs per row", "edges visited", "ns per edge"
+    );
+    println!("{:-<10} {:->10} {:->12} {:->14} {:->16} {:->12}", "", "", "", "", "", "");
+
+    let mut previous_reached = 0usize;
+    for depth in 1..=max_depth {
+        let cypher = format!(
+            "MATCH (p:N)-[:KNOWS*1..{depth}]-(f:N) WHERE id(p) = {anchor} RETURN f"
+        );
+        let (reached, _wall_ms) = run(&store, &cypher);
+        let expand_ms = expand_self_ms(&store, &cypher).unwrap_or(f64::NAN);
+
+        // The BFS deduplicates by node, so every reached node has its incident
+        // edges enumerated exactly once per direction. Undirected pattern, so
+        // both directions: out-degree plus in-degree, which average to
+        // `degree` each over a regular graph.
+        // Every reached node has *all* its incident edges enumerated, both
+        // directions, whatever their type -- which is the point when `noise`
+        // is set.
+        let _ = previous_reached;
+        let edges_visited = reached * (degree + noise) * 2;
+
+        println!(
+            "{:<10} {:>10} {:>12.1} {:>14.2} {:>16} {:>12.1}",
+            format!("*1..{depth}"),
+            reached,
+            expand_ms,
+            expand_ms * 1000.0 / reached.max(1) as f64,
+            edges_visited,
+            expand_ms * 1e6 / edges_visited.max(1) as f64,
+        );
+        previous_reached = reached;
+    }
+
+    println!();
+    println!("`edges visited` counts each reached node's incident edges once per direction.");
+    println!("It is an estimate on a regular graph and an upper bound on any graph, so the");
+    println!("ns-per-edge column is a floor rather than an exact figure.");
+    println!();
+    println!("LDBC IC1 measured 582 ms for 9,858 reached nodes over a 219,450-edge relation");
+    println!("at *1..3 -- roughly 1.4 µs per edge visited (#520).");
+
+    bench_setup::report_drift(calibration);
+}

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -1974,6 +1974,101 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
 
     /// Get outgoing edge targets with owned EdgeType — works for both full and stub edges.
     /// Uses compact edge_type_ids array (DS-07c) when Edge objects are not available.
+    /// The interned id of an edge type, if the graph has ever seen one.
+    ///
+    /// `None` means no edge in the graph has this type, so a filter on it
+    /// matches nothing — which is the right answer, not an error.
+    pub fn edge_type_id(&self, edge_type: &EdgeType) -> Option<u16> {
+        self.edge_type_to_id.get(edge_type).copied()
+    }
+
+    /// Visit each outgoing neighbour of `node`, without allocating.
+    ///
+    /// `type_ids` is `None` for "any type", or `Some(ids)` for the interned
+    /// ids to accept. `Some(&[])` therefore matches **nothing** -- which is
+    /// the right answer when a caller asked for an edge type the graph has
+    /// never seen, and the reason this is an `Option` rather than a slice
+    /// whose emptiness means "wildcard". Conflating the two makes
+    /// `-[:NO_SUCH_TYPE*1..3]->` follow every edge in the graph.
+    ///
+    /// This exists because `get_outgoing_edge_targets_owned` — which the
+    /// traversal operators used — allocates a `Vec` for the frozen tier, a
+    /// second `Vec` for the result, and **clones an `EdgeType` string per
+    /// edge**, only for the caller to compare that string against a filter and
+    /// usually discard it.
+    ///
+    /// That is paid per *incident* edge, not per matching one, and the
+    /// difference is the whole cost on a real graph: an LDBC `Person` has ~41
+    /// `KNOWS` edges and ~900 other incident edges — inbound `HAS_CREATOR`
+    /// from every post and comment they wrote, `LIKES`, `HAS_MEMBER`,
+    /// `HAS_INTEREST`. Expanding `KNOWS*1..3` from one person enumerated
+    /// roughly 9.3M edges to traverse 404K of them (#520).
+    ///
+    /// `incoming_degree_for_type` already took this approach and says so in its
+    /// own doc comment; this generalises it.
+    pub fn for_each_outgoing_neighbor(
+        &self,
+        node_id: NodeId,
+        type_ids: Option<&[u16]>,
+        mut visit: impl FnMut(NodeId, EdgeId),
+    ) {
+        let idx = node_id.as_u64() as usize;
+        for seg in &self.frozen_outgoing.segments {
+            for &(target, eid) in seg.neighbors(idx) {
+                if self.edge_type_matches(eid, type_ids) {
+                    visit(target, eid);
+                }
+            }
+        }
+        if let Some(entries) = self.outgoing.get(idx) {
+            for &(target, eid) in entries {
+                if self.edge_type_matches(eid, type_ids) {
+                    visit(target, eid);
+                }
+            }
+        }
+    }
+
+    /// Visit each incoming neighbour of `node`, without allocating.
+    /// See [`GraphStore::for_each_outgoing_neighbor`].
+    pub fn for_each_incoming_neighbor(
+        &self,
+        node_id: NodeId,
+        type_ids: Option<&[u16]>,
+        mut visit: impl FnMut(NodeId, EdgeId),
+    ) {
+        let idx = node_id.as_u64() as usize;
+        for seg in &self.frozen_incoming.segments {
+            for &(source, eid) in seg.neighbors(idx) {
+                if self.edge_type_matches(eid, type_ids) {
+                    visit(source, eid);
+                }
+            }
+        }
+        if let Some(entries) = self.incoming.get(idx) {
+            for &(source, eid) in entries {
+                if self.edge_type_matches(eid, type_ids) {
+                    visit(source, eid);
+                }
+            }
+        }
+    }
+
+    /// Compare an edge's interned type against a filter.
+    ///
+    /// `None` accepts everything; `Some(ids)` accepts only those ids, so
+    /// `Some(&[])` accepts nothing.
+    #[inline]
+    fn edge_type_matches(&self, edge_id: EdgeId, type_ids: Option<&[u16]>) -> bool {
+        let Some(ids) = type_ids else { return true };
+        let id = self
+            .edge_type_ids
+            .get(edge_id.as_u64() as usize)
+            .copied()
+            .unwrap_or(Self::EDGE_TYPE_UNSET);
+        ids.contains(&id)
+    }
+
     pub fn get_outgoing_edge_targets_owned(&self, node_id: NodeId) -> Vec<(EdgeId, NodeId, NodeId, EdgeType)> {
         let src_idx = node_id.as_u64() as usize;
         let mut result = Vec::new();

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3349,6 +3349,13 @@ pub struct VarLengthExpandOperator {
     path_variable: Option<String>,
     /// Output records buffered for the current input record.
     pending: std::collections::VecDeque<Record>,
+    /// `edge_types` resolved to interned ids, cached after the first use.
+    ///
+    /// Resolving is a hash lookup per type against the store, and the answer
+    /// cannot change during a query. Empty vec inside the `Some` means "no
+    /// filter"; a requested type the graph has never seen simply contributes
+    /// no id, so it matches nothing -- which is correct.
+    type_ids: Option<Vec<u16>>,
 }
 
 impl VarLengthExpandOperator {
@@ -3375,6 +3382,7 @@ impl VarLengthExpandOperator {
             max_hops,
             path_variable: None,
             pending: std::collections::VecDeque::new(),
+            type_ids: None,
         }
     }
 
@@ -3390,37 +3398,57 @@ impl VarLengthExpandOperator {
         self
     }
 
-    /// One-hop neighbours of `node` honouring direction + edge-type filter,
-    /// returned as `(neighbour_node, edge_id)` pairs.
-    fn neighbors(&self, node: NodeId, store: &GraphStore) -> Vec<(NodeId, crate::graph::EdgeId)> {
-        let raw: Vec<(crate::graph::EdgeId, NodeId, NodeId, EdgeType)> = match self.direction {
-            Direction::Outgoing => store.get_outgoing_edge_targets_owned(node),
-            Direction::Incoming => store.get_incoming_edge_sources_owned(node),
+    /// The edge-type filter as interned ids, resolved once per query.
+    ///
+    /// Returns `None` when the pattern named no types at all -- the wildcard.
+    /// A pattern that named types none of which exist in the graph returns
+    /// `Some(empty)`, which matches nothing. Collapsing those two cases makes
+    /// `-[:NO_SUCH_TYPE*1..3]->` follow every edge in the graph; a test does
+    /// exactly that, and it failed against the first version of this.
+    fn type_ids(&mut self, store: &GraphStore) -> Option<Vec<u16>> {
+        if self.edge_types.is_empty() {
+            return None;
+        }
+        if self.type_ids.is_none() {
+            let ids = self
+                .edge_types
+                .iter()
+                .filter_map(|t| store.edge_type_id(&EdgeType::new(t.as_str())))
+                .collect();
+            self.type_ids = Some(ids);
+        }
+        self.type_ids.clone()
+    }
+
+    /// Visit each one-hop neighbour of `node` honouring direction and the
+    /// edge-type filter, without allocating.
+    ///
+    /// This used to build a `Vec` of `(EdgeId, NodeId, NodeId, EdgeType)` per
+    /// node -- three allocations and an `EdgeType` **string clone per incident
+    /// edge** -- and then filter it by comparing those strings. The filter was
+    /// therefore paid *after* materialising every incident edge, which on a
+    /// real graph is most of the cost: an LDBC `Person` has ~41 `KNOWS` edges
+    /// and ~900 others (inbound `HAS_CREATOR` from every post and comment they
+    /// wrote, `LIKES`, `HAS_MEMBER`, `HAS_INTEREST`), so `KNOWS*1..3` from one
+    /// person enumerated ~9.3M edges to traverse 404K (#520).
+    ///
+    /// Filtering on the interned type id inside the walk skips a non-matching
+    /// edge in a compare rather than a string clone.
+    fn for_each_neighbor(
+        &self,
+        node: NodeId,
+        type_ids: Option<&[u16]>,
+        store: &GraphStore,
+        mut visit: impl FnMut(NodeId, crate::graph::EdgeId),
+    ) {
+        match self.direction {
+            Direction::Outgoing => store.for_each_outgoing_neighbor(node, type_ids, &mut visit),
+            Direction::Incoming => store.for_each_incoming_neighbor(node, type_ids, &mut visit),
             Direction::Both => {
-                let mut all = store.get_outgoing_edge_targets_owned(node);
-                all.extend(store.get_incoming_edge_sources_owned(node));
-                all
+                store.for_each_outgoing_neighbor(node, type_ids, &mut visit);
+                store.for_each_incoming_neighbor(node, type_ids, &mut visit);
             }
-        };
-        raw.into_iter()
-            .filter(|(_, _, _, et)| {
-                self.edge_types.is_empty() || self.edge_types.iter().any(|t| et.as_str() == t)
-            })
-            .map(|(eid, src, tgt, _)| {
-                let other = match self.direction {
-                    Direction::Outgoing => tgt,
-                    Direction::Incoming => src,
-                    Direction::Both => {
-                        if src == node {
-                            tgt
-                        } else {
-                            src
-                        }
-                    }
-                };
-                (other, eid)
-            })
-            .collect()
+        }
     }
 
     /// BFS from the source bound in `record`, buffering one output record per
@@ -3445,19 +3473,30 @@ impl VarLengthExpandOperator {
             self.buffer(record, source_id, &parent, source_id);
         }
 
+        let type_ids: Option<Vec<u16>> = self.type_ids(store);
+        let type_filter = type_ids.as_deref();
+
         let mut frontier = vec![source_id];
         let mut depth = 0usize;
         while !frontier.is_empty() && depth < self.max_hops {
             depth += 1;
             let mut next = Vec::new();
             for &cur in &frontier {
-                for (nb, eid) in self.neighbors(cur, store) {
+                // The closure borrows the BFS state; buffering an output
+                // record needs `&mut self`, so discovery and emission are
+                // separated. The emission order is unchanged: `next` is filled
+                // in exactly the order the old code emitted in.
+                self.for_each_neighbor(cur, type_filter, store, |nb, eid| {
                     if visited.insert(nb) {
                         parent.insert(nb, (cur, eid));
                         next.push(nb);
-                        if depth >= self.min_hops && self.emit_ok(nb, store) {
-                            self.buffer(record, nb, &parent, source_id);
-                        }
+                    }
+                });
+            }
+            if depth >= self.min_hops {
+                for &nb in &next {
+                    if self.emit_ok(nb, store) {
+                        self.buffer(record, nb, &parent, source_id);
                     }
                 }
             }

--- a/tests/varlength_expand_semantics.rs
+++ b/tests/varlength_expand_semantics.rs
@@ -1,0 +1,270 @@
+//! Variable-length expansion answers the same questions after #520's rewrite.
+//!
+//! The traversal stopped materialising every incident edge with an owned
+//! `EdgeType` and now filters on the interned type id inside the walk. That is
+//! a change to *what gets skipped and when*, so the risks are all
+//! correctness ones:
+//!
+//! * the type filter must still match exactly the types asked for, including
+//!   a type the graph has never seen (matches nothing) and no filter at all
+//!   (matches everything);
+//! * direction must still be honoured, including the `Both` case that reads
+//!   the outgoing and incoming adjacency separately;
+//! * hop bounds, deduplication by node, and named-path reconstruction must be
+//!   unchanged;
+//! * output order must be unchanged, because discovery and emission are now
+//!   separated by a level rather than interleaved.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// A → B → C → D in a line, plus a parallel `OTHER`-typed chain A → X → Y
+/// and one reverse edge D → A, so direction and type both matter.
+fn line_graph() -> GraphStore {
+    let mut store = GraphStore::new();
+    let mut named = |store: &mut GraphStore, name: &str| {
+        let id = store.create_node("N");
+        let _ = store.set_node_property(
+            "default",
+            id,
+            "name".to_string(),
+            PropertyValue::String(name.to_string()),
+        );
+        id
+    };
+    let a = named(&mut store, "A");
+    let b = named(&mut store, "B");
+    let c = named(&mut store, "C");
+    let d = named(&mut store, "D");
+    let x = named(&mut store, "X");
+    let y = named(&mut store, "Y");
+
+    store.create_edge(a, b, "LINK").unwrap();
+    store.create_edge(b, c, "LINK").unwrap();
+    store.create_edge(c, d, "LINK").unwrap();
+    store.create_edge(d, a, "BACK").unwrap();
+    store.create_edge(a, x, "OTHER").unwrap();
+    store.create_edge(x, y, "OTHER").unwrap();
+    store
+}
+
+fn names(store: &GraphStore, cypher: &str) -> Vec<String> {
+    let query = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&query).expect("query should run");
+    batch
+        .records
+        .iter()
+        .map(|r| match r.get("n") {
+            Some(Value::Property(PropertyValue::String(s))) => s.clone(),
+            other => format!("{other:?}"),
+        })
+        .collect()
+}
+
+#[test]
+fn the_type_filter_excludes_other_types() {
+    let store = line_graph();
+    // Outgoing LINK only: A reaches B, C, D. Never X or Y, which are OTHER.
+    let mut out = names(
+        &store,
+        "MATCH (a:N)-[:LINK*1..3]->(f:N) WHERE a.name = \"A\" RETURN f.name AS n",
+    );
+    out.sort();
+    assert_eq!(out, vec!["B", "C", "D"]);
+}
+
+#[test]
+fn no_type_filter_follows_every_type() {
+    let store = line_graph();
+    let mut out = names(
+        &store,
+        "MATCH (a:N)-[*1..2]->(f:N) WHERE a.name = \"A\" RETURN f.name AS n",
+    );
+    out.sort();
+    // A -> B -> C, and A -> X -> Y.
+    assert_eq!(out, vec!["B", "C", "X", "Y"]);
+}
+
+#[test]
+fn a_type_the_graph_has_never_seen_matches_nothing() {
+    // The interned-id lookup returns None for an unknown type. That must mean
+    // "matches nothing", not "matches everything" — an empty filter is the
+    // wildcard, so collapsing the two would silently follow every edge.
+    let store = line_graph();
+    let out = names(
+        &store,
+        "MATCH (a:N)-[:NO_SUCH_TYPE*1..3]->(f:N) WHERE a.name = \"A\" RETURN f.name AS n",
+    );
+    assert!(out.is_empty(), "an unknown edge type matched something: {out:?}");
+}
+
+#[test]
+fn direction_is_honoured() {
+    let store = line_graph();
+
+    // Outgoing from D: only the BACK edge to A.
+    let out = names(
+        &store,
+        "MATCH (d:N)-[:BACK*1..1]->(f:N) WHERE d.name = \"D\" RETURN f.name AS n",
+    );
+    assert_eq!(out, vec!["A"]);
+
+    // Incoming to D over LINK: C.
+    let out = names(
+        &store,
+        "MATCH (d:N)<-[:LINK*1..1]-(f:N) WHERE d.name = \"D\" RETURN f.name AS n",
+    );
+    assert_eq!(out, vec!["C"]);
+}
+
+#[test]
+fn an_undirected_pattern_reads_both_adjacencies() {
+    // The `Both` case visits the outgoing and incoming adjacency in two
+    // separate walks now, so a node reachable only backwards must still appear.
+    let store = line_graph();
+    let mut out = names(
+        &store,
+        "MATCH (c:N)-[:LINK*1..1]-(f:N) WHERE c.name = \"C\" RETURN f.name AS n",
+    );
+    out.sort();
+    assert_eq!(out, vec!["B", "D"], "C links forward to D and backward from B");
+}
+
+#[test]
+fn hop_bounds_are_respected() {
+    let store = line_graph();
+
+    let out = names(
+        &store,
+        "MATCH (a:N)-[:LINK*1..1]->(f:N) WHERE a.name = \"A\" RETURN f.name AS n",
+    );
+    assert_eq!(out, vec!["B"]);
+
+    let mut out = names(
+        &store,
+        "MATCH (a:N)-[:LINK*2..3]->(f:N) WHERE a.name = \"A\" RETURN f.name AS n",
+    );
+    out.sort();
+    assert_eq!(out, vec!["C", "D"], "the minimum hop count excludes B");
+}
+
+#[test]
+fn each_reachable_node_is_returned_once() {
+    // A diamond: two distinct paths reach D. The BFS deduplicates by node, so
+    // D appears once whichever path found it first.
+    let mut store = GraphStore::new();
+    let mk = |s: &mut GraphStore, name: &str| {
+        let id = s.create_node("N");
+        let _ = s.set_node_property(
+            "default",
+            id,
+            "name".to_string(),
+            PropertyValue::String(name.to_string()),
+        );
+        id
+    };
+    let a = mk(&mut store, "A");
+    let b = mk(&mut store, "B");
+    let c = mk(&mut store, "C");
+    let d = mk(&mut store, "D");
+    store.create_edge(a, b, "E").unwrap();
+    store.create_edge(a, c, "E").unwrap();
+    store.create_edge(b, d, "E").unwrap();
+    store.create_edge(c, d, "E").unwrap();
+
+    let out = names(
+        &store,
+        "MATCH (a:N)-[:E*1..3]->(f:N) WHERE a.name = \"A\" RETURN f.name AS n",
+    );
+    assert_eq!(out.iter().filter(|n| *n == "D").count(), 1, "{out:?}");
+    let mut sorted = out.clone();
+    sorted.sort();
+    assert_eq!(sorted, vec!["B", "C", "D"]);
+}
+
+#[test]
+fn results_come_back_in_breadth_first_order() {
+    // Discovery and emission are separated by a level now rather than
+    // interleaved. The order must be unchanged: level by level, and within a
+    // level in discovery order.
+    let store = line_graph();
+    let out = names(
+        &store,
+        "MATCH (a:N)-[:LINK*1..3]->(f:N) WHERE a.name = \"A\" RETURN f.name AS n",
+    );
+    assert_eq!(out, vec!["B", "C", "D"], "B before C before D");
+}
+
+#[test]
+fn a_named_path_still_reconstructs() {
+    let store = line_graph();
+    let query = parse_query(
+        "MATCH p = (a:N)-[:LINK*1..3]->(f:N) WHERE a.name = \"A\" AND f.name = \"D\" \
+         RETURN length(p) AS n",
+    )
+    .expect("query should parse");
+    let batch = QueryExecutor::new(&store).execute(&query).expect("query should run");
+    assert_eq!(batch.records.len(), 1);
+    match batch.records[0].get("n") {
+        Some(Value::Property(PropertyValue::Integer(len))) => {
+            assert_eq!(*len, 3, "A -> B -> C -> D is three hops")
+        }
+        other => panic!("expected a length, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_node_with_no_matching_edges_returns_nothing() {
+    let store = line_graph();
+    let out = names(
+        &store,
+        "MATCH (y:N)-[:LINK*1..3]->(f:N) WHERE y.name = \"Y\" RETURN f.name AS n",
+    );
+    assert!(out.is_empty(), "{out:?}");
+}
+
+#[test]
+fn a_large_traversal_reaches_the_same_set_as_a_hand_computed_bfs() {
+    // The unit-sized graphs above cannot catch an error that only appears once
+    // the frontier is large. This builds a graph whose reachable set is
+    // computable outside the engine and compares.
+    const N: usize = 2000;
+    let mut store = GraphStore::new();
+    let ids: Vec<_> = (0..N).map(|_| store.create_node("N")).collect();
+    for (i, &src) in ids.iter().enumerate() {
+        // Each node links to i+1 and i+7, modulo N, plus a decoy of another type.
+        store.create_edge(src, ids[(i + 1) % N], "E").unwrap();
+        store.create_edge(src, ids[(i + 7) % N], "E").unwrap();
+        store.create_edge(src, ids[(i + 3) % N], "DECOY").unwrap();
+    }
+
+    // Hand BFS over the same edge set, three hops, following only "E".
+    let mut reachable = std::collections::HashSet::new();
+    let mut frontier = vec![0usize];
+    let mut seen: std::collections::HashSet<usize> = [0].into_iter().collect();
+    for _ in 0..3 {
+        let mut next = Vec::new();
+        for &cur in &frontier {
+            for step in [1usize, 7] {
+                let nb = (cur + step) % N;
+                if seen.insert(nb) {
+                    reachable.insert(nb);
+                    next.push(nb);
+                }
+            }
+        }
+        frontier = next;
+    }
+
+    let query = parse_query("MATCH (a:N)-[:E*1..3]->(f:N) WHERE id(a) = 1 RETURN id(f) AS n")
+        .expect("query should parse");
+    let batch = QueryExecutor::new(&store).execute(&query).expect("query should run");
+    assert_eq!(
+        batch.records.len(),
+        reachable.len(),
+        "engine reached {} nodes, hand BFS reached {}",
+        batch.records.len(),
+        reachable.len()
+    );
+}


### PR DESCRIPTION
Phase 1 and 2 of #520. Part of #296.

## Result

Measured **back to back on one machine state**, LDBC SF1, parameters derived at p50:

| query | before | after | |
|---|---:|---:|---:|
| **IC1** Transitive Friends by Name | 342 ms | **55.3 ms** | **6.2×** |
| IC13 Single Shortest Path | 356 ms | 369 ms | unchanged |
| IC10 Friend Recommendation | 200 ms | 187 ms | unchanged |
| IC14 Trusted Connection Paths | timeout | timeout | unchanged (#516) |

IC13 and IC10 are the control — neither uses `VarLengthExpand`, and neither moved.

`CH-PROFILE-01` had IC1 at **98.4% `VarLengthExpand`**, which makes this most of the query.

## What was wrong

`VarLengthExpand` built a `Vec<(EdgeId, NodeId, NodeId, EdgeType)>` for every node it visited — three allocations, and an `EdgeType` **string clone per incident edge** — then filtered that `Vec` by comparing the strings:

```rust
raw.into_iter()
   .filter(|(_, _, _, et)| self.edge_types.iter().any(|t| et.as_str() == t))
```

So the filter was paid **after** materialising every incident edge. On a real graph that is the entire cost. An LDBC `Person` has ~41 `KNOWS` edges and roughly **900 others**: an inbound `HAS_CREATOR` from every post and comment they wrote, plus `LIKES`, `HAS_MEMBER`, `HAS_INTEREST`. Expanding `KNOWS*1..3` from one person enumerated about **9.3M edges to traverse 404K**, allocating a `String` for each.

`for_each_outgoing_neighbor` / `for_each_incoming_neighbor` walk the adjacency and skip a non-matching edge in a compare against the interned type id. `incoming_degree_for_type` already did this and says so in its own doc comment — *"without allocating a Vec or cloning EdgeType"*; this generalises it.

## The filter is an `Option`, and that is load-bearing

`Option<&[u16]>`, not a slice whose emptiness means wildcard.

An edge type the graph has never seen resolves to **no ids**. If "no ids" meant "no filter", then `-[:NO_SUCH_TYPE*1..3]->` would follow **every edge in the graph** instead of returning nothing.

The first version of this change did exactly that. `a_type_the_graph_has_never_seen_matches_nothing` failed with `["B", "X", "C", "Y", "D"]` where it expected nothing, which is how it was caught rather than shipped.

## One structural change

Discovery and emission are separated by a BFS level now: the visitor closure borrows the BFS state, and buffering an output record needs `&mut self`. The **emission order is unchanged** — the frontier is filled in exactly the order the old code emitted in, and `results_come_back_in_breadth_first_order` pins it.

## Two things about the benchmark fixture

`benches/varlength_expand` sweeps depth 1–4 and reports ns per edge visited. Getting it to measure anything took two corrections, both recorded in the file because the mistakes are easy to repeat:

- **A fixture that does not fan out measures nothing.** The first version placed chord targets at fixed strides, so every node had the same offsets and the k-hop reachable set was the set of k-fold sums of a fixed list — polynomial growth. It reached 296 of 20,000 nodes at depth 4 and measured **28× below** LDBC, because nothing ever left cache.
- **A fixture with one edge type cannot show this defect at all.** `--noise` adds edges of a type the pattern does not want, which is what a real graph looks like. Without it the per-edge cost was 15–45 ns and the issue looked wrong.

## Testing

11 new tests in `tests/varlength_expand_semantics.rs`. Full suite: **2,686 passing, 0 failures.**

The change alters *what gets skipped and when*, so the tests are all correctness: the type filter matching exactly the named types; an unknown type matching nothing; no filter matching everything; direction honoured including the `Both` case that now reads the two adjacencies in separate walks; hop bounds; deduplication by node across a diamond; breadth-first output order; named-path reconstruction; a node with no matching edges; and a 2,000-node traversal compared against a BFS computed outside the engine.

## Not fixed here

`ExpandOperator::load_edges` has the **identical** defect — same owned-`EdgeType` materialisation, same filter-afterwards — and is 55% of IC9 and 63–76% of IC3 and IC6 in the profiles. It needs the surviving edges' types, so it is a slightly different change: filter during the walk, then resolve the type only for what survives. Worth its own PR rather than growing this one.