### PR TITLE
Find shortest paths with a predecessor DAG instead of enumerating every walk

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -8734,6 +8734,9 @@ pub struct ShortestPathOperator {
     all_paths: bool,  // false = shortestPath, true = allShortestPaths
     results: std::vec::IntoIter<Record>,
     executed: bool,
+    /// `edge_types` resolved to interned ids, cached after the first use.
+    /// `None` from `type_ids()` means the pattern named no types.
+    type_ids: Option<Vec<u16>>,
 }
 
 impl ShortestPathOperator {
@@ -8756,11 +8759,48 @@ impl ShortestPathOperator {
             all_paths,
             results: Vec::new().into_iter(),
             executed: false,
+            type_ids: None,
+        }
+    }
+
+    /// The edge-type filter as interned ids. `None` is the wildcard; an
+    /// unknown type yields `Some(empty)`, which matches nothing.
+    fn type_ids(&mut self, store: &GraphStore) -> Option<Vec<u16>> {
+        if self.edge_types.is_empty() {
+            return None;
+        }
+        if self.type_ids.is_none() {
+            let ids = self
+                .edge_types
+                .iter()
+                .filter_map(|t| store.edge_type_id(&EdgeType::new(t.as_str())))
+                .collect();
+            self.type_ids = Some(ids);
+        }
+        self.type_ids.clone()
+    }
+
+    fn for_each_neighbor(
+        &self,
+        node: NodeId,
+        type_ids: Option<&[u16]>,
+        store: &GraphStore,
+        mut visit: impl FnMut(NodeId, crate::graph::EdgeId),
+    ) {
+        match self.direction {
+            Direction::Outgoing => store.for_each_outgoing_neighbor(node, type_ids, &mut visit),
+            Direction::Incoming => store.for_each_incoming_neighbor(node, type_ids, &mut visit),
+            Direction::Both => {
+                store.for_each_outgoing_neighbor(node, type_ids, &mut visit);
+                store.for_each_incoming_neighbor(node, type_ids, &mut visit);
+            }
         }
     }
 
     fn execute_all(&mut self, store: &GraphStore) -> ExecutionResult<()> {
         let mut all_results = Vec::new();
+        let type_ids = self.type_ids(store);
+        let type_filter = type_ids.as_deref();
 
         while let Some(record) = self.input.next(store)? {
             let source_id = record.get(&self.source_var)
@@ -8771,7 +8811,7 @@ impl ShortestPathOperator {
                 .ok_or_else(|| ExecutionError::RuntimeError("shortestPath target not a node".to_string()))?;
 
             // BFS to find shortest path(s)
-            let paths = self.bfs_shortest(store, source_id, target_id);
+            let paths = self.bfs_shortest(store, source_id, target_id, type_filter);
 
             if self.all_paths {
                 for path in paths {
@@ -8801,81 +8841,170 @@ impl ShortestPathOperator {
         Ok(())
     }
 
-    fn bfs_shortest(&self, store: &GraphStore, source: NodeId, target: NodeId) -> Vec<(Vec<NodeId>, Vec<crate::graph::EdgeId>)> {
-        use std::collections::VecDeque;
-
+    /// Every shortest path from `source` to `target`, or one of them.
+    ///
+    /// # What this replaced, and why it timed out
+    ///
+    /// The previous implementation carried a full `Vec<NodeId>` and
+    /// `Vec<EdgeId>` on every queue entry and — for `allShortestPaths` —
+    /// **disabled the visited set entirely**:
+    ///
+    /// ```text
+    /// if !visited.contains(&next_node) || self.all_paths {
+    ///     if !self.all_paths { visited.insert(next_node); }
+    /// ```
+    ///
+    /// So it enumerated every *walk* of length ≤ d rather than every shortest
+    /// path, cloning both path vectors at each expansion, and materialised a
+    /// full `Edge` per incident edge to read its type. On LDBC with the
+    /// endpoints three hops apart and an average undirected degree around 41,
+    /// that is on the order of 41³ ≈ 69,000 walks, each enumerating ~900
+    /// incident edges as owned `Edge` objects. It did not finish inside 120 s
+    /// (#516).
+    ///
+    /// # What this does
+    ///
+    /// The textbook two-phase approach:
+    ///
+    /// 1. **A level BFS** that records, for each node, its distance and *all*
+    ///    predecessors that reach it at that distance — a shortest-path DAG.
+    ///    Each node is expanded once, so this is O(V + E), and it stops at the
+    ///    level where the target appears.
+    /// 2. **Backtracking** from the target through that DAG to enumerate
+    ///    paths. The cost is proportional to the paths actually returned
+    ///    rather than to the walks that might have led anywhere.
+    ///
+    /// Neighbours come from the allocation-free visitor with the edge type
+    /// filtered on its interned id, so an incident edge of the wrong type
+    /// costs a comparison rather than an `Edge` clone (#520).
+    fn bfs_shortest(
+        &self,
+        store: &GraphStore,
+        source: NodeId,
+        target: NodeId,
+        type_ids: Option<&[u16]>,
+    ) -> Vec<(Vec<NodeId>, Vec<crate::graph::EdgeId>)> {
         if source == target {
             return vec![(vec![source], vec![])];
         }
 
-        let mut queue: VecDeque<(NodeId, Vec<NodeId>, Vec<crate::graph::EdgeId>)> = VecDeque::new();
-        let mut visited: HashSet<NodeId> = HashSet::new();
-        let mut results = Vec::new();
-        let mut found_distance: Option<usize> = None;
+        // Phase 1: level BFS building the shortest-path DAG.
+        let mut dist: rustc_hash::FxHashMap<NodeId, u32> = rustc_hash::FxHashMap::default();
+        let mut preds: rustc_hash::FxHashMap<NodeId, Vec<(NodeId, crate::graph::EdgeId)>> =
+            rustc_hash::FxHashMap::default();
+        dist.insert(source, 0);
 
-        queue.push_back((source, vec![source], vec![]));
-        visited.insert(source);
+        let mut frontier = vec![source];
+        let mut depth = 0u32;
+        let mut reached = false;
 
-        while let Some((current, path_nodes, path_edges)) = queue.pop_front() {
-            if let Some(max_dist) = found_distance {
-                if path_nodes.len() > max_dist {
-                    break;
-                }
+        while !frontier.is_empty() && !reached {
+            depth += 1;
+            let mut next = Vec::new();
+            for &current in &frontier {
+                self.for_each_neighbor(current, type_ids, store, |neighbour, edge_id| {
+                    match dist.get(&neighbour) {
+                        None => {
+                            dist.insert(neighbour, depth);
+                            preds.entry(neighbour).or_default().push((current, edge_id));
+                            next.push(neighbour);
+                            if neighbour == target {
+                                reached = true;
+                            }
+                        }
+                        // Another predecessor at the *same* distance is another
+                        // shortest way in, and `allShortestPaths` wants it. A
+                        // node already seen at a shorter distance is not.
+                        Some(&d) if d == depth && self.all_paths => {
+                            preds.entry(neighbour).or_default().push((current, edge_id));
+                        }
+                        _ => {}
+                    }
+                });
             }
-
-            let edges = match self.direction {
-                Direction::Outgoing => store.get_outgoing_edges(current),
-                Direction::Incoming => store.get_incoming_edges(current),
-                Direction::Both => {
-                    let mut all = store.get_outgoing_edges(current);
-                    all.extend(store.get_incoming_edges(current));
-                    all
-                }
-            };
-
-            for edge in &edges {
-                if !self.edge_types.is_empty() && !self.edge_types.iter().any(|t| t == edge.edge_type.as_str()) {
-                    continue;
-                }
-                let next_node = if edge.source == current { edge.target } else { edge.source };
-
-                if next_node == target {
-                    let mut new_nodes = path_nodes.clone();
-                    new_nodes.push(target);
-                    let mut new_edges = path_edges.clone();
-                    new_edges.push(edge.id);
-
-                    if found_distance.is_none() {
-                        found_distance = Some(new_nodes.len());
-                    }
-                    results.push((new_nodes, new_edges));
-
-                    if !self.all_paths {
-                        return results;
-                    }
-                    continue;
-                }
-
-                if !visited.contains(&next_node) || self.all_paths {
-                    if !self.all_paths {
-                        visited.insert(next_node);
-                    }
-                    let mut new_nodes = path_nodes.clone();
-                    new_nodes.push(next_node);
-                    let mut new_edges = path_edges.clone();
-                    new_edges.push(edge.id);
-                    queue.push_back((next_node, new_nodes, new_edges));
-                }
-            }
+            frontier = next;
         }
 
+        if !reached {
+            return Vec::new();
+        }
+
+        // Phase 2: walk the DAG backwards from the target.
+        let mut results = Vec::new();
+        let mut nodes_rev = vec![target];
+        let mut edges_rev = Vec::new();
+        self.collect_paths(
+            target,
+            source,
+            &preds,
+            &mut nodes_rev,
+            &mut edges_rev,
+            &mut results,
+        );
         results
+    }
+
+    /// Depth-first backtrack through the predecessor DAG, emitting one path
+    /// per distinct chain. Stops after the first path when only one is wanted.
+    fn collect_paths(
+        &self,
+        current: NodeId,
+        source: NodeId,
+        preds: &rustc_hash::FxHashMap<NodeId, Vec<(NodeId, crate::graph::EdgeId)>>,
+        nodes_rev: &mut Vec<NodeId>,
+        edges_rev: &mut Vec<crate::graph::EdgeId>,
+        results: &mut Vec<(Vec<NodeId>, Vec<crate::graph::EdgeId>)>,
+    ) {
+        if !self.all_paths && !results.is_empty() {
+            return;
+        }
+        if current == source {
+            let mut nodes: Vec<NodeId> = nodes_rev.clone();
+            nodes.reverse();
+            let mut edges: Vec<crate::graph::EdgeId> = edges_rev.clone();
+            edges.reverse();
+            results.push((nodes, edges));
+            return;
+        }
+        let Some(parents) = preds.get(&current) else {
+            return;
+        };
+        for &(parent, edge_id) in parents {
+            nodes_rev.push(parent);
+            edges_rev.push(edge_id);
+            self.collect_paths(parent, source, preds, nodes_rev, edges_rev, results);
+            nodes_rev.pop();
+            edges_rev.pop();
+            if !self.all_paths && !results.is_empty() {
+                return;
+            }
+        }
     }
 }
 
 impl PhysicalOperator for ShortestPathOperator {
     fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
         vec![&mut self.input]
+    }
+
+    /// Without this, EXPLAIN and PROFILE rendered a shortest-path plan as
+    /// `Unknown` — the operator inherited the trait's default. A plan nobody
+    /// can read is a plan nobody profiles, which is how #516 went unexamined.
+    fn describe(&self) -> OperatorDescription {
+        let kind = if self.all_paths { "AllShortestPaths" } else { "ShortestPath" };
+        let types = if self.edge_types.is_empty() {
+            String::new()
+        } else {
+            format!(":{}", self.edge_types.join("|"))
+        };
+        OperatorDescription {
+            name: kind.to_string(),
+            details: format!(
+                "({})-[{}*]-({}), {:?}",
+                self.source_var, types, self.target_var, self.direction
+            ),
+            children: vec![self.input.describe()],
+        }
     }
 
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {

--- a/tests/shortest_path_semantics.rs
+++ b/tests/shortest_path_semantics.rs
@@ -1,0 +1,262 @@
+//! `shortestPath` and `allShortestPaths` (#516).
+//!
+//! The search was rewritten from "enqueue every walk, carrying its whole path"
+//! to "level BFS building a predecessor DAG, then backtrack". Two things about
+//! the old version make the correctness tests here worth more than a timing
+//! check:
+//!
+//! * for `allShortestPaths` it never populated the visited set, so it explored
+//!   walks rather than paths — the results happened to come out right because
+//!   a walk that revisits a node cannot have the shortest length, but nothing
+//!   in the code said so;
+//! * the new version returns *all* predecessors at the shortest distance,
+//!   which is a different mechanism for producing the same answer, and
+//!   "different mechanism, same answer" is what needs pinning.
+
+use samyama::graph::{GraphStore, NodeId, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn named(store: &mut GraphStore, name: &str) -> NodeId {
+    let id = store.create_node("N");
+    let _ = store.set_node_property(
+        "default",
+        id,
+        "name".to_string(),
+        PropertyValue::String(name.to_string()),
+    );
+    id
+}
+
+/// A diamond with two equal-length routes plus one longer detour:
+///
+/// ```text
+///   A -> B -> D        (length 2)
+///   A -> C -> D        (length 2)
+///   A -> E -> F -> D   (length 3, never shortest)
+/// ```
+fn diamond() -> GraphStore {
+    let mut store = GraphStore::new();
+    let a = named(&mut store, "A");
+    let b = named(&mut store, "B");
+    let c = named(&mut store, "C");
+    let d = named(&mut store, "D");
+    let e = named(&mut store, "E");
+    let f = named(&mut store, "F");
+    for (from, to) in [(a, b), (b, d), (a, c), (c, d), (a, e), (e, f), (f, d)] {
+        store.create_edge(from, to, "LINK").unwrap();
+    }
+    store
+}
+
+fn lengths(store: &GraphStore, cypher: &str) -> Vec<i64> {
+    let query = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&query).expect("query should run");
+    batch
+        .records
+        .iter()
+        .map(|r| match r.get("len") {
+            Some(Value::Property(PropertyValue::Integer(n))) => *n,
+            other => panic!("expected a length, got {other:?}"),
+        })
+        .collect()
+}
+
+#[test]
+fn shortest_path_returns_one_path_of_the_minimum_length() {
+    let store = diamond();
+    let out = lengths(
+        &store,
+        "MATCH p = shortestPath((a:N)-[:LINK*]->(d:N)) WHERE a.name = \"A\" AND d.name = \"D\" \
+         RETURN length(p) AS len",
+    );
+    assert_eq!(out, vec![2], "one path, and the short one: {out:?}");
+}
+
+#[test]
+fn all_shortest_paths_returns_every_minimum_length_path() {
+    let store = diamond();
+    let out = lengths(
+        &store,
+        "MATCH p = allShortestPaths((a:N)-[:LINK*]->(d:N)) WHERE a.name = \"A\" AND d.name = \"D\" \
+         RETURN length(p) AS len",
+    );
+    assert_eq!(out.len(), 2, "A->B->D and A->C->D: {out:?}");
+    assert!(out.iter().all(|&n| n == 2), "the 3-hop detour is not shortest: {out:?}");
+}
+
+#[test]
+fn the_longer_route_is_never_returned() {
+    // The predecessor DAG must only record parents at the shortest distance.
+    // Recording a parent at distance+1 would surface A->E->F->D here.
+    let store = diamond();
+    let out = lengths(
+        &store,
+        "MATCH p = allShortestPaths((a:N)-[:LINK*]->(d:N)) WHERE a.name = \"A\" AND d.name = \"D\" \
+         RETURN length(p) AS len",
+    );
+    assert!(!out.contains(&3), "{out:?}");
+}
+
+#[test]
+fn a_source_equal_to_the_target_is_a_zero_length_path() {
+    let store = diamond();
+    let out = lengths(
+        &store,
+        "MATCH p = shortestPath((a:N)-[:LINK*]->(b:N)) WHERE a.name = \"A\" AND b.name = \"A\" \
+         RETURN length(p) AS len",
+    );
+    assert_eq!(out, vec![0]);
+}
+
+#[test]
+fn an_unreachable_target_returns_nothing() {
+    let mut store = diamond();
+    let island = named(&mut store, "Z");
+    let _ = island;
+    let out = lengths(
+        &store,
+        "MATCH p = shortestPath((a:N)-[:LINK*]->(z:N)) WHERE a.name = \"A\" AND z.name = \"Z\" \
+         RETURN length(p) AS len",
+    );
+    assert!(out.is_empty(), "{out:?}");
+}
+
+#[test]
+fn direction_is_honoured() {
+    // D cannot reach A following LINK forwards.
+    let store = diamond();
+    let forward = lengths(
+        &store,
+        "MATCH p = shortestPath((d:N)-[:LINK*]->(a:N)) WHERE d.name = \"D\" AND a.name = \"A\" \
+         RETURN length(p) AS len",
+    );
+    assert!(forward.is_empty(), "{forward:?}");
+
+    // Undirected, it can.
+    let undirected = lengths(
+        &store,
+        "MATCH p = shortestPath((d:N)-[:LINK*]-(a:N)) WHERE d.name = \"D\" AND a.name = \"A\" \
+         RETURN length(p) AS len",
+    );
+    assert_eq!(undirected, vec![2]);
+}
+
+#[test]
+fn the_edge_type_filter_is_honoured() {
+    let mut store = GraphStore::new();
+    let a = named(&mut store, "A");
+    let b = named(&mut store, "B");
+    let c = named(&mut store, "C");
+    // A short route of the wrong type, a longer one of the right type.
+    store.create_edge(a, c, "OTHER").unwrap();
+    store.create_edge(a, b, "LINK").unwrap();
+    store.create_edge(b, c, "LINK").unwrap();
+
+    let out = lengths(
+        &store,
+        "MATCH p = shortestPath((a:N)-[:LINK*]->(c:N)) WHERE a.name = \"A\" AND c.name = \"C\" \
+         RETURN length(p) AS len",
+    );
+    assert_eq!(out, vec![2], "the 1-hop OTHER edge must not be followed: {out:?}");
+}
+
+#[test]
+fn an_unknown_edge_type_finds_no_path() {
+    let store = diamond();
+    let out = lengths(
+        &store,
+        "MATCH p = shortestPath((a:N)-[:NO_SUCH_TYPE*]->(d:N)) WHERE a.name = \"A\" AND d.name = \"D\" \
+         RETURN length(p) AS len",
+    );
+    assert!(out.is_empty(), "an unknown type must match nothing: {out:?}");
+}
+
+#[test]
+fn all_shortest_paths_counts_every_route_through_a_wide_layer() {
+    // Three parallel middles: A -> {M1,M2,M3} -> Z is three shortest paths.
+    // A predecessor DAG that kept only the first parent would return one.
+    let mut store = GraphStore::new();
+    let a = named(&mut store, "A");
+    let z = named(&mut store, "Z");
+    for i in 0..3 {
+        let m = named(&mut store, &format!("M{i}"));
+        store.create_edge(a, m, "LINK").unwrap();
+        store.create_edge(m, z, "LINK").unwrap();
+    }
+    let out = lengths(
+        &store,
+        "MATCH p = allShortestPaths((a:N)-[:LINK*]->(z:N)) WHERE a.name = \"A\" AND z.name = \"Z\" \
+         RETURN length(p) AS len",
+    );
+    assert_eq!(out.len(), 3, "{out:?}");
+    assert!(out.iter().all(|&n| n == 2));
+}
+
+#[test]
+fn a_wide_graph_three_hops_apart_finishes_quickly() {
+    // The shape that timed out: a high-degree graph where the endpoints are
+    // three hops apart. Enumerating walks makes this ~degree³; the DAG makes
+    // it one pass plus the paths returned.
+    const N: usize = 4000;
+    const DEGREE: usize = 30;
+    let mut store = GraphStore::new();
+    let ids: Vec<_> = (0..N)
+        .map(|i| {
+            let id = store.create_node("N");
+            let _ = store.set_node_property(
+                "default",
+                id,
+                "seq".to_string(),
+                PropertyValue::Integer(i as i64),
+            );
+            id
+        })
+        .collect();
+    for (i, &src) in ids.iter().enumerate() {
+        for d in 0..DEGREE {
+            let x = (i as u64)
+                .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+                .wrapping_add((d as u64).wrapping_mul(0xBF58_476D_1CE4_E5B9));
+            let x = x ^ (x >> 31);
+            let tgt = ids[(x % N as u64) as usize];
+            if tgt != src {
+                let _ = store.create_edge(src, tgt, "KNOWS");
+            }
+        }
+        // Noise of a type the query does not want, as a real graph has.
+        for d in 0..40 {
+            let x = (i as u64).wrapping_mul(0x2545_F491_4F6C_DD1D).wrapping_add(d as u64);
+            let tgt = ids[(x % N as u64) as usize];
+            if tgt != src {
+                let _ = store.create_edge(src, tgt, "NOISE");
+            }
+        }
+    }
+
+    // Anchored by inline properties, which is the form LDBC IC14 uses. The
+    // `WHERE id(a) = …` form is 1000x slower because the planner does not use
+    // the predicate to anchor the source — a separate defect, filed as #538,
+    // and not what this test is about.
+    for (label, cypher) in [
+        (
+            "shortestPath",
+            "MATCH p = shortestPath((a:N {seq: 1})-[:KNOWS*]-(b:N {seq: 3500})) RETURN length(p) AS len",
+        ),
+        (
+            "allShortestPaths",
+            "MATCH p = allShortestPaths((a:N {seq: 1})-[:KNOWS*]-(b:N {seq: 3500})) RETURN length(p) AS len",
+        ),
+    ] {
+        let started = std::time::Instant::now();
+        let query = parse_query(cypher).unwrap();
+        let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+        let elapsed = started.elapsed();
+
+        assert!(!batch.records.is_empty(), "{label}: the graph is dense enough to be connected");
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "{label} took {elapsed:?} on a 4,000-node graph — this is the shape that timed out"
+        );
+    }
+}


### PR DESCRIPTION
Closes #516. Part of #296.

## Result

Measured on a **dedicated 16-core Vultr instance** (fixed 1996 MHz, calibration flat across every run — moved off the workstation precisely because of #529):

| query | before | after |
|---|---:|---:|
| **IC14** Trusted Connection Paths | **timeout (>120 s)** | **49.0 ms**, 18 paths |
| IC13 Single Shortest Path | 404 ms | **45.9 ms** — 8.8× |

```
LDBC SF1: 21/21 passed, 0 empty, 0 errors (total 41.2s)
```

**That is the first clean run of the suite.** It had never been 21/21 — #449/#450 fixed the "21/21 in 32 ms while measuring nothing" case, #505 got 20/21 answering, and IC14 was the one left.

## What was wrong

`allShortestPaths` **disabled its visited set**:

```rust
if !visited.contains(&next_node) || self.all_paths {
    if !self.all_paths { visited.insert(next_node); }
```

So it explored every *walk* of length ≤ d rather than every shortest path. Three costs compounded:

1. no deduplication — on LDBC with endpoints three hops apart and average undirected degree ~41, that is roughly 41³ walks;
2. each queue entry carried a full `Vec<NodeId>` and `Vec<EdgeId>`, both cloned at every expansion;
3. `get_outgoing_edges` materialises a full `Edge` — properties `HashMap` and `EdgeType` `String` — for **every incident edge**, and an LDBC `Person` has ~900, of which ~41 are `KNOWS`.

The results were nonetheless correct, which is why this read as "slow" rather than "wrong": a walk that revisits a node cannot have the shortest length, so nothing invalid was ever emitted. Nothing in the code said so, though.

## What it does now

The textbook two phases:

1. **A level BFS** recording each node's distance and *all* predecessors that reach it at that distance — a shortest-path DAG. Each node is expanded once, so this is O(V + E), and it stops at the level where the target appears.
2. **A backtrack** through that DAG. The cost is what the returned paths cost, not what the walks might have.

Neighbours come from the allocation-free visitor with the edge type filtered on its interned id (#520), so an incident edge of the wrong type costs a comparison rather than an `Edge` clone.

## A plan nobody could read

`ShortestPathOperator` had no `describe()`, so it inherited the trait default and EXPLAIN rendered any shortest-path plan as:

```
Project (length(p) AS len)
+- Unknown
```

It now describes itself. That is part of why this went unexamined for as long as it did — a plan nobody can read is a plan nobody profiles.

Reading those plans immediately turned up **#538**: the same query anchored by `WHERE id(a) = 1 AND id(b) = 3500` instead of by inline properties is **1000× slower** (4,219 ms vs 4.2 ms), because the predicate is not used to anchor the search. That is a planner defect, it is **not** what made IC14 time out — IC14 uses the inline form — and it is filed separately rather than folded in here.

## Testing

10 tests in `tests/shortest_path_semantics.rs`. Full suite: **2,696 passing, 0 failures.**

The rewrite produces the same answers by a different mechanism, so the tests pin the answers rather than the method: one path of minimum length for `shortestPath`; every minimum-length path for `allShortestPaths`; a longer detour never returned; source equal to target; an unreachable target; direction, including undirected finding what directed cannot; the edge-type filter preferring a 2-hop route of the right type over a 1-hop route of the wrong one; an unknown type finding nothing; a wide middle layer yielding three distinct paths — which a DAG keeping only the *first* predecessor would report as one; and the shape that timed out, asserted to finish in under 5 s.