### PR TITLE
Load LDBC properties through the store API, not straight onto the Node

### DIFF
--- a/benches/ldbc_common/mod.rs
+++ b/benches/ldbc_common/mod.rs
@@ -86,15 +86,30 @@ where
 
         let node_id = graph.create_node(label);
 
-        // Set properties
+        // Properties go through `GraphStore::set_node_property`, which is what
+        // `CREATE` and CSV import use.
+        //
+        // This used to write `node.set_property(...)` directly on the `Node`,
+        // which reaches row storage and never the columnar store. That is a
+        // path no user takes: `CREATE` writes both, and snapshot import --
+        // every published `.sgsnap` KG -- writes only columns. So the suite
+        // every performance decision rests on exercised a third path, and one
+        // that costs 61.7 ns per property read against the column store's
+        // 10.5 ns (#534).
+        //
+        // Going through the store also means the columnar work in #532 and
+        // #535 is visible here at all; before this, an 11.4x improvement to a
+        // property read moved LDBC by nothing.
         let props = parse_props(&headers, &fields);
-        if let Some(node) = graph.get_node_mut(node_id) {
-            for (key, val) in props {
-                node.set_property(key, val);
-            }
-            // Store the LDBC id as a property too
-            node.set_property("id", ldbc_id);
+        for (key, val) in props {
+            let _ = graph.set_node_property("default", node_id, key.to_string(), val);
         }
+        let _ = graph.set_node_property(
+            "default",
+            node_id,
+            "id".to_string(),
+            PropertyValue::Integer(ldbc_id),
+        );
 
         id_map.insert(ldbc_id, node_id);
         count += 1;


### PR DESCRIPTION
Closes #534.

## The problem

`ldbc_common::load_nodes` wrote properties with `node.set_property(...)` directly on the `Node`, reaching row storage and never the columnar store. That is a path **no user takes**:

| loader | row storage | columnar |
|---|---|---|
| `GraphStore::set_node_property` — `CREATE`, CSV import | yes | yes |
| snapshot import — every published `.sgsnap` KG | no | **yes** |
| `benches/ldbc_common` | **yes** | no |

So the suite every performance decision rests on exercised a *third* path. It also cost 61.7 ns per property read against the column store's 10.5 ns, and it is why #532 and #535 — together **11.4×** on a property read — moved LDBC by nothing at all.

## The decision

Loading through `set_node_property` — what `CREATE` does. Of the three options in #534 this is the one that makes LDBC measure *what a user building a graph through the API gets*, and it covers both storage paths rather than neither. Option 2 (columns only) would match published `.sgsnap` KGs more closely but would stop the suite covering the row path that `CREATE`-heavy workloads use.

## Result

Dedicated 16-core Vultr instance, two interleaved rounds:

| query | main | this branch | |
|---|---:|---:|---:|
| IC6 | 474 ms | 395 ms | 1.20× |
| IC5 | 3,785 ms | 3,337 ms | 1.13× |
| IC4 | 23.2 ms | 20.6 ms | 1.13× |
| IC1 | 85.0 ms | 77.1 ms | 1.10× |
| IC11 | 61.9 ms | 56.1 ms | 1.10× |
| IC12 | 280 ms | 261 ms | 1.07× |
| IC13 | 44.5 ms | 41.7 ms | 1.07× |
| IC9 | 1,445 ms | 1,392 ms | 1.04× |
| IC3, IC7, IC8, IC14 | — | — | unchanged |

**21/21 passed on both sides.** Every read is same-or-faster.

## The cost, and what it measures

```
load time     50.4s  -> 59.4s     +18%
peak RSS     10.70GB -> 11.50GB   +7.6%   (+808 MB)
```

That 808 MB is less the price of this change than a **measurement of an existing one**. `set_node_property` writes the same value to row *and* columnar storage, and `resolve_property` reads columns first with the row as fallback. On a graph built through the API the row copy is dead weight — about **217 bytes per node** of it here, on a `PERF-10` figure that is already 🔴.

Filed separately as a footprint issue. It is a reason to look at the duplication, not a reason to keep the loader on a path nobody uses.

## A note for anyone reading old numbers

Every LDBC figure recorded before this was measured against row storage. They are not comparable with anything measured after it, in either direction.