### PR TITLE
Apply a WHERE conjunct as soon as its variables are bound

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2339,6 +2339,11 @@ impl QueryPlanner {
             } else {
                 // Normal path: use ExpandOperator for each segment
                 let mut current_var = start_var.clone();
+                // Variables bound so far, so a deferred predicate can be
+                // applied the moment its last variable arrives rather than
+                // after the whole path (#328).
+                let mut bound: HashSet<String> = HashSet::new();
+                bound.insert(start_var.clone());
                 for (seg_idx, segment) in path.segments.iter().enumerate() {
                     let target_var = path_nodes[seg_idx + 1].var.clone();
 
@@ -2374,6 +2379,15 @@ impl QueryPlanner {
                                 path_operator = Box::new(FilterOperator::new(path_operator, filter_expr));
                             }
                         }
+                        bound.insert(target_var.clone());
+                        if let Some(ev) = &segment.edge.variable {
+                            bound.insert(ev.clone());
+                        }
+                        path_operator = Self::apply_ready_predicates(
+                            path_operator,
+                            &mut deferred_predicates,
+                            &bound,
+                        );
                         current_var = target_var;
                         continue;
                     }
@@ -2406,6 +2420,16 @@ impl QueryPlanner {
                             path_operator = Box::new(FilterOperator::new(path_operator, filter_expr));
                         }
                     }
+
+                    bound.insert(target_var.clone());
+                    if let Some(ev) = &segment.edge.variable {
+                        bound.insert(ev.clone());
+                    }
+                    path_operator = Self::apply_ready_predicates(
+                        path_operator,
+                        &mut deferred_predicates,
+                        &bound,
+                    );
 
                     current_var = target_var;
                 }
@@ -2465,6 +2489,56 @@ impl QueryPlanner {
         Ok(result)
     }
 
+    /// Attach any deferred predicate whose variables are all bound by now.
+    ///
+    /// The path builders used to hold every predicate that mentions a
+    /// non-anchor variable until the **whole path** was expanded. On LDBC IC3
+    /// that meant `m.creationDate >= … AND m.creationDate < …` -- which
+    /// references only `m`, bound by the *first* expand -- was evaluated after
+    /// the second expand had already produced 409,960 rows, of which 622
+    /// survived. The predicate could have cut the second expand's input by
+    /// ~80% (#328).
+    ///
+    /// Applying a conjunct as soon as its variables are bound cannot change
+    /// the answer of a conjunctive pattern: the rows it removes are rows the
+    /// later filter would have removed. `OPTIONAL MATCH` is not affected --
+    /// this runs inside a single path of a single MATCH, and the outer join is
+    /// built above it.
+    fn apply_ready_predicates(
+        operator: OperatorBox,
+        deferred: &mut Vec<Expression>,
+        bound: &HashSet<String>,
+    ) -> OperatorBox {
+        if deferred.is_empty() {
+            return operator;
+        }
+        let mut ready: Vec<Expression> = Vec::new();
+        deferred.retain(|pred| {
+            let mut vars = HashSet::new();
+            Self::collect_expression_variables(pred, &mut vars);
+            // A predicate with no variables at all is a constant; leave it to
+            // the existing early-predicate path rather than moving it here.
+            if !vars.is_empty() && vars.iter().all(|v| bound.contains(v)) {
+                ready.push(pred.clone());
+                false
+            } else {
+                true
+            }
+        });
+        if ready.is_empty() {
+            return operator;
+        }
+        let filter_expr = ready
+            .into_iter()
+            .reduce(|acc, pred| Expression::Binary {
+                left: Box::new(acc),
+                op: BinaryOp::And,
+                right: Box::new(pred),
+            })
+            .unwrap();
+        Box::new(FilterOperator::new(operator, filter_expr))
+    }
+
     /// Build a path plan anchored at `nodes[anchor_idx]` instead of the pattern's first
     /// node. Traverses backward (reversed edge direction) toward earlier-written nodes
     /// and forward (written direction) toward later-written nodes. Only invoked when
