### PR TITLE
Group an aggregate on identity, and resolve the key once per group

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,3 +183,7 @@ harness = false
 opt-level = 3
 lto = true
 codegen-units = 1
+
+[[bench]]
+name = "aggregate_grouping"
+harness = false

--- a/benches/aggregate_grouping.rs
+++ b/benches/aggregate_grouping.rs
@@ -1,0 +1,201 @@
+//! What a hash group-by costs per input row (#521).
+//!
+//! `CH-PROFILE-01` put **60.1% of LDBC IC5 in `Aggregate`** — 1,947 ms to fold
+//! 1,678,980 input rows into 96,862 groups, or ~1.16 µs per input row. On the
+//! same run the `Expand` that *produced* those rows cost 0.55 µs each, so the
+//! aggregate cost more than twice as much per row as the traversal, while doing
+//! strictly less work per row. A hash aggregation over an integer key should be
+//! in the tens of nanoseconds.
+//!
+//! IC5's group key is `(forum.id, forum.title)` — two properties of one node.
+//! That shape is the point of this bench, because it is where the three costs
+//! separate:
+//!
+//!   * **one key vs two.** A single key hashes a `Value`; two keys allocate a
+//!     `Vec<Value>` per input row.
+//!   * **integer vs string.** A string key clones the string per row.
+//!   * **groups vs rows.** Resolving a property per *row* rather than per
+//!     *group* is a 17× multiplier at IC5's ratio, and the ratio is the whole
+//!     question.
+//!
+//! So the sweep varies the key and holds the row count fixed, and reports
+//! ns/row against a `count(*)` with no grouping at all as the floor.
+//!
+//!   cargo bench --bench aggregate_grouping
+//!   cargo bench --bench aggregate_grouping -- --rows 2000000 --groups 100000
+
+use std::time::Instant;
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+
+#[path = "common/bench_setup.rs"]
+mod bench_setup;
+
+/// `rows` Item nodes over `groups` distinct Forum nodes, each Item pointing at
+/// one Forum. Aggregating over `(f)<-[:IN]-(i)` then reproduces IC5's shape:
+/// many rows, far fewer groups, key drawn from the low-cardinality side.
+fn fixture(rows: usize, groups: usize) -> GraphStore {
+    let mut store = GraphStore::new();
+    let forums: Vec<_> = (0..groups)
+        .map(|g| {
+            let id = store.create_node("Forum");
+            let _ = store.set_node_property(
+                "default",
+                id,
+                "fid".to_string(),
+                PropertyValue::Integer(g as i64),
+            );
+            // Long enough that cloning it per row is visible, as LDBC forum
+            // titles are ("Wall of …", "Album N of …").
+            let _ = store.set_node_property(
+                "default",
+                id,
+                "title".to_string(),
+                PropertyValue::String(format!("Wall of Person Number {g} With A Realistic Length")),
+            );
+            id
+        })
+        .collect();
+
+    for i in 0..rows {
+        let item = store.create_node("Item");
+        let _ = store.set_node_property(
+            "default",
+            item,
+            "v".to_string(),
+            PropertyValue::Integer((i % 977) as i64),
+        );
+        store.create_edge(item, forums[i % groups], "IN").unwrap();
+    }
+    store
+}
+
+/// The top operator that actually folds the rows, from EXPLAIN.
+///
+/// Printed per case because of a trap worth naming: the planner rewrites
+/// `RETURN f.x, count(i)` over an expand into `AdjacencyCountAggregate`, which
+/// reads degrees off the adjacency index and never groups anything. The first
+/// version of this bench reported 88 ns/row for the IC5 shape and looked like
+/// #521 was wrong -- it was measuring the rewrite. Any case whose operator is
+/// not `Aggregate` says nothing about hash aggregation.
+fn fold_operator(store: &GraphStore, cypher: &str) -> String {
+    let query = parse_query(&format!("EXPLAIN {cypher}")).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&query).expect("EXPLAIN should run");
+    let text = match batch.records[0].get("plan") {
+        Some(samyama::query::executor::Value::Property(PropertyValue::String(t))) => t.clone(),
+        _ => return "?".into(),
+    };
+    for name in ["AdjacencyCountAggregate", "Aggregate"] {
+        if text.contains(name) {
+            return name.into();
+        }
+    }
+    "none".into()
+}
+
+/// Median of `runs` timings, in ms. Median rather than min because the question
+/// is the typical cost, and rather than mean because one page fault should not
+/// move it.
+fn time(store: &GraphStore, cypher: &str, runs: usize) -> (usize, f64) {
+    let query = parse_query(cypher).expect("query should parse");
+    // Warm: the first execution pays for statistics the rest skip.
+    let warm = QueryExecutor::new(store).execute(&query).expect("query should run");
+
+    let mut samples: Vec<f64> = (0..runs)
+        .map(|_| {
+            let started = Instant::now();
+            let _ = QueryExecutor::new(store).execute(&query).expect("query should run");
+            started.elapsed().as_secs_f64() * 1000.0
+        })
+        .collect();
+    samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    (warm.records.len(), samples[samples.len() / 2])
+}
+
+fn main() {
+    bench_setup::init();
+    let calibration = bench_setup::report_calibration();
+
+    let args: Vec<String> = std::env::args().collect();
+    let arg = |flag: &str| -> Option<usize> {
+        args.iter().position(|a| a == flag).and_then(|i| args.get(i + 1)).and_then(|v| v.parse().ok())
+    };
+    let rows = arg("--rows").unwrap_or(1_000_000);
+    let groups = arg("--groups").unwrap_or(50_000);
+    let runs = arg("--runs").unwrap_or(5);
+
+    eprintln!("Building {rows} rows over {groups} groups…");
+    let started = Instant::now();
+    let store = fixture(rows, groups);
+    eprintln!("built in {:.1}s\n", started.elapsed().as_secs_f64());
+
+    // Every case folds the same `rows` input rows. Only the key differs.
+    let cases: Vec<(&str, String)> = vec![
+        (
+            "no grouping (floor)",
+            "MATCH (f:Forum)<-[:IN]-(i:Item) RETURN count(i) AS c".into(),
+        ),
+        (
+            "1 key, node identity",
+            "MATCH (f:Forum)<-[:IN]-(i:Item) RETURN f, count(i) AS c".into(),
+        ),
+        (
+            "1 key, int property",
+            "MATCH (f:Forum)<-[:IN]-(i:Item) RETURN f.fid, count(i) AS c".into(),
+        ),
+        (
+            "1 key, string property",
+            "MATCH (f:Forum)<-[:IN]-(i:Item) RETURN f.title, count(i) AS c".into(),
+        ),
+        (
+            "2 keys, int + string (IC5)",
+            "MATCH (f:Forum)<-[:IN]-(i:Item) RETURN f.fid, f.title, count(i) AS c".into(),
+        ),
+        (
+            "1 key int, + sum",
+            "MATCH (f:Forum)<-[:IN]-(i:Item) RETURN f.fid, sum(i.v) AS s".into(),
+        ),
+        (
+            "1 key string, + sum",
+            "MATCH (f:Forum)<-[:IN]-(i:Item) RETURN f.title, sum(i.v) AS s".into(),
+        ),
+        (
+            "2 keys + sum, not count",
+            "MATCH (f:Forum)<-[:IN]-(i:Item) RETURN f.fid, f.title, sum(i.v) AS s".into(),
+        ),
+    ];
+
+    println!("{rows} input rows, {groups} groups, median of {runs}\n");
+    println!(
+        "{:<28} {:>8} {:>12} {:>14}  {}",
+        "case", "groups", "median ms", "ns per row", "operator"
+    );
+    println!("{:-<28} {:->8} {:->12} {:->14}  {:-<24}", "", "", "", "", "");
+
+    for (label, cypher) in &cases {
+        let (out_rows, ms) = time(&store, cypher, runs);
+        println!(
+            "{:<28} {:>8} {:>12.1} {:>14.0}  {}",
+            label,
+            out_rows,
+            ms,
+            ms * 1e6 / rows as f64,
+            fold_operator(&store, cypher),
+        );
+    }
+
+    println!();
+    println!("The `no grouping` row is the floor: same input, same traversal, no hash map.");
+    println!("Subtracting it from the others isolates the grouping cost itself.");
+    println!();
+    println!("Read the operator column first. Cases folded by `AdjacencyCountAggregate` never");
+    println!("built a group and say nothing about hash aggregation -- they are kept because");
+    println!("the rewrite is real and worth seeing, not because they measure grouping.");
+    println!();
+    println!("LDBC IC5 measured 1,947 ms over 1,678,980 input rows into 96,862 groups on the");
+    println!("`2 keys, int + string` shape -- ~1,160 ns per row (#521).");
+
+    bench_setup::report_drift(calibration);
+}

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -16,6 +16,16 @@ run yourself:
 | Memory footprint | `cargo bench --bench memory_footprint` |
 | Cardinality accuracy | `cargo bench --bench cardinality_accuracy` |
 | Ingestion profile | `cargo bench --bench ingest_profile` |
