### PR TITLE
Stop Expand allocating its variable names on every output row

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -173,22 +173,22 @@ Samyama Graph's own results on the [LDBC Social Network Benchmark (SNB) Interact
 
 | Query | Name | SF1 | previous SF1 | SF10 |
 |---|---|---|---|---|
-| IC1 | Transitive Friends by Name | **58.6 ms** | 62.0 ms | 14.0 s |
-| IC2 | Recent Friend Posts | **14.1 ms** | 12.2 ms | 306 ms |
-| IC3 | Friends in Countries | **990 ms** | 1044 ms | 15.7 s |
-| IC4 | Popular Tags in Period | **18.9 ms** | 18.0 ms | 527 ms |
-| IC5 | New Forum Members | **1828 ms** | 1874 ms | 31.1 s |
-| IC6 | Tag Co-occurrence | **174 ms** | 173 ms | 31.5 s |
-| IC7 | Recent Likers | **0.06 ms** | 0.07 ms | 1.70 ms |
-| IC8 | Recent Replies | **0.17 ms** | 0.18 ms | 4.00 ms |
-| IC9 | Recent FoF Posts | **1260 ms** | 1329 ms | 26.3 s |
-| IC10 | Friend Recommendation | **136 ms** | 138 ms | 2.3 s |
-| IC11 | Job Referral | **36.4 ms** | 36.3 ms | 4.5 s |
-| IC12 | Expert Reply | **121 ms** | 151 ms | 3.2 s |
-| IC13 | Single Shortest Path | **43.5 ms** | 45.2 ms | 37.00 ms |
-| IC14 | Trusted Connection Paths | **49.4 ms** | 53.0 ms | 696 ms |
+| IC1 | Transitive Friends by Name | **59.5 ms** | 58.6 ms | 14.0 s |
+| IC2 | Recent Friend Posts | **9.7 ms** | 14.1 ms | 306 ms |
+| IC3 | Friends in Countries | **861 ms** | 990 ms | 15.7 s |
+| IC4 | Popular Tags in Period | **14.1 ms** | 18.9 ms | 527 ms |
+| IC5 | New Forum Members | **1204 ms** | 1828 ms | 31.1 s |
+| IC6 | Tag Co-occurrence | **185 ms** | 174 ms | 31.5 s |
+| IC7 | Recent Likers | **0.06 ms** | 0.06 ms | 1.70 ms |
+| IC8 | Recent Replies | **0.15 ms** | 0.17 ms | 4.00 ms |
+| IC9 | Recent FoF Posts | **1194 ms** | 1260 ms | 26.3 s |
+| IC10 | Friend Recommendation | **102 ms** | 136 ms | 2.3 s |
+| IC11 | Job Referral | **31.4 ms** | 36.4 ms | 4.5 s |
+| IC12 | Expert Reply | **86.2 ms** | 121 ms | 3.2 s |
+| IC13 | Single Shortest Path | **43.1 ms** | 43.5 ms | 37.00 ms |
+| IC14 | Trusted Connection Paths | **50.9 ms** | 49.4 ms | 696 ms |
 
-**Whole suite: 19.3 s, 21/21 passed, 0 empty, 0 errors.**
+**Whole suite: 15.8 s, 21/21 passed, 0 empty, 0 errors.**
 
 ### What the "previous SF1" column is
 
