### PR TITLE
Locate a sort key's column once per query, not once per row

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,3 +199,7 @@ harness = false
 [[bench]]
 name = "adjacency_walk"
 harness = false
+
+[[bench]]
+name = "sort_topn"
+harness = false

--- a/benches/sort_topn.rs
+++ b/benches/sort_topn.rs
@@ -1,0 +1,90 @@
+//! What a bounded `ORDER BY … LIMIT k` costs, by input order (#568, #518).
+//!
+//! Input order is the parameter, because a top-k over data already sorted by
+//! the key is a different path from one over scattered data — and because it is
+//! what decided a rejection-cutoff optimisation was not worth having. The
+//! cutoff (discard a row once the buffer's worst retained key bounds it) was
+//! 1-8% *slower* in every column below: records are moved into the buffer
+//! rather than cloned, so skipping the move saves little, and the extra
+//! comparison costs more than it saves.
+//!
+//! What did help was locating the sort key's column once instead of once per
+//! row (#557), which is what the operator now does:
+//!
+//! | input order | before | after |
+//! |---|---:|---:|
+//! | best-first  | 176.8 ms | 154.5 ms |
+//! | scattered   | 256.4 ms | 251.3 ms |
+//! | worst-first | 243.3 ms | 232.1 ms |
+//!
+//! LDBC IC9 is the worst case for anything order-dependent here: its messages
+//! arrive roughly in creation order and it sorts by creation date descending,
+//! so the winners are in the last batch.
+//!
+//!   cargo bench --bench sort_topn
+//!   cargo bench --bench sort_topn -- --rows 1000000 --limit 100
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+use std::time::Instant;
+
+#[path = "common/bench_setup.rs"]
+mod bench_setup;
+
+/// `n` nodes whose sort key arrives in the given order.
+fn build(order: &str, n: usize) -> GraphStore {
+    let mut store = GraphStore::new();
+    for i in 0..n {
+        let id = store.create_node("N");
+        let v = match order {
+            "best-first" => (n - i) as i64,
+            "worst-first" => i as i64,
+            _ => {
+                let x = (i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+                ((x ^ (x >> 31)) % 1_000_000) as i64
+            }
+        };
+        let _ = store.set_node_property("default", id, "v", PropertyValue::Integer(v));
+    }
+    store
+}
+
+fn main() {
+    bench_setup::init();
+    let calibration = bench_setup::report_calibration();
+
+    let args: Vec<String> = std::env::args().collect();
+    let arg = |flag: &str| -> Option<usize> {
+        args.iter().position(|a| a == flag).and_then(|i| args.get(i + 1)).and_then(|v| v.parse().ok())
+    };
+    let n = arg("--rows").unwrap_or(400_000);
+    let limit = arg("--limit").unwrap_or(20);
+    let runs = arg("--runs").unwrap_or(5);
+
+    println!("{n} rows, top-{limit}, minimum of {runs}\n");
+    println!("{:<14} {:>12} {:>14}", "input order", "ms", "ns per row");
+    println!("{:-<14} {:->12} {:->14}", "", "", "");
+
+    for order in ["best-first", "scattered", "worst-first"] {
+        let store = build(order, n);
+        let cypher = format!("MATCH (n:N) RETURN n.v AS v ORDER BY n.v DESC LIMIT {limit}");
+        let q = parse_query(&cypher).expect("query should parse");
+        let _ = QueryExecutor::new(&store).execute(&q).expect("query should run");
+        let mut best = f64::INFINITY;
+        for _ in 0..runs {
+            let t = Instant::now();
+            let out = QueryExecutor::new(&store).execute(&q).expect("query should run");
+            assert_eq!(out.records.len(), limit.min(n));
+            best = best.min(t.elapsed().as_secs_f64() * 1000.0);
+        }
+        println!("{order:<14} {best:>12.1} {:>14.0}", best * 1e6 / n as f64);
+    }
+
+    println!();
+    println!("Worst-first is the adversarial order: every row that belongs in the answer");
+    println!("arrives after the buffer has already been trimmed, so nothing can be skipped");
+    println!("early. It is also LDBC IC9's shape.");
+
+    bench_setup::report_drift(calibration);
+}

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -173,22 +173,22 @@ Samyama Graph's own results on the [LDBC Social Network Benchmark (SNB) Interact
 
 | Query | Name | SF1 | previous SF1 | SF10 |
 |---|---|---|---|---|
-| IC1 | Transitive Friends by Name | **59.5 ms** | 58.6 ms | 14.0 s |
-| IC2 | Recent Friend Posts | **9.7 ms** | 14.1 ms | 306 ms |
-| IC3 | Friends in Countries | **861 ms** | 990 ms | 15.7 s |
-| IC4 | Popular Tags in Period | **14.1 ms** | 18.9 ms | 527 ms |
-| IC5 | New Forum Members | **1204 ms** | 1828 ms | 31.1 s |
-| IC6 | Tag Co-occurrence | **185 ms** | 174 ms | 31.5 s |
-| IC7 | Recent Likers | **0.06 ms** | 0.06 ms | 1.70 ms |
-| IC8 | Recent Replies | **0.15 ms** | 0.17 ms | 4.00 ms |
-| IC9 | Recent FoF Posts | **1194 ms** | 1260 ms | 26.3 s |
-| IC10 | Friend Recommendation | **102 ms** | 136 ms | 2.3 s |
-| IC11 | Job Referral | **31.4 ms** | 36.4 ms | 4.5 s |
-| IC12 | Expert Reply | **86.2 ms** | 121 ms | 3.2 s |
-| IC13 | Single Shortest Path | **43.1 ms** | 43.5 ms | 37.00 ms |
-| IC14 | Trusted Connection Paths | **50.9 ms** | 49.4 ms | 696 ms |
+| IC1 | Transitive Friends by Name | **58.9 ms** | 59.5 ms | 14.0 s |
+| IC2 | Recent Friend Posts | **8.1 ms** | 9.7 ms | 306 ms |
+| IC3 | Friends in Countries | **862 ms** | 861 ms | 15.7 s |
+| IC4 | Popular Tags in Period | **13.9 ms** | 14.1 ms | 527 ms |
+| IC5 | New Forum Members | **1203 ms** | 1204 ms | 31.1 s |
+| IC6 | Tag Co-occurrence | **185 ms** | 185 ms | 31.5 s |
+| IC7 | Recent Likers | **0.09 ms** | 0.06 ms | 1.70 ms |
+| IC8 | Recent Replies | **0.16 ms** | 0.15 ms | 4.00 ms |
+| IC9 | Recent FoF Posts | **1131 ms** | 1194 ms | 26.3 s |
+| IC10 | Friend Recommendation | **104 ms** | 102 ms | 2.3 s |
+| IC11 | Job Referral | **32.2 ms** | 31.4 ms | 4.5 s |
+| IC12 | Expert Reply | **84.7 ms** | 86.2 ms | 3.2 s |
+| IC13 | Single Shortest Path | **43.4 ms** | 43.1 ms | 37.00 ms |
+| IC14 | Trusted Connection Paths | **49.8 ms** | 50.9 ms | 696 ms |
 
-**Whole suite: 15.8 s, 21/21 passed, 0 empty, 0 errors.**
+**Whole suite: 15.6 s, 21/21 passed, 0 empty, 0 errors.**
 
 ### What the "previous SF1" column is
 
@@ -197,10 +197,14 @@ derived parameters (#505), so the two columns differ only by engine changes.
 Both were taken with the host calibration reported and matching, which is what
 makes them comparable at all (#529).
 
-This round: `Expand` holds its variable names as `Arc<str>`, so binding one on
+This round: `Sort` locates its key columns once instead of once per input row
+(#568). It is a small change and most of the table moves by less than the
+run-to-run noise; IC9, which spends 22% of itself sorting, moves 5%.
+
+Before that: `Expand` holds its variable names as `Arc<str>`, so binding one on
 an output row is a refcount bump rather than two heap allocations, and it
 refills its edge buffer instead of allocating a new one per source record
-(#564). IC5 is a third faster on that alone.
+(#564). IC5 was a third faster on that alone.
 
 The rounds before, which is what the previous column and the ones before it
 reflect: records cloned with room for the bindings about to be added (#562);
@@ -210,8 +214,8 @@ columns located once per query rather than once per row (#557); and `Filter`
 deciding whether to go parallel from the predicate's cost rather than the batch
 size (#559).
 
-Together, over this sequence, the suite went from **24.2 s to 15.8 s** on the
-same host at the same derived parameters — a 35% reduction, all of it in
+Together, over this sequence, the suite went from **24.2 s to 15.6 s** on the
+same host at the same derived parameters — a 36% reduction, all of it in
 per-row constants rather than in algorithms.
 
 Nothing here is a parameter change. The parameter shift that made several

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -5312,6 +5312,38 @@ impl SortOperator {
             .collect()
     }
 
+    /// `key_of`, but reading each `x.prop` key through a cursor that located
+    /// its column once (#557).
+    ///
+    /// Only plain property expressions take the cursor; anything else -- an
+    /// arithmetic expression, a function call -- falls back to `key_of`'s
+    /// walker, and produces the same value either way.
+    fn key_of_cached(
+        readers: &mut [PropertyCursor],
+        sort_items: &[(Expression, bool)],
+        record: &Record,
+        store: &GraphStore,
+    ) -> Vec<PropertyValue> {
+        let mut key = Vec::with_capacity(sort_items.len());
+        let mut cursor = readers.iter_mut();
+        for (expr, _) in sort_items {
+            match expr {
+                Expression::Property { .. } => {
+                    let c = cursor.next().expect("one cursor per property key");
+                    key.push(c.read(record, store));
+                }
+                other => key.push(
+                    Self::evaluate_expression(other, record, store)
+                        .unwrap_or(Value::Null)
+                        .as_property()
+                        .cloned()
+                        .unwrap_or(PropertyValue::Null),
+                ),
+            }
+        }
+        key
+    }
+
     /// Compare two precomputed keys under the per-column sort directions.
     fn cmp_keys(a: &[PropertyValue], b: &[PropertyValue], items: &[(Expression, bool)]) -> std::cmp::Ordering {
         for (i, (_, ascending)) in items.iter().enumerate() {
@@ -5507,11 +5539,24 @@ impl SortOperator {
         // would otherwise run on nearly every batch.
         let trim_at = bound.map(|k| k.saturating_mul(2).max(4096));
 
+        // One cursor per property-valued sort key, in the order those keys
+        // appear, so `key_of_cached` can walk the two together.
+        let mut readers: Vec<PropertyCursor> = self
+            .sort_items
+            .iter()
+            .filter_map(|(expr, _)| match expr {
+                Expression::Property { variable, property } => {
+                    Some(PropertyCursor::new(variable.as_str(), property.as_str()))
+                }
+                _ => None,
+            })
+            .collect();
+
         let mut keyed: Vec<(Vec<PropertyValue>, Record)> = Vec::new();
         while let Some(batch) = self.input.next_batch(store, batch_size)? {
             keyed.reserve(batch.records.len());
             for record in batch.records {
-                let key = self.key_of(&record, store);
+                let key = Self::key_of_cached(&mut readers, &self.sort_items, &record, store);
                 keyed.push((key, record));
             }
             if let (Some(k), Some(threshold)) = (bound, trim_at) {

--- a/tests/bounded_sort_semantics.rs
+++ b/tests/bounded_sort_semantics.rs
@@ -1,0 +1,256 @@
+//! A bounded `ORDER BY … LIMIT k` returns what sorting everything would (#568).
+//!
+//! These began as tests for a rejection cutoff — once the buffer has been
+//! trimmed to `k`, the worst key retained bounds what can still qualify, so
+//! most rows could be discarded after one comparison. **That optimisation was
+//! measured and rejected**: it was 1-8% *slower* in every input order, because
+//! the per-row cost of a bounded sort is evaluating the key, not allocating it.
+//! Records are moved into the buffer, not cloned, so skipping the move saves
+//! little and the extra comparison costs more. The measurement is on #568 and
+//! reproducible with `cargo bench --bench sort_topn`.
+//!
+//! The tests stayed, because bounded `ORDER BY` had no coverage of the cases
+//! that actually decide it:
+//!
+//! * **input order**, since a top-k over data already sorted by the key is a
+//!   different path from one over scattered data, and the adversarial case —
+//!   every winner arriving in the last batch — is where a wrong bound shows;
+//! * **ties**, where rows equal to the cut are still eligible;
+//! * **nulls**, which sort *greatest* here (#369), so they lead under DESC and
+//!   trail under ASC — asserted against `main` rather than assumed, after an
+//!   earlier draft encoded "nulls last" for both directions and failed against
+//!   correct output.
+//!
+//! Every case is checked against the whole input sorted in the test, so the
+//! assertion is "same as sorting everything", not a hand-written expectation.
+//!
+//! The fixture must exceed the input batch size. An earlier draft used 20,000
+//! rows against a batch size of 65,536, so the whole input arrived at once;
+//! every test passed with the implementation deliberately broken two different
+//! ways, because no row was ever compared against anything.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// `values` in the order given, so a test controls when good rows arrive.
+fn store_of(values: &[Option<i64>]) -> GraphStore {
+    let mut store = GraphStore::new();
+    for (i, v) in values.iter().enumerate() {
+        let id = store.create_node("N");
+        let _ = store.set_node_property("default", id, "seq".to_string(), PropertyValue::Integer(i as i64));
+        if let Some(v) = v {
+            let _ = store.set_node_property("default", id, "v".to_string(), PropertyValue::Integer(*v));
+        }
+    }
+    store
+}
+
+fn run(store: &GraphStore, cypher: &str) -> Vec<Option<i64>> {
+    let query = parse_query(cypher).expect("query should parse");
+    QueryExecutor::new(store)
+        .execute(&query)
+        .expect("query should run")
+        .records
+        .iter()
+        .map(|r| match r.get("v") {
+            Some(Value::Property(PropertyValue::Integer(n))) => Some(*n),
+            Some(Value::Property(PropertyValue::Null)) | Some(Value::Null) | None => None,
+            other => panic!("{other:?}"),
+        })
+        .collect()
+}
+
+/// What sorting the whole input and taking `k` would give.
+///
+/// Null sorts **greatest** in this engine (#369), so it comes first under DESC
+/// and last under ASC. Verified against `main` rather than assumed: an earlier
+/// draft of these tests encoded "nulls last" for both directions and failed
+/// against correct output.
+fn reference(values: &[Option<i64>], k: usize, descending: bool) -> Vec<Option<i64>> {
+    let mut sorted: Vec<Option<i64>> = values.to_vec();
+    sorted.sort_by(|a, b| {
+        let ord = match (a, b) {
+            (Some(x), Some(y)) => x.cmp(y),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        };
+        if descending { ord.reverse() } else { ord }
+    });
+    sorted.into_iter().take(k).collect()
+}
+
+/// Enough rows to fill several input batches. See the note at the top of the
+/// file: a fixture that fits in one batch tests almost nothing here.
+const N: usize = 200_000;
+
+#[test]
+fn the_winners_are_found_when_they_arrive_last() {
+    // The adversarial case. Rows arrive worst-first, so every row that belongs
+    // in the answer arrives after a cutoff has already been set. A threshold
+    // that failed to improve, or that rejected on the wrong side, loses them.
+    let values: Vec<Option<i64>> = (0..N as i64).map(Some).collect();
+    let store = store_of(&values);
+    let got = run(&store, "MATCH (n:N) RETURN n.v AS v ORDER BY n.v DESC LIMIT 20");
+    assert_eq!(got, reference(&values, 20, true));
+    assert_eq!(got[0], Some(N as i64 - 1), "the largest value arrived last: {got:?}");
+}
+
+#[test]
+fn the_winners_are_found_when_they_arrive_first() {
+    // The opposite: the cutoff goes tight almost immediately and nearly every
+    // subsequent row is rejected. This is the path the optimisation is for.
+    let values: Vec<Option<i64>> = (0..N as i64).rev().map(Some).collect();
+    let store = store_of(&values);
+    let got = run(&store, "MATCH (n:N) RETURN n.v AS v ORDER BY n.v DESC LIMIT 20");
+    assert_eq!(got, reference(&values, 20, true));
+}
+
+#[test]
+fn a_scattered_order_agrees_with_sorting_everything() {
+    let values: Vec<Option<i64>> = (0..N as u64)
+        .map(|i| {
+            let x = i.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+            Some(((x ^ (x >> 31)) % 1_000_000) as i64)
+        })
+        .collect();
+    let store = store_of(&values);
+    for (cypher, desc) in [
+        ("MATCH (n:N) RETURN n.v AS v ORDER BY n.v DESC LIMIT 20", true),
+        ("MATCH (n:N) RETURN n.v AS v ORDER BY n.v ASC LIMIT 20", false),
+    ] {
+        assert_eq!(run(&store, cypher), reference(&values, 20, desc), "{cypher}");
+    }
+}
+
+#[test]
+fn ties_at_the_threshold_are_not_dropped() {
+    // Every row shares one value, so every row ties with the cutoff. Rejecting
+    // on `>=` instead of `>` would return nothing after the first trim.
+    let values: Vec<Option<i64>> = std::iter::repeat(Some(7)).take(N).collect();
+    let store = store_of(&values);
+    let got = run(&store, "MATCH (n:N) RETURN n.v AS v ORDER BY n.v DESC LIMIT 20");
+    assert_eq!(got.len(), 20, "{got:?}");
+    assert!(got.iter().all(|v| *v == Some(7)), "{got:?}");
+}
+
+#[test]
+fn a_tie_spanning_the_cut_still_returns_k_rows() {
+    // Half the rows share the winning value, so the cut falls inside a tie.
+    let mut values: Vec<Option<i64>> = std::iter::repeat(Some(100)).take(N / 2).collect();
+    values.extend(std::iter::repeat(Some(1)).take(N / 2));
+    let store = store_of(&values);
+    let got = run(&store, "MATCH (n:N) RETURN n.v AS v ORDER BY n.v DESC LIMIT 20");
+    assert_eq!(got.len(), 20);
+    assert!(got.iter().all(|v| *v == Some(100)), "{got:?}");
+}
+
+#[test]
+fn a_handful_of_values_among_many_nulls_is_still_found() {
+    // Null sorts greatest, so ASC is the direction where the real values are
+    // the answer — and they are three rows in twenty thousand, two of which
+    // arrive long after the cutoff is set. A cutoff that compared nulls wrongly
+    // would reject them.
+    let mut values: Vec<Option<i64>> = std::iter::repeat(None).take(N).collect();
+    for (slot, v) in [(N - 1, 5i64), (N / 2, 9), (3, 1)] {
+        values[slot] = Some(v);
+    }
+    let store = store_of(&values);
+
+    let ascending = run(&store, "MATCH (n:N) RETURN n.v AS v ORDER BY n.v ASC LIMIT 5");
+    assert_eq!(ascending[..3].to_vec(), vec![Some(1), Some(5), Some(9)], "{ascending:?}");
+    assert!(ascending[3].is_none() && ascending[4].is_none(), "nulls fill the rest: {ascending:?}");
+
+    // And the other direction, where nulls win outright.
+    let descending = run(&store, "MATCH (n:N) RETURN n.v AS v ORDER BY n.v DESC LIMIT 5");
+    assert!(descending.iter().all(|v| v.is_none()), "null sorts greatest: {descending:?}");
+}
+
+#[test]
+fn a_limit_larger_than_the_input_returns_everything_sorted() {
+    let values: Vec<Option<i64>> = (0..50i64).map(Some).collect();
+    let store = store_of(&values);
+    let got = run(&store, "MATCH (n:N) RETURN n.v AS v ORDER BY n.v DESC LIMIT 500");
+    assert_eq!(got, reference(&values, 500, true));
+    assert_eq!(got.len(), 50);
+}
+
+#[test]
+fn skip_is_accounted_for_in_the_bound() {
+    // The bound pushed down is SKIP + LIMIT. A cutoff computed from LIMIT
+    // alone would discard exactly the rows SKIP is meant to step over.
+    let values: Vec<Option<i64>> = (0..N as i64).map(Some).collect();
+    let store = store_of(&values);
+    let got = run(&store, "MATCH (n:N) RETURN n.v AS v ORDER BY n.v DESC SKIP 10 LIMIT 5");
+    let full = reference(&values, 15, true);
+    assert_eq!(got, full[10..15].to_vec(), "{got:?}");
+}
+
+#[test]
+fn an_unbounded_order_by_is_unaffected() {
+    // No LIMIT means no bound and no cutoff; every row must survive.
+    let values: Vec<Option<i64>> = (0..500i64).map(Some).collect();
+    let store = store_of(&values);
+    let got = run(&store, "MATCH (n:N) RETURN n.v AS v ORDER BY n.v DESC");
+    assert_eq!(got.len(), 500);
+    assert_eq!(got, reference(&values, 500, true));
+}
+
+#[test]
+fn a_two_key_sort_agrees_with_sorting_everything() {
+    // The cutoff compares whole key tuples. A comparison that stopped at the
+    // first key would reject rows that the second key would have rescued.
+    let mut store = GraphStore::new();
+    for i in 0..N as i64 {
+        let id = store.create_node("N");
+        // `major` has only 5 distinct values, so ties on it are constant and
+        // `minor` decides — which is exactly where a truncated compare fails.
+        let _ = store.set_node_property("default", id, "major".to_string(), PropertyValue::Integer(i % 5));
+        let _ = store.set_node_property("default", id, "minor".to_string(), PropertyValue::Integer(i));
+    }
+    let query = parse_query(
+        "MATCH (n:N) RETURN n.major AS a, n.minor AS b ORDER BY n.major DESC, n.minor DESC LIMIT 10",
+    )
+    .unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    let got: Vec<(i64, i64)> = batch
+        .records
+        .iter()
+        .map(|r| {
+            let g = |k: &str| match r.get(k) {
+                Some(Value::Property(PropertyValue::Integer(n))) => *n,
+                other => panic!("{other:?}"),
+            };
+            (g("a"), g("b"))
+        })
+        .collect();
+
+    let mut expected: Vec<(i64, i64)> = (0..N as i64).map(|i| (i % 5, i)).collect();
+    expected.sort_by(|x, y| y.cmp(x));
+    assert_eq!(got, expected[..10].to_vec());
+}
+
+#[test]
+fn a_bounded_sort_does_not_scale_with_the_rows_it_discards() {
+    // The property the change is for. A top-20 over 400,000 rows should cost
+    // about what a top-20 over 40,000 does plus the scan, not ten times.
+    let time = |n: usize| -> f64 {
+        let values: Vec<Option<i64>> = (0..n as i64).map(Some).collect();
+        let store = store_of(&values);
+        let query =
+            parse_query("MATCH (n:N) RETURN n.v AS v ORDER BY n.v DESC LIMIT 20").unwrap();
+        let _ = QueryExecutor::new(&store).execute(&query).unwrap();
+        let started = std::time::Instant::now();
+        let out = QueryExecutor::new(&store).execute(&query).unwrap();
+        assert_eq!(out.records.len(), 20);
+        started.elapsed().as_secs_f64()
+    };
+    let small = time(40_000);
+    let large = time(400_000);
+    assert!(
+        large < small * 40.0,
+        "10x the rows cost {:.1}x the time ({small:.4}s -> {large:.4}s)",
+        large / small
+    );
+}


### PR DESCRIPTION
Closes #568 — but **not** with the change that issue proposed. That one was implemented, measured, and rejected; the details are below because the reasoning is the useful part.

## What landed

`SortOperator` evaluated each `ORDER BY` expression through the general expression walker for **every input row**, resolving `m.creationDate` against the store's column index 389,461 times on IC9 to reach the same column. It now reads plain property keys through a `PropertyCursor`, as the aggregate paths did in #557.

`cargo bench --bench sort_topn`, top-20 over 400,000 rows, dedicated box:

| input order | before | after |
|---|---:|---:|
| best-first | 176.8 ms | **154.5 ms** |
| scattered | 256.4 ms | **251.3 ms** |
| worst-first | 243.3 ms | **232.1 ms** |

LDBC SF1: **IC9 1194 ms → 1131 ms**, suite **15.8 s → 15.6 s**. Most of the table moves by less than run-to-run noise; IC9 spends 22% of itself sorting, so it is where this shows.

## What was rejected, and why

#568 proposed a **rejection cutoff**: once the buffer has been trimmed to `k`, the worst key retained bounds what can still qualify, so most rows could be discarded after one comparison instead of allocating a key and being moved into the buffer. For a top-20 over 389,461 rows that is 99.995% of the work, so it looked obvious.

Implemented and measured, it was **slower in every input order**:

| input order | main | with cutoff |
|---|---:|---:|
| best-first | 58.6 ms | 59.6 ms |
| scattered | 65.3 ms | 66.6 ms |
| worst-first | 97.3 ms | 105.0 ms |

The premise was wrong. Records are **moved** into the buffer, not cloned — `keyed.push((key, record))` moves 24 bytes — so skipping the move saves little, and the extra comparison per row costs more than it saves. The per-row cost of a bounded sort is **evaluating the key**, which is what this PR addresses instead.

`benches/sort_topn.rs` records this so it is not retried blind.

## On input order

It is the parameter that decides anything order-dependent here, so the bench sweeps it. **Worst-first is adversarial** — every row in the answer arrives in the last batch — and it is also IC9's shape: its messages arrive roughly in creation order and it sorts by creation date descending. That is why IC9, the query the issue targeted, was the one case a cutoff could never have helped.

## Testing

`tests/bounded_sort_semantics.rs` — 11 tests written for the cutoff and **kept**, because bounded `ORDER BY` had no coverage of what actually decides it: input order (best-first, worst-first, scattered), ties at the cut, ties spanning the cut, nulls, `SKIP` in the bound, a limit larger than the input, and an unbounded sort.

Two things worth flagging about them:

- **Nulls sort *greatest*** here (#369), so they lead under `DESC` and trail under `ASC`. Checked against `main` rather than assumed — a first draft encoded "nulls last" for both directions and failed against correct output.
- **The fixture is 200,000 rows because it must exceed the 65,536-row input batch.** An earlier draft used 20,000, and every test passed with the implementation deliberately broken two different ways, because the whole input arrived in one batch and no row was ever compared against anything. Noted at the constant so it is not shrunk back.

Suite on a dedicated box: **exit 0, 2,771 tests, 0 failures.** `docs/BENCHMARKS.md` updated.