+| Operator micro-benchmarks | `cargo bench --bench aggregate_grouping`, `--bench varlength_expand`, `--bench property_access`, `--bench aggregate_throughput` |
+
+**Reading the operator micro-benchmarks.** These report ns per row for a single
+operator, and each prints the operator the planner actually chose. Check that
+column before drawing a conclusion: the planner rewrites several shapes, and a
+case that was rewritten measures the rewrite rather than the operator named in
+the row. `aggregate_grouping` reported 88 ns/row for LDBC IC5's shape until that
+column was added — `RETURN f.x, count(i)` over an expand becomes
+`AdjacencyCountAggregate`, which reads degrees off the adjacency index and never
+groups anything. The honest figure for that shape was 12× higher.
 
 **Not on this page: cross-engine comparisons.** Results against Neo4j,
 FalkorDB and TigerGraph are maintained internally alongside the competitor

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3954,6 +3954,24 @@ impl CountDistinctSet {
             Self::Props(s) => s.len(),
         }
     }
+
+    /// Absorb another set. Used when two group identities turn out to share a
+    /// key tuple and their partial aggregates have to become one.
+    fn merge(&mut self, other: Self) {
+        match other {
+            Self::Empty => {}
+            Self::Ids(ids) => {
+                for id in ids {
+                    self.insert_id(id);
+                }
+            }
+            Self::Props(props) => {
+                for p in props {
+                    self.insert_prop(p);
+                }
+            }
+        }
+    }
 }
 
 impl AggregatorState {
@@ -4082,6 +4100,66 @@ impl AggregatorState {
                     else if let Some(i) = prop.as_integer() { values.push(i as f64); }
                 }
             }
