### PR TITLE
Stop storing a Value per group in the aggregate's group table

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -173,22 +173,22 @@ Samyama Graph's own results on the [LDBC Social Network Benchmark (SNB) Interact
 
 | Query | Name | SF1 | previous SF1 | SF10 |
 |---|---|---|---|---|
-| IC1 | Transitive Friends by Name | **58.9 ms** | 59.5 ms | 14.0 s |
-| IC2 | Recent Friend Posts | **8.1 ms** | 9.7 ms | 306 ms |
-| IC3 | Friends in Countries | **862 ms** | 861 ms | 15.7 s |
-| IC4 | Popular Tags in Period | **13.9 ms** | 14.1 ms | 527 ms |
-| IC5 | New Forum Members | **1203 ms** | 1204 ms | 31.1 s |
-| IC6 | Tag Co-occurrence | **185 ms** | 185 ms | 31.5 s |
-| IC7 | Recent Likers | **0.09 ms** | 0.06 ms | 1.70 ms |
-| IC8 | Recent Replies | **0.16 ms** | 0.15 ms | 4.00 ms |
-| IC9 | Recent FoF Posts | **1131 ms** | 1194 ms | 26.3 s |
-| IC10 | Friend Recommendation | **104 ms** | 102 ms | 2.3 s |
-| IC11 | Job Referral | **32.2 ms** | 31.4 ms | 4.5 s |
-| IC12 | Expert Reply | **84.7 ms** | 86.2 ms | 3.2 s |
-| IC13 | Single Shortest Path | **43.4 ms** | 43.1 ms | 37.00 ms |
-| IC14 | Trusted Connection Paths | **49.8 ms** | 50.9 ms | 696 ms |
+| IC1 | Transitive Friends by Name | **61.6 ms** | 58.9 ms | 14.0 s |
+| IC2 | Recent Friend Posts | **7.8 ms** | 8.1 ms | 306 ms |
+| IC3 | Friends in Countries | **866 ms** | 862 ms | 15.7 s |
+| IC4 | Popular Tags in Period | **13.5 ms** | 13.9 ms | 527 ms |
+| IC5 | New Forum Members | **1028 ms** | 1203 ms | 31.1 s |
+| IC6 | Tag Co-occurrence | **177 ms** | 185 ms | 31.5 s |
+| IC7 | Recent Likers | **0.05 ms** | 0.09 ms | 1.70 ms |
+| IC8 | Recent Replies | **0.15 ms** | 0.16 ms | 4.00 ms |
+| IC9 | Recent FoF Posts | **1170 ms** | 1131 ms | 26.3 s |
+| IC10 | Friend Recommendation | **99.9 ms** | 104 ms | 2.3 s |
+| IC11 | Job Referral | **31.5 ms** | 32.2 ms | 4.5 s |
+| IC12 | Expert Reply | **86.3 ms** | 84.7 ms | 3.2 s |
+| IC13 | Single Shortest Path | **44.9 ms** | 43.4 ms | 37.00 ms |
+| IC14 | Trusted Connection Paths | **49.9 ms** | 49.8 ms | 696 ms |
 
-**Whole suite: 15.6 s, 21/21 passed, 0 empty, 0 errors.**
+**Whole suite: 14.9 s, 21/21 passed, 0 empty, 0 errors.**
 
 ### What the "previous SF1" column is
 