@@ -197,15 +197,22 @@ derived parameters (#505), so the two columns differ only by engine changes.
 Both were taken with the host calibration reported and matching, which is what
 makes them comparable at all (#529).
 
-This round: a record is cloned with room for the bindings about to be added,
-so deriving a row no longer reallocates it (#562).
+This round: `Expand` holds its variable names as `Arc<str>`, so binding one on
+an output row is a refcount bump rather than two heap allocations, and it
+refills its edge buffer instead of allocating a new one per source record
+(#564). IC5 is a third faster on that alone.
 
-The round before that — which the previous column reflects — was `id()`
-predicates anchoring a scan instead of filtering one (#538), aggregates grouping
-on identity and resolving their keys once per group (#521), property columns
-located once per query rather than once per row (#557), and `Filter` deciding
-whether to go parallel from the predicate's cost rather than the batch size
-(#559). Together those took the suite from 24.2 s to 20.3 s.
+The rounds before, which is what the previous column and the ones before it
+reflect: records cloned with room for the bindings about to be added (#562);
+`id()` predicates anchoring a scan instead of filtering one (#538); aggregates
+grouping on identity and resolving their keys once per group (#521); property
+columns located once per query rather than once per row (#557); and `Filter`
+deciding whether to go parallel from the predicate's cost rather than the batch
+size (#559).
+
+Together, over this sequence, the suite went from **24.2 s to 15.8 s** on the
+same host at the same derived parameters — a 35% reduction, all of it in
+per-row constants rather than in algorithms.
 
 Nothing here is a parameter change. The parameter shift that made several
 queries look slower — deriving substitution parameters from the dataset at the

--- a/docs/product/oeh-hierarchy-prompt.md
+++ b/docs/product/oeh-hierarchy-prompt.md
@@ -1,0 +1,170 @@
+# Prompt: OEH hierarchy index + ontology-scale HIER benchmark for samyama-graph (OSS)
+
+You are working in `/home/vm-1/projects/graph_ws/samyama-graph` (OSS, Rust, v0.9.0).
+Read `CLAUDE.md` first. TDD at all times; `cargo test && cargo fmt -- --check && cargo clippy -- -D warnings`
+must pass before every commit. `export PATH="$HOME/.cargo/bin:$PATH"`.
+
+## Source of the capability
+
+Implement the capabilities of **arXiv:2606.24677 — "One Index for Subsumption and Roll-up
+across Time, Geography, and Ontology"** (Mandarapu & Kunkunuru) inside the engine.
+The validated Python reference implementation is a sibling repo:
+`../relationship-hierarchy-index/src/relhier/` (`poset.py`, `oeh.py`, `oracle.py`,
+`baselines/{grail,pll,transitive_closure}.py`, `datasets/`). Port its semantics, not its code
+shape — it is pure Python and single-threaded; you are writing a storage-engine index.
+
+The core claim to reproduce in the engine: time, geography and ontology are all
+**subsumption posets** with one shared workload — **order testing** (`is x under y?`) and
+**hierarchical roll-up** (aggregate a measure over everything under `y`) — and one
+structure-selected index answers both, with the roll-up answered *from* the index
+(index-resident), not by a join-group-aggregate the index merely filters.
+
+## Part 1 — Engine capability: the OEH index
+
+Add a new declarable index type alongside `src/index/{property_index,manager}.rs`.
+Write `docs/ADR/ADR-035-oeh-hierarchy-index.md` first (next free number; 034 is taken by
+the unified-memory seam) and let the ADR drive the implementation.
+
+1. **Structural probe.** Given a relationship type (or a set of them) forming the covering
+   relation, classify the poset cheaply: tree / low-width DAG / high-width DAG. Reproduce
+   the reference's `~8√n` width cap and its *decline* path — above the cap the index must
+   refuse to build and the planner must fall back to the existing traversal/2-hop route.
+   The decline is a feature; do not paper over it.
+2. **Tree → nested-set order embedding.** DFS `[in,out]` interval per node, 2 ints/node;
+   subsumption is 2-D containment in O(1). The subtree of `y` is a contiguous in-order
+   range, so roll-up is a **Fenwick range-sum in O(log n)**.
+3. **Low-width DAG → chain decomposition** (Jagadish chain index). Descendants on a chain
+   are a contiguous suffix ⇒ set-semantics roll-up is Σ of per-chain suffix sums —
+   **exact and double-count-free**. Double counting on multi-parent DAGs is the single
+   easiest correctness bug here; make it an explicit test class.
+4. **Monoid roll-up.** Parameterize over a commutative monoid: `SUM`, `COUNT`, `MIN`, `MAX`,
+   and a generic `(identity, combine)` seam. Non-invertible monoids (MIN/MAX) cannot use a
+   Fenwick difference — use a sparse table / segment tree for those; state the choice in the ADR.
+5. **Persistence + lifecycle.** Serialize into the `.sgsnap` snapshot format (see
+   ADR-022) so an imported snapshot does not silently lose the index. OEH is a **static**
+   index: define write behaviour explicitly — mark stale on mutation of the hierarchy edge
+   type, serve from the stale index only when the query opts in, and provide an explicit
+   rebuild. Online insert/delete is out of scope for v1; say so in the ADR's non-goals.
+   Note the known quirk: after snapshot import, `node.properties` is empty and values must
+   be read via node_columns — the measure attribute the roll-up aggregates lives in the
+   columnar store, so wire it there, not through the property map.
+
+## Part 2 — Query surface and planner integration
+
+The index is worthless if users must call it explicitly. Make the optimizer pick it up.
+
+- **DDL**: `CREATE HIERARCHY INDEX <name> ON ()-[:IS_A|PART_OF]->() [MEASURE <Label>.<prop>]`
+  and the matching `DROP`/`SHOW`. Follow the existing Cypher DDL grammar; heed the PEG
+  ordering trap in the parser (longest alternative first) documented in the repo's lessons.
+- **Predicate rewrite**: `MATCH (x)-[:IS_A*]->(y)` / `*0..` / `EXISTS { (x)-[:IS_A*]->(y) }`
+  used as an existence test must rewrite to an O(1) order test, not a var-length expansion.
+- **Roll-up rewrite**: `MATCH (d)-[:IS_A*0..]->(root {id:$r}) RETURN sum(d.measure)` must
+  rewrite to a single index-resident range-sum. This is the headline result — a rewrite that
+  turns O(subtree) into O(log n).
+- **New physical operators** visible in `EXPLAIN`: `HierarchyOrderTest`, `HierarchyRollup`,
+  `HierarchyDescendantScan`. Add cost-model entries so the planner chooses them on cost,
+  and add planner regression tests asserting the plan shape (not just the answer).
+- Also expose the direct functions `subsumes(a, b)` and `hierarchy_rollup(root, 'measure', 'sum')`
+  for cases the rewrite cannot reach.
+- Cypher literal quirks apply to the tests: use double-quoted strings, and beware
+  float-vs-int comparison in `WHERE` silently returning empty.
+
+## Part 3 — Ontology-enriched large-scale benchmark data
+
+Take the existing large-scale corpus (the 200M-node / multi-KG federation and the
+500-query mega benchmark) and add the hierarchy backbones it currently lacks. The KGs are
+siblings in `graph_ws/`: `pubmed-kg`, `clinicaltrials-kg`, `druginteractions-kg`,
+`mitre-attack-kg`, `nvd-cve-kg`, `d3fend-kg`, `telecom-kg`, `powergrid-kg`, `pathways-kg`.
+
+Attach, as loaders under `examples/` following the existing `*_loader` pattern:
+
+| Axis | Ontology / dimension | Attach to |
+|---|---|---|
+| Ontology (taxonomic) | **NCBI Taxonomy** (1.3M, tree) | pubmed-kg organisms |
+| Ontology (disease) | **MONDO** / **ICD-10** (tree-ish) | clinicaltrials-kg conditions, pubmed-kg MeSH |
+| Ontology (drug) | **ATC** (strict 5-level tree) | druginteractions-kg |
+| Ontology (bio-process) | **Gene Ontology** (high-width DAG) | pathways-kg — expected to **decline**, keep it |
+| Geography | **GeoNames** (330k) + country/state/city/zip | trial sites, telecom cells, grid substations |
+| Time | generated **calendar dimension** (day ⊑ month ⊑ quarter ⊑ year, ~2.6M rows) | every timestamped edge |
+| Threat | **MITRE ATT&CK** tactic ⊑ technique ⊑ sub-technique, **CWE** tree | mitre-attack-kg, nvd-cve-kg |
+| Industry/asset | **NAICS** or **ISA-95** equipment hierarchy | telecom-kg, powergrid-kg |
+
+Ground rules: public-data KGs stay public on GitHub with a Gitea mirror; anything
+license-restricted (UMLS/SNOMED — see the UMLS licence process) must be gated behind an
+opt-in loader flag and must not be committed as data. Record provenance in the S3
+MANIFEST/PROVENANCE/INDEX convention under the `samyama-ai` profile. Any big load runs on
+**spot instances only**, resumable, and you verify no orphaned instances afterwards.
+
+## Part 4 — The new benchmark category: HIER
+
+Create a new benchmark category for hierarchy-heavy complex queries — the existing LDBC
+SNB / BI / FinBench / Graphalytics suites contain almost no subsumption or roll-up, which
+is exactly why this capability is invisible today. Deliver:
+
+- `benches/hierarchy_benchmark.rs` (Criterion, follows `ldbc_bi_benchmark.rs` conventions)
+- `benchmarks/hier/` — the query corpus as data (YAML/JSON: id, class, cypher, params,
+  expected-shape, oracle spec), a runner, and committed `results/*.csv` + figures.
+
+**Target ≥100 queries across these classes** (name them H1…H10, keep IDs out of engine source):
+
+- **H1 Order test** — is `x` under `y`, over each axis, at each depth.
+- **H2 Single roll-up** — aggregate a measure over a subtree, across subtree sizes spanning
+  4 orders of magnitude.
+- **H3 Level roll-up** — group-by-level (`GROUP BY depth`), the classic OLAP shape.
+- **H4 Cross-hierarchy conjunction** — *the paper's whole point*: ontology × time × geography
+  in one query ("all trials for any descendant of MONDO:X, in any city under state Y,
+  in any month under 2025"). One index type, three axes, no per-silo machinery.
+- **H5 Hierarchy × traversal** — k-hop graph traversal whose predicate is a subsumption test
+  (drug interaction paths where both endpoints are under an ATC class).
+- **H6 Anti-subsumption / negation** — `NOT` under `y`, and set-difference of two subtrees.
+- **H7 LCA / merge-base** — lowest common ancestor; validate against `git merge-base`
+  the way the reference repo does.
+- **H8 Top-k over roll-up** — rank subtrees by rolled-up measure; forces roll-up in a loop.
+- **H9 Hierarchy-filtered vector search** — ANN restricted to a subtree (this is where a
+  graph engine beats a time-series DB; the paper's TimescaleDB baseline cannot express it).
+- **H10 Temporal roll-up windows** — sliding month/quarter aggregates, head-to-head with
+  the TimescaleDB continuous-aggregate numbers from the paper.
+
+**Baselines, per query**: (a) same Cypher with the OEH index disabled (recursive var-length
+traversal) — the honest in-engine before/after; (b) the 2-hop/PLL path where the index
+declines; (c) where the data permits, Neo4j and TigerGraph via
+`../samyama-graph-competitor-benchmarks`; (d) for H10, TimescaleDB continuous aggregates.
+
+**Report**: latency p50/p99, build time, index bytes/node, and speedup — plus a
+*regime plot* showing where the index declines and the fallback takes over. Reproduce the
+paper's claims in-engine or report the delta honestly: ~half the space and 6–7× faster build
+vs PLL at query parity on trees; index-resident roll-up in the single-digit-µs regime.
+
+**Correctness is the gate, not a footnote.** Every HIER query is validated against a
+brute-force oracle (port `oracle.py`) on a small graph and against a materialized
+ground-truth table at scale. A roll-up that double-counts on a multi-parent DAG is a
+release blocker. Exactness against TimescaleDB must match to the unit
+(the reference gets day 704,800 / month 21,168,000 exactly).
+
+## Phasing (fail-fast — do not start a stage until the prior gate is green)
+
+1. ADR-035 written and self-consistent → 2. poset + probe + nested-set + oracle tests →
+3. chain decomposition + double-count tests → 4. monoid roll-up (Fenwick / segment tree) →
+5. snapshot persistence + staleness → 6. DDL + planner rewrites + EXPLAIN + cost model →
+7. ontology loaders + provenance → 8. HIER corpus + runner + baselines →
+9. results, figures, `docs/BENCHMARKS.md` + README, ADR closed out.
+
+Stop and report at any gate that cannot be made green, rather than routing around it.
+
+## Deliverables and process
+
+- Code, tests (aim 95%+ coverage on new modules), ADR-035, `docs/BENCHMARKS.md` section,
+  README mention, committed results CSVs and figures.
+- Ship **GitHub-first** on `samyama-graph`, then mirror to Gitea. Raise, approve and merge
+  the PR in the same turn. No `Co-Authored-By` trailers.
+- No benchmark IDs, customer or prospect names in engine source — describe patterns
+  domain-agnostically; the HIER IDs live in `benchmarks/hier/` data files only.
+- Update the `samyama-cloud` wiki with what changed.
+
+## Honest scope to preserve
+
+Carry the reference repo's "Honest scope" section into the ADR: OEH is static; order
+embedding / nested sets / dominance-as-subsumption are classical prior art built upon, not
+claimed; the contribution is the **unification** plus **index-resident roll-up**. Genuinely
+low-width multi-parent DAGs are rare in practice — if the ontology corpus mostly yields
+trees and high-width DAGs, say that in the results rather than selecting datasets to hide it.

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -64,6 +64,7 @@
 //! - `HashMap` — build phase of hash joins in `JoinOperator`
 //! - `BTreeSet` — sorted unique results where ordering matters
 
+use std::sync::Arc;
 use crate::query::executor::record::PropertyCursor;
 use crate::graph::{GraphStore, Label, NodeId, EdgeType};
 use crate::query::ast::{Expression, BinaryOp, UnaryOp, Direction, Pattern};
@@ -3191,12 +3192,18 @@ impl PhysicalOperator for FilterOperator {
 pub struct ExpandOperator {
     /// Input operator
     input: OperatorBox,
-    /// Source variable
-    source_var: String,
+    /// Source variable.
+    ///
+    /// `Arc<str>` rather than `String` because `Record::bind` takes
+    /// `impl Into<Arc<str>>`: passing a `String` allocates twice per bind --
+    /// once to clone the `String`, once to build the `Arc<str>` from it -- for
+    /// a name that is fixed for the whole query. On IC5 that was 3.4 million
+    /// allocations for the target variable alone (#564).
+    source_var: Arc<str>,
     /// Target variable
-    target_var: String,
+    target_var: Arc<str>,
     /// Edge variable (optional)
-    edge_var: Option<String>,
+    edge_var: Option<Arc<str>>,
     /// Edge types to expand (empty = all types)
     edge_types: Vec<String>,
     /// Target node labels to filter (empty = any label)
@@ -3234,9 +3241,9 @@ impl ExpandOperator {
     ) -> Self {
         Self {
             input,
-            source_var,
-            target_var,
-            edge_var,
+            source_var: source_var.into(),
+            target_var: target_var.into(),
+            edge_var: edge_var.map(Into::into),
             edge_types,
             target_labels: Vec::new(),
             direction,
@@ -3250,7 +3257,7 @@ impl ExpandOperator {
 
     /// Set path variable for named path materialization (CY-04)
     pub fn with_path_variable(mut self, var: String) -> Self {
-        self.path_variable = Some(var);
+        self.path_variable = Some(var.into());
         self
     }
 
@@ -3266,24 +3273,21 @@ impl ExpandOperator {
     /// named types none of which exist returns `Some(empty)`, which matches
     /// nothing; conflating the two makes `-[:NO_SUCH_TYPE]->` follow every
     /// edge in the graph (#520).
-    fn type_ids(&mut self, store: &GraphStore) -> Option<Vec<u16>> {
-        if self.edge_types.is_empty() {
-            return None;
+    fn ensure_type_ids(&mut self, store: &GraphStore) {
+        if self.edge_types.is_empty() || self.type_ids.is_some() {
+            return;
         }
-        if self.type_ids.is_none() {
-            let ids = self
-                .edge_types
-                .iter()
-                .filter_map(|t| store.edge_type_id(&EdgeType::new(t.as_str())))
-                .collect();
-            self.type_ids = Some(ids);
-        }
-        self.type_ids.clone()
+        let ids = self
+            .edge_types
+            .iter()
+            .filter_map(|t| store.edge_type_id(&EdgeType::new(t.as_str())))
+            .collect();
+        self.type_ids = Some(ids);
     }
 
     fn load_edges(&mut self, record: &Record, store: &GraphStore) -> ExecutionResult<()> {
         let source_val = record.get(&self.source_var)
-            .ok_or_else(|| ExecutionError::VariableNotFound(self.source_var.clone()))?;
+            .ok_or_else(|| ExecutionError::VariableNotFound(self.source_var.to_string()))?;
 
         let node_id = source_val.node_id()
             .ok_or_else(|| ExecutionError::TypeError(format!("{} is not a node", self.source_var)))?;
@@ -3298,10 +3302,15 @@ impl ExpandOperator {
         // `HAS_CREATOR` from every post and comment they wrote, `LIKES`,
         // `HAS_MEMBER`, `HAS_INTEREST`), so a `[:KNOWS]` expansion cloned ~900
         // strings to keep 41 (#520).
-        let type_ids = self.type_ids(store);
-        let type_filter = type_ids.as_deref();
+        self.ensure_type_ids(store);
 
-        let mut collected: Vec<(crate::graph::EdgeId, NodeId, NodeId)> = Vec::new();
+        // Refill the existing buffer. Allocating a fresh `Vec` per source
+        // record meant one allocation plus roughly log2(degree) reallocations
+        // as it doubled, and a free of the previous one -- once per source, for
+        // a buffer that is the same shape every time (#564).
+        let mut collected = std::mem::take(&mut self.current_edges);
+        collected.clear();
+        let type_filter = self.type_ids.as_deref();
         match self.direction {
             Direction::Outgoing => {
                 store.for_each_outgoing_neighbor(node_id, type_filter, |target, eid| {
@@ -3590,19 +3599,16 @@ impl VarLengthExpandOperator {
     /// `Some(empty)`, which matches nothing. Collapsing those two cases makes
     /// `-[:NO_SUCH_TYPE*1..3]->` follow every edge in the graph; a test does
     /// exactly that, and it failed against the first version of this.
-    fn type_ids(&mut self, store: &GraphStore) -> Option<Vec<u16>> {
-        if self.edge_types.is_empty() {
-            return None;
+    fn ensure_type_ids(&mut self, store: &GraphStore) {
+        if self.edge_types.is_empty() || self.type_ids.is_some() {
+            return;
         }
-        if self.type_ids.is_none() {
-            let ids = self
-                .edge_types
-                .iter()
-                .filter_map(|t| store.edge_type_id(&EdgeType::new(t.as_str())))
-                .collect();
-            self.type_ids = Some(ids);
-        }
-        self.type_ids.clone()
+        let ids = self
+            .edge_types
+            .iter()
+            .filter_map(|t| store.edge_type_id(&EdgeType::new(t.as_str())))
+            .collect();
+        self.type_ids = Some(ids);
     }
 
     /// Visit each one-hop neighbour of `node` honouring direction and the
@@ -3658,7 +3664,11 @@ impl VarLengthExpandOperator {
             self.buffer(record, source_id, &parent, source_id);
         }
 
-        let type_ids: Option<Vec<u16>> = self.type_ids(store);
+        // Cloned rather than borrowed: the BFS below calls `&mut self` methods
+        // to buffer output records, so an outstanding borrow of `self.type_ids`
+        // would not live. This is once per source record, not once per row.
+        self.ensure_type_ids(store);
+        let type_ids: Option<Vec<u16>> = self.type_ids.clone();
         let type_filter = type_ids.as_deref();
 
         let mut frontier = vec![source_id];
@@ -9177,19 +9187,16 @@ impl ShortestPathOperator {
 
     /// The edge-type filter as interned ids. `None` is the wildcard; an
     /// unknown type yields `Some(empty)`, which matches nothing.
-    fn type_ids(&mut self, store: &GraphStore) -> Option<Vec<u16>> {
-        if self.edge_types.is_empty() {
-            return None;
+    fn ensure_type_ids(&mut self, store: &GraphStore) {
+        if self.edge_types.is_empty() || self.type_ids.is_some() {
+            return;
         }
-        if self.type_ids.is_none() {
-            let ids = self
-                .edge_types
-                .iter()
-                .filter_map(|t| store.edge_type_id(&EdgeType::new(t.as_str())))
-                .collect();
-            self.type_ids = Some(ids);
-        }
-        self.type_ids.clone()
+        let ids = self
+            .edge_types
+            .iter()
+            .filter_map(|t| store.edge_type_id(&EdgeType::new(t.as_str())))
+            .collect();
+        self.type_ids = Some(ids);
     }
 
     fn for_each_neighbor(
@@ -9211,7 +9218,10 @@ impl ShortestPathOperator {
 
     fn execute_all(&mut self, store: &GraphStore) -> ExecutionResult<()> {
         let mut all_results = Vec::new();
-        let type_ids = self.type_ids(store);
+        // Cloned rather than borrowed: the loop below pulls from `self.input`,
+        // which needs `&mut self`. Once per query, not once per row.
+        self.ensure_type_ids(store);
+        let type_ids = self.type_ids.clone();
         let type_filter = type_ids.as_deref();
 
         while let Some(record) = self.input.next(store)? {


### PR DESCRIPTION
Closes #564.

## LDBC SNB Interactive SF1

Same host, calibration matching at 43 ms / 1996 MHz.

| | before | after | |
|---|---:|---:|---:|
| IC2 Recent Friend Posts | 14.1 ms | **9.7 ms** | −31% |
| IC3 Friends in Countries | 990 ms | **861 ms** | −13% |
| IC4 Popular Tags in Period | 18.9 ms | **14.1 ms** | −25% |
| **IC5 New Forum Members** | 1828 ms | **1204 ms** | **−34%** |
| IC9 Recent FoF Posts | 1260 ms | **1194 ms** | −5% |
| IC10 Friend Recommendation | 136 ms | **102 ms** | −25% |
| IC11 Job Referral | 36.4 ms | **31.4 ms** | −14% |
| IC12 Expert Reply | 121 ms | **86.2 ms** | −29% |
| **whole suite** | **19.3 s** | **15.8 s** | **−18%** |

21/21 passing.

## What it was

`ExpandOperator` held its variable names as `String`, and the per-output-row loop did:

```rust
new_record.bind(self.target_var.clone(), Value::NodeRef(target_id));
```

`Record::bind` takes `impl Into<Arc<str>>`, so each row paid **twice**: once to clone the `String`, once to build an `Arc<str>` from it. **Two heap allocations per output row**, for a name fixed for the whole query — 3.4 million of them on IC5. A pattern naming an edge variable paid it again.

`bind`'s own documentation says the fix — *"an operator holding its variable name as an `Arc<str>` binds with a refcount bump"*. The mechanism arrived with #546 phase 2; this operator was never converted to use it.

## Two more, per source record

- `load_edges` allocated a **fresh `Vec` per source record**, grew it by doubling, and dropped the previous one. It now refills the existing buffer, keeping its capacity.
- `type_ids` returned a **cloned `Vec<u16>` per call**. `ExpandOperator` now borrows it.

`VarLengthExpand` and `ShortestPath` still clone, because both call `&mut self` methods while the filter is live. That is once per source and once per query respectively — noted at each site rather than left to be rediscovered.

## Why IC9 moves least

Its profile says it directly: IC9's Expand **binds no edge variable**, so it saved one allocation pair per row where IC5 saved two over four times as many rows. Expand self time 810 ms → 748 ms, still 54.7% of the query — the rest of IC9 is `Sort` (23.3%) and `Filter` (15.4%).

## Testing

Suite on a dedicated box: **exit 0, 2,760 tests, 0 failures.** No new tests here: this is a representation change behind an unchanged public constructor, and the behaviour it could break — variable binding through every combination of edge and path variable — is already covered by `tests/record_capacity.rs`, `tests/varlength_expand_semantics.rs` and `tests/shortest_path_semantics.rs`, which all pass.

## Cumulative

With #538, #521, #557, #559 and #562, the SF1 suite has gone from **24.2 s to 15.8 s** on the same host at the same derived parameters — **−35%**, all of it in per-row constants rather than algorithms. `docs/BENCHMARKS.md` records the sequence.