+        }
+    }
+
+    /// Fold another partial aggregate of the same shape into this one.
+    ///
+    /// Every aggregate here is associative and commutative, which is what makes
+    /// grouping on identity and merging afterwards legal: partial states over a
+    /// partition of the input combine to the state over the whole input.
+    /// `collect` is the one to look at twice — list order is the order rows
+    /// arrived, which was already unspecified across groups, and concatenation
+    /// keeps each partial run contiguous.
+    fn merge(&mut self, other: Self) {
+        match (self, other) {
+            (AggregatorState::Count(a), AggregatorState::Count(b)) => *a += b,
+            (AggregatorState::CountDistinct(a), AggregatorState::CountDistinct(b)) => a.merge(b),
+            (
+                AggregatorState::Sum { int_acc, float_acc, int_only },
+                AggregatorState::Sum { int_acc: bi, float_acc: bf, int_only: bint },
+            ) => {
+                if *int_only && bint {
+                    *int_acc += bi;
+                } else {
+                    // Whichever side is still integral has to be promoted
+                    // before the two float accumulators can be added.
+                    if *int_only {
+                        *int_only = false;
+                        *float_acc = *int_acc as f64;
+                    }
+                    *float_acc += if bint { bi as f64 } else { bf };
+                }
+            }
+            (AggregatorState::Avg { sum, count }, AggregatorState::Avg { sum: bs, count: bc }) => {
+                *sum += bs;
+                *count += bc;
+            }
+            (AggregatorState::Min(a), AggregatorState::Min(b)) => {
+                if let Some(b) = b {
+                    if a.is_none() || &b < a.as_ref().unwrap() {
+                        *a = Some(b);
+                    }
+                }
+            }
+            (AggregatorState::Max(a), AggregatorState::Max(b)) => {
+                if let Some(b) = b {
+                    if a.is_none() || &b > a.as_ref().unwrap() {
+                        *a = Some(b);
+                    }
+                }
+            }
+            (AggregatorState::Collect(a), AggregatorState::Collect(b)) => a.extend(b),
+            (AggregatorState::CollectDistinct(a), AggregatorState::CollectDistinct(b)) => a.extend(b),
+            (AggregatorState::Percentile { values, .. }, AggregatorState::Percentile { values: b, .. }) => {
+                values.extend(b)
+            }
+            (AggregatorState::StDev { values, .. }, AggregatorState::StDev { values: b, .. }) => {
+                values.extend(b)
+            }
+            // Both sides are built from the same `AggregateFunction`, so a
+            // mismatch is a construction bug rather than bad input.
+            (a, b) => debug_assert!(false, "cannot merge {a:?} with {b:?}"),
         }
     }
 
@@ -4281,15 +4359,184 @@ impl PhysicalOperator for AggregateOperator {
     }
 }
 
