### PR TITLE
Anchor a scan on id() instead of scanning and filtering

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -9468,6 +9468,12 @@ pub struct NodeByIdOperator {
     node_ids: Vec<NodeId>,
     position: usize,
     variable: String,
+    /// Labels the pattern required, checked per id.
+    ///
+    /// A scan by id bypasses the label index, so `MATCH (n:Person) WHERE
+    /// id(n) = 5` would otherwise match a node of any label that happens to
+    /// hold that id (#538).
+    labels: Vec<Label>,
 }
 
 impl NodeByIdOperator {
@@ -9476,7 +9482,14 @@ impl NodeByIdOperator {
             node_ids,
             position: 0,
             variable,
+            labels: Vec::new(),
         }
+    }
+
+    /// Require the node to carry every one of these labels.
+    pub fn with_labels(mut self, labels: Vec<Label>) -> Self {
+        self.labels = labels;
+        self
     }
 }
 
@@ -9486,8 +9499,12 @@ impl PhysicalOperator for NodeByIdOperator {
             let node_id = self.node_ids[self.position];
             self.position += 1;
 
-            // Verify node still exists
-            if store.has_node(node_id) {
+            // Verify the node still exists and carries the pattern's labels.
+            let matches = match store.get_node(node_id) {
+                Some(node) => self.labels.iter().all(|l| node.has_label(l)),
+                None => false,
+            };
+            if matches {
                 let mut record = Record::new();
                 record.bind(self.variable.clone(), Value::NodeRef(node_id));
                 return Ok(Some(record));

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -62,7 +62,7 @@ use std::sync::Mutex;
 use crate::query::executor::{
     ExecutionError, ExecutionResult, OperatorBox,
     // Added CreateNodeOperator and CreateNodesAndEdgesOperator for CREATE statement support
-    operator::{NodeScanOperator, FilterOperator, ExpandOperator, ProjectOperator, LimitOperator, SkipOperator, CreateNodeOperator, CreateNodesAndEdgesOperator, CartesianProductOperator, VectorSearchOperator, JoinOperator, LeftOuterJoinOperator, CreateVectorIndexOperator, CreateIndexOperator, CompositeCreateIndexOperator, CreateConstraintOperator, DropIndexOperator, ShowIndexesOperator, ShowConstraintsOperator, DistinctOperator, ShowLabelsOperator, ShowRelationshipTypesOperator, ShowPropertyKeysOperator, SchemaVisualizationOperator, AlgorithmOperator, IndexScanOperator, AggregateOperator, AggregateType, AggregateFunction, AlgorithmOperator as _AlgoOp, SortOperator, DeleteOperator, SetPropertyOperator, RemovePropertyOperator, UnwindOperator, MergeOperator, ForeachOperator, ShortestPathOperator, VarLengthExpandOperator, WithBarrierOperator, LabelCountOperator, EdgeTypeCountOperator, EdgeCountOperator},
+    operator::{NodeScanOperator, NodeByIdOperator, FilterOperator, ExpandOperator, ProjectOperator, LimitOperator, SkipOperator, CreateNodeOperator, CreateNodesAndEdgesOperator, CartesianProductOperator, VectorSearchOperator, JoinOperator, LeftOuterJoinOperator, CreateVectorIndexOperator, CreateIndexOperator, CompositeCreateIndexOperator, CreateConstraintOperator, DropIndexOperator, ShowIndexesOperator, ShowConstraintsOperator, DistinctOperator, ShowLabelsOperator, ShowRelationshipTypesOperator, ShowPropertyKeysOperator, SchemaVisualizationOperator, AlgorithmOperator, IndexScanOperator, AggregateOperator, AggregateType, AggregateFunction, AlgorithmOperator as _AlgoOp, SortOperator, DeleteOperator, SetPropertyOperator, RemovePropertyOperator, UnwindOperator, MergeOperator, ForeachOperator, ShortestPathOperator, VarLengthExpandOperator, WithBarrierOperator, LabelCountOperator, EdgeTypeCountOperator, EdgeCountOperator},
 };
 use crate::graph::EdgeType;  // Added for CREATE edge support
 use std::collections::{HashMap, HashSet};  // Added for CREATE properties and JOIN logic
@@ -2257,7 +2257,23 @@ impl QueryPlanner {
             // Optimization: Check for index usage (using this path's assigned predicates).
             // Recognizes both `n.prop OP literal` and `literal OP n.prop` operand orders.
             let mut remaining_predicates: Vec<Expression> = per_path_preds[path_idx].clone();
-            let mut path_operator: OperatorBox = if let Some((idx, label, property, op, val)) =
+            let mut path_operator: OperatorBox = if let Some((idx, ids)) =
+                find_id_predicate(&start_var, &remaining_predicates)
+            {
+                // `id()` before any index: it is unique by construction, so
+                // there is nothing for a cost model to weigh. Without this,
+                // `MATCH (n) WHERE id(n) = 5` scanned the whole label and
+                // filtered (#538).
+                //
+                // The label, if the pattern named one, still has to be
+                // checked -- `MATCH (n:Person) WHERE id(n) = 5` must not
+                // match a node of another label that happens to hold that id.
+                remaining_predicates.remove(idx);
+                Box::new(
+                    NodeByIdOperator::new(ids, start_var.clone())
+                        .with_labels(path.start.labels.clone()),
+                )
+            } else if let Some((idx, label, property, op, val)) =
                 find_index_predicate(&start_var, &path.start.labels, &remaining_predicates, store)
             {
                 remaining_predicates.remove(idx);
@@ -2584,7 +2600,17 @@ impl QueryPlanner {
         }
         candidates.extend(anchor_only_preds);
 
-        let mut path_operator: OperatorBox = if let Some((idx, label, property, op, val)) =
+        // `id()` first: it is unique by construction, so it beats any index
+        // and needs no statistics to know that (#538).
+        let mut path_operator: OperatorBox = if let Some((idx, ids)) =
+            find_id_predicate(&anchor_var, &candidates)
+        {
+            candidates.remove(idx);
+            Box::new(
+                NodeByIdOperator::new(ids, anchor_var.clone())
+                    .with_labels(anchor.labels.clone()),
+            )
+        } else if let Some((idx, label, property, op, val)) =
             find_index_predicate(&anchor_var, &anchor.labels, &candidates, store)
         {
             candidates.remove(idx);
@@ -3530,6 +3556,71 @@ fn flip_comparison_op(op: &BinaryOp) -> BinaryOp {
 /// either operand order (`var.prop OP literal` or `literal OP var.prop`).
 /// Returns the predicate's index within `preds` plus the matched label,
 /// property, normalized operator, and literal value.
+/// Find an `id(var) = <literal>` or `id(var) IN [...]` predicate.
+///
+/// Returns the predicate's position and the node ids it pins, so the caller
+/// can drop it and scan those ids directly.
+///
+/// `id()` is unique by construction, so this needs no cost model and no
+/// statistics: the predicate selects at most one node per literal. Without it
+/// `MATCH (n) WHERE id(n) = 5` lowered to a full label scan plus a filter, and
+/// `shortestPath((a)-[:KNOWS*]-(b)) WHERE id(a) = 1 AND id(b) = 3500` ran
+/// ~1000x slower than the same query written with inline properties (#538).
+fn find_id_predicate(var: &str, preds: &[Expression]) -> Option<(usize, Vec<crate::graph::NodeId>)> {
+    /// `id(x)` applied to exactly this variable.
+    fn is_id_of(expr: &Expression, var: &str) -> bool {
+        matches!(
+            expr,
+            Expression::Function { name, args, .. }
+                if name.eq_ignore_ascii_case("id")
+                    && args.len() == 1
+                    && matches!(&args[0], Expression::Variable(v) if v == var)
+        )
+    }
+
+    fn as_node_id(value: &PropertyValue) -> Option<crate::graph::NodeId> {
+        match value {
+            // Negative ids cannot exist, and `as u64` would wrap one into a
+            // very large positive id that matches nothing slowly.
+            PropertyValue::Integer(i) if *i >= 0 => Some(crate::graph::NodeId::new(*i as u64)),
+            _ => None,
+        }
+    }
+
+    for (i, pred) in preds.iter().enumerate() {
+        let Expression::Binary { left, op, right } = pred else {
+            continue;
+        };
+        // Accept the literal on either side: `id(n) = 5` and `5 = id(n)`.
+        let literal = match (left.as_ref(), right.as_ref()) {
+            (l, Expression::Literal(v)) if is_id_of(l, var) => Some(v),
+            (Expression::Literal(v), r) if is_id_of(r, var) => Some(v),
+            _ => None,
+        };
+        let Some(literal) = literal else { continue };
+
+        match op {
+            BinaryOp::Eq => {
+                if let Some(id) = as_node_id(literal) {
+                    return Some((i, vec![id]));
+                }
+            }
+            BinaryOp::In => {
+                if let PropertyValue::Array(items) = literal {
+                    let ids: Vec<crate::graph::NodeId> = items.iter().filter_map(as_node_id).collect();
+                    // Only if every element was a usable id -- dropping one
+                    // silently would lose rows.
+                    if !ids.is_empty() && ids.len() == items.len() {
+                        return Some((i, ids));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 fn find_index_predicate(
     var: &str,
     labels: &[Label],
@@ -3593,6 +3684,12 @@ fn anchor_cardinality(
         }
     }
     candidates.extend(path_preds.iter().cloned());
+
+    // `id()` pins exactly one node per literal, whatever the label holds.
+    if let Some((_, ids)) = find_id_predicate(&node.var, &candidates) {
+        let n = ids.len() as f64;
+        return (n, n);
+    }
 
     if let Some((_, label, property, op, val)) =
         find_index_predicate(&node.var, &node.labels, &candidates, store)

--- a/tests/id_anchor.rs
+++ b/tests/id_anchor.rs
@@ -1,0 +1,161 @@
+//! `WHERE id(n) = …` anchors the scan instead of filtering one (#538).
+//!
+//! `id()` is unique by construction, so this needs no statistics and no cost
+//! model — which is what made it worth handling separately from the
+//! index-selection path. Before, `MATCH (n) WHERE id(n) = 5` scanned the whole
+//! label and filtered, and `shortestPath(…) WHERE id(a) = 1 AND id(b) = …` ran
+//! ~1000× slower than the same query written with inline properties.
+
+use samyama::graph::{GraphStore, NodeId, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn graph(n: i64) -> GraphStore {
+    let mut store = GraphStore::new();
+    for i in 0..n {
+        let id = store.create_node("N");
+        let _ = store.set_node_property("default", id, "v".to_string(), PropertyValue::Integer(i));
+    }
+    store
+}
+
+fn plan(store: &GraphStore, cypher: &str) -> String {
+    let query = parse_query(&format!("EXPLAIN {cypher}")).expect("parse");
+    match QueryExecutor::new(store).execute(&query).unwrap().records[0].get("plan") {
+        Some(Value::Property(PropertyValue::String(t))) => {
+            t.lines().take_while(|l| !l.starts_with("---")).collect::<Vec<_>>().join("\n")
+        }
+        other => panic!("{other:?}"),
+    }
+}
+
+fn values(store: &GraphStore, cypher: &str) -> Vec<i64> {
+    let query = parse_query(cypher).expect("parse");
+    QueryExecutor::new(store)
+        .execute(&query)
+        .unwrap()
+        .records
+        .iter()
+        .map(|r| match r.get("v") {
+            Some(Value::Property(PropertyValue::Integer(i))) => *i,
+            other => panic!("{other:?}"),
+        })
+        .collect()
+}
+
+#[test]
+fn an_id_equality_anchors_the_scan() {
+    let store = graph(1000);
+    let text = plan(&store, "MATCH (n:N) WHERE id(n) = 5 RETURN n.v AS v");
+    assert!(text.contains("NodeById"), "{text}");
+    assert!(!text.contains("NodeScan"), "the label scan should be gone:\n{text}");
+}
+
+#[test]
+fn it_works_without_a_label_too() {
+    let store = graph(1000);
+    let text = plan(&store, "MATCH (n) WHERE id(n) = 5 RETURN n.v AS v");
+    assert!(text.contains("NodeById"), "{text}");
+}
+
+#[test]
+fn the_answer_is_unchanged() {
+    let store = graph(1000);
+    assert_eq!(values(&store, "MATCH (n:N) WHERE id(n) = 5 RETURN n.v AS v").len(), 1);
+    // Ids start at 1, and `v` counts from 0, so id 5 holds v = 4.
+    assert_eq!(values(&store, "MATCH (n:N) WHERE id(n) = 5 RETURN n.v AS v"), vec![4]);
+}
+
+#[test]
+fn a_label_that_does_not_match_returns_nothing() {
+    // The hazard of scanning by id: it bypasses the label index, so the
+    // pattern's labels have to be checked per node or `(n:Other)` would match
+    // whatever node holds that id.
+    let mut store = graph(10);
+    let other = store.create_node("Other");
+    let _ = store.set_node_property("default", other, "v".to_string(), PropertyValue::Integer(99));
+
+    let other_id = other.as_u64() as i64;
+    assert_eq!(
+        values(&store, &format!("MATCH (n:Other) WHERE id(n) = {other_id} RETURN n.v AS v")),
+        vec![99]
+    );
+    assert!(
+        values(&store, &format!("MATCH (n:N) WHERE id(n) = {other_id} RETURN n.v AS v")).is_empty(),
+        "an :N pattern must not match an :Other node by id"
+    );
+}
+
+#[test]
+fn an_id_that_does_not_exist_returns_nothing() {
+    let store = graph(10);
+    assert!(values(&store, "MATCH (n:N) WHERE id(n) = 99999 RETURN n.v AS v").is_empty());
+}
+
+#[test]
+fn a_negative_id_returns_nothing_rather_than_wrapping() {
+    // `as u64` on a negative literal wraps to a very large positive id, which
+    // matches nothing but does so after a full scan.
+    let store = graph(10);
+    assert!(values(&store, "MATCH (n:N) WHERE id(n) = -1 RETURN n.v AS v").is_empty());
+}
+
+#[test]
+fn the_literal_may_be_on_either_side() {
+    let store = graph(100);
+    let text = plan(&store, "MATCH (n:N) WHERE 5 = id(n) RETURN n.v AS v");
+    assert!(text.contains("NodeById"), "{text}");
+    assert_eq!(values(&store, "MATCH (n:N) WHERE 5 = id(n) RETURN n.v AS v"), vec![4]);
+}
+
+#[test]
+fn an_id_list_anchors_on_every_element() {
+    let store = graph(1000);
+    let text = plan(&store, "MATCH (n:N) WHERE id(n) IN [3, 5, 7] RETURN n.v AS v");
+    assert!(text.contains("NodeById"), "{text}");
+    let mut got = values(&store, "MATCH (n:N) WHERE id(n) IN [3, 5, 7] RETURN n.v AS v");
+    got.sort();
+    assert_eq!(got, vec![2, 4, 6]);
+}
+
+#[test]
+fn a_point_lookup_does_not_scale_with_the_graph() {
+    // The property this is really about: the cost should not depend on how
+    // many nodes exist.
+    let store = graph(200_000);
+    let started = std::time::Instant::now();
+    let rows = values(&store, "MATCH (n:N) WHERE id(n) = 5 RETURN n.v AS v");
+    let elapsed = started.elapsed();
+
+    assert_eq!(rows, vec![4]);
+    assert!(
+        elapsed < std::time::Duration::from_millis(5),
+        "a point lookup on 200,000 nodes took {elapsed:?} — it is still scanning"
+    );
+}
+
+#[test]
+fn both_endpoints_of_a_path_can_be_pinned_by_id() {
+    // #538's original shape.
+    let mut store = GraphStore::new();
+    let ids: Vec<NodeId> = (0..2000).map(|_| store.create_node("N")).collect();
+    for w in ids.windows(2) {
+        store.create_edge(w[0], w[1], "KNOWS").unwrap();
+    }
+    let (a, b) = (ids[0].as_u64(), ids[5].as_u64());
+
+    let cypher = format!(
+        "MATCH p = shortestPath((a:N)-[:KNOWS*]-(b:N)) WHERE id(a) = {a} AND id(b) = {b} \
+         RETURN length(p) AS v"
+    );
+    let started = std::time::Instant::now();
+    let query = parse_query(&cypher).unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    let elapsed = started.elapsed();
+
+    assert_eq!(batch.records.len(), 1, "the chain connects them");
+    assert!(
+        elapsed < std::time::Duration::from_millis(500),
+        "took {elapsed:?} — the endpoints are not being pinned"
+    );
+}


### PR DESCRIPTION
Closes #538.

## Result

On 200,000 nodes:

| query | before | after |
|---|---:|---:|
| `MATCH (n:N) WHERE id(n) = 5 RETURN n.v` | 27.27 ms | **0.01 ms** |

```
Project (n.v)
+- Filter (id(n) = Integer(5))
   +- NodeById (var=n, ids=[5])        ← was NodeScan (var=n, labels=["N"])
```

`id()` is **unique by construction**, so a predicate on it selects at most one node per literal. That needs no statistics and no cost model, which is why it is worth handling separately from index selection.

`NodeByIdOperator` already existed, with unit tests, and **no planner path had ever built one**.

## What is handled

`id(n) = 5`, `5 = id(n)`, and `id(n) IN [...]`.

An `IN` list is only taken when **every** element converts to an id — dropping one silently would lose rows. A negative literal is rejected rather than cast: `as u64` would wrap it into a very large id that matches nothing, slowly.

`anchor_cardinality` costs an id predicate at one row per literal, so the path-cost model from #543 prefers an id-pinned end over any index.

## The hazard, and the test for it

Scanning by id **bypasses the label index**. So `MATCH (n:Person) WHERE id(n) = 5` would match whatever node holds id 5, whatever its label. `NodeByIdOperator` gained a label filter, and `a_label_that_does_not_match_returns_nothing` fails without it.

## Testing

10 tests in `tests/id_anchor.rs`. Suite on a dedicated box: **cargo exit 0, 2,725 tests.**

Covered: the plan anchoring with and without a label; the answer unchanged; a mismatched label returning nothing; a non-existent id; a negative id; the literal on either side; an `IN` list; both endpoints of a `shortestPath` pinned (#538's original shape); and a point lookup on 200,000 nodes asserted to stay under 5 ms — the property that actually matters, that cost should not scale with the graph.

## Two notes

**LDBC is unchanged** at 21/21 in 24.2 s. None of its queries use `id()`, which is why this never showed up there and had to be found by reading a plan while working on #516.

**The redundant top-level filter stays.** #526 subtracts conjuncts that a descendant `Filter` is applying; this one is applied by the *scan*, so the subtraction does not see it. It costs one comparison per returned row — one row, in the common case — and removing it means teaching that pass about non-`Filter` operators, which is a bigger change than the saving justifies.