### PR TITLE
Clone a record with room for the bindings about to be added

### DIFF
--- a/benches/record_ops.rs
+++ b/benches/record_ops.rs
@@ -145,7 +145,7 @@ fn main() {
     });
 
     // Binding, which every operator does to derive a row.
-    time("bind a 4th binding onto a 3-binding record", n / 5, || {
+    let grow_ns = time("clone, then bind a 4th (clone sized exactly)", n / 5, || {
         let mut acc = 0u64;
         for i in 0..(n / 5) {
             let mut copy = record.clone();
@@ -155,6 +155,32 @@ fn main() {
         acc
     });
 
+    let reserved_ns = time("clone_with_capacity(1), then bind a 4th", n / 5, || {
+        let mut acc = 0u64;
+        for i in 0..(n / 5) {
+            let mut copy = record.clone_with_capacity(1);
+            copy.bind("extra", Value::Property(PropertyValue::Integer(i as i64)));
+            acc = acc.wrapping_add(copy.bindings().len() as u64);
+        }
+        acc
+    });
+
+    // What an Expand binding a target and an edge variable pays.
+    time("clone_with_capacity(2), then bind two more", n / 5, || {
+        let mut acc = 0u64;
+        for i in 0..(n / 5) {
+            let mut copy = record.clone_with_capacity(2);
+            copy.bind("edge", Value::Property(PropertyValue::Integer(i as i64)));
+            copy.bind("target", Value::NodeRef(NodeId::from(i as u64)));
+            acc = acc.wrapping_add(copy.bindings().len() as u64);
+        }
+        acc
+    });
+
+    println!();
+    println!("Deriving a row: {grow_ns:.1} ns to clone and bind against {reserved_ns:.1} ns when the clone");
+    println!("reserves the room first. `Vec::clone` allocates exact capacity, so the next bind");
+    println!("reallocates -- and clone-then-bind is how nearly every operator derives a row (#562).");
     println!();
     println!("Lookup: {last:.1} ns by name against {by_slot:.1} ns by slot, and a name that is");
     println!("not bound costs {missing:.1} ns because the scan has to finish. Position matters --");

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -173,22 +173,22 @@ Samyama Graph's own results on the [LDBC Social Network Benchmark (SNB) Interact
 
 | Query | Name | SF1 | previous SF1 | SF10 |
 |---|---|---|---|---|
-| IC1 | Transitive Friends by Name | **62.0 ms** | 71.7 ms | 14.0 s |
-| IC2 | Recent Friend Posts | **12.2 ms** | 16.5 ms | 306 ms |
-| IC3 | Friends in Countries | **1044 ms** | 1101 ms | 15.7 s |
-| IC4 | Popular Tags in Period | **18.0 ms** | 16.2 ms | 527 ms |
-| IC5 | New Forum Members | **1874 ms** | 2614 ms | 31.1 s |
-| IC6 | Tag Co-occurrence | **173 ms** | 259 ms | 31.5 s |
-| IC7 | Recent Likers | **0.07 ms** | 0.07 ms | 1.70 ms |
-| IC8 | Recent Replies | **0.18 ms** | 0.18 ms | 4.00 ms |
-| IC9 | Recent FoF Posts | **1329 ms** | 1379 ms | 26.3 s |
-| IC10 | Friend Recommendation | **138 ms** | 160 ms | 2.3 s |
-| IC11 | Job Referral | **36.3 ms** | 44.8 ms | 4.5 s |
-| IC12 | Expert Reply | **151 ms** | 208 ms | 3.2 s |
-| IC13 | Single Shortest Path | **45.2 ms** | 46.3 ms | 37.00 ms |
-| IC14 | Trusted Connection Paths | **53.0 ms** | 54.0 ms | 696 ms |
+| IC1 | Transitive Friends by Name | **58.6 ms** | 62.0 ms | 14.0 s |
+| IC2 | Recent Friend Posts | **14.1 ms** | 12.2 ms | 306 ms |
+| IC3 | Friends in Countries | **990 ms** | 1044 ms | 15.7 s |
+| IC4 | Popular Tags in Period | **18.9 ms** | 18.0 ms | 527 ms |
+| IC5 | New Forum Members | **1828 ms** | 1874 ms | 31.1 s |
+| IC6 | Tag Co-occurrence | **174 ms** | 173 ms | 31.5 s |
+| IC7 | Recent Likers | **0.06 ms** | 0.07 ms | 1.70 ms |
+| IC8 | Recent Replies | **0.17 ms** | 0.18 ms | 4.00 ms |
+| IC9 | Recent FoF Posts | **1260 ms** | 1329 ms | 26.3 s |
+| IC10 | Friend Recommendation | **136 ms** | 138 ms | 2.3 s |
+| IC11 | Job Referral | **36.4 ms** | 36.3 ms | 4.5 s |
+| IC12 | Expert Reply | **121 ms** | 151 ms | 3.2 s |
+| IC13 | Single Shortest Path | **43.5 ms** | 45.2 ms | 37.00 ms |
+| IC14 | Trusted Connection Paths | **49.4 ms** | 53.0 ms | 696 ms |
 
-**Whole suite: 20.3 s, 21/21 passed, 0 empty, 0 errors.**
+**Whole suite: 19.3 s, 21/21 passed, 0 empty, 0 errors.**
 
 ### What the "previous SF1" column is
 
@@ -197,11 +197,15 @@ derived parameters (#505), so the two columns differ only by engine changes.
 Both were taken with the host calibration reported and matching, which is what
 makes them comparable at all (#529).
 
-This round: `id()` predicates now anchor a scan instead of filtering one (#538),
-aggregates group on identity and resolve their keys once per group (#521),
-property columns are located once per query rather than once per row (#557), and
-`Filter` decides whether to go parallel from the predicate's cost rather than
-from the batch size (#559). The last of those is most of IC1 and IC3.
+This round: a record is cloned with room for the bindings about to be added,
+so deriving a row no longer reallocates it (#562).
+
+The round before that — which the previous column reflects — was `id()`
+predicates anchoring a scan instead of filtering one (#538), aggregates grouping
+on identity and resolving their keys once per group (#521), property columns
+located once per query rather than once per row (#557), and `Filter` deciding
+whether to go parallel from the predicate's cost rather than the batch size
+(#559). Together those took the suite from 24.2 s to 20.3 s.
 
 Nothing here is a parameter change. The parameter shift that made several
 queries look slower — deriving substitution parameters from the dataset at the

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -708,7 +708,7 @@ fn eval_predicate_function(
 
     let mut true_count = 0usize;
     for item in &items {
-        let mut inner_record = record.clone();
+        let mut inner_record = record.clone_with_capacity(1);
         inner_record.bind(variable.to_string(), Value::Property(item.clone()));
         let result = eval_expression(predicate, &inner_record, store)?;
         if matches!(result, Value::Property(PropertyValue::Boolean(true))) {
@@ -831,7 +831,7 @@ fn eval_pattern_comprehension(
                                 if !matches { continue; }
                             } else { continue; }
                         }
-                        let mut temp_record = record.clone();
+                        let mut temp_record = record.clone_with_capacity(2);
                         if let Some(var) = start_var {
                             temp_record.bind(var.to_string(), Value::NodeRef(*node_id));
                         }
@@ -3361,7 +3361,14 @@ impl PhysicalOperator for ExpandOperator {
                 let (edge_id, src, tgt) = self.current_edges[self.edge_index];
                 self.edge_index += 1;
 
-                let mut new_record = self.current_record.as_ref().unwrap().clone();
+                // Room for the target, and for the edge and path variables when
+                // the pattern names them -- otherwise the first bind below
+                // reallocates a Vec that was cloned at exact capacity (#562).
+                let extra = 1
+                    + self.edge_var.is_some() as usize
+                    + self.path_variable.is_some() as usize;
+                let mut new_record =
+                    self.current_record.as_ref().unwrap().clone_with_capacity(extra);
 
                 // Determine target node based on direction
                 let target_id = match self.direction {
@@ -3419,7 +3426,14 @@ impl PhysicalOperator for ExpandOperator {
 
                 for i in 0..take {
                     let (edge_id, src, tgt) = self.current_edges[self.edge_index + i];
-                    let mut new_record = self.current_record.as_ref().unwrap().clone();
+                    // Room for the target, and for the edge and path variables when
+                // the pattern names them -- otherwise the first bind below
+                // reallocates a Vec that was cloned at exact capacity (#562).
+                let extra = 1
+                    + self.edge_var.is_some() as usize
+                    + self.path_variable.is_some() as usize;
+                let mut new_record =
+                    self.current_record.as_ref().unwrap().clone_with_capacity(extra);
 
                     let target_id = match self.direction {
                         Direction::Outgoing => tgt,

--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -159,6 +159,23 @@ impl Record {
         }
     }
 
+    /// Clone this record leaving room for `extra` further bindings.
+    ///
+    /// `Vec::clone` allocates *exact* capacity, so a cloned record has
+    /// `len == cap` and the very next `bind` reallocates: allocate, memcpy,
+    /// free. Clone-then-bind is how nearly every operator derives an output row
+    /// from an input row, so nearly every row in every query was paying for
+    /// that. Measured on a 3-binding record: 79.8 ns to clone, and 175.7 ns to
+    /// clone and bind a fourth -- 95.9 ns of the difference being the
+    /// reallocation alone (#562).
+    ///
+    /// Callers that bind a known number of variables should say how many.
+    pub fn clone_with_capacity(&self, extra: usize) -> Record {
+        let mut bindings = Vec::with_capacity(self.bindings.len() + extra);
+        bindings.extend(self.bindings.iter().cloned());
+        Record { bindings }
+    }
+
     /// Bind a variable to a value, replacing any previous binding.
     ///
     /// Accepts anything that converts to `Arc<str>`, so an operator holding

--- a/tests/record_capacity.rs
+++ b/tests/record_capacity.rs
@@ -1,0 +1,125 @@
+//! Deriving a row without reallocating it (#562).
+//!
+//! `Vec::clone` allocates *exact* capacity, so a cloned record has
+//! `len == cap` and the very next `bind` reallocates. Clone-then-bind is how
+//! nearly every operator derives an output row from an input row, so nearly
+//! every row in every query was paying for that: 79.8 ns to clone a 3-binding
+//! record and 175.7 ns to clone and bind a fourth.
+//!
+//! `clone_with_capacity` is a pure optimisation — it must be indistinguishable
+//! from `clone` in every observable way, which is what these assert. The
+//! capacity itself is checked through `Record`'s behaviour rather than by
+//! reaching into the `Vec`, so the test does not pin the representation.
+
+use samyama::graph::{NodeId, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Record, Value};
+use samyama::query::parser::parse_query;
+
+fn sample() -> Record {
+    let mut r = Record::new();
+    r.bind("person", Value::NodeRef(NodeId::from(1u64)));
+    r.bind("friend", Value::NodeRef(NodeId::from(2u64)));
+    r.bind("n", Value::Property(PropertyValue::Integer(7)));
+    r
+}
+
+#[test]
+fn it_copies_every_binding() {
+    let original = sample();
+    let copy = original.clone_with_capacity(3);
+    assert_eq!(copy.bindings(), original.bindings());
+}
+
+#[test]
+fn zero_extra_is_a_plain_clone() {
+    let original = sample();
+    assert_eq!(original.clone_with_capacity(0).bindings(), original.clone().bindings());
+}
+
+#[test]
+fn an_empty_record_survives_it() {
+    let empty = Record::new();
+    let copy = empty.clone_with_capacity(4);
+    assert!(copy.bindings().is_empty());
+}
+
+#[test]
+fn reserving_more_than_is_used_is_harmless() {
+    // Operators reserve for bindings a pattern *may* have — an edge variable,
+    // a path variable — and often bind fewer.
+    let mut copy = sample().clone_with_capacity(10);
+    copy.bind("extra", Value::Property(PropertyValue::Integer(1)));
+    assert_eq!(copy.bindings().len(), 4);
+    assert_eq!(
+        copy.get("extra"),
+        Some(&Value::Property(PropertyValue::Integer(1)))
+    );
+}
+
+#[test]
+fn rebinding_an_existing_name_still_replaces_rather_than_appends() {
+    // The reserved room must not turn `bind` into a push. A second bind of the
+    // same name replaces, and a record with two `person` entries would make
+    // `get` return whichever came first.
+    let mut copy = sample().clone_with_capacity(4);
+    copy.bind("person", Value::NodeRef(NodeId::from(99u64)));
+    assert_eq!(copy.bindings().len(), 3, "rebinding must not append");
+    assert_eq!(copy.get("person"), Some(&Value::NodeRef(NodeId::from(99u64))));
+}
+
+#[test]
+fn the_original_is_untouched() {
+    let original = sample();
+    let mut copy = original.clone_with_capacity(2);
+    copy.bind("added", Value::Property(PropertyValue::Integer(5)));
+    assert_eq!(original.bindings().len(), 3);
+    assert!(original.get("added").is_none());
+}
+
+#[test]
+fn an_expand_returns_the_same_rows_as_before() {
+    // End to end: ExpandOperator now reserves before binding the target, the
+    // edge variable and the path variable. Every combination of those, since
+    // the reservation is computed from which of them the pattern names.
+    let mut store = samyama::graph::GraphStore::new();
+    let hub = store.create_node("Hub");
+    for i in 0..200i64 {
+        let n = store.create_node("N");
+        let _ = store.set_node_property("default", n, "v".to_string(), PropertyValue::Integer(i));
+        let e = store.create_edge(n, hub, "IN").unwrap();
+        let _ = store.set_edge_property(e, "w", PropertyValue::Integer(i * 2));
+    }
+
+    let count = |cypher: &str| -> usize {
+        let query = parse_query(cypher).expect("query should parse");
+        QueryExecutor::new(&store).execute(&query).expect("query should run").records.len()
+    };
+
+    // No edge variable, no path variable.
+    assert_eq!(count("MATCH (h:Hub)<-[:IN]-(n:N) RETURN n.v"), 200);
+    // An edge variable.
+    assert_eq!(count("MATCH (h:Hub)<-[e:IN]-(n:N) RETURN n.v, e.w"), 200);
+    // A path variable.
+    assert_eq!(count("MATCH p = (h:Hub)<-[:IN]-(n:N) RETURN length(p)"), 200);
+    // Both.
+    assert_eq!(count("MATCH p = (h:Hub)<-[e:IN]-(n:N) RETURN length(p), e.w"), 200);
+
+    // And the values, not just the count — a mis-sized reservation that
+    // silently dropped a binding would keep the row count right.
+    let query = parse_query("MATCH (h:Hub)<-[e:IN]-(n:N) WHERE n.v = 5 RETURN e.w AS w").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    assert_eq!(batch.records.len(), 1);
+    assert_eq!(batch.records[0].get("w"), Some(&Value::Property(PropertyValue::Integer(10))));
+}
+
+#[test]
+fn unwind_still_binds_one_variable_per_item() {
+    let store = samyama::graph::GraphStore::new();
+    let query = parse_query("UNWIND [1, 2, 3] AS x RETURN x").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    assert_eq!(batch.records.len(), 3);
+    assert_eq!(
+        batch.records[2].get("x"),
+        Some(&Value::Property(PropertyValue::Integer(3)))
+    );
+}


### PR DESCRIPTION
Closes #562. Re-scopes #546.

## Measured

Dedicated box, a 3-binding record:

| operation | before | after |
|---|---:|---:|
| clone, then bind a 4th | 168.5 ns | **106.5 ns** (−37%) |

`Vec::clone` allocates **exact** capacity, so a cloned record has `len == cap` and the very next `bind` reallocates — allocate, memcpy, free. Clone-then-bind is how nearly every operator derives an output row from an input row, so nearly every row in every query was paying for it.

## LDBC SNB Interactive SF1

Same host, calibration matching at 43 ms / 1996 MHz.

| | before | after |
|---|---:|---:|
| IC1 Transitive Friends by Name | 62.0 ms | **58.6 ms** |
| IC3 Friends in Countries | 1044 ms | **990 ms** |
| IC9 Recent FoF Posts | 1329 ms | **1260 ms** |
| IC12 Expert Reply | 151 ms | **121 ms** |
| IC14 Trusted Connection Paths | 53.0 ms | **49.4 ms** |
| **whole suite** | **20.3 s** | **19.3 s** |

21/21 passing. `docs/BENCHMARKS.md` updated.

## Where it applies

`ExpandOperator` reserves for the target plus the edge and path variables **when the pattern names them**; `UNWIND` reserves one; the pattern-expansion helper reserves two.

Over-reserving is harmless, and there is a test saying so — worth having, because the reservation is computed from which variables a pattern happens to name, and getting it low is a silent 62 ns rather than a failure.

## This re-scopes #546

#546 proposes replacing binding names with **slots assigned at plan time**, on the strength of a `HashMap<String, Value>` per row hashed with SipHash. Phases 1 and 2 removed that. Measuring what is actually left:

| | ns |
|---|---:|
| `get` by name, last of 3 bindings | 4.9 |
| a `Vec<Value>` indexed by slot | 0.8 |
| clone a record | 76.6 |
| — of which `Arc<str>` refcount traffic | 16.1 |

So slots buy roughly **4 ns per lookup and 13 ns per clone** — against the **62 ns** that was sitting in a reallocation nobody had looked for, and they require touching every operator that constructs a row.

#546's own text contains the right answer — "one `Vec` allocation of known size, **or none if reused**". The reuse is the win; the slot indexing is a detail. That issue should be re-read against these numbers before phase 3 starts.

## Testing

8 tests in `tests/record_capacity.rs`. `clone_with_capacity` is a pure optimisation, so most of them assert it is **indistinguishable** from `clone`: every binding copied, zero-extra equals a plain clone, an empty record survives, the original is untouched, and — the one that would actually break — **rebinding an existing name still replaces rather than appends**, since reserved room must not turn `bind` into a push.

Plus an end-to-end expand over all four combinations of edge variable and path variable present or absent, checking values and not only row counts: a mis-sized reservation that dropped a binding would keep the row count right.

Suite on a dedicated box: **exit 0, 2,760 tests** (2,752 before, +8).