-impl AggregateOperator {
-    fn execute_all(&mut self, store: &GraphStore) -> ExecutionResult<()> {
-        // Fast path: single group-by key avoids Vec allocation per record
-        if self.group_by.len() == 1 {
-            return self.execute_all_single_key(store);
+/// The group key of a row, before the key expressions are evaluated.
+///
+/// Grouping on a node's *identity* is at least as fine as grouping on any
+/// tuple of its properties: two rows with the same node necessarily agree on
+/// every property of it. It is not equivalent — two *different* nodes may
+/// share a key tuple — which is why the identity path has a merge step.
+///
+/// The point of the enum is that building one costs nothing for a node: a
+/// `u64` copy, against resolving and cloning a property per row.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum IdentityKey {
+    Node(u64),
+    Edge(u64),
+    /// Anything else, cloned. Reached only where a key expression reads a
+    /// property of something that is not a graph element, which is a
+    /// degenerate query rather than a hot path.
+    Other(Value),
+}
+
+impl IdentityKey {
+    fn of(value: Option<&Value>) -> Self {
+        match value {
+            Some(Value::NodeRef(id)) | Some(Value::Node(id, _)) => IdentityKey::Node(id.0),
+            Some(Value::EdgeRef(id, ..)) | Some(Value::Edge(id, _)) => IdentityKey::Edge(id.0),
+            Some(other) => IdentityKey::Other(other.clone()),
+            None => IdentityKey::Other(Value::Null),
         }
+    }
+}
+
+impl AggregateOperator {
+    /// True when every aggregate can be satisfied by counting rows, so the
+    /// argument expressions never have to be evaluated.
+    ///
+    /// Valid only when the argument cannot be null per row — `count(*)` (a
+    /// literal) or `count(var)` for a bound node or edge. `count(x.prop)`
+    /// counts *non-null values*, so skipping the evaluation there counts rows
+    /// instead and reports every row as a value (#358).
+    fn all_simple_count(aggregates: &[AggregateFunction]) -> bool {
+        aggregates.iter().all(|a| {
+            matches!(a.func, AggregateType::Count)
+                && !a.distinct
+                && matches!(a.expr, Expression::Literal(_) | Expression::Variable(_))
+        })
+    }
+
+    /// The single variable every group-by key is a property of, if there is one.
+    ///
+    /// `RETURN forum.id, forum.title, count(*)` — LDBC IC5's shape — keys on
+    /// two properties of one node. Evaluating them per row resolves a property
+    /// (and clones a string) 1.7M times to distinguish 96,862 groups that the
+    /// node id already distinguishes.
+    fn identity_group_variable(&self) -> Option<String> {
+        let mut found: Option<&str> = None;
+        for (expr, _) in &self.group_by {
+            match expr {
+                Expression::Property { variable, .. } => match found {
+                    None => found = Some(variable),
+                    Some(v) if v == variable => {}
+                    Some(_) => return None,
+                },
+                _ => return None,
+            }
+        }
+        found.map(|v| v.to_string())
+    }
+
+    /// Group on the identity of `var`, then resolve the key expressions once
+    /// per group rather than once per row (#521).
+    ///
+    /// Two phases, because identity grouping is finer than key grouping:
+    ///
+    /// 1. fold rows into partial aggregates keyed by `var`'s identity — no
+    ///    property resolution, no allocation, a `u64` hash per row;
+    /// 2. resolve each group's key tuple once and merge any groups whose
+    ///    tuples are equal.
+    ///
+    /// Phase 2 is what keeps this exactly equivalent to the general path. Two
+    /// distinct nodes carrying the same `(id, title)` are one group in Cypher,
+    /// and without the merge they would come out as two.
+    fn execute_all_by_identity(&mut self, var: &str, store: &GraphStore) -> ExecutionResult<()> {
+        let all_simple_count = Self::all_simple_count(&self.aggregates);
+
+        // The representative is the first `Value` seen for an identity, kept so
+        // phase 2 has something to resolve properties against. Cloned once per
+        // group, not once per row -- which is the whole point.
+        let mut groups: rustc_hash::FxHashMap<IdentityKey, (Value, Vec<AggregatorState>)> =
+            rustc_hash::FxHashMap::default();
+
+        let batch_size = 65536;
+        let mut batch_count = 0u64;
+        while let Some(batch) = self.input.next_batch(store, batch_size)? {
+            batch_count += 1;
+            if batch_count % 10 == 0 {
+                check_deadline()?;
+            }
+            for record in batch.records {
+                let bound = record.get(var);
+                let key = IdentityKey::of(bound);
+                let (_, states) = groups.entry(key).or_insert_with(|| {
+                    (
+                        bound.cloned().unwrap_or(Value::Null),
+                        self.aggregates
+                            .iter()
+                            .map(|agg| AggregatorState::new(&agg.func, agg.distinct))
+                            .collect(),
+                    )
+                });
+
+                if all_simple_count {
+                    for state in states.iter_mut() {
+                        if let AggregatorState::Count(c) = state {
+                            *c += 1;
+                        }
+                    }
+                } else {
+                    for (i, agg) in self.aggregates.iter().enumerate() {
+                        let val = Self::evaluate_expression(&agg.expr, &record, store)?;
+                        states[i].update(&val);
+                    }
+                }
+            }
+        }
+
+        // Phase 2. Every key expression is a property of `var` (that is what
+        // `identity_group_variable` established), so a record binding `var`
+        // alone is enough to evaluate them.
+        let mut merged: rustc_hash::FxHashMap<Vec<Value>, Vec<AggregatorState>> =
+            rustc_hash::FxHashMap::with_capacity_and_hasher(groups.len(), Default::default());
+        for (_, (representative, states)) in groups {
+            let mut probe = Record::new();
+            probe.bind(var.to_string(), representative);
+            let mut tuple = Vec::with_capacity(self.group_by.len());
+            for (expr, _) in &self.group_by {
+                tuple.push(Self::evaluate_expression(expr, &probe, store)?);
+            }
+            match merged.entry(tuple) {
+                std::collections::hash_map::Entry::Occupied(mut slot) => {
+                    for (dst, src) in slot.get_mut().iter_mut().zip(states) {
+                        dst.merge(src);
+                    }
+                }
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert(states);
+                }
+            }
+        }
+
+        let mut output_records = Vec::with_capacity(merged.len());
+        for (tuple, states) in merged {
+            let mut record = Record::new();
+            for (i, (_, alias)) in self.group_by.iter().enumerate() {
+                record.bind(alias.clone(), tuple[i].clone());
+            }
+            for (i, agg) in self.aggregates.iter().enumerate() {
+                record.bind(agg.alias.clone(), states[i].result());
+            }
+            output_records.push(record);
+        }
+
+        self.results = output_records.into_iter();
+        self.executed = true;
+        Ok(())
+    }
+
+    fn execute_all(&mut self, store: &GraphStore) -> ExecutionResult<()> {
         // Fast path: no group-by (global aggregate) — avoids HashMap entirely
         if self.group_by.is_empty() {
             return self.execute_all_no_group(store);
+        }
+        // Fast path: the keys are all properties of one variable, so its
+        // identity groups the rows and the properties are resolved per group.
+        if let Some(var) = self.identity_group_variable() {
+            return self.execute_all_by_identity(&var, store);
+        }
+        // Fast path: single group-by key avoids Vec allocation per record
+        if self.group_by.len() == 1 {
+            return self.execute_all_single_key(store);
         }
 
         // FxHashMap is 2-3x faster than std HashMap on simple keys (no
@@ -4297,6 +4544,13 @@ impl AggregateOperator {
         // each insert ~1M (group_key, aggregator) pairs.
         let mut groups: rustc_hash::FxHashMap<Vec<Value>, Vec<AggregatorState>> =
             rustc_hash::FxHashMap::default();
+        let all_simple_count = Self::all_simple_count(&self.aggregates);
+
+        // Reused across rows. `entry` needs an owned key, so building the tuple
+        // straight into the map allocated a `Vec` per input row and freed it
+        // again on every hit -- 1.68M allocations for 96,862 groups on IC5.
+        // Probing first means the allocation happens once per group.
+        let mut scratch: Vec<Value> = Vec::with_capacity(self.group_by.len());
 
         let batch_size = 65536;
         let mut batch_count = 0u64;
@@ -4304,18 +4558,29 @@ impl AggregateOperator {
             batch_count += 1;
             if batch_count % 10 == 0 { check_deadline()?; }
             for record in batch.records {
-                let mut key = Vec::with_capacity(self.group_by.len());
+                scratch.clear();
                 for (expr, _) in &self.group_by {
-                    key.push(Self::evaluate_expression(expr, &record, store)?);
+                    scratch.push(Self::evaluate_expression(expr, &record, store)?);
                 }
 
-                let states = groups.entry(key).or_insert_with(|| {
-                    self.aggregates.iter().map(|agg| AggregatorState::new(&agg.func, agg.distinct)).collect()
-                });
+                let states = match groups.get_mut(&scratch) {
+                    Some(states) => states,
+                    None => groups.entry(scratch.clone()).or_insert_with(|| {
+                        self.aggregates.iter().map(|agg| AggregatorState::new(&agg.func, agg.distinct)).collect()
+                    }),
+                };
 
-                for (i, agg) in self.aggregates.iter().enumerate() {
-                    let val = Self::evaluate_expression(&agg.expr, &record, store)?;
-                    states[i].update(&val);
+                if all_simple_count {
+                    for state in states.iter_mut() {
+                        if let AggregatorState::Count(c) = state {
+                            *c += 1;
+                        }
+                    }
+                } else {
+                    for (i, agg) in self.aggregates.iter().enumerate() {
+                        let val = Self::evaluate_expression(&agg.expr, &record, store)?;
+                        states[i].update(&val);
+                    }
                 }
             }
         }
@@ -4343,16 +4608,7 @@ impl AggregateOperator {
             rustc_hash::FxHashMap::default();
         let group_expr = &self.group_by[0].0;
 
-        // Check if all aggregates are simple count (non-distinct) — can skip aggregate expression evaluation
-        // Fast path: count rows without evaluating the argument. Valid only when the
-        // argument cannot be null per row — `count(*)` (a literal) or `count(var)` for a
-        // bound node or edge. `count(x.prop)` counts *non-null values*, so skipping the
-        // evaluation there counted rows instead and reported every row as a value (#358).
-        let all_simple_count = self.aggregates.iter().all(|a| {
-            matches!(a.func, AggregateType::Count)
-                && !a.distinct
-                && matches!(a.expr, Expression::Literal(_) | Expression::Variable(_))
-        });
+        let all_simple_count = Self::all_simple_count(&self.aggregates);
 
         let batch_size = 65536;
         let mut batch_count = 0u64;
@@ -4404,15 +4660,7 @@ impl AggregateOperator {
             .map(|agg| AggregatorState::new(&agg.func, agg.distinct))
             .collect();
 
-        // Fast path: count rows without evaluating the argument. Valid only when the
-        // argument cannot be null per row — `count(*)` (a literal) or `count(var)` for a
-        // bound node or edge. `count(x.prop)` counts *non-null values*, so skipping the
-        // evaluation there counted rows instead and reported every row as a value (#358).
-        let all_simple_count = self.aggregates.iter().all(|a| {
-            matches!(a.func, AggregateType::Count)
-                && !a.distinct
-                && matches!(a.expr, Expression::Literal(_) | Expression::Variable(_))
-        });
+        let all_simple_count = Self::all_simple_count(&self.aggregates);
 
         let batch_size = 65536;
         let mut batch_count = 0u64;

--- a/tests/aggregate_identity_grouping.rs
+++ b/tests/aggregate_identity_grouping.rs
@@ -1,0 +1,304 @@
+//! Grouping on identity, and the merge that keeps it equivalent (#521).
+//!
+//! `RETURN forum.id, forum.title, count(*)` keys on two properties of one
+//! node. Resolving them per row is 1.68M property resolutions — with a string
+//! clone among them — to distinguish 96,862 groups the node id already
+//! distinguishes. So the operator now groups on the node and resolves the key
+//! once per group.
+//!
+//! That is **finer**, not equivalent: two different nodes may carry the same
+//! key tuple, and Cypher says they are one group. So there is a merge step,
+//! and these tests are mostly about the merge. A merge that is missing, or
+//! wrong for one aggregate, shows up only when two nodes collide on the key —
+//! which no LDBC query does, and no benchmark would catch.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn prop(store: &mut GraphStore, id: samyama::graph::NodeId, k: &str, v: PropertyValue) {
+    let _ = store.set_node_property("default", id, k.to_string(), v);
+}
+
+/// `teams` Team nodes, each with `members` Member nodes pointing at it.
+/// `title` is deliberately a function of the caller's choosing, so a test can
+/// make two distinct teams share one.
+fn teams(spec: &[(&str, i64, usize)]) -> GraphStore {
+    let mut store = GraphStore::new();
+    for (title, score, members) in spec {
+        let t = store.create_node("Team");
+        prop(&mut store, t, "title", PropertyValue::String(title.to_string()));
+        prop(&mut store, t, "score", PropertyValue::Integer(*score));
+        for i in 0..*members {
+            let m = store.create_node("Member");
+            prop(&mut store, m, "v", PropertyValue::Integer(i as i64));
+            store.create_edge(m, t, "IN").unwrap();
+        }
+    }
+    store
+}
+
+/// Asserts the query actually reaches `AggregateOperator`.
+///
+/// Worth its own helper because of a trap that cost real time: the planner
+/// rewrites `RETURN t.x, count(m)` over an expand into `AdjacencyCountAggregate`,
+/// which reads degrees off the adjacency index and never builds a group at all.
+/// Eight of the first ten tests here passed with the merge step deleted, because
+/// eight of them were exercising that rewrite instead of the operator they name.
+/// A second aggregate, or any aggregate that is not a plain count, defeats it.
+fn assert_hash_aggregate(store: &GraphStore, cypher: &str) {
+    let query = parse_query(&format!("EXPLAIN {cypher}")).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&query).expect("EXPLAIN should run");
+    let text = match batch.records[0].get("plan") {
+        Some(Value::Property(PropertyValue::String(t))) => t.clone(),
+        other => panic!("{other:?}"),
+    };
+    assert!(
+        text.contains("Aggregate (group_by="),
+        "this query does not reach AggregateOperator, so it proves nothing about it:\n{text}"
+    );
+}
+
+/// Rows as sorted `(column, rendered value)` pairs, so comparisons do not
+/// depend on the hash-map order the aggregate emits groups in.
+fn rows(store: &GraphStore, cypher: &str) -> Vec<Vec<String>> {
+    assert_hash_aggregate(store, cypher);
+    let query = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&query).expect("query should run");
+    let mut out: Vec<Vec<String>> = batch
+        .records
+        .iter()
+        .map(|r| {
+            let mut cells: Vec<String> =
+                r.bindings().iter().map(|(k, v)| format!("{k}={v:?}")).collect();
+            cells.sort();
+            cells
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn two_nodes_sharing_a_key_tuple_are_one_group() {
+    // The whole reason the merge exists. Two distinct Teams, same title and
+    // score, 3 and 4 members. Grouping on identity gives 2 groups of 3 and 4;
+    // Cypher wants 1 group of 7.
+    let store = teams(&[("Ops", 10, 3), ("Ops", 10, 4)]);
+    let got = rows(
+        &store,
+        "MATCH (t:Team)<-[:IN]-(m:Member) RETURN t.title AS title, t.score AS score, count(m) AS c, sum(m.v) AS s",
+    );
+    assert_eq!(got.len(), 1, "the two teams share a key tuple: {got:?}");
+    assert!(got[0].iter().any(|c| c.contains("Integer(7)")), "{got:?}");
+}
+
+#[test]
+fn distinct_key_tuples_stay_distinct() {
+    let store = teams(&[("Ops", 10, 3), ("Ops", 11, 4)]);
+    let got = rows(
+        &store,
+        "MATCH (t:Team)<-[:IN]-(m:Member) RETURN t.title AS title, t.score AS score, count(m) AS c, sum(m.v) AS s",
+    );
+    assert_eq!(got.len(), 2, "the scores differ: {got:?}");
+}
+
+#[test]
+fn a_single_key_on_a_property_also_merges() {
+    // One key is the same argument: `t.title` is a property of `t`, so this
+    // takes the identity path too, and two teams share the title.
+    let store = teams(&[("Ops", 10, 3), ("Ops", 11, 4), ("Dev", 1, 5)]);
+    let got = rows(&store, "MATCH (t:Team)<-[:IN]-(m:Member) RETURN t.title AS title, count(m) AS c, sum(m.v) AS s");
+    assert_eq!(got.len(), 2, "Ops and Dev: {got:?}");
+    let ops = got.iter().find(|r| r.iter().any(|c| c.contains("Ops"))).unwrap();
+    assert!(ops.iter().any(|c| c.contains("Integer(7)")), "3 + 4 = 7: {ops:?}");
+}
+
+/// Every aggregate has to survive a merge, and each merges differently. A
+/// missing arm shows up only on a key collision, so each gets a collision.
+#[test]
+fn every_aggregate_survives_a_merge() {
+    // Two teams, same key, members with values 0,1,2 and 0,1,2,3.
+    let store = teams(&[("Ops", 10, 3), ("Ops", 10, 4)]);
+    let one = teams(&[("Ops", 10, 7)]); // no collision, but not the same values
+
+    for (cypher, expected) in [
+        ("count(m)", "Integer(7)"),
+        ("sum(m.v)", "Integer(9)"),   // (0+1+2) + (0+1+2+3)
+        ("min(m.v)", "Integer(0)"),
+        ("max(m.v)", "Integer(3)"),
+        ("avg(m.v)", "Float(1.2857142857142858)"), // 9 / 7
+        ("count(DISTINCT m.v)", "Integer(4)"),     // {0,1,2} ∪ {0,1,2,3}
+    ] {
+        let q = format!("MATCH (t:Team)<-[:IN]-(m:Member) RETURN t.title AS ti, t.score AS s, {cypher} AS a, collect(m.v) AS keep");
+        let got = rows(&store, &q);
+        assert_eq!(got.len(), 1, "{cypher}: {got:?}");
+        assert!(
+            got[0].iter().any(|c| c.contains(expected)),
+            "{cypher} should be {expected}, got {got:?}"
+        );
+    }
+
+    // collect() merges by concatenation, so check the multiset rather than the
+    // order, which Cypher does not specify.
+    let got = rows(
+        &store,
+        "MATCH (t:Team)<-[:IN]-(m:Member) RETURN t.title AS ti, t.score AS s, collect(m.v) AS a",
+    );
+    assert_eq!(got.len(), 1, "{got:?}");
+    let rendered = got[0].join(" ");
+    for want in ["Integer(0)", "Integer(1)", "Integer(2)", "Integer(3)"] {
+        assert!(rendered.contains(want), "collect lost {want}: {rendered}");
+    }
+    assert_eq!(rendered.matches("Integer(0)").count(), 2, "both zeroes: {rendered}");
+
+    let _ = one;
+}
+
+#[test]
+fn count_of_a_property_still_counts_non_null_values() {
+    // The `all_simple_count` guard (#358), now shared by three paths. Half the
+    // members have no `w`, so `count(m.w)` must not equal `count(m)`.
+    let mut store = GraphStore::new();
+    let t = store.create_node("Team");
+    prop(&mut store, t, "title", PropertyValue::String("Ops".into()));
+    prop(&mut store, t, "score", PropertyValue::Integer(1));
+    for i in 0..10 {
+        let m = store.create_node("Member");
+        store.create_edge(m, t, "IN").unwrap();
+        if i % 2 == 0 {
+            prop(&mut store, m, "w", PropertyValue::Integer(i));
+        }
+    }
+    let got = rows(
+        &store,
+        "MATCH (t:Team)<-[:IN]-(m:Member) RETURN t.title AS ti, t.score AS s, count(m.w) AS a",
+    );
+    assert_eq!(got.len(), 1);
+    assert!(got[0].iter().any(|c| c.contains("Integer(5)")), "half have w: {got:?}");
+}
+
+#[test]
+fn a_key_spanning_two_variables_takes_the_general_path() {
+    // `identity_group_variable` must decline here: the keys are properties of
+    // two different nodes, so no single identity groups them.
+    let store = teams(&[("Ops", 10, 3), ("Dev", 20, 2)]);
+    let got = rows(
+        &store,
+        "MATCH (t:Team)<-[:IN]-(m:Member) RETURN t.title AS ti, m.v AS mv, count(m) AS c, sum(m.v) AS s",
+    );
+    // 3 members with v 0,1,2 in Ops and 2 with v 0,1 in Dev: 5 groups.
+    assert_eq!(got.len(), 5, "{got:?}");
+}
+
+#[test]
+fn a_null_property_groups_with_the_other_nulls() {
+    // Teams with no title: the key tuple is (Null, score). Identity keeps them
+    // apart, and the merge has to bring them back together where the scores
+    // agree — including that Null equals Null as a group key, which is not how
+    // Null compares elsewhere.
+    let mut store = GraphStore::new();
+    for _ in 0..2 {
+        let t = store.create_node("Team");
+        prop(&mut store, t, "score", PropertyValue::Integer(5));
+        for _ in 0..3 {
+            let m = store.create_node("Member");
+            store.create_edge(m, t, "IN").unwrap();
+        }
+    }
+    let got = rows(
+        &store,
+        "MATCH (t:Team)<-[:IN]-(m:Member) RETURN t.title AS ti, t.score AS s, count(m) AS c, collect(m) AS ms",
+    );
+    assert_eq!(got.len(), 1, "both untitled teams group together: {got:?}");
+    assert!(got[0].iter().any(|c| c.contains("Integer(6)")), "{got:?}");
+}
+
+#[test]
+fn the_identity_path_agrees_with_the_general_path_on_a_wide_graph() {
+    // A differential check. `t.title, t.score` takes the identity path;
+    // `t.title, m.team_score` is the same partition expressed across two
+    // variables, so it takes the general path. Same groups, same counts.
+    let mut store = GraphStore::new();
+    for g in 0..200 {
+        let t = store.create_node("Team");
+        // 200 teams over 50 titles, so four teams share each title, and the
+        // merge runs 150 times.
+        prop(&mut store, t, "title", PropertyValue::String(format!("t{}", g % 50)));
+        prop(&mut store, t, "score", PropertyValue::Integer((g % 50) as i64));
+        for i in 0..(g % 7 + 1) {
+            let m = store.create_node("Member");
+            prop(&mut store, m, "v", PropertyValue::Integer(i as i64));
+            prop(&mut store, m, "team_score", PropertyValue::Integer((g % 50) as i64));
+            store.create_edge(m, t, "IN").unwrap();
+        }
+    }
+
+    let identity = rows(
+        &store,
+        "MATCH (t:Team)<-[:IN]-(m:Member) RETURN t.title AS a, t.score AS b, count(m) AS c, sum(m.v) AS d",
+    );
+    let general = rows(
+        &store,
+        "MATCH (t:Team)<-[:IN]-(m:Member) RETURN t.title AS a, m.team_score AS b, count(m) AS c, sum(m.v) AS d",
+    );
+    assert_eq!(identity.len(), 50, "50 distinct titles: {}", identity.len());
+    assert_eq!(identity, general, "the two paths disagree");
+}
+
+#[test]
+fn grouping_cost_does_not_scale_with_the_string_key() {
+    // The regression this is guarding: a long string key used to be resolved
+    // and cloned once per input row. Now it is resolved once per group, so a
+    // 400-character title should cost about what a short one does.
+    fn build(title_len: usize) -> GraphStore {
+        let mut store = GraphStore::new();
+        for g in 0..500 {
+            let t = store.create_node("Team");
+            prop(&mut store, t, "title", PropertyValue::String(format!("{g}").repeat(title_len)));
+            prop(&mut store, t, "score", PropertyValue::Integer(g as i64));
+            for i in 0..200 {
+                let m = store.create_node("Member");
+                prop(&mut store, m, "v", PropertyValue::Integer(i));
+                store.create_edge(m, t, "IN").unwrap();
+            }
+        }
+        store
+    }
+    let cypher =
+        "MATCH (t:Team)<-[:IN]-(m:Member) RETURN t.title AS a, t.score AS b, sum(m.v) AS c";
+
+    let time = |store: &GraphStore| {
+        let q = parse_query(cypher).unwrap();
+        let _ = QueryExecutor::new(store).execute(&q).unwrap();
+        let started = std::time::Instant::now();
+        let out = QueryExecutor::new(store).execute(&q).unwrap();
+        assert_eq!(out.records.len(), 500);
+        started.elapsed().as_secs_f64()
+    };
+
+    let short = time(&build(1));
+    let long = time(&build(200));
+    assert!(
+        long < short * 4.0,
+        "a 200x longer key cost {:.1}x more ({short:.4}s -> {long:.4}s) — it is being cloned per row",
+        long / short
+    );
+}
+
+#[test]
+fn explain_is_unchanged_by_the_grouping_strategy() {
+    // The plan is the contract; which of three fold paths runs is not part of
+    // it. Asserted so a future reader does not go looking for a `GroupBy` node
+    // that was never there.
+    let store = teams(&[("Ops", 10, 3)]);
+    let query =
+        parse_query("EXPLAIN MATCH (t:Team)<-[:IN]-(m:Member) RETURN t.title AS a, t.score AS b, sum(m.v) AS c")
+            .unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    let text = match batch.records[0].get("plan") {
+        Some(Value::Property(PropertyValue::String(t))) => t.clone(),
+        other => panic!("{other:?}"),
+    };
+    assert!(text.contains("Aggregate (group_by="), "{text}");
+}


### PR DESCRIPTION
Closes #521. Splits out #557.

## Measured

One host, one fixture, `PROFILE`, **`Aggregate` self time** so the traversal around it is not folded in. 1,000,000 input rows → 50,000 groups:

| query | main | this branch | |
|---|---:|---:|---:|
| `RETURN count(i)` — no grouping (control) | 66.1 ms | 65.2 ms | — |
| `RETURN f.fid, f.title, sum(i.v)` | 276.6 ms | **180.4 ms** | **−35%** |
| `RETURN f.fid, f.title, count(i), min(i.v)` | 282.2 ms | **174.7 ms** | **−38%** |

The control does not take the new path and does not move. That is the check that the other two rows measure what they claim.

## What changed

IC5 keys on `(forum.id, forum.title)` — two properties of **one node** — and resolved both **once per input row**: 3.4M property resolutions, half of them cloning a string, to distinguish 96,862 groups that the node id already distinguishes.

`AggregateOperator` now folds that shape in two phases:

1. group on the **identity** of the variable the keys are properties of — a `u64` hash per row, no resolution, no allocation;
2. resolve each group's key tuple **once**, and merge groups whose tuples turn out equal.

## The merge is not optional

Grouping on identity is **finer** than grouping on a key tuple. Two distinct nodes carrying the same `(id, title)` are **one group** in Cypher and would otherwise come out as two. So every aggregate grew a `merge` — all of them are associative and commutative, which is what makes a two-phase fold legal at all.

`tests/aggregate_identity_grouping.rs` is mostly about that merge, because a missing or wrong arm shows up only on a key collision — which no LDBC query has, and no benchmark would catch.

## Also in the general path

The multi-key path still runs whenever keys span more than one variable. Two things there:

- it built its key `Vec` straight into `entry()`, allocating and freeing one **per input row** rather than one per group;
- it lacked the `all_simple_count` guard the other two paths had, so `count(x)` evaluated its argument per row.

## A trap worth naming

This benchmark reported **88 ns/row** for IC5's shape and made #521 look wrong.

The planner rewrites `RETURN f.x, count(i)` over an expand into `AdjacencyCountAggregate`, which reads degrees off the adjacency index and **never groups anything**. That case was measuring the rewrite, not aggregation. The honest figure for the shape was 12× higher.

The same trap hit the tests: **eight of the first ten passed with the merge step deleted**, because eight were exercising the rewrite instead of the operator they named.

Both now assert which operator they reached — the bench prints an `operator` column, the tests call `assert_hash_aggregate`. `docs/BENCHMARKS.md` says to read that column first.

## Testing

10 tests, verified load-bearing by mutation:

- delete the merge → **5 fail** (every collision test)
- disable the identity path entirely → **10 pass**, confirming it is semantically transparent

Full suite on a dedicated box: **2,735 passed, 0 failed, 0 compile errors** (2,725 before, +10 here).

## Residual

180 ns/row is now ~65 ns of fold plus **~115 ns for the one remaining property read**. That is not an aggregation cost — it is `get_property` hashing the property name and looking up the column once per row, and it is paid by `Filter`, `Project` and `Sort` too. Filed as **#557** with the measurement.