### PR TITLE
docs: make the README front screen match what we can verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
   <h1 align="center">Samyama Graph</h1>
   <p align="center">A Rust-native graph-vector database for GraphRAG, knowledge graphs, and billion-edge analytics.</p>
   <p align="center">
-    <strong>The graph database that queried 1 billion edges for $2.50</strong>
+    <strong>Graph traversal, OpenCypher, and vector search in one Rust engine.</strong>
   </p>
   <p align="center">
-    <a href="https://github.com/samyama-ai/samyama-graph/releases"><img src="https://img.shields.io/badge/version-1.1.0-blue" alt="Version"></a>
-    <a href="https://github.com/samyama-ai/samyama-graph/actions"><img src="https://img.shields.io/badge/tests-2238_passing-brightgreen" alt="Tests"></a>
+    <a href="https://github.com/samyama-ai/samyama-graph/releases"><img src="https://img.shields.io/github/v/release/samyama-ai/samyama-graph?color=blue&label=version" alt="Version"></a>
+    <a href="https://github.com/samyama-ai/samyama-graph/actions/workflows/ci.yml"><img src="https://github.com/samyama-ai/samyama-graph/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache_2.0-blue" alt="License"></a>
     <a href="https://graph.samyama.cloud/book/"><img src="https://img.shields.io/badge/book-read_the_docs-orange" alt="Book"></a>
     <a href="https://chat.whatsapp.com/Jjjkb3uWRDi1YMdfffaD9d"><img src="https://img.shields.io/badge/community-WhatsApp-25D366?logo=whatsapp&logoColor=white" alt="WhatsApp Community"></a>
@@ -23,6 +23,11 @@
 Samyama Graph is a Rust-native graph-vector database that lets developers store, query, search, and analyze connected data in one system.
 
 It brings together graph traversal, OpenCypher-style querying, vector search, graph algorithms, and Redis-compatible access, making it useful for GraphRAG, knowledge graphs, AI agent memory, and large-scale relationship analytics.
+
+**Prefer to check rather than take our word for it?** [`case_studies/`](case_studies) runs real
+public knowledge graphs end to end in one command — every showcase query must return rows or the
+build fails. [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) has our LDBC SNB numbers, including the
+ones we don't come out well on and the column we've marked unverified.
 
 ### Quickstart
 


### PR DESCRIPTION
The front screen makes three claims we can't currently back, while the two most
credible artifacts in the repo sit below a 90-line Compose block. Four lines, no
content restructuring.

### 1. The cost headline

```diff
- The graph database that queried 1 billion edges for $2.50
+ Graph traversal, OpenCypher, and vector search in one Rust engine.
```

`docs/BENCHMARKS.md` contains no cost figure — I searched it for `$2`, `2.50`, `cost`
and `1 billion`, and there is no methodology, hardware note or provenance for this
anywhere in the repo. It's the most prominent claim on the page and the only one with
nothing behind it.

That reads worse now than it did a month ago, because #501/#502 set a much higher bar
in the same repo:

> "The SF10 column is still unverified and **should not be quoted**."
>
> "The old numbers were not fabricated, they were merely unprovable."
>
> "The previously documented 3,181,724 / 17,256,038 matched neither, and was 17% and
> 22% low. Anything divided by those counts was wrong by the same margin."

A reader who follows that standard into `BENCHMARKS.md` and then looks back at line 5
learns the wrong thing about how carefully this project handles numbers. The
replacement is descriptive, so it can't go stale.

The subtitle above it already positions the project, so nothing is lost. **Note the
repo *description* carries the same sentence** — that's a settings change and needs
someone with admin.

### 2. Version badge was hardcoded to 1.1.0

```diff
- img.shields.io/badge/version-1.1.0-blue
+ img.shields.io/github/v/release/samyama-ai/samyama-graph?color=blue&label=version
```

v1.7.0 shipped on 21 July; the badge has said 1.1.0 since. Now reads the latest release
directly, so it can't drift again.

### 3. Tests badge was a hardcoded count

```diff
- img.shields.io/badge/tests-2238_passing-brightgreen
+ actions/workflows/ci.yml/badge.svg?branch=main
```

`tests-2238_passing` is a static string that was true whenever it was typed. Since #486
added a lane that actually runs the tests, a live CI badge is both honest and more
useful — and a frozen count sitting next to real CI is the kind of detail that makes a
reader discount every other badge.

### 4. Surfaced the two artifacts worth finding

One line above the Quickstart pointing at `case_studies/` and `docs/BENCHMARKS.md`.
Someone landing here can currently read 90 lines of Docker Compose without learning that
11 real knowledge graphs run in one command, with a gate that fails the build if any
showcase query returns zero rows.

---

Happy to split this into separate PRs, or to drop any item — item 1 is the one I'd argue
for keeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
