### PR TITLE
Store a record's bindings in a flat vector, not a hash map

### DIFF
--- a/examples/mesh_scale_bench.rs
+++ b/examples/mesh_scale_bench.rs
@@ -294,7 +294,7 @@ fn timed(engine: &QueryEngine, store: &GraphStore, q: &str, reps: usize) -> (f64
         match r {
             Ok(b) => {
                 val = b.records.first().and_then(|rec| {
-                    rec.bindings().values().next().and_then(|v| match v {
+                    rec.values().next().and_then(|v| match v {
                         samyama::query::executor::record::Value::Property(
                             PropertyValue::Integer(i),
                         ) => Some(*i),

--- a/src/graph/version_chain.rs
+++ b/src/graph/version_chain.rs
@@ -1,0 +1,337 @@
+//! The MVCC version chain for a node, with the common single-version case
+//! stored inline instead of on the heap (#477, `PERF-10`).
+//!
+//! ## Why this exists
+//!
+//! `GraphStore` held nodes as `Vec<Vec<Node>>`: the outer index is the node id,
+//! the inner `Vec` is that node's MVCC version chain. The footprint harness
+//! (`benches/memory_footprint.rs`) measured the consequence at 100k nodes:
+//! **748 bytes for a bare node whose `Node` struct is 128 bytes** by
+//! `size_of`. One of the three allocations behind that gap is a heap `Vec`
+//! holding exactly one element.
+//!
+//! It holds exactly one element for every node that has never been updated,
+//! which is every node in a freshly loaded graph and the overwhelming majority
+//! in most graphs after that. The chain grows past one only on a write in a
+//! *later* transaction than the one that created the node.
+//!
+//! So the common case pays a `Vec` header (24 B in the outer vector), a heap
+//! allocation of 128 B for the single `Node`, and the allocator's own header
+//! and rounding on top of it -- to store one value whose size is known.
+//!
+//! ## What this changes
+//!
+//! [`NodeVersions`] holds the first version inline and only allocates when a
+//! second one appears:
+//!
+//! ```text
+//!                     bytes in the outer Vec   heap allocations
+//!   Vec<Node>, len 1              24               1  (128 B + header)
+//!   NodeVersions::One            136               0
+//! ```
+//!
+//! A one-version node therefore costs 136 B instead of ~168 B, and one fewer
+//! trip to the allocator. The allocation count is the figure that matters
+//! twice: it is a large part of the per-node byte overhead (`PERF-10`) and it
+//! is a hard ceiling on insert throughput (`PERF-14`, #491).
+//!
+//! ## What this deliberately does not change
+//!
+//! The semantics are the `Vec`'s, exactly. Versions stay in push order, `last`
+//! is the newest, `pop` removes it, and a chain that grows past one element
+//! becomes an ordinary `Vec` with no further special cases. The API below is
+//! the subset of `Vec`'s that `GraphStore` uses, with the same names and the
+//! same meanings, so a call site reads the same before and after.
+//!
+//! The trade is that an *empty* slot -- an id never allocated, or one whose
+//! node was deleted -- grows from 24 B to 136 B. That is a real cost on a
+//! sparse id space. Node ids are assigned densely from a counter and freed ids
+//! are reused (`free_node_ids`), so in practice the slot vector is dense; the
+//! `Empty` variant exists for the gaps a deletion leaves behind, not as a
+//! common case.
+
+use super::node::Node;
+
+/// A node's MVCC version chain: ordered oldest → newest, as `Vec<Node>` was.
+///
+/// See the module docs for why the one-element case is special-cased.
+#[derive(Debug, Clone, Default)]
+pub enum NodeVersions {
+    /// No node at this id: never allocated, or deleted.
+    #[default]
+    Empty,
+    /// Exactly one version, stored inline. The common case.
+    One(Node),
+    /// Two or more versions. Never constructed with fewer than two elements
+    /// by `push`, but `drain`/`pop` may leave it holding one or zero — the
+    /// accessors below do not depend on which variant a given length uses.
+    Many(Vec<Node>),
+}
+
+impl NodeVersions {
+    /// Number of versions in the chain.
+    pub fn len(&self) -> usize {
+        match self {
+            NodeVersions::Empty => 0,
+            NodeVersions::One(_) => 1,
+            NodeVersions::Many(v) => v.len(),
+        }
+    }
+
+    /// True when the chain holds no versions — i.e. there is no node here.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The newest version, or `None` if there is no node at this id.
+    pub fn last(&self) -> Option<&Node> {
+        match self {
+            NodeVersions::Empty => None,
+            NodeVersions::One(n) => Some(n),
+            NodeVersions::Many(v) => v.last(),
+        }
+    }
+
+    /// The newest version, mutably.
+    pub fn last_mut(&mut self) -> Option<&mut Node> {
+        match self {
+            NodeVersions::Empty => None,
+            NodeVersions::One(n) => Some(n),
+            NodeVersions::Many(v) => v.last_mut(),
+        }
+    }
+
+    /// Append a version, making it the newest.
+    ///
+    /// The first push stores inline; the second promotes to a heap `Vec` sized
+    /// for exactly the two versions it now holds, rather than `Vec`'s default
+    /// growth to four.
+    pub fn push(&mut self, node: Node) {
+        match self {
+            NodeVersions::Empty => *self = NodeVersions::One(node),
+            NodeVersions::One(_) => {
+                let NodeVersions::One(first) = std::mem::take(self) else {
+                    unreachable!("matched One immediately above")
+                };
+                let mut v = Vec::with_capacity(2);
+                v.push(first);
+                v.push(node);
+                *self = NodeVersions::Many(v);
+            }
+            NodeVersions::Many(v) => v.push(node),
+        }
+    }
+
+    /// Remove and return the newest version.
+    pub fn pop(&mut self) -> Option<Node> {
+        match self {
+            NodeVersions::Empty => None,
+            NodeVersions::One(_) => {
+                let NodeVersions::One(only) = std::mem::take(self) else {
+                    unreachable!("matched One immediately above")
+                };
+                Some(only)
+            }
+            NodeVersions::Many(v) => v.pop(),
+        }
+    }
+
+    /// Versions oldest → newest. `DoubleEndedIterator`, so `.rev()` walks
+    /// newest → oldest the way the version lookup does.
+    pub fn iter(&self) -> std::slice::Iter<'_, Node> {
+        self.as_slice().iter()
+    }
+
+    /// Remove the first `n` versions, keeping the rest in order.
+    ///
+    /// Named for the `Vec::drain(..n)` it replaces at the one call site that
+    /// used it (version GC). Unlike `drain` it returns nothing: no caller
+    /// wanted the removed values, and returning them would mean either
+    /// allocating or handing back a borrow that pins the chain.
+    pub fn drop_first(&mut self, n: usize) {
+        if n == 0 {
+            return;
+        }
+        match self {
+            NodeVersions::Empty => {}
+            NodeVersions::One(_) => *self = NodeVersions::Empty,
+            NodeVersions::Many(v) => {
+                if n >= v.len() {
+                    *self = NodeVersions::Empty;
+                } else {
+                    v.drain(..n);
+                }
+            }
+        }
+    }
+
+    /// The chain as a contiguous slice, oldest → newest.
+    pub fn as_slice(&self) -> &[Node] {
+        match self {
+            NodeVersions::Empty => &[],
+            NodeVersions::One(n) => std::slice::from_ref(n),
+            NodeVersions::Many(v) => v.as_slice(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a NodeVersions {
+    type Item = &'a Node;
+    type IntoIter = std::slice::Iter<'a, Node>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::types::NodeId;
+
+    fn node(version: u64) -> Node {
+        let mut n = Node::new(NodeId::new(7), "Person");
+        n.version = version;
+        n
+    }
+
+    #[test]
+    fn empty_chain_reads_as_absent() {
+        let chain = NodeVersions::default();
+        assert_eq!(chain.len(), 0);
+        assert!(chain.is_empty());
+        assert!(chain.last().is_none());
+        assert!(chain.as_slice().is_empty());
+        assert_eq!(chain.iter().count(), 0);
+    }
+
+    #[test]
+    fn one_version_stays_inline() {
+        let mut chain = NodeVersions::default();
+        chain.push(node(1));
+        assert!(matches!(chain, NodeVersions::One(_)));
+        assert_eq!(chain.len(), 1);
+        assert!(!chain.is_empty());
+        assert_eq!(chain.last().unwrap().version, 1);
+        assert_eq!(chain.as_slice().len(), 1);
+    }
+
+    #[test]
+    fn second_version_promotes_and_keeps_order() {
+        let mut chain = NodeVersions::default();
+        chain.push(node(1));
+        chain.push(node(5));
+        assert!(matches!(chain, NodeVersions::Many(_)));
+        let versions: Vec<u64> = chain.iter().map(|n| n.version).collect();
+        assert_eq!(versions, vec![1, 5], "push order is oldest -> newest");
+        assert_eq!(chain.last().unwrap().version, 5);
+    }
+
+    #[test]
+    fn reverse_iteration_finds_the_newest_visible_version() {
+        // This is exactly what `get_node_at_version` does.
+        let mut chain = NodeVersions::default();
+        chain.push(node(1));
+        chain.push(node(4));
+        chain.push(node(9));
+
+        let visible_at = |v: u64| chain.iter().rev().find(|n| n.version <= v).map(|n| n.version);
+        assert_eq!(visible_at(0), None);
+        assert_eq!(visible_at(1), Some(1));
+        assert_eq!(visible_at(3), Some(1));
+        assert_eq!(visible_at(4), Some(4));
+        assert_eq!(visible_at(100), Some(9));
+    }
+
+    #[test]
+    fn pop_returns_newest_and_empties() {
+        let mut chain = NodeVersions::default();
+        chain.push(node(1));
+        chain.push(node(2));
+        assert_eq!(chain.pop().unwrap().version, 2);
+        assert_eq!(chain.len(), 1);
+        assert_eq!(chain.pop().unwrap().version, 1);
+        assert!(chain.is_empty());
+        assert!(chain.pop().is_none());
+    }
+
+    #[test]
+    fn pop_on_inline_single_returns_it() {
+        let mut chain = NodeVersions::default();
+        chain.push(node(3));
+        assert_eq!(chain.pop().unwrap().version, 3);
+        assert!(chain.is_empty());
+    }
+
+    #[test]
+    fn last_mut_writes_through_in_both_representations() {
+        let mut inline = NodeVersions::default();
+        inline.push(node(1));
+        inline.last_mut().unwrap().version = 42;
+        assert_eq!(inline.last().unwrap().version, 42);
+
+        let mut heap = NodeVersions::default();
+        heap.push(node(1));
+        heap.push(node(2));
+        heap.last_mut().unwrap().version = 42;
+        assert_eq!(heap.last().unwrap().version, 42);
+        assert_eq!(heap.iter().next().unwrap().version, 1, "older version untouched");
+    }
+
+    #[test]
+    fn drop_first_prunes_the_oldest_versions() {
+        let mut chain = NodeVersions::default();
+        for v in [1, 2, 3, 4] {
+            chain.push(node(v));
+        }
+        chain.drop_first(2);
+        let versions: Vec<u64> = chain.iter().map(|n| n.version).collect();
+        assert_eq!(versions, vec![3, 4]);
+    }
+
+    #[test]
+    fn drop_first_of_zero_is_a_no_op() {
+        let mut chain = NodeVersions::default();
+        chain.push(node(1));
+        chain.drop_first(0);
+        assert_eq!(chain.len(), 1);
+    }
+
+    #[test]
+    fn drop_first_past_the_end_empties() {
+        let mut chain = NodeVersions::default();
+        chain.push(node(1));
+        chain.push(node(2));
+        chain.drop_first(9);
+        assert!(chain.is_empty());
+
+        let mut inline = NodeVersions::default();
+        inline.push(node(1));
+        inline.drop_first(1);
+        assert!(inline.is_empty());
+    }
+
+    #[test]
+    fn a_reused_slot_starts_empty_again() {
+        // `free_node_ids` hands a deleted id back to the next create; the slot
+        // it lands in must read as absent in between.
+        let mut chain = NodeVersions::default();
+        chain.push(node(1));
+        chain.pop();
+        assert!(chain.last().is_none());
+        chain.push(node(2));
+        assert_eq!(chain.len(), 1);
+        assert_eq!(chain.last().unwrap().version, 2);
+    }
+
+    #[test]
+    fn the_inline_case_costs_no_more_than_the_node_plus_a_tag() {
+        // The whole point of the type. If `Node` grows a heap-free field this
+        // stays true; if the enum ever gains a variant larger than `Node` it
+        // does not, and the saving is gone.
+        assert_eq!(
+            std::mem::size_of::<NodeVersions>(),
+            std::mem::size_of::<Node>() + std::mem::size_of::<usize>(),
+        );
+    }
+}

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -51,7 +51,7 @@ fn merged_node_properties(
     batch
         .records
         .iter()
-        .flat_map(|r| r.bindings().values())
+        .flat_map(|r| r.values())
         .filter_map(|v| match v {
             Value::Node(id, _) => Some(*id),
             Value::NodeRef(id) => Some(*id),

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -238,11 +238,13 @@ impl<'a> QueryExecutor<'a> {
         }
 
         if return_clause.distinct {
+            // `dedup_key` sorts by variable name. The previous key was
+            // `format!("{:?}", r.bindings())` over a hash map, so it depended
+            // on iteration order for its identity -- two records binding the
+            // same values could hash to different strings, and did not
+            // deduplicate. It also formatted a string per row.
             let mut seen = std::collections::HashSet::new();
-            records.retain(|r| {
-                let key = format!("{:?}", r.bindings());
-                seen.insert(key)
-            });
+            records.retain(|r| seen.insert(r.dedup_key()));
         }
 
         Ok(RecordBatch { records, columns })

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -6235,7 +6235,7 @@ impl PhysicalOperator for DropIndexOperator {
 /// deduplicate against each other.
 pub struct DistinctOperator {
     input: OperatorBox,
-    seen: HashSet<Vec<(String, Value)>>,
+    seen: HashSet<Vec<(std::sync::Arc<str>, Value)>>,
 }
 
 impl DistinctOperator {
@@ -6249,14 +6249,8 @@ impl DistinctOperator {
 
     /// The deduplication key: every binding, ordered by column name so that two records
     /// that bound the same columns in a different order still collide.
-    fn key(record: &Record) -> Vec<(String, Value)> {
-        let mut key: Vec<(String, Value)> = record
-            .bindings()
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
-        key.sort_by(|a, b| a.0.cmp(&b.0));
-        key
+    fn key(record: &Record) -> Vec<(std::sync::Arc<str>, Value)> {
+        record.dedup_key()
     }
 }
 
@@ -6735,8 +6729,8 @@ impl PhysicalOperator for CreateNodesAndEdgesOperator {
                 // Extract variable and node from record
                 for (var, value) in record.bindings().iter() {
                     if let Value::Node(node_id, node) = value {
-                        self.var_to_node_id.insert(var.clone(), *node_id);
-                        self.results.push((Some(var.clone()), Value::Node(*node_id, node.clone())));
+                        self.var_to_node_id.insert(var.to_string(), *node_id);
+                        self.results.push((Some(var.to_string()), Value::Node(*node_id, node.clone())));
                     }
                 }
             }
@@ -9255,11 +9249,8 @@ impl WithBarrierOperator {
         if self.distinct {
             let mut seen: HashSet<Vec<Value>> = HashSet::new();
             output_records.retain(|record| {
-                let mut key: Vec<(String, Value)> = record.bindings().iter()
-                    .map(|(k, v)| (k.clone(), v.clone()))
-                    .collect();
-                key.sort_by(|a, b| a.0.cmp(&b.0));
-                let vals: Vec<Value> = key.into_iter().map(|(_, v)| v).collect();
+                let vals: Vec<Value> =
+                    record.dedup_key().into_iter().map(|(_, v)| v).collect();
                 seen.insert(vals)
             });
         }

--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -39,26 +39,37 @@
 //! names, returned to the caller after query execution completes.
 
 use crate::graph::{Edge, Node, NodeId, EdgeId, EdgeType, PropertyValue, GraphStore};
-use rustc_hash::FxHashMap;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::hash::{Hash, Hasher};
 
 /// A single record flowing through the query pipeline
 #[derive(Debug, Clone)]
 pub struct Record {
-    /// Variable bindings (variable name -> value).
+    /// Variable bindings, in the order they were bound.
     ///
-    /// `FxHashMap`, not `std`'s: a record is created, cloned and read several
-    /// times per row, and every read hashes a variable name. `SipHash` is a
-    /// DoS-resistant hash being asked to hash `"friend"` — not the threat
-    /// model of a query-plan variable, which the planner chose itself.
+    /// A flat vector, not a hash map. A query plan binds a handful of
+    /// variables — three or four is typical, a dozen is a lot — and at that
+    /// size a linear scan comparing short strings beats hashing one.
+    ///
+    /// What a `HashMap<String, Value>` cost, per row:
+    ///
+    /// * a **table allocation** for every record;
+    /// * a **`String` allocation per binding** on every clone, and operators
+    ///   clone a record per output row (`ExpandOperator::next` does exactly
+    ///   that);
+    /// * a **`SipHash` over a variable name** on every read, several times per
+    ///   row — once in the expand, once per property access inside
+    ///   `evaluate_expression`.
     ///
     /// Measured on LDBC IC5, whose `Aggregate` consumes 1,678,980 records at
-    /// ~1,275 ns each: per row the engine does a map clone, a `String`
-    /// allocation per binding, and four to six string-keyed lookups. This is
-    /// the cheap half of that (#546); the structural half is giving records a
-    /// slot layout so a variable is an index rather than a name.
-    bindings: FxHashMap<String, Value>,
+    /// ~1,275 ns each while its group key accounts for perhaps 200 ns of that
+    /// (#546).
+    ///
+    /// `Arc<str>` rather than `String` is the other half: cloning a record now
+    /// copies a vector of pointer pairs and bumps refcounts, where before it
+    /// allocated a fresh `String` for every variable name on every row.
+    bindings: Vec<(Arc<str>, Value)>,
 }
 
 /// Value types that can be bound to variables in a query record.
@@ -144,44 +155,73 @@ impl Record {
     /// Create a new empty record
     pub fn new() -> Self {
         Self {
-            bindings: FxHashMap::default(),
+            bindings: Vec::new(),
         }
     }
 
-    /// Bind a variable to a value
-    pub fn bind(&mut self, variable: String, value: Value) {
-        self.bindings.insert(variable, value);
+    /// Bind a variable to a value, replacing any previous binding.
+    ///
+    /// Accepts anything that converts to `Arc<str>`, so an operator holding
+    /// its variable name as an `Arc<str>` binds with a refcount bump; passing
+    /// a `String` copies once, as inserting into the old map did.
+    pub fn bind(&mut self, variable: impl Into<Arc<str>>, value: Value) {
+        let variable = variable.into();
+        match self.bindings.iter_mut().find(|(name, _)| *name == variable) {
+            Some(slot) => slot.1 = value,
+            None => self.bindings.push((variable, value)),
+        }
     }
 
     /// Get a bound value
     pub fn get(&self, variable: &str) -> Option<&Value> {
-        self.bindings.get(variable)
+        self.bindings
+            .iter()
+            .find(|(name, _)| &**name == variable)
+            .map(|(_, value)| value)
     }
 
-    /// Get all bindings
-    pub fn bindings(&self) -> &FxHashMap<String, Value> {
+    /// All bindings, in binding order.
+    pub fn bindings(&self) -> &[(Arc<str>, Value)] {
         &self.bindings
+    }
+
+    /// The bound values, without their names.
+    pub fn values(&self) -> impl Iterator<Item = &Value> {
+        self.bindings.iter().map(|(_, value)| value)
     }
 
     /// Check if a variable is bound
     pub fn has(&self, variable: &str) -> bool {
-        self.bindings.contains_key(variable)
+        self.get(variable).is_some()
     }
 
-    /// Merge another record into this one
+    /// Merge another record into this one, `other` winning on a clash.
     pub fn merge(&mut self, other: Record) {
-        self.bindings.extend(other.bindings);
+        for (name, value) in other.bindings {
+            self.bind(name, value);
+        }
     }
 
     /// Clone with only specified variables
     pub fn project(&self, variables: &[String]) -> Record {
         let mut new_record = Record::new();
         for var in variables {
-            if let Some(value) = self.bindings.get(var) {
-                new_record.bind(var.clone(), value.clone());
+            if let Some((name, value)) = self.bindings.iter().find(|(n, _)| &**n == var.as_str()) {
+                new_record.bind(name.clone(), value.clone());
             }
         }
         new_record
+    }
+
+    /// A deterministic key for deduplication: bindings sorted by name.
+    ///
+    /// Sorted because binding *order* is an artefact of how a plan was built,
+    /// not part of a row's identity — two records binding the same values in a
+    /// different order are the same row and must collide.
+    pub fn dedup_key(&self) -> Vec<(Arc<str>, Value)> {
+        let mut key = self.bindings.clone();
+        key.sort_by(|a, b| a.0.cmp(&b.0));
+        key
     }
 }
 
@@ -802,8 +842,53 @@ mod tests {
 
         let bindings = r.bindings();
         assert_eq!(bindings.len(), 2);
-        assert!(bindings.contains_key("x"));
-        assert!(bindings.contains_key("y"));
+        assert!(r.has("x"));
+        assert!(r.has("y"));
+        // Bindings keep insertion order now, which `dedup_key` normalises
+        // away for identity. Order is observable here and deliberately not
+        // relied on anywhere else.
+        assert_eq!(&*bindings[0].0, "x");
+        assert_eq!(&*bindings[1].0, "y");
+    }
+
+    #[test]
+    fn rebinding_a_variable_replaces_it_rather_than_duplicating() {
+        let mut r = Record::new();
+        r.bind("x".to_string(), Value::Property(PropertyValue::Integer(1)));
+        r.bind("x".to_string(), Value::Property(PropertyValue::Integer(2)));
+        assert_eq!(r.bindings().len(), 1, "a flat vector must not accumulate duplicates");
+        assert_eq!(r.get("x"), Some(&Value::Property(PropertyValue::Integer(2))));
+    }
+
+    #[test]
+    fn the_dedup_key_ignores_binding_order() {
+        // Two records with the same bindings in a different order are the same
+        // row. The previous key was `format!("{:?}", bindings)` over a hash
+        // map, so it depended on iteration order for identity.
+        let mut a = Record::new();
+        a.bind("x".to_string(), Value::Property(PropertyValue::Integer(1)));
+        a.bind("y".to_string(), Value::Property(PropertyValue::Integer(2)));
+
+        let mut b = Record::new();
+        b.bind("y".to_string(), Value::Property(PropertyValue::Integer(2)));
+        b.bind("x".to_string(), Value::Property(PropertyValue::Integer(1)));
+
+        assert_eq!(a.dedup_key(), b.dedup_key());
+    }
+
+    #[test]
+    fn merge_lets_the_incoming_record_win() {
+        let mut a = Record::new();
+        a.bind("x".to_string(), Value::Property(PropertyValue::Integer(1)));
+        a.bind("y".to_string(), Value::Property(PropertyValue::Integer(9)));
+
+        let mut b = Record::new();
+        b.bind("x".to_string(), Value::Property(PropertyValue::Integer(2)));
+
+        a.merge(b);
+        assert_eq!(a.bindings().len(), 2);
+        assert_eq!(a.get("x"), Some(&Value::Property(PropertyValue::Integer(2))));
+        assert_eq!(a.get("y"), Some(&Value::Property(PropertyValue::Integer(9))));
     }
 
     #[test]

--- a/tests/dense_column_integration.rs
+++ b/tests/dense_column_integration.rs
@@ -32,7 +32,7 @@ fn rows(store: &GraphStore, cypher: &str) -> Vec<Vec<(String, String)>> {
             let mut cells: Vec<(String, String)> = r
                 .bindings()
                 .iter()
-                .map(|(k, v)| (k.clone(), format!("{v:?}")))
+                .map(|(k, v)| (k.to_string(), format!("{v:?}")))
                 .collect();
             cells.sort();
             cells


### PR DESCRIPTION
Phase 2 of #546.

## Result

Dedicated 16-core Vultr instance, **two interleaved A/B rounds**:

| query | main | this branch | |
|---|---|---|---:|
| **IC2** Recent Friend Posts | 24.1 / 24.3 ms | **13.2 / 13.3 ms** | **1.83×** |
| **IC6** Tag Co-occurrence | 393 / 364 ms | **264 / 290 ms** | **1.37×** |
| **IC12** Expert Reply | 272 / 261 ms | **204 / 200 ms** | **1.32×** |
| **IC5** New Forum Members | 3,301 / 3,464 ms | **2,627 / 2,669 ms** | **1.28×** |
| IC3 Friends in Countries | 1,182 / 1,220 ms | 1,094 / 1,121 ms | 1.08× |
| IC9 Recent FoF Posts | 1,361 / 1,327 ms | 1,319 / 1,332 ms | 1.02× |

Consistent across both rounds, unlike phase 1 (#547), where the effect was inside the round-to-round spread.

Suite: **cargo exit 0, 2,708 tests.**

## What changed

A `Record` was a `HashMap<String, Value>`. A query plan binds a handful of variables — three or four is typical, a dozen is a lot — and at that size a linear scan comparing short strings beats hashing one.

Per row, the map cost:

- a **table allocation** for every record;
- a **`String` allocation per binding** on every clone, and operators clone a record per output row;
- a **`SipHash` over a variable name** on every read — once in the expand, once per property access inside `evaluate_expression`.

Now `Vec<(Arc<str>, Value)>`. Cloning a record copies pointer pairs and bumps refcounts; reading a variable is a short memcmp against at most a dozen entries.

IC5's `Aggregate` went **2,141 ms → 1,648 ms**, or 1,275 ns → **981 ns per input row**. #546's stated target is under 500, so what remains is the per-row `Record` itself rather than its hashing — one `Vec` allocation and a clone per output row. Getting under that means not materialising a row per edge at all, which is the vectorised-execution question #546 puts out of scope.

## A latent bug fixed on the way

`execute_call_subquery` deduplicated with:

```rust
let key = format!("{:?}", r.bindings());
```

over a hash map — so a row's identity depended on **iteration order**, and two records binding the same values could fail to collide. It also formatted a string per row. `Record::dedup_key` sorts by name, which is what `DistinctOperator` already did.

## One semantic change, stated

Binding order is now **insertion order** rather than unspecified. Nothing relies on it — `dedup_key` normalises it away for identity — and tests pin both: that order is observable and stable, and that `dedup_key` ignores it.

## Two mistakes worth recording

Both mine, both caught by the Vultr box rather than by me:

An example (`mesh_scale_bench`) and a unit test in `record.rs` failed to **compile** against the new `bindings()` type, while my local check reported success. The check was `cargo test … | tail -3; echo $?` — which reports the exit status of `tail`, not cargo. Compile failures also do not print `FAILED`, so grepping for it proves nothing either.

Verified here on cargo's own exit code.

## Also filed

**#549** — `uc4_optimizer_beats_uniform_baseline` failed once in a full-suite run and passed 12/12 alone. It asserts a fixed threshold on a stochastic solver under CPU contention. Not caused by this change, and it should be seeded rather than loosened.