### PR TITLE
Locate a property's column once per query, not once per row

### DIFF
--- a/benches/property_access.rs
+++ b/benches/property_access.rs
@@ -114,6 +114,25 @@ fn main() {
     let columns = &fx.store.node_columns;
     let ids = &fx.rows;
 
+    // The same rows, visited in scattered order. A scan reads in id order, but
+    // anything downstream of an `Expand` does not: a traversal arrives at nodes
+    // in adjacency order, which is scattered with respect to the id space. Since
+    // the two orders read exactly the same values through exactly the same code,
+    // any difference between them is cache and nothing else.
+    let scattered: Vec<usize> = {
+        let mut v = ids.clone();
+        // Deterministic shuffle -- a benchmark that varies run to run cannot be
+        // compared across commits (#529).
+        let mut state = 0x2545_F491_4F6C_DD1Du64;
+        for i in (1..v.len()).rev() {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            v.swap(i, (state % (i as u64 + 1)) as usize);
+        }
+        v
+    };
+
     println!("{:<46} {:>10}", "access", "ns");
     println!("{:-<46} {:->10}", "", "");
 
@@ -173,6 +192,39 @@ fn main() {
         acc
     });
 
+    let scattered_ns = time("get_property, dense int, scattered order", rows, || {
+        let mut acc = 0u64;
+        for &idx in &scattered {
+            if let PropertyValue::Integer(v) = columns.get_property(idx, "dense_int") {
+                acc = acc.wrapping_add(v as u64);
+            }
+        }
+        acc
+    });
+
+    let scattered_hoisted = time("  ... with the column hoisted", rows, || {
+        let mut acc = 0u64;
+        if let Some(col) = columns.get_column("dense_int") {
+            for &idx in &scattered {
+                if let PropertyValue::Integer(v) = col.get(idx) {
+                    acc = acc.wrapping_add(v as u64);
+                }
+            }
+        }
+        acc
+    });
+
+    let scattered_vec = {
+        let plain: Vec<i64> = (0..rows as i64).collect();
+        time("a dense Vec<i64>, scattered order", rows, || {
+            let mut acc = 0u64;
+            for &idx in &scattered {
+                acc = acc.wrapping_add(plain[idx.min(plain.len() - 1)] as u64);
+            }
+            acc
+        })
+    };
+
     let row_nodes = &fx.row_nodes;
     time("row storage, node.properties HashMap", rows, || {
         let mut acc = 0u64;
@@ -197,11 +249,19 @@ fn main() {
 
     println!();
     println!(
-        "A dense integer read costs {:.0}x an array index ({:.1} ns vs {:.1} ns).",
-        dense_int / vec_ns.max(0.01),
-        dense_int,
-        vec_ns
+        "A dense integer read costs {:.0}x an array index ({dense_int:.1} ns vs {vec_ns:.1} ns).",
+        dense_int / vec_ns.max(0.01)
     );
+    println!();
+    println!("Order matters more than the lookup does. The same read in scattered order costs");
+    println!("{scattered_ns:.1} ns against {dense_int:.1} ns in id order, and a bare Vec<i64> read scattered costs");
+    println!("{scattered_vec:.1} ns against {vec_ns:.1} ns -- so most of the gap is a DRAM round trip that any");
+    println!("representation would pay. Hoisting the column lookup out of the loop takes the");
+    println!("scattered read to {scattered_hoisted:.1} ns, which is the part an operator can fix without");
+    println!("touching storage (#557).");
+    println!();
+    println!("This is why an operator downstream of an Expand pays more per property than a");
+    println!("scan does: it arrives at nodes in adjacency order, not id order.");
     println!("Most of that is cache, not hashing: at {rows} rows the inner table is tens of");
     println!("megabytes and the hash scatters access, so even a scan in id order misses.");
 

--- a/src/graph/storage/columnar.rs
+++ b/src/graph/storage/columnar.rs
@@ -483,14 +483,33 @@ impl Column {
     }
 }
 
+/// A column's position in the store, stable for the store's lifetime.
+///
+/// The point of handing these out is that a property name is fixed at plan
+/// time but was hashed once per *row*: `get_property(idx, "title")` probed a
+/// `FxHashMap<String, Column>` a million times to reach the same column. An
+/// operator can resolve the id once and index directly, which measured 37.6 ns
+/// to 22.6 ns per read in scattered order (#557).
+///
+/// Stability is what makes caching one safe: columns are only ever appended.
+/// `clear_row` clears a row's *values*; nothing removes a column, so an id
+/// handed out earlier still names the same column later.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ColumnId(u32);
+
 /// Manages multiple property columns.
 #[derive(Debug, Default, Clone)]
 pub struct ColumnStore {
-    /// Mapping from property key -> Column.
+    /// Columns by id. Append-only, so a `ColumnId` never dangles or shifts.
+    columns: Vec<Column>,
+    /// Parallel to `columns`, for reporting a row's property names back.
+    names: Vec<String>,
+    /// Property key -> id. Consulted once per query per property rather than
+    /// once per row, wherever the caller keeps the id.
     ///
-    /// Also `FxHashMap`: property names are short, the set of them is small
-    /// and fixed after load, and this lookup happens on every property read.
-    columns: FxHashMap<String, Column>,
+    /// `FxHashMap`: property names are short, the set of them is small and
+    /// fixed after load.
+    index: FxHashMap<String, ColumnId>,
 }
 
 impl ColumnStore {
@@ -498,9 +517,28 @@ impl ColumnStore {
         Self::default()
     }
 
+    /// The id of a property's column, if it has one.
+    ///
+    /// Resolve this once and read with `get_by_id`. `None` means no column
+    /// exists *yet* — a later `set_property` may create one, so a caller that
+    /// caches a `None` has to keep asking.
+    #[inline]
+    pub fn column_id(&self, key: &str) -> Option<ColumnId> {
+        self.index.get(key).copied()
+    }
+
+    /// Read a value by column id — a bounds-checked index, no hashing.
+    #[inline]
+    pub fn get_by_id(&self, id: ColumnId, idx: usize) -> PropertyValue {
+        match self.columns.get(id.0 as usize) {
+            Some(col) => col.get(idx),
+            None => PropertyValue::Null,
+        }
+    }
+
     pub fn set_property(&mut self, idx: usize, key: &str, value: PropertyValue) {
-        if let Some(col) = self.columns.get_mut(key) {
-            col.set(idx, value);
+        if let Some(&ColumnId(slot)) = self.index.get(key) {
+            self.columns[slot as usize].set(idx, value);
         } else {
             // Every `PropertyValue` gets a column. Returning early for the
             // ones without a typed representation is what made row storage
@@ -508,7 +546,10 @@ impl ColumnStore {
             // there, so the duplication could not be removed (#545).
             let mut col = Column::for_value(&value);
             col.set(idx, value);
-            self.columns.insert(key.to_string(), col);
+            let id = ColumnId(self.columns.len() as u32);
+            self.columns.push(col);
+            self.names.push(key.to_string());
+            self.index.insert(key.to_string(), id);
         }
     }
 
@@ -519,24 +560,28 @@ impl ColumnStore {
     /// occupant left in each column — values from deleted data reappearing on new data
     /// (#364). Deletion has to clear the columns as well as the sparse map.
     pub fn clear_row(&mut self, idx: usize) {
-        for col in self.columns.values_mut() {
+        for col in self.columns.iter_mut() {
             col.remove(idx);
         }
     }
 
     pub fn get_property(&self, idx: usize, key: &str) -> PropertyValue {
-        self.columns.get(key).map(|col| col.get(idx)).unwrap_or(PropertyValue::Null)
+        match self.index.get(key) {
+            Some(&ColumnId(slot)) => self.columns[slot as usize].get(idx),
+            None => PropertyValue::Null,
+        }
     }
 
     /// Optimized batch read for a single property
     pub fn get_column(&self, key: &str) -> Option<&Column> {
-        self.columns.get(key)
+        self.index.get(key).and_then(|&ColumnId(slot)| self.columns.get(slot as usize))
     }
 
     /// Get all property keys that have a non-null value for a given node index.
     /// Used by `keys()` function to discover column-store-only properties.
     pub fn get_property_keys(&self, idx: usize) -> Vec<String> {
-        self.columns.iter()
+        self.names.iter()
+            .zip(self.columns.iter())
             .filter(|(_, col)| col.has(idx))
             .map(|(key, _)| key.clone())
             .collect()

--- a/src/graph/storage/mod.rs
+++ b/src/graph/storage/mod.rs
@@ -1,3 +1,3 @@
 pub mod columnar;
 
-pub use columnar::{Column, ColumnStore};
+pub use columnar::{Column, ColumnId, ColumnStore};

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -94,7 +94,7 @@ pub mod record;
 // Export operators - added CreateNodeOperator, CreateEdgeOperator, CartesianProductOperator for CREATE support
 pub use operator::{PhysicalOperator, OperatorBox, OperatorDescription, CreateNodeOperator, CreateEdgeOperator, MatchCreateEdgeOperator, CartesianProductOperator};
 pub use planner::{QueryPlanner, ExecutionPlan, PlannerConfig};
-pub use record::{Record, RecordBatch, Value};
+pub use record::{PropertyCursor, Record, RecordBatch, Value};
 
 use crate::graph::GraphStore;
 use crate::query::ast::Query;

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -64,6 +64,7 @@
 //! - `HashMap` — build phase of hash joins in `JoinOperator`
 //! - `BTreeSet` — sorted unique results where ordering matters
 
+use crate::query::executor::record::PropertyCursor;
 use crate::graph::{GraphStore, Label, NodeId, EdgeType};
 use crate::query::ast::{Expression, BinaryOp, UnaryOp, Direction, Pattern};
 use crate::query::executor::{ExecutionError, ExecutionResult, Record, Value, RecordBatch};
@@ -4359,6 +4360,38 @@ impl PhysicalOperator for AggregateOperator {
     }
 }
 
+
+/// Per-row evaluation of one expression, specialised where it is a plain
+/// `x.prop`.
+///
+/// Built once per fold rather than held on the operator, because the operator
+/// borrows `self.aggregates` immutably across the loop and a cursor needs
+/// `&mut` to memoise its column.
+enum RowReader {
+    /// `x.prop` — the column is located once (#557).
+    Cursor(PropertyCursor),
+    /// Anything else: a literal, an arithmetic expression, a function call.
+    General(Expression),
+}
+
+impl RowReader {
+    fn for_expression(expr: &Expression) -> Self {
+        match expr {
+            Expression::Property { variable, property } => {
+                RowReader::Cursor(PropertyCursor::new(variable.as_str(), property.as_str()))
+            }
+            other => RowReader::General(other.clone()),
+        }
+    }
+
+    fn read(&mut self, record: &Record, store: &GraphStore) -> ExecutionResult<Value> {
+        match self {
+            RowReader::Cursor(cursor) => Ok(Value::Property(cursor.read(record, store))),
+            RowReader::General(expr) => AggregateOperator::evaluate_expression(expr, record, store),
+        }
+    }
+}
+
 /// The group key of a row, before the key expressions are evaluated.
 ///
 /// Grouping on a node's *identity* is at least as fine as grouping on any
@@ -4441,6 +4474,8 @@ impl AggregateOperator {
     /// and without the merge they would come out as two.
     fn execute_all_by_identity(&mut self, var: &str, store: &GraphStore) -> ExecutionResult<()> {
         let all_simple_count = Self::all_simple_count(&self.aggregates);
+        let mut readers: Vec<RowReader> =
+            self.aggregates.iter().map(|a| RowReader::for_expression(&a.expr)).collect();
 
         // The representative is the first `Value` seen for an identity, kept so
         // phase 2 has something to resolve properties against. Cloned once per
@@ -4475,8 +4510,8 @@ impl AggregateOperator {
                         }
                     }
                 } else {
-                    for (i, agg) in self.aggregates.iter().enumerate() {
-                        let val = Self::evaluate_expression(&agg.expr, &record, store)?;
+                    for (i, reader) in readers.iter_mut().enumerate() {
+                        let val = reader.read(&record, store)?;
                         states[i].update(&val);
                     }
                 }
@@ -4545,6 +4580,10 @@ impl AggregateOperator {
         let mut groups: rustc_hash::FxHashMap<Vec<Value>, Vec<AggregatorState>> =
             rustc_hash::FxHashMap::default();
         let all_simple_count = Self::all_simple_count(&self.aggregates);
+        let mut key_readers: Vec<RowReader> =
+            self.group_by.iter().map(|(e, _)| RowReader::for_expression(e)).collect();
+        let mut readers: Vec<RowReader> =
+            self.aggregates.iter().map(|a| RowReader::for_expression(&a.expr)).collect();
 
         // Reused across rows. `entry` needs an owned key, so building the tuple
         // straight into the map allocated a `Vec` per input row and freed it
@@ -4559,8 +4598,8 @@ impl AggregateOperator {
             if batch_count % 10 == 0 { check_deadline()?; }
             for record in batch.records {
                 scratch.clear();
-                for (expr, _) in &self.group_by {
-                    scratch.push(Self::evaluate_expression(expr, &record, store)?);
+                for reader in key_readers.iter_mut() {
+                    scratch.push(reader.read(&record, store)?);
                 }
 
                 let states = match groups.get_mut(&scratch) {
@@ -4577,8 +4616,8 @@ impl AggregateOperator {
                         }
                     }
                 } else {
-                    for (i, agg) in self.aggregates.iter().enumerate() {
-                        let val = Self::evaluate_expression(&agg.expr, &record, store)?;
+                    for (i, reader) in readers.iter_mut().enumerate() {
+                        let val = reader.read(&record, store)?;
                         states[i].update(&val);
                     }
                 }
@@ -4606,7 +4645,9 @@ impl AggregateOperator {
     fn execute_all_single_key(&mut self, store: &GraphStore) -> ExecutionResult<()> {
         let mut groups: rustc_hash::FxHashMap<Value, Vec<AggregatorState>> =
             rustc_hash::FxHashMap::default();
-        let group_expr = &self.group_by[0].0;
+        let mut key_reader = RowReader::for_expression(&self.group_by[0].0);
+        let mut readers: Vec<RowReader> =
+            self.aggregates.iter().map(|a| RowReader::for_expression(&a.expr)).collect();
 
         let all_simple_count = Self::all_simple_count(&self.aggregates);
 
@@ -4616,7 +4657,7 @@ impl AggregateOperator {
             batch_count += 1;
             if batch_count % 10 == 0 { check_deadline()?; }
             for record in batch.records {
-                let key = Self::evaluate_expression(group_expr, &record, store)?;
+                let key = key_reader.read(&record, store)?;
 
                 let states = groups.entry(key).or_insert_with(|| {
                     self.aggregates.iter().map(|agg| AggregatorState::new(&agg.func, agg.distinct)).collect()
@@ -4630,8 +4671,8 @@ impl AggregateOperator {
                         }
                     }
                 } else {
-                    for (i, agg) in self.aggregates.iter().enumerate() {
-                        let val = Self::evaluate_expression(&agg.expr, &record, store)?;
+                    for (i, reader) in readers.iter_mut().enumerate() {
+                        let val = reader.read(&record, store)?;
                         states[i].update(&val);
                     }
                 }
@@ -4661,6 +4702,8 @@ impl AggregateOperator {
             .collect();
 
         let all_simple_count = Self::all_simple_count(&self.aggregates);
+        let mut readers: Vec<RowReader> =
+            self.aggregates.iter().map(|a| RowReader::for_expression(&a.expr)).collect();
 
         let batch_size = 65536;
         let mut batch_count = 0u64;
@@ -4678,8 +4721,8 @@ impl AggregateOperator {
                 }
             } else {
                 for record in batch.records {
-                    for (i, agg) in self.aggregates.iter().enumerate() {
-                        let val = Self::evaluate_expression(&agg.expr, &record, store)?;
+                    for (i, reader) in readers.iter_mut().enumerate() {
+                        let val = reader.read(&record, store)?;
                         states[i].update(&val);
                     }
                 }

--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -968,3 +968,95 @@ mod tests {
         assert_ne!(hash_value(&Value::Null), hash_value(&v1));
     }
 }
+
+/// One `x.prop` read, with the column located once instead of once per row.
+///
+/// `Value::resolve_property` takes the property name as a `&str` and hashes it
+/// against the store's column index on every call. For an operator looping over
+/// a million rows evaluating the same expression, that is a million hashes to
+/// reach the same column: 37.6 ns per read in scattered order against 22.6 ns
+/// when the column is hoisted out of the loop (#557).
+///
+/// The name is fixed at plan time, so the operator holds one of these per
+/// property expression and the lookup happens once.
+///
+/// Two things it does **not** do, both deliberate:
+///
+/// * it caches only a *found* column. `None` means no column exists **yet** —
+///   a `MERGE` or `SET` later in the same query may create one — so a miss
+///   re-resolves rather than being remembered as absent;
+/// * it keeps the row-storage fallback. A property whose value has no typed
+///   column representation is readable only from the per-node map (#545), and
+///   dropping that path would silently return null for complex types.
+#[derive(Debug, Clone)]
+pub struct PropertyCursor {
+    variable: Arc<str>,
+    property: Arc<str>,
+    node_column: Option<crate::graph::storage::columnar::ColumnId>,
+    edge_column: Option<crate::graph::storage::columnar::ColumnId>,
+}
+
+impl PropertyCursor {
+    pub fn new(variable: impl Into<Arc<str>>, property: impl Into<Arc<str>>) -> Self {
+        Self {
+            variable: variable.into(),
+            property: property.into(),
+            node_column: None,
+            edge_column: None,
+        }
+    }
+
+    /// The value of `variable.property` in `record`.
+    ///
+    /// Equivalent to `record.get(variable).resolve_property(property, store)`,
+    /// which is what it falls back to for anything that is not a node or edge.
+    pub fn read(&mut self, record: &Record, store: &GraphStore) -> PropertyValue {
+        match record.get(&self.variable) {
+            Some(Value::NodeRef(id)) | Some(Value::Node(id, _)) => {
+                let idx = id.as_u64() as usize;
+                let column = match self.node_column {
+                    Some(id) => Some(id),
+                    None => {
+                        let found = store.node_columns.column_id(&self.property);
+                        self.node_column = found;
+                        found
+                    }
+                };
+                if let Some(column) = column {
+                    let value = store.node_columns.get_by_id(column, idx);
+                    if !value.is_null() {
+                        return value;
+                    }
+                }
+                // The column has no value here. Row storage may still.
+                match store.get_node(*id) {
+                    Some(node) => node.get_property(&self.property).cloned().unwrap_or(PropertyValue::Null),
+                    None => PropertyValue::Null,
+                }
+            }
+            Some(Value::EdgeRef(id, ..)) | Some(Value::Edge(id, _)) => {
+                let idx = id.as_u64() as usize;
+                let column = match self.edge_column {
+                    Some(id) => Some(id),
+                    None => {
+                        let found = store.edge_columns.column_id(&self.property);
+                        self.edge_column = found;
+                        found
+                    }
+                };
+                if let Some(column) = column {
+                    let value = store.edge_columns.get_by_id(column, idx);
+                    if !value.is_null() {
+                        return value;
+                    }
+                }
+                match store.get_edge(*id) {
+                    Some(edge) => edge.get_property(&self.property).cloned().unwrap_or(PropertyValue::Null),
+                    None => PropertyValue::Null,
+                }
+            }
+            Some(other) => other.resolve_property(&self.property, store),
+            None => PropertyValue::Null,
+        }
+    }
+}

--- a/tests/property_cursor.rs
+++ b/tests/property_cursor.rs
@@ -1,0 +1,201 @@
+//! Reading a property through a cached column id (#557).
+//!
+//! `PropertyCursor` exists to hoist one hash lookup out of a per-row loop, and
+//! the whole value of it is that it is otherwise **indistinguishable** from
+//! `Value::resolve_property`. So these tests are differential: same input, both
+//! paths, same answer. A cursor that is merely fast is a bug.
+//!
+//! The cases that matter are the ones where the column is *not* the answer —
+//! a property with no column yet, a value whose type has no typed column
+//! representation and lives only in row storage (#545), a deleted row. Each is
+//! a way for a cached column id to return the wrong thing confidently.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{PropertyCursor, QueryExecutor, Record, Value};
+use samyama::query::parser::parse_query;
+
+/// Both paths, asserted equal, and the value returned for further checking.
+fn both_ways(store: &GraphStore, record: &Record, var: &str, property: &str) -> PropertyValue {
+    let direct = record
+        .get(var)
+        .map(|v| v.resolve_property(property, store))
+        .unwrap_or(PropertyValue::Null);
+    let mut cursor = PropertyCursor::new(var, property);
+    let cached = cursor.read(record, store);
+    assert_eq!(cached, direct, "cursor disagreed with resolve_property on {var}.{property}");
+    // Read again: the second read comes from the memoised column id, which is
+    // the path every row after the first takes.
+    assert_eq!(cursor.read(record, store), direct, "the memoised read disagreed");
+    direct
+}
+
+fn record_for(id: samyama::graph::NodeId) -> Record {
+    let mut r = Record::new();
+    r.bind("n", Value::NodeRef(id));
+    r
+}
+
+#[test]
+fn a_column_backed_property_reads_the_same_both_ways() {
+    let mut store = GraphStore::new();
+    let id = store.create_node("N");
+    let _ = store.set_node_property("default", id, "v".to_string(), PropertyValue::Integer(42));
+    assert_eq!(both_ways(&store, &record_for(id), "n", "v"), PropertyValue::Integer(42));
+}
+
+#[test]
+fn a_property_that_does_not_exist_is_null_both_ways() {
+    let mut store = GraphStore::new();
+    let id = store.create_node("N");
+    let _ = store.set_node_property("default", id, "v".to_string(), PropertyValue::Integer(1));
+    assert_eq!(both_ways(&store, &record_for(id), "n", "absent"), PropertyValue::Null);
+}
+
+#[test]
+fn a_column_created_after_the_cursor_first_missed_is_still_found() {
+    // The reason a miss is not cached. A cursor that remembered "no column"
+    // would keep returning null after a SET created one.
+    let mut store = GraphStore::new();
+    let id = store.create_node("N");
+    let record = record_for(id);
+
+    let mut cursor = PropertyCursor::new("n", "later");
+    assert_eq!(cursor.read(&record, &store), PropertyValue::Null);
+
+    let _ = store.set_node_property("default", id, "later".to_string(), PropertyValue::Integer(7));
+    assert_eq!(
+        cursor.read(&record, &store),
+        PropertyValue::Integer(7),
+        "the cursor cached the absence of a column"
+    );
+}
+
+#[test]
+fn a_value_that_lives_only_in_row_storage_is_still_found() {
+    // Complex values round-trip only through the per-node map (#545). A cursor
+    // that trusted the column and stopped would return null for them.
+    let mut store = GraphStore::new();
+    let id = store.create_node("N");
+    if let Some(node) = store.get_node_mut(id) {
+        node.set_property(
+            "tags",
+            PropertyValue::Array(vec![
+                PropertyValue::String("a".into()),
+                PropertyValue::String("b".into()),
+            ]),
+        );
+    }
+    let got = both_ways(&store, &record_for(id), "n", "tags");
+    assert!(matches!(got, PropertyValue::Array(ref a) if a.len() == 2), "{got:?}");
+}
+
+#[test]
+fn a_row_with_no_value_in_a_column_that_exists_falls_back() {
+    // The column exists because another node has the property. This node does
+    // not, so the column returns null and row storage has to be consulted.
+    let mut store = GraphStore::new();
+    let other = store.create_node("N");
+    let _ = store.set_node_property("default", other, "v".to_string(), PropertyValue::Integer(1));
+
+    let id = store.create_node("N");
+    if let Some(node) = store.get_node_mut(id) {
+        node.set_property("v", PropertyValue::Integer(99));
+    }
+    assert_eq!(both_ways(&store, &record_for(id), "n", "v"), PropertyValue::Integer(99));
+}
+
+#[test]
+fn an_edge_property_reads_the_same_both_ways() {
+    let mut store = GraphStore::new();
+    let a = store.create_node("N");
+    let b = store.create_node("N");
+    let e = store.create_edge(a, b, "LINK").unwrap();
+    let _ = store.set_edge_property(e, "weight", PropertyValue::Float(1.5));
+
+    let mut record = Record::new();
+    record.bind("r", Value::EdgeRef(e, a, b, samyama::graph::EdgeType::new("LINK")));
+    assert_eq!(both_ways(&store, &record, "r", "weight"), PropertyValue::Float(1.5));
+}
+
+#[test]
+fn an_unbound_variable_is_null_rather_than_a_panic() {
+    let store = GraphStore::new();
+    let mut cursor = PropertyCursor::new("missing", "v");
+    assert_eq!(cursor.read(&Record::new(), &store), PropertyValue::Null);
+}
+
+#[test]
+fn a_non_graph_value_falls_through_to_the_general_path() {
+    // `duration.days`, `datetime.year` and friends resolve against the value
+    // itself, not against any column.
+    let store = GraphStore::new();
+    let mut record = Record::new();
+    record.bind("d", Value::Property(PropertyValue::DateTime(1_700_000_000_000)));
+    let got = both_ways(&store, &record, "d", "year");
+    assert!(matches!(got, PropertyValue::Integer(_)), "{got:?}");
+}
+
+#[test]
+fn column_ids_survive_new_columns_being_added() {
+    // The property that makes caching an id safe at all: ids are handed out on
+    // append and never shift.
+    let mut store = GraphStore::new();
+    let id = store.create_node("N");
+    let _ = store.set_node_property("default", id, "first".to_string(), PropertyValue::Integer(1));
+
+    let first = store.node_columns.column_id("first").expect("column exists");
+    for k in 0..64 {
+        let _ = store.set_node_property("default", id, format!("p{k}"), PropertyValue::Integer(k));
+    }
+    assert_eq!(store.node_columns.column_id("first"), Some(first), "the id moved");
+    assert_eq!(
+        store.node_columns.get_by_id(first, id.as_u64() as usize),
+        PropertyValue::Integer(1)
+    );
+}
+
+#[test]
+fn a_recycled_row_does_not_read_the_previous_occupants_value() {
+    // Node ids come off a free list (#364). Reading by cached column id must
+    // see the cleared slot, not a stale one.
+    let mut store = GraphStore::new();
+    let victim = store.create_node("N");
+    let _ = store.set_node_property("default", victim, "v".to_string(), PropertyValue::Integer(5));
+    let column = store.node_columns.column_id("v").unwrap();
+
+    let query = parse_query("MATCH (n:N) WHERE n.v = 5 DETACH DELETE n").unwrap();
+    let mut mutating =
+        samyama::query::executor::MutQueryExecutor::new(&mut store, "default".to_string());
+    mutating.execute(&query).expect("delete should run");
+
+    let fresh = store.create_node("Ghost");
+    assert_eq!(
+        store.node_columns.get_by_id(column, fresh.as_u64() as usize),
+        PropertyValue::Null
+    );
+    let mut cursor = PropertyCursor::new("n", "v");
+    let mut record = Record::new();
+    record.bind("n", Value::NodeRef(fresh));
+    assert_eq!(cursor.read(&record, &store), PropertyValue::Null);
+}
+
+#[test]
+fn an_aggregate_over_many_rows_agrees_with_a_scan() {
+    // End to end: the aggregate paths now read through cursors, so a whole-graph
+    // fold has to match a hand-computed answer.
+    let mut store = GraphStore::new();
+    let hub = store.create_node("Hub");
+    let mut expected_sum = 0i64;
+    for i in 0..5000i64 {
+        let n = store.create_node("N");
+        let _ = store.set_node_property("default", n, "v".to_string(), PropertyValue::Integer(i));
+        store.create_edge(n, hub, "IN").unwrap();
+        expected_sum += i;
+    }
+    let query = parse_query("MATCH (h:Hub)<-[:IN]-(n:N) RETURN sum(n.v) AS s").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    assert_eq!(
+        batch.records[0].get("s"),
+        Some(&Value::Property(PropertyValue::Integer(expected_sum)))
+    );
+}


### PR DESCRIPTION
Closes #557.

## Measured

Isolating the read as `sum(i.v)` minus `count(i)` over the same 1,000,000 rows, so only the property access differs:

| | main | this branch |
|---|---:|---:|
| one property read, per row | 23.98 ns | **16.90 ns** (−30%) |

And directly, in `benches/property_access.rs`:

| access | main | this branch |
|---|---:|---:|
| dense int column, **id order** | 19.5 ns | **17.1 ns** |
| dense int column, **scattered order** | 37.6 ns | **22.9 ns** (−39%) |

## What changed

`get_property(idx, "title")` hashed the property name against the column index **on every call**. An operator looping over a million rows evaluating the same expression did that a million times to reach the same column — and the name is fixed at plan time.

Columns now have **stable ids**. `ColumnStore` holds a `Vec<Column>` with a name→id map beside it; a caller resolves the id once and reads by index. Ids are safe to cache because columns are only ever appended — `clear_row` clears a row's *values*, and nothing removes a column.

`PropertyCursor` is the caller. It memoises the column id on first read and is otherwise **indistinguishable** from `Value::resolve_property` — which is the point, and what `tests/property_cursor.rs` asserts by running both paths and comparing.

All four aggregate fold paths now read through cursors, for group keys and aggregate arguments alike.

## Two things it deliberately does not do

- **It does not cache a miss.** A later `SET` may create the column, so a cursor that remembered "no column" would keep returning null. There is a test.
- **It keeps the row-storage fallback.** A value whose type has no typed column representation is readable only from the per-node map (#545); dropping that path would silently return null for complex types. There is a test.

## The honest frame

The benchmark gained a **scattered-order** case, because the gap between access *orders* turned out larger than the gap this change closes:

```
dense int, id order        17.1 ns
dense int, scattered       22.9 ns
a bare Vec<i64>, id order   0.6 ns
a bare Vec<i64>, scattered  3.1 ns
```

Most of a scattered read is a DRAM round trip that no representation avoids. That matters because a scan reads in id order but **anything downstream of an `Expand` does not** — it arrives at nodes in adjacency order. Saying so is the right frame for what is left.

Also visible and worth its own work: **row storage costs 150 ns** against a column's 17 — 9×. That is #545.

## Testing

11 tests in `tests/property_cursor.rs`, all differential — same input, both paths, same answer. Covering: a column-backed read; an absent property; a column created *after* the cursor first missed; a value living only in row storage; a row with no value in a column that exists; an edge property; an unbound variable; a non-graph value (`datetime.year`); id stability across 64 appended columns; a recycled node id (#364); and a whole-graph fold against a hand-computed sum.

Suite on a dedicated box: **exit 0, 2,746 tests** (2,735 before, +11). LDBC SF1 unchanged at **21/21 in 24.2 s**.