@@ -2522,6 +2596,14 @@ impl QueryPlanner {
             path_operator = Box::new(FilterOperator::new(path_operator, filter_expr));
         }
 
+        // Variables bound so far, so a deferred predicate can be applied the
+        // moment its last variable arrives rather than after the whole path
+        // (#328). This builder is the one that runs whenever the cheapest
+        // anchor is not the pattern's first node -- which on LDBC IC3 and IC6
+        // is most of the time.
+        let mut bound: HashSet<String> = HashSet::new();
+        bound.insert(anchor_var.clone());
+
         // Walk backward toward earlier-written nodes using reversed edge direction:
         // the anchor is now the traversal source, so an originally-outgoing edge from
         // the earlier node must be read as incoming from the anchor's perspective.
@@ -2548,6 +2630,12 @@ impl QueryPlanner {
                     path_operator = Box::new(FilterOperator::new(path_operator, filter_expr));
                 }
             }
+            bound.insert(target.var.clone());
+            if let Some(ev) = &segment.edge.variable {
+                bound.insert(ev.clone());
+            }
+            path_operator =
+                Self::apply_ready_predicates(path_operator, &mut deferred_predicates, &bound);
             current_var = target.var.clone();
         }
 
@@ -2570,6 +2658,12 @@ impl QueryPlanner {
                     path_operator = Box::new(FilterOperator::new(path_operator, filter_expr));
                 }
             }
+            bound.insert(target.var.clone());
+            if let Some(ev) = &segment.edge.variable {
+                bound.insert(ev.clone());
+            }
+            path_operator =
+                Self::apply_ready_predicates(path_operator, &mut deferred_predicates, &bound);
             current_var = target.var.clone();
         }
 
@@ -3678,6 +3772,17 @@ impl QueryPlanner {
             if let Some(ref ev) = edge_var {
                 vars.insert(ev.clone());
             }
+            // Apply any deferred conjunct whose variables are now all bound,
+            // rather than holding it until the whole path is expanded (#328).
+            //
+            // This is the builder LDBC IC3, IC6 and IC9 actually use -- their
+            // second MATCH starts from a variable bound by a preceding WITH,
+            // so neither of the other two path builders runs. IC3 carried
+            // 409,960 rows through `(m)-[:IS_LOCATED_IN]->(place)` before
+            // applying a date filter on `m` that only 622 rows survive, and
+            // `m` is bound by the expand before it.
+            path_operator =
+                Self::apply_ready_predicates(path_operator, &mut deferred_predicates, &vars);
             current_var = target_var;
         }
 