@@ -197,11 +197,14 @@ derived parameters (#505), so the two columns differ only by engine changes.
 Both were taken with the host calibration reported and matching, which is what
 makes them comparable at all (#529).
 
-This round: `Sort` locates its key columns once instead of once per input row
-(#568). It is a small change and most of the table moves by less than the
-run-to-run noise; IC9, which spends 22% of itself sorting, moves 5%.
+This round: the aggregate's group table no longer stores a `Value` per group
+(#570). `Value` is 144 bytes — `Value::Node` embeds a whole `Node` inline — so
+an entry that is logically a node id and a counter was ~320 bytes wide. IC5's
+`Aggregate` drops 23%, and IC5 with it.
 
-Before that: `Expand` holds its variable names as `Arc<str>`, so binding one on
+Before that: `Sort` locates its key columns once instead of once per input row
+(#568), worth 5% on IC9, which spends a fifth of itself sorting. And before
+that: `Expand` holds its variable names as `Arc<str>`, so binding one on
 an output row is a refcount bump rather than two heap allocations, and it
 refills its edge buffer instead of allocating a new one per source record
 (#564). IC5 was a third faster on that alone.
@@ -214,8 +217,8 @@ columns located once per query rather than once per row (#557); and `Filter`
 deciding whether to go parallel from the predicate's cost rather than the batch
 size (#559).
 
-Together, over this sequence, the suite went from **24.2 s to 15.6 s** on the
-same host at the same derived parameters — a 36% reduction, all of it in
+Together, over this sequence, the suite went from **24.2 s to 14.9 s** on the
+same host at the same derived parameters — a 38% reduction, all of it in
 per-row constants rather than in algorithms.
 
 Nothing here is a parameter change. The parameter shift that made several

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -4542,10 +4542,13 @@ impl RowReader {
 enum IdentityKey {
     Node(u64),
     Edge(u64),
-    /// Anything else, cloned. Reached only where a key expression reads a
-    /// property of something that is not a graph element, which is a
-    /// degenerate query rather than a hot path.
-    Other(Value),
+    /// Anything else. Boxed because `Value` is 144 bytes -- `Value::Node`
+    /// embeds a whole `Node` inline (#570) -- and carrying that inline would
+    /// set the width of every entry in the group table for the sake of a case
+    /// that is reached only where a key expression reads a property of
+    /// something that is not a graph element. That is a degenerate query, not
+    /// a hot path.
+    Other(Box<Value>),
 }
 
 impl IdentityKey {
@@ -4553,8 +4556,35 @@ impl IdentityKey {
         match value {
             Some(Value::NodeRef(id)) | Some(Value::Node(id, _)) => IdentityKey::Node(id.0),
             Some(Value::EdgeRef(id, ..)) | Some(Value::Edge(id, _)) => IdentityKey::Edge(id.0),
-            Some(other) => IdentityKey::Other(other.clone()),
-            None => IdentityKey::Other(Value::Null),
+            Some(other) => IdentityKey::Other(Box::new(other.clone())),
+            None => IdentityKey::Other(Box::new(Value::Null)),
+        }
+    }
+
+    /// A `Value` to evaluate the group-by expressions against, rebuilt from the
+    /// key rather than stored beside it.
+    ///
+    /// Keeping a representative `Value` per group cost 144 bytes an entry on
+    /// top of the key, for something the id already determines. `NodeRef`
+    /// resolves properties from the store, which is what a materialised
+    /// `Value::Node` would do here too -- this is the read executor, and a
+    /// node's properties come from the store either way.
+    fn probe_value(&self, store: &GraphStore) -> Value {
+        match self {
+            IdentityKey::Node(id) => Value::NodeRef(NodeId(*id)),
+            IdentityKey::Edge(id) => {
+                let edge_id = crate::graph::EdgeId(*id);
+                match store.get_edge(edge_id) {
+                    Some(edge) => Value::EdgeRef(
+                        edge_id,
+                        edge.source,
+                        edge.target,
+                        edge.edge_type.clone(),
+                    ),
+                    None => Value::Null,
+                }
+            }
+            IdentityKey::Other(value) => (**value).clone(),
         }
     }
 }
@@ -4614,10 +4644,11 @@ impl AggregateOperator {
         let mut readers: Vec<RowReader> =
             self.aggregates.iter().map(|a| RowReader::for_expression(&a.expr)).collect();
 
-        // The representative is the first `Value` seen for an identity, kept so
-        // phase 2 has something to resolve properties against. Cloned once per
-        // group, not once per row -- which is the whole point.
-        let mut groups: rustc_hash::FxHashMap<IdentityKey, (Value, Vec<AggregatorState>)> =
+        // Keyed on identity alone. Phase 2 rebuilds what it needs to resolve
+        // properties against from the key itself, so no `Value` is stored per
+        // group -- which at IC5's 96,862 groups took the table from ~320 bytes
+        // an entry to ~40 (#570).
+        let mut groups: rustc_hash::FxHashMap<IdentityKey, Vec<AggregatorState>> =
             rustc_hash::FxHashMap::default();
 
         let batch_size = 65536;
@@ -4628,16 +4659,12 @@ impl AggregateOperator {
                 check_deadline()?;
             }
             for record in batch.records {
-                let bound = record.get(var);
-                let key = IdentityKey::of(bound);
-                let (_, states) = groups.entry(key).or_insert_with(|| {
-                    (
-                        bound.cloned().unwrap_or(Value::Null),
-                        self.aggregates
-                            .iter()
-                            .map(|agg| AggregatorState::new(&agg.func, agg.distinct))
-                            .collect(),
-                    )
+                let key = IdentityKey::of(record.get(var));
+                let states = groups.entry(key).or_insert_with(|| {
+                    self.aggregates
+                        .iter()
+                        .map(|agg| AggregatorState::new(&agg.func, agg.distinct))
+                        .collect()
                 });
 
                 if all_simple_count {
@@ -4660,9 +4687,9 @@ impl AggregateOperator {
         // alone is enough to evaluate them.
         let mut merged: rustc_hash::FxHashMap<Vec<Value>, Vec<AggregatorState>> =
             rustc_hash::FxHashMap::with_capacity_and_hasher(groups.len(), Default::default());
-        for (_, (representative, states)) in groups {
+        for (key, states) in groups {
             let mut probe = Record::new();
-            probe.bind(var.to_string(), representative);
+            probe.bind(var.to_string(), key.probe_value(store));
             let mut tuple = Vec::with_capacity(self.group_by.len());
             for (expr, _) in &self.group_by {
                 tuple.push(Self::evaluate_expression(expr, &probe, store)?);

--- a/tests/aggregate_identity_grouping.rs
+++ b/tests/aggregate_identity_grouping.rs
@@ -302,3 +302,51 @@ fn explain_is_unchanged_by_the_grouping_strategy() {
     };
     assert!(text.contains("Aggregate (group_by="), "{text}");
 }
+
+#[test]
+fn grouping_on_edge_properties_rebuilds_the_edge() {
+    // The group table keys on identity and stores no `Value` (#570), so phase 2
+    // rebuilds one from the key. For an edge that means going back to the store
+    // for its endpoints and type. If that rebuild returned Null, every group
+    // would collapse into one and the counts would be wrong rather than absent.
+    let mut store = GraphStore::new();
+    let hub = store.create_node("Hub");
+    for i in 0..60i64 {
+        let n = store.create_node("N");
+        let e = store.create_edge(n, hub, "IN").unwrap();
+        // Three distinct edge weights, so there should be three groups.
+        let _ = store.set_edge_property(e, "w", PropertyValue::Integer(i % 3));
+        let _ = store.set_node_property("default", n, "v".to_string(), PropertyValue::Integer(i));
+    }
+
+    let got = rows(
+        &store,
+        "MATCH (n:N)-[r:IN]->(h:Hub) RETURN r.w AS w, count(n) AS c, sum(n.v) AS s",
+    );
+    assert_eq!(got.len(), 3, "three distinct edge weights: {got:?}");
+    // 60 edges over 3 weights.
+    assert!(
+        got.iter().all(|r| r.iter().any(|c| c.contains("Integer(20)"))),
+        "each group holds 20 edges: {got:?}"
+    );
+}
+
+#[test]
+fn grouping_on_a_property_of_a_map_still_works() {
+    // The `Other` arm: the group variable is bound to a `PropertyValue`, not a
+    // graph element, so the key carries the value itself. Boxing it must not
+    // change what the group key is.
+    let store = GraphStore::new();
+    let cypher = "UNWIND [{a: 1, b: 10}, {a: 2, b: 20}, {a: 1, b: 30}] AS m \
+                  RETURN m.a AS a, count(m) AS c, sum(m.b) AS s";
+    assert_hash_aggregate(&store, cypher);
+    let got = rows(&store, cypher);
+    assert_eq!(got.len(), 2, "two distinct values of a: {got:?}");
+
+    let group_one = got
+        .iter()
+        .find(|r| r.iter().any(|c| c == "a=Property(Integer(1))"))
+        .unwrap_or_else(|| panic!("{got:?}"));
+    assert!(group_one.iter().any(|c| c.contains("Integer(2)")), "count 2: {group_one:?}");
+    assert!(group_one.iter().any(|c| c.contains("Integer(40)")), "10 + 30: {group_one:?}");
+}


### PR DESCRIPTION
The contained part of #570; that issue stays open for the rest.

## Measured

Dedicated box, calibration matching at 43 ms:

| | before | after | |
|---|---:|---:|---:|
| IC5 `Aggregate` self | 621.75 ms | **477.18 ms** | **−23%** |
| IC5 total | 1259 ms | **1028 ms** | −18% |
| whole SF1 suite | 15.6 s | **14.9 s** | −4.5% |

## What it was

The identity-grouping path (#521) kept a representative `Value` beside each group's aggregator states, so phase 2 had something to resolve the group-by expressions against.

`Value` is **144 bytes** — `Value::Node` embeds a whole `Node` inline, and `Node` holds a `HashSet<Label>` and a `PropertyMap` inline. `IdentityKey` embedded one too, through its `Other` arm. So an entry that is logically **a node id and a counter** was about **320 bytes** wide, and IC5's 96,862 groups made a ~31 MB table where every probe missed cache.

## What it is now

The key already determines the representative, so nothing extra is stored:

- `IdentityKey::Node(id)` rebuilds `Value::NodeRef(id)` — and `NodeRef` resolves properties from the store, which is what a materialised `Value::Node` would do here anyway, since this is the read executor;
- an edge rebuilds from the store — endpoints and type;
- `Other` is boxed, because it is reached only where a group key reads a property of something that is **not** a graph element, and it should not set the width of every entry.

Entry width goes ~320 → ~40 bytes.

## Testing

Two new tests, because a `probe_value` that returned `Null` would **collapse every group into one and report a plausible row count** rather than erroring:

- **grouping on an edge property**, which has to go back to the store for endpoints and type — three distinct edge weights must stay three groups;
- **grouping on a map property**, which takes the `Other` arm. That case was not even reachable until #571 landed — map property access returned `Null`, so the arm existed but every key through it was `Null`.

Suite on a dedicated box: **exit 0, 2,783 tests, 0 failures.** `docs/BENCHMARKS.md` updated.

## What is left on #570

`Value` is still 144 bytes and still sets the width of every record binding (so every record clone memcpys 160 bytes per binding) and every sort key. Boxing `Value::Node`/`Value::Edge` and `PropertyValue::Map` should take it to ~48. That is a wider change and it stays on #570 with the measurements.