### PR TITLE
Read merged properties in the schema and visualisation endpoints

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -1974,6 +1974,35 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
 
     /// Get outgoing edge targets with owned EdgeType — works for both full and stub edges.
     /// Uses compact edge_type_ids array (DS-07c) when Edge objects are not available.
+    /// Every property a node has, from wherever it is stored.
+    ///
+    /// A graph built through the API writes both the columnar store and the
+    /// row map on the `Node`; a graph restored from a `.sgsnap` writes only
+    /// the columns, so its row maps are empty. `resolve_property` handles that
+    /// by reading the column first and falling back to the row, and anything
+    /// that reads `node.properties` directly gets nothing on an imported graph
+    /// -- which is what #554 was.
+    ///
+    /// Columns win on a clash, matching `resolve_property`: the column holds
+    /// the current value, the row can hold a superseded one.
+    pub fn node_properties_merged(&self, node_id: NodeId) -> PropertyMap {
+        let idx = node_id.as_u64() as usize;
+        let mut merged: PropertyMap = PropertyMap::new();
+
+        if let Some(node) = self.get_node(node_id) {
+            for (key, value) in &node.properties {
+                merged.insert(key.clone(), value.clone());
+            }
+        }
+        for key in self.node_columns.get_property_keys(idx) {
+            let value = self.node_columns.get_property(idx, &key);
+            if !value.is_null() {
+                merged.insert(key, value);
+            }
+        }
+        merged
+    }
+
     /// The interned id of an edge type, if the graph has ever seen one.
     ///
     /// `None` means no edge in the graph has this type, so a filter on it

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -270,8 +270,12 @@ pub async fn schema_handler(
             .label_index_ids(label)
             .and_then(|ids| ids.iter().next())
         {
-            if let Some(node) = store_guard.get_node(sample_id) {
-                for (key, val) in &node.properties {
+            // Merged, not `node.properties`: a snapshot-imported graph keeps
+            // its properties in the columnar store and its row maps are
+            // empty, so reading the row reported "this label has no
+            // properties" for every published `.sgsnap` (#554).
+            if store_guard.get_node(sample_id).is_some() {
+                for (key, val) in &store_guard.node_properties_merged(sample_id) {
                     let prop_type = match val {
                         PropertyValue::String(_) => "String",
                         PropertyValue::Integer(_) => "Integer",
@@ -407,9 +411,12 @@ pub async fn sample_handler(
             if i % stride == 0 {
                 sampled_ids.insert(node.id);
 
-                // Build node JSON with all properties
+                // Merged, not `node.properties`: an imported graph's row
+                // maps are empty and every node came back with `{}` and a
+                // numeric name (#554).
+                let merged = store_guard.node_properties_merged(node.id);
                 let mut props = serde_json::Map::new();
-                for (k, v) in &node.properties {
+                for (k, v) in &merged {
                     props.insert(k.clone(), match v {
                         PropertyValue::String(s) => json!(s),
                         PropertyValue::Integer(i) => json!(i),
@@ -421,10 +428,10 @@ pub async fn sample_handler(
                 }
 
                 // Determine node name (first string property, or id)
-                let name = node.properties.iter()
-                    .find(|(k, _)| k.as_str() == "name" || k.as_str() == "title" || k.as_str() == "label")
-                    .and_then(|(_, v)| match v {
-                        PropertyValue::String(s) => Some(s.clone()),
+                let name = ["name", "title", "label"]
+                    .iter()
+                    .find_map(|k| match merged.get(*k) {
+                        Some(PropertyValue::String(s)) => Some(s.clone()),
                         _ => None,
                     })
                     .unwrap_or_else(|| format!("{}", node.id.as_u64()));
@@ -809,6 +816,111 @@ mod tests {
             .route("/api/status", get(status_handler))
             .with_state(state.clone());
         (app, state)
+    }
+
+    /// A graph whose properties live only in the columnar store, as every
+    /// snapshot-imported graph's do.
+    ///
+    /// Built by exporting and re-importing rather than by poking the store
+    /// directly, so the fixture is the real thing: `import_tenant` writes
+    /// columns and leaves `Node.properties` empty.
+    fn imported_graph() -> GraphStore {
+        use crate::graph::PropertyValue;
+        let mut built = GraphStore::new();
+        for i in 0..5 {
+            let id = built.create_node("Person");
+            let _ = built.set_node_property(
+                "default",
+                id,
+                "name".to_string(),
+                PropertyValue::String(format!("p{i}")),
+            );
+            let _ = built.set_node_property(
+                "default",
+                id,
+                "age".to_string(),
+                PropertyValue::Integer(i),
+            );
+        }
+
+        let mut bytes = Vec::new();
+        crate::snapshot::export_tenant(&built, &mut bytes).expect("export");
+        let mut restored = GraphStore::new();
+        crate::snapshot::import_tenant(&mut restored, bytes.as_slice()).expect("import");
+
+        // The premise of the test: the row maps really are empty.
+        let first = restored.get_node(crate::graph::NodeId::new(1)).expect("node 1");
+        assert!(
+            first.properties.is_empty(),
+            "fixture is wrong: an imported graph should keep properties in columns only"
+        );
+        restored
+    }
+
+    #[tokio::test]
+    async fn schema_lists_properties_of_an_imported_graph() {
+        // Reading `node.properties` here reported "this label has no
+        // properties" for every published .sgsnap (#554).
+        let state = AppState {
+            store: Arc::new(RwLock::new(imported_graph())),
+            engine: Arc::new(QueryEngine::new()),
+            data_path: None,
+            tenant_manager: None,
+            embed_pipeline: None,
+            embed_cache: Arc::new(RwLock::new(std::collections::HashMap::new())),
+        };
+        let app = Router::new()
+            .route("/api/schema", get(schema_handler))
+            .with_state(state);
+
+        let response = app
+            .oneshot(Request::builder().uri("/api/schema").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        let person = json["node_types"]
+            .as_array()
+            .and_then(|types| types.iter().find(|t| t["label"] == "Person"))
+            .expect("Person label in schema");
+        let props = person["properties"].as_object().expect("properties object");
+
+        assert_eq!(props.get("name").and_then(|v| v.as_str()), Some("String"), "{json}");
+        assert_eq!(props.get("age").and_then(|v| v.as_str()), Some("Integer"), "{json}");
+    }
+
+    #[test]
+    fn merged_properties_prefer_the_column_over_the_row() {
+        use crate::graph::PropertyValue;
+        // The column holds the current value; the row can hold a superseded
+        // one, so the column wins -- the same order `resolve_property` uses.
+        let mut store = GraphStore::new();
+        let id = store.create_node("N");
+        if let Some(node) = store.get_node_mut(id) {
+            node.set_property("k", PropertyValue::Integer(1));
+            node.set_property("row_only", PropertyValue::Integer(9));
+        }
+        store.set_column_property(id, "k", PropertyValue::Integer(2));
+
+        let merged = store.node_properties_merged(id);
+        assert_eq!(merged.get("k"), Some(&PropertyValue::Integer(2)), "column wins");
+        assert_eq!(
+            merged.get("row_only"),
+            Some(&PropertyValue::Integer(9)),
+            "a row-only property is still returned"
+        );
+    }
+
+    #[test]
+    fn merged_properties_of_an_imported_graph_are_not_empty() {
+        use crate::graph::PropertyValue;
+        let store = imported_graph();
+        let merged = store.node_properties_merged(crate::graph::NodeId::new(1));
+        assert_eq!(merged.len(), 2, "{merged:?}");
+        assert_eq!(merged.get("name"), Some(&PropertyValue::String("p0".to_string())));
+        assert_eq!(merged.get("age"), Some(&PropertyValue::Integer(0)));
     }
 
     /// Helper: send a POST /api/query with the given body and return (status, json).


### PR DESCRIPTION
Closes #554.

## The bug

Snapshot import writes properties to the **columnar store only**, so an imported graph's `Node.properties` maps are empty. Every query path handles that — `resolve_property` reads the column first and falls back to the row. Two HTTP paths read the row directly:

- **`schema_handler`** samples one node per label to discover property names and types → reported *"this label exists and has no properties"* for every published `.sgsnap`.
- **The visualisation sample** builds each node's JSON the same way and picks a display name from `name`/`title`/`label` → every node came back with `{}` for properties and a numeric id for its name.

Verified before fixing:

```
built-graph  row props: ["age", "name"]
imported     row props: []
imported col name: String("p0")
imported col age : Integer(0)
```

And after, on a genuinely imported fixture:

```json
"node_types":[{"count":5,"label":"Person","properties":{"age":"Integer","name":"String"}}]
```

## Why it matters

Every published `.sgsnap` is an imported graph, so this was broken for the whole open-data programme (`SLT-8`) — and broken specifically in the two endpoints whose job is to say what is *in* a graph.

It also lands on Axiom 4: *"agents cannot read docs at query time; they need introspectable schema"*. An agent asking a published KG for its schema was told it had labels and no properties. That is worse than an error — it is a confident wrong answer, and the agent then writes queries against nothing.

Same class as #303 and #507: correct for `CREATE`-built graphs, silently wrong for imported ones. The query result path at `handler.rs:145` already merged correctly, which is why no case study caught it — they all go through Cypher.

## The fix

`GraphStore::node_properties_merged` unions the two, **column winning** — the order `resolve_property` already uses, and the accessor `snapshot/mod.rs` had open-coded. It is also what #545 needs before the row copy can be removed.

The display-name lookup becomes deterministic as a side effect: it previously scanned the property map for whichever of `name`/`title`/`label` it met first, and map iteration order is unspecified. It now prefers them in that order.

## Testing

Suite on a dedicated box: **cargo exit 0, 2,715 tests.**

3 new tests. The fixture is built by exporting and re-importing rather than by poking the store, so it is the real thing — and it **asserts its own premise** (`Node.properties` really is empty after import) so it cannot quietly stop testing what it claims to.

Covered: the schema endpoint listing both properties with their types on an imported graph; merged reads preferring the column over a stale row value; and merged reads returning a row-only property, since both directions matter.