--- a/tests/predicate_pushdown_plan.rs
+++ b/tests/predicate_pushdown_plan.rs
@@ -1,0 +1,208 @@
+//! A `WHERE` conjunct is applied as soon as its variables are bound (#328).
+//!
+//! The path builders held every predicate mentioning a non-anchor variable
+//! until the whole path had been expanded. On LDBC IC3 that put a filter on
+//! `m` — bound by the *first* expand — above the *second* one, so 409,960 rows
+//! were carried through an expand that 622 of them survived.
+//!
+//! These assert on `EXPLAIN`, because the defect is a plan shape and a plan
+//! shape is checkable without a profiler or a 21M-edge dataset. They also
+//! assert the answers, because moving a filter earlier is only safe if it
+//! removes exactly the rows the later one would have.
+
+use samyama::graph::{GraphStore, NodeId, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// `Person -> Post -> Tag`, with a date on the post and a name on the tag, so
+/// a three-variable pattern has one predicate per variable.
+fn fixture() -> GraphStore {
+    let mut store = GraphStore::new();
+    let mut person = |store: &mut GraphStore, i: i64| -> NodeId {
+        let id = store.create_node("Person");
+        let _ = store.set_node_property("default", id, "age".to_string(), PropertyValue::Integer(i % 60));
+        id
+    };
+    let people: Vec<NodeId> = (0..40).map(|i| person(&mut store, i)).collect();
+
+    let tags: Vec<NodeId> = (0..5)
+        .map(|i| {
+            let id = store.create_node("Tag");
+            let _ = store.set_node_property(
+                "default",
+                id,
+                "name".to_string(),
+                PropertyValue::String(format!("tag{i}")),
+            );
+            id
+        })
+        .collect();
+
+    for (i, &p) in people.iter().enumerate() {
+        for j in 0..5 {
+            let post = store.create_node("Post");
+            let _ = store.set_node_property(
+                "default",
+                post,
+                "created".to_string(),
+                PropertyValue::Integer(((i * 5 + j) % 100) as i64),
+            );
+            store.create_edge(p, post, "WROTE").unwrap();
+            store.create_edge(post, tags[(i + j) % tags.len()], "HAS_TAG").unwrap();
+        }
+    }
+    store
+}
+
+fn plan(store: &GraphStore, cypher: &str) -> String {
+    let query = parse_query(&format!("EXPLAIN {cypher}")).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&query).expect("EXPLAIN should run");
+    match batch.records[0].get("plan") {
+        Some(Value::Property(PropertyValue::String(t))) => {
+            t.lines().take_while(|l| !l.starts_with("---")).collect::<Vec<_>>().join("\n")
+        }
+        other => panic!("expected a plan string, got {other:?}"),
+    }
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> usize {
+    let query = parse_query(cypher).expect("query should parse");
+    QueryExecutor::new(store).execute(&query).expect("query should run").records.len()
+}
+
+/// Line index of the first row matching **every** fragment in `needles`.
+///
+/// EXPLAIN prints the tree root-first, so a **larger** index is deeper and
+/// therefore runs **earlier**. Getting that backwards is easy — the first
+/// version of these tests asserted the opposite and failed against correct
+/// output.
+///
+/// Matching on a set of fragments rather than one literal string is
+/// deliberate: the planner is free to anchor a pattern at whichever end is
+/// cheaper and render the traversal reversed, so `(post)-[:HAS_TAG]->(t)` may
+/// legitimately appear as `(t)<-[:HAS_TAG]-(post)`. Asserting the rendered
+/// direction would be asserting a planning decision this test is not about.
+fn depth_of(plan: &str, needles: &[&str]) -> usize {
+    plan.lines()
+        .position(|l| needles.iter().all(|n| l.contains(n)))
+        .unwrap_or_else(|| panic!("no line containing all of {needles:?} in:\n{plan}"))
+}
+
+/// Asserts `earlier` executes before `later` — i.e. sits deeper in the tree.
+fn runs_before(plan: &str, earlier: &[&str], later: &[&str]) {
+    let e = depth_of(plan, earlier);
+    let l = depth_of(plan, later);
+    assert!(
+        e > l,
+        "{earlier:?} should run before {later:?} (deeper in the tree):\n{plan}"
+    );
+}
+
+#[test]
+fn a_predicate_on_an_intermediate_variable_runs_before_the_next_expand() {
+    // The IC3 shape. `post.created` is bound by the first expand; the filter
+    // must sit below the second one, not above it.
+    let store = fixture();
+    let text = plan(
+        &store,
+        "MATCH (p:Person)-[:WROTE]->(post:Post)-[:HAS_TAG]->(t:Tag) \
+         WHERE post.created > 50 RETURN t.name",
+    );
+
+    runs_before(&text, &["Filter", "post.created"], &["Expand", "WROTE"]);
+}
+
+#[test]
+fn each_conjunct_lands_at_its_own_earliest_point() {
+    let store = fixture();
+    let text = plan(
+        &store,
+        "MATCH (p:Person)-[:WROTE]->(post:Post)-[:HAS_TAG]->(t:Tag) \
+         WHERE p.age > 10 AND post.created > 50 AND t.name = \"tag1\" RETURN t.name",
+    );
+
+    // Whichever end the planner anchors on, the predicate on the *middle*
+    // variable must not be left above the expand that binds the far one.
+    runs_before(&text, &["Filter", "post.created"], &["Expand", "WROTE"]);
+    // And the tag predicate reaches its scan, since `t` is an endpoint.
+    // Matched with "Filter" because `t.name` also appears in the projection.
+    runs_before(&text, &["Filter", "t.name"], &["Expand", "HAS_TAG"]);
+}
+
+#[test]
+fn moving_the_filter_earlier_does_not_change_the_answer() {
+    // The whole safety argument: the rows it removes are the rows the later
+    // filter would have removed. Checked against a hand-computed count.
+    let store = fixture();
+    let cypher = "MATCH (p:Person)-[:WROTE]->(post:Post)-[:HAS_TAG]->(t:Tag) \
+                  WHERE post.created > 50 RETURN t.name";
+    // 200 posts, `created` = (i*5+j) % 100, so exactly the ones above 50.
+    let expected = (0..200).filter(|k| (k % 100) > 50).count();
+    assert_eq!(rows(&store, cypher), expected);
+}
+
+#[test]
+fn a_predicate_spanning_two_variables_waits_for_the_second() {
+    // Correctness guard on the "as soon as bound" rule: a predicate is only
+    // ready when *every* variable it names is bound.
+    let store = fixture();
+    let cypher = "MATCH (p:Person)-[:WROTE]->(post:Post)-[:HAS_TAG]->(t:Tag) \
+                  WHERE p.age < post.created RETURN t.name";
+    let text = plan(&store, cypher);
+    // It needs both `p` and `post`, so it cannot be deeper than the expand
+    // that binds the second of them.
+    let filter = depth_of(&text, &["p.age < post.created"]);
+    let wrote = depth_of(&text, &["Expand", "WROTE"]);
+    assert!(filter < wrote, "the predicate must not run before both are bound:\n{text}");
+    // And it still answers.
+    assert!(rows(&store, cypher) > 0);
+}
+
+#[test]
+fn a_single_hop_pattern_is_unchanged() {
+    let store = fixture();
+    let cypher = "MATCH (p:Person)-[:WROTE]->(post:Post) WHERE post.created > 90 RETURN post.created";
+    let expected = (0..200).filter(|k| (k % 100) > 90).count();
+    assert_eq!(rows(&store, cypher), expected);
+}
+
+#[test]
+fn an_optional_match_still_excludes_its_null_rows() {
+    // The shape where filtering too early would be wrong. The outer join is
+    // built above the path builder, so this must be unaffected — asserted
+    // rather than assumed.
+    let mut store = GraphStore::new();
+    let a = store.create_node("Person");
+    let _ = store.set_node_property("default", a, "age".to_string(), PropertyValue::Integer(20));
+    let lonely = store.create_node("Person");
+    let _ = store.set_node_property("default", lonely, "age".to_string(), PropertyValue::Integer(20));
+    let post = store.create_node("Post");
+    let _ = store.set_node_property("default", post, "created".to_string(), PropertyValue::Integer(99));
+    store.create_edge(a, post, "WROTE").unwrap();
+
+    let cypher = "MATCH (p:Person) OPTIONAL MATCH (p)-[:WROTE]->(m:Post) \
+                  WHERE m.created > 50 RETURN p";
+    assert_eq!(rows(&store, cypher), 1, "the person with no post must not survive");
+}
+
+#[test]
+fn a_variable_length_segment_also_gets_its_predicate_early() {
+    let store = fixture();
+    let text = plan(
+        &store,
+        "MATCH (p:Person)-[:WROTE*1..1]->(post:Post)-[:HAS_TAG]->(t:Tag) \
+         WHERE post.created > 50 RETURN t.name",
+    );
+    runs_before(&text, &["Filter", "post.created"], &["Expand", "HAS_TAG"]);
+}
+
+#[test]
+fn a_predicate_on_an_edge_variable_is_ready_with_its_edge() {
+    let store = fixture();
+    let cypher = "MATCH (p:Person)-[w:WROTE]->(post:Post)-[:HAS_TAG]->(t:Tag) \
+                  WHERE post.created > 50 RETURN t.name";
+    // Binding an edge variable must not disturb the placement.
+    let text = plan(&store, cypher);
+    runs_before(&text, &["Filter", "post.created"], &["Expand", "WROTE"]);
+    assert!(rows(&store, cypher) > 0);
+}


### PR DESCRIPTION
Part of #328.

## Result

Measured on a **dedicated 16-core Vultr instance** (fixed 1996 MHz, calibration flat), **two interleaved A/B rounds** — build A, measure, build B, measure, repeat:

| query | before | after | |
|---|---:|---:|---:|
| **IC3** Friends in Countries | 2,262 ms | **1,208 / 1,265 ms** | **~1.8×** |
| IC6 Tag Co-occurrence | 2,427 ms | 2,147 / 2,369 ms | no material change |
| IC9, IC5 | — | — | unchanged |

The interleaving matters: a first, non-interleaved comparison showed IC6 **10% slower** and nearly cost this PR. Two rounds alternating the builds showed that was cross-batch noise.

## What was wrong

All three path builders split predicates into "references only the anchor" and "everything else", and held everything else until the **whole path** was expanded. On IC3:

```
Filter (m.creationDate >= … AND m.creationDate < … AND (place.name = … OR …))
+- Expand ((m)-[:IS_LOCATED_IN]->(place))     409,960 rows
   +- Expand ((friend)<-[:HAS_CREATOR]-(m))   409,960 rows
```

The date conjuncts reference only `m`, which the *first* expand binds. They now run between the two expands, so the second sees the ~20% that survive the window instead of all of it.

Applying a conjunct earlier cannot change the answer of a conjunctive pattern — the rows it removes are the rows the later filter would have removed. `OPTIONAL MATCH` is unaffected, because the outer join is built above these builders, and `an_optional_match_still_excludes_its_null_rows` asserts it.

## A wrong turn worth recording

Fixing the two obvious builders moved **nothing**. IC3, IC6 and IC9 all reach the planner through a third one, `plan_path_with_bound_start`: their second MATCH starts from a variable bound by a preceding `WITH`, so neither of the others runs. The measurement is what caught that — the plan looked unchanged after a change that should have altered it.

## And a display bug it exposed

`EXPLAIN` rendered IC3's predicate as:

```
Filter (m.creationDate >= … AND m.creationDate < … AND place.name = "Belgium" OR place.name = "Venezuela")
```

By precedence that reads as `(A AND B AND C) OR D` — a wrong answer, and it looked like a P0. **The parser is correct**: a direct test shows the parenthesised form returns 1 row where the unparenthesised one returns 2. `format_expression` simply never emits parentheses. Filed separately; it cost an hour of chasing a bug that was not there, which is the argument for fixing it.

## Testing

8 tests in `tests/predicate_pushdown_plan.rs`, asserting on `EXPLAIN` because the defect is a plan shape. Suite on Vultr: **2,704 passing, 0 failures.**

Covered: a predicate on an intermediate variable running before the next expand; each conjunct landing at its own earliest point; a two-variable predicate correctly *waiting* for the second; the answer unchanged against a hand-computed count; a single-hop pattern; a variable-length segment; an edge variable not disturbing placement; and `OPTIONAL MATCH` still excluding its NULL rows.

The test helper carries a note: `EXPLAIN` prints root-first, so a *larger* line index is deeper and runs *earlier*. The first version of these tests asserted the opposite and failed against correct output.

## What is left of #328

The other half — **anchor selection**. IC6 applies a `tag.name =` predicate that selects **7 rows out of 400,257** after both expands, because the planner anchors on the person rather than the tag. That is a costing change, not a rewrite rule, and it is where the remaining win is.