### PR TITLE
Box the node and edge payloads so a Value is 56 bytes, not 144

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -173,22 +173,22 @@ Samyama Graph's own results on the [LDBC Social Network Benchmark (SNB) Interact
 
 | Query | Name | SF1 | previous SF1 | SF10 |
 |---|---|---|---|---|
-| IC1 | Transitive Friends by Name | **61.6 ms** | 58.9 ms | 14.0 s |
-| IC2 | Recent Friend Posts | **7.8 ms** | 8.1 ms | 306 ms |
-| IC3 | Friends in Countries | **866 ms** | 862 ms | 15.7 s |
-| IC4 | Popular Tags in Period | **13.5 ms** | 13.9 ms | 527 ms |
-| IC5 | New Forum Members | **1028 ms** | 1203 ms | 31.1 s |
-| IC6 | Tag Co-occurrence | **177 ms** | 185 ms | 31.5 s |
-| IC7 | Recent Likers | **0.05 ms** | 0.09 ms | 1.70 ms |
-| IC8 | Recent Replies | **0.15 ms** | 0.16 ms | 4.00 ms |
-| IC9 | Recent FoF Posts | **1170 ms** | 1131 ms | 26.3 s |
-| IC10 | Friend Recommendation | **99.9 ms** | 104 ms | 2.3 s |
-| IC11 | Job Referral | **31.5 ms** | 32.2 ms | 4.5 s |
-| IC12 | Expert Reply | **86.3 ms** | 84.7 ms | 3.2 s |
-| IC13 | Single Shortest Path | **44.9 ms** | 43.4 ms | 37.00 ms |
-| IC14 | Trusted Connection Paths | **49.9 ms** | 49.8 ms | 696 ms |
+| IC1 | Transitive Friends by Name | **57.8 ms** | 61.6 ms | 14.0 s |
+| IC2 | Recent Friend Posts | **9.3 ms** | 7.8 ms | 306 ms |
+| IC3 | Friends in Countries | **905 ms** | 866 ms | 15.7 s |
+| IC4 | Popular Tags in Period | **16.9 ms** | 13.5 ms | 527 ms |
+| IC5 | New Forum Members | **926 ms** | 1028 ms | 31.1 s |
+| IC6 | Tag Co-occurrence | **162 ms** | 177 ms | 31.5 s |
+| IC7 | Recent Likers | **0.05 ms** | 0.05 ms | 1.70 ms |
+| IC8 | Recent Replies | **0.15 ms** | 0.15 ms | 4.00 ms |
+| IC9 | Recent FoF Posts | **1141 ms** | 1170 ms | 26.3 s |
+| IC10 | Friend Recommendation | **94.8 ms** | 99.9 ms | 2.3 s |
+| IC11 | Job Referral | **30.2 ms** | 31.5 ms | 4.5 s |
+| IC12 | Expert Reply | **76.9 ms** | 86.3 ms | 3.2 s |
+| IC13 | Single Shortest Path | **40.5 ms** | 44.9 ms | 37.00 ms |
+| IC14 | Trusted Connection Paths | **47.4 ms** | 49.9 ms | 696 ms |
 
-**Whole suite: 14.9 s, 21/21 passed, 0 empty, 0 errors.**
+**Whole suite: 14.4 s, 21/21 passed, 0 empty, 0 errors.**
 
 ### What the "previous SF1" column is
 
@@ -197,10 +197,13 @@ derived parameters (#505), so the two columns differ only by engine changes.
 Both were taken with the host calibration reported and matching, which is what
 makes them comparable at all (#529).
 
-This round: the aggregate's group table no longer stores a `Value` per group
-(#570). `Value` is 144 bytes — `Value::Node` embeds a whole `Node` inline — so
-an entry that is logically a node id and a counter was ~320 bytes wide. IC5's
-`Aggregate` drops 23%, and IC5 with it.
+This round: `Value` is **56 bytes instead of 144**. `Value::Node` and
+`Value::Edge` carried a whole `Node`/`Edge` inline; boxing them shrinks every
+binding in every record, since `Value` is the executor's universal cell.
+Cloning a three-binding record drops from 76.6 ns to 53.1 ns (#570).
+
+Before that: the aggregate's group table stopped storing a `Value` per group,
+taking an entry from ~320 bytes to ~40 and IC5's `Aggregate` down 23%.
 
 Before that: `Sort` locates its key columns once instead of once per input row
 (#568), worth 5% on IC9, which spends a fifth of itself sorting. And before
@@ -217,8 +220,8 @@ columns located once per query rather than once per row (#557); and `Filter`
 deciding whether to go parallel from the predicate's cost rather than the batch
 size (#559).
 
-Together, over this sequence, the suite went from **24.2 s to 14.9 s** on the
-same host at the same derived parameters — a 38% reduction, all of it in
+Together, over this sequence, the suite went from **24.2 s to 14.4 s** on the
+same host at the same derived parameters — a 40% reduction, all of it in
 per-row constants rather than in algorithms.
 
 Nothing here is a parameter change. The parameter shift that made several

--- a/src/protocol/command.rs
+++ b/src/protocol/command.rs
@@ -737,7 +737,7 @@ mod tests {
 
         let handler = CommandHandler::new(None);
         let node = Node::new(NodeId::new(1), "Person");
-        let value = Value::Node(NodeId::new(1), node);
+        let value = Value::Node(NodeId::new(1), Box::new(node));
         let result = handler.format_value(&value);
         match result {
             RespValue::BulkString(Some(bytes)) => {
@@ -772,7 +772,7 @@ mod tests {
 
         let handler = CommandHandler::new(None);
         let edge = Edge::new(EdgeId::new(10), NodeId::new(1), NodeId::new(2), "KNOWS");
-        let value = Value::Edge(EdgeId::new(10), edge);
+        let value = Value::Edge(EdgeId::new(10), Box::new(edge));
         let result = handler.format_value(&value);
         match result {
             RespValue::BulkString(Some(bytes)) => {

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3821,12 +3821,12 @@ impl ProjectOperator {
                     Value::NodeRef(id) => {
                         let node = store.get_node(id)
                             .ok_or_else(|| ExecutionError::RuntimeError(format!("Node {:?} not found", id)))?;
-                        Ok(Value::Node(id, node.clone()))
+                        Ok(Value::Node(id, Box::new(node.clone())))
                     }
                     Value::EdgeRef(id, ..) => {
                         let edge = store.get_edge(id)
                             .ok_or_else(|| ExecutionError::RuntimeError(format!("Edge {:?} not found", id)))?;
-                        Ok(Value::Edge(id, edge.clone()))
+                        Ok(Value::Edge(id, Box::new(edge.clone())))
                     }
                     other => Ok(other),
                 }
@@ -6373,7 +6373,7 @@ impl PhysicalOperator for CreateNodeOperator {
             Some(var) => var.clone(),
             None => format!("__created_node_{}", self.current - 1),
         };
-        record.bind(bind_name, Value::Node(*node_id, node.clone()));
+        record.bind(bind_name, Value::Node(*node_id, Box::new(node.clone())));
 
         Ok(Some(record))
     }
@@ -7154,7 +7154,7 @@ impl PhysicalOperator for CreateEdgeOperator {
             Some(var) => var.clone(),
             None => format!("__created_edge_{}", self.current - 1),
         };
-        record.bind(bind_name, Value::Edge(*edge_id, edge.clone()));
+        record.bind(bind_name, Value::Edge(*edge_id, Box::new(edge.clone())));
 
         Ok(Some(record))
     }
@@ -7256,7 +7256,7 @@ impl PhysicalOperator for CreateNodesAndEdgesOperator {
                 // Always track created edges for persistence (even without variable names)
                 if let Some(edge) = store.get_edge(edge_id) {
                     let var_name = edge_var.clone().or_else(|| Some(format!("__created_edge_{}", self.created_edges.len())));
-                    self.results.push((var_name, Value::Edge(edge_id, edge.clone())));
+                    self.results.push((var_name, Value::Edge(edge_id, Box::new(edge.clone()))));
                     self.created_edges.push((edge_id, edge, edge_var.clone()));
                 }
             }
@@ -7402,7 +7402,7 @@ impl PhysicalOperator for MatchCreateEdgeOperator {
                         }
                     }
                     if let Some(node) = store.get_node(node_id) {
-                        record.bind(handle.clone(), Value::Node(node_id, node.clone()));
+                        record.bind(handle.clone(), Value::Node(node_id, Box::new(node.clone())));
                     }
                 }
 
@@ -7432,7 +7432,7 @@ impl PhysicalOperator for MatchCreateEdgeOperator {
                     // Build result record with the created edge
                     let mut result_record = record.clone();
                     if let Some(edge) = store.get_edge(edge_id) {
-                        result_record.bind("_edge".to_string(), Value::Edge(edge_id, edge));
+                        result_record.bind("_edge".to_string(), Value::Edge(edge_id, Box::new(edge)));
                     }
                     self.results.push(result_record);
                 }
@@ -7532,7 +7532,7 @@ impl PhysicalOperator for MatchMergeEdgeOperator {
                         }
                         if let Some(ref ev) = edge_var {
                             if let Some(edge) = store.get_edge(edge_id) {
-                                result_record.bind(ev.clone(), Value::Edge(edge_id, edge.clone()));
+                                result_record.bind(ev.clone(), Value::Edge(edge_id, Box::new(edge.clone())));
                             }
                         }
                     } else {
@@ -7555,7 +7555,7 @@ impl PhysicalOperator for MatchMergeEdgeOperator {
 
                         if let Some(ref ev) = edge_var {
                             if let Some(edge) = store.get_edge(edge_id) {
-                                result_record.bind(ev.clone(), Value::Edge(edge_id, edge.clone()));
+                                result_record.bind(ev.clone(), Value::Edge(edge_id, Box::new(edge.clone())));
                             }
                         }
                     }
@@ -7739,7 +7739,7 @@ lcc([label, edgeType]), wcc(), scc(), triangleCount(), or.solve({config})"
             let node_id = NodeId::new(algo_id);
             let mut record = Record::new();
             if let Some(node) = store.get_node(node_id) {
-                record.bind("node".to_string(), Value::Node(node_id, node.clone()));
+                record.bind("node".to_string(), Value::Node(node_id, Box::new(node.clone())));
                 record.bind("score".to_string(), Value::Property(PropertyValue::Float(score)));
                 self.results.push(record);
             }
@@ -7833,7 +7833,7 @@ lcc([label, edgeType]), wcc(), scc(), triangleCount(), or.solve({config})"
             let nid = NodeId::new(node_id);
             let mut record = Record::new();
             if let Some(node) = store.get_node(nid) {
-                record.bind("node".to_string(), Value::Node(nid, node.clone()));
+                record.bind("node".to_string(), Value::Node(nid, Box::new(node.clone())));
                 record.bind("componentId".to_string(), Value::Property(PropertyValue::Integer(component_id as i64)));
                 self.results.push(record);
             }
@@ -7884,7 +7884,7 @@ lcc([label, edgeType]), wcc(), scc(), triangleCount(), or.solve({config})"
             let nid = NodeId::new(node_id);
             let mut record = Record::new();
             if let Some(node) = store.get_node(nid) {
-                record.bind("node".to_string(), Value::Node(nid, node.clone()));
+                record.bind("node".to_string(), Value::Node(nid, Box::new(node.clone())));
                 record.bind(
                     "communityId".to_string(),
                     Value::Property(PropertyValue::Integer(community_id as i64)),
@@ -7930,7 +7930,7 @@ lcc([label, edgeType]), wcc(), scc(), triangleCount(), or.solve({config})"
             let nid = NodeId::new(node_id);
             let mut record = Record::new();
             if let Some(node) = store.get_node(nid) {
-                record.bind("node".to_string(), Value::Node(nid, node.clone()));
+                record.bind("node".to_string(), Value::Node(nid, Box::new(node.clone())));
                 record.bind(
                     "coefficient".to_string(),
                     Value::Property(PropertyValue::Float(coeff)),
@@ -8211,10 +8211,10 @@ lcc([label, edgeType]), wcc(), scc(), triangleCount(), or.solve({config})"
             
             let mut record = Record::new();
             if let Some(node_u) = store.get_node(u) {
-                record.bind("source".to_string(), Value::Node(u, node_u.clone()));
+                record.bind("source".to_string(), Value::Node(u, Box::new(node_u.clone())));
             }
             if let Some(node_v) = store.get_node(v) {
-                record.bind("target".to_string(), Value::Node(v, node_v.clone()));
+                record.bind("target".to_string(), Value::Node(v, Box::new(node_v.clone())));
             }
             record.bind("weight".to_string(), Value::Property(PropertyValue::Float(w)));
             self.results.push(record);
@@ -8245,7 +8245,7 @@ lcc([label, edgeType]), wcc(), scc(), triangleCount(), or.solve({config})"
             let nid = NodeId::new(node_id);
             let mut record = Record::new();
             if let Some(node) = store.get_node(nid) {
-                record.bind("node".to_string(), Value::Node(nid, node.clone()));
+                record.bind("node".to_string(), Value::Node(nid, Box::new(node.clone())));
                 record.bind("componentId".to_string(), Value::Property(PropertyValue::Integer(component_id as i64)));
                 self.results.push(record);
             }

--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -95,12 +95,22 @@ pub struct Record {
 /// three-valued logic (true/false/null).
 #[derive(Debug, Clone)]
 pub enum Value {
-    /// A fully materialized node
-    Node(NodeId, Node),
+    /// A fully materialized node.
+    ///
+    /// Boxed. `Node` is 128 bytes -- a `HashSet<Label>` and a `PropertyMap`
+    /// held inline, plus id, version and two timestamps -- and carrying it
+    /// inline made `Value` 144 bytes. `Value` is the executor's universal cell,
+    /// so that width was paid by every binding in every record, every hash
+    /// entry holding one, and every sort key.
+    ///
+    /// Late materialization (ADR-012) exists so scans produce `NodeRef` and
+    /// this variant stays rare, which is exactly what makes the indirection
+    /// cheap and the saving broad (#570).
+    Node(NodeId, Box<Node>),
     /// A lazy node reference (no property clone)
     NodeRef(NodeId),
-    /// A fully materialized edge
-    Edge(EdgeId, Edge),
+    /// A fully materialized edge. Boxed, for the same reason as `Node`.
+    Edge(EdgeId, Box<Edge>),
     /// A lazy edge reference (structural data only, no property clone)
     EdgeRef(EdgeId, NodeId, NodeId, EdgeType),
     /// A property value
@@ -336,7 +346,7 @@ impl Value {
         match self {
             Value::NodeRef(id) => {
                 if let Some(node) = store.get_node(id) {
-                    Value::Node(id, node.clone())
+                    Value::Node(id, Box::new(node.clone()))
                 } else {
                     Value::Null
                 }
@@ -351,7 +361,7 @@ impl Value {
         match self {
             Value::EdgeRef(id, ..) => {
                 if let Some(edge) = store.get_edge(id) {
-                    Value::Edge(id, edge.clone())
+                    Value::Edge(id, Box::new(edge.clone()))
                 } else {
                     Value::Null
                 }
@@ -505,7 +515,7 @@ mod tests {
         let mut record = Record::new();
         let node = Node::new(NodeId::new(1), Label::new("Person"));
 
-        record.bind("n".to_string(), Value::Node(NodeId::new(1), node));
+        record.bind("n".to_string(), Value::Node(NodeId::new(1), Box::new(node)));
 
         assert!(record.has("n"));
         assert!(record.get("n").is_some());
@@ -541,7 +551,7 @@ mod tests {
 
     #[test]
     fn test_value_types() {
-        let node_val = Value::Node(NodeId::new(1), Node::new(NodeId::new(1), Label::new("Test")));
+        let node_val = Value::Node(NodeId::new(1), Box::new(Node::new(NodeId::new(1), Label::new("Test"))));
         assert!(node_val.as_node().is_some());
         assert!(node_val.as_edge().is_none());
 
@@ -573,7 +583,7 @@ mod tests {
             NodeId::new(20),
             crate::graph::EdgeType::new("KNOWS"),
         );
-        let val = Value::Edge(EdgeId::new(1), edge);
+        let val = Value::Edge(EdgeId::new(1), Box::new(edge));
         let (eid, e) = val.as_edge().unwrap();
         assert_eq!(eid, EdgeId::new(1));
         assert_eq!(e.source, NodeId::new(10));
@@ -588,7 +598,7 @@ mod tests {
     fn test_node_id() {
         // From Node
         let node = Node::new(NodeId::new(5), Label::new("Person"));
-        let val = Value::Node(NodeId::new(5), node);
+        let val = Value::Node(NodeId::new(5), Box::new(node));
         assert_eq!(val.node_id(), Some(NodeId::new(5)));
 
         // From NodeRef
@@ -609,7 +619,7 @@ mod tests {
             NodeId::new(2),
             crate::graph::EdgeType::new("E"),
         );
-        let val = Value::Edge(EdgeId::new(3), edge);
+        let val = Value::Edge(EdgeId::new(3), Box::new(edge));
         assert_eq!(val.edge_id(), Some(EdgeId::new(3)));
 
         // From EdgeRef
@@ -634,7 +644,7 @@ mod tests {
             NodeId::new(20),
             crate::graph::EdgeType::new("E"),
         );
-        let val = Value::Edge(EdgeId::new(1), edge);
+        let val = Value::Edge(EdgeId::new(1), Box::new(edge));
         assert_eq!(val.edge_endpoints(), Some((NodeId::new(10), NodeId::new(20))));
 
         // From EdgeRef
@@ -658,7 +668,7 @@ mod tests {
             NodeId::new(2),
             crate::graph::EdgeType::new("KNOWS"),
         );
-        let val = Value::Edge(EdgeId::new(1), edge);
+        let val = Value::Edge(EdgeId::new(1), Box::new(edge));
         assert_eq!(val.edge_type().unwrap().as_str(), "KNOWS");
 
         let val = Value::EdgeRef(
@@ -675,7 +685,7 @@ mod tests {
     #[test]
     fn test_is_node_is_edge() {
         let node = Node::new(NodeId::new(1), Label::new("A"));
-        assert!(Value::Node(NodeId::new(1), node).is_node());
+        assert!(Value::Node(NodeId::new(1), Box::new(node)).is_node());
         assert!(Value::NodeRef(NodeId::new(1)).is_node());
         assert!(!Value::Null.is_node());
         assert!(!Value::Property(PropertyValue::Integer(1)).is_node());
@@ -684,7 +694,7 @@ mod tests {
             EdgeId::new(1), NodeId::new(1), NodeId::new(2),
             crate::graph::EdgeType::new("E"),
         );
-        assert!(Value::Edge(EdgeId::new(1), edge).is_edge());
+        assert!(Value::Edge(EdgeId::new(1), Box::new(edge)).is_edge());
         assert!(Value::EdgeRef(
             EdgeId::new(1), NodeId::new(1), NodeId::new(2),
             crate::graph::EdgeType::new("E"),
@@ -713,7 +723,7 @@ mod tests {
 
         // Already materialized stays the same
         let node = store.get_node(id).unwrap().clone();
-        let val = Value::Node(id, node).materialize_node(&store);
+        let val = Value::Node(id, Box::new(node)).materialize_node(&store);
         assert!(matches!(val, Value::Node(..)));
 
         // Non-existent NodeRef becomes Null
@@ -767,7 +777,7 @@ mod tests {
 
         // Resolve from Node (materialized)
         let node = store.get_node(id).unwrap().clone();
-        let val = Value::Node(id, node);
+        let val = Value::Node(id, Box::new(node));
         let prop = val.resolve_property("name", &store);
         assert_eq!(prop, PropertyValue::String("Alice".to_string()));
 
@@ -807,7 +817,7 @@ mod tests {
 
         // From Edge
         let edge = store.get_edge(eid).unwrap();
-        let val = Value::Edge(eid, edge);
+        let val = Value::Edge(eid, Box::new(edge));
         let prop = val.resolve_property("since", &store);
         assert_eq!(prop, PropertyValue::Integer(2020));
     }
@@ -932,7 +942,7 @@ mod tests {
     fn test_value_partial_eq_cross_variant() {
         // Node == NodeRef with same ID
         let node = Node::new(NodeId::new(5), Label::new("A"));
-        let v1 = Value::Node(NodeId::new(5), node.clone());
+        let v1 = Value::Node(NodeId::new(5), Box::new(node.clone()));
         let v2 = Value::NodeRef(NodeId::new(5));
         assert_eq!(v1, v2);
         assert_eq!(v2, v1);
@@ -946,7 +956,7 @@ mod tests {
             EdgeId::new(1), NodeId::new(1), NodeId::new(2),
             crate::graph::EdgeType::new("E"),
         );
-        let ev1 = Value::Edge(EdgeId::new(1), edge);
+        let ev1 = Value::Edge(EdgeId::new(1), Box::new(edge));
         let ev2 = Value::EdgeRef(
             EdgeId::new(1), NodeId::new(1), NodeId::new(2),
             crate::graph::EdgeType::new("E"),
@@ -978,7 +988,7 @@ mod tests {
 
         // Node and NodeRef with same ID should hash the same
         let node = Node::new(NodeId::new(5), Label::new("A"));
-        let v1 = Value::Node(NodeId::new(5), node);
+        let v1 = Value::Node(NodeId::new(5), Box::new(node));
         let v2 = Value::NodeRef(NodeId::new(5));
         assert_eq!(hash_value(&v1), hash_value(&v2));
 
@@ -987,7 +997,7 @@ mod tests {
             EdgeId::new(3), NodeId::new(1), NodeId::new(2),
             crate::graph::EdgeType::new("E"),
         );
-        let ev1 = Value::Edge(EdgeId::new(3), edge);
+        let ev1 = Value::Edge(EdgeId::new(3), Box::new(edge));
         let ev2 = Value::EdgeRef(
             EdgeId::new(3), NodeId::new(1), NodeId::new(2),
             crate::graph::EdgeType::new("E"),

--- a/tests/value_size.rs
+++ b/tests/value_size.rs
@@ -1,0 +1,75 @@
+//! `Value` is the executor's universal cell, so its width is paid everywhere
+//! (#570).
+//!
+//! Every binding in every record is one. Every hash table that groups or joins
+//! on one is at least that wide per entry. `Value` was **144 bytes**, because
+//! `Value::Node` carried a whole `Node` inline — and `Node` is 128 bytes, a
+//! `HashSet<Label>` and a `PropertyMap` held inline plus id, version and two
+//! timestamps. Late materialization (ADR-012) exists so that variant stays
+//! rare; it was still setting the size of the type for everything else.
+//!
+//! These are guards, not designs. A `Box` removed from `Value::Node`, or a
+//! large field added to `PropertyValue`, would be invisible in every other test
+//! and would quietly make every record wider again.
+
+use samyama::graph::{Node, PropertyValue};
+use samyama::query::executor::{Record, Value};
+
+/// Set by `Property(PropertyValue)`, which is as small as `Value` can be
+/// without shrinking `PropertyValue` itself.
+#[test]
+fn a_value_is_no_wider_than_a_property_value() {
+    let value = std::mem::size_of::<Value>();
+    let property = std::mem::size_of::<PropertyValue>();
+    assert_eq!(
+        value, property,
+        "Value is {value} bytes against PropertyValue's {property} — some other \
+         variant has grown past it. `Value::Node` and `Value::Edge` are boxed \
+         deliberately (#570); check nothing has unboxed them."
+    );
+}
+
+#[test]
+fn a_value_stays_under_the_ceiling_it_was_brought_to() {
+    // 144 before #570. The exact figure matters less than that it does not
+    // drift back, so this is a ceiling rather than an equality.
+    let value = std::mem::size_of::<Value>();
+    assert!(
+        value <= 64,
+        "Value is {value} bytes; it was brought down to 56 from 144 and every \
+         record binding pays it"
+    );
+}
+
+#[test]
+fn boxing_did_not_change_what_a_node_value_holds() {
+    // The representation changed; the behaviour must not. A materialised node
+    // still answers for its id, its labels and its properties.
+    let mut node = Node::new(samyama::graph::NodeId::new(7), samyama::graph::Label::new("Person"));
+    node.set_property("name", PropertyValue::String("Ada".into()));
+
+    let value = Value::Node(samyama::graph::NodeId::new(7), Box::new(node));
+    assert!(value.is_node());
+    assert_eq!(value.node_id(), Some(samyama::graph::NodeId::new(7)));
+
+    // And it compares and hashes by id, as it did before (`NodeRef` equals
+    // `Node` with the same id).
+    assert_eq!(value, Value::NodeRef(samyama::graph::NodeId::new(7)));
+    assert_ne!(value, Value::NodeRef(samyama::graph::NodeId::new(8)));
+}
+
+#[test]
+fn a_record_binding_costs_a_value_plus_its_name() {
+    // What the width actually buys, stated so the number has a meaning:
+    // a three-binding row is this much memory to clone per derived row (#562).
+    let per_binding = std::mem::size_of::<(std::sync::Arc<str>, Value)>();
+    assert!(
+        per_binding <= 80,
+        "a binding is {per_binding} bytes; at 144-byte Values it was 160"
+    );
+
+    let mut record = Record::new();
+    record.bind("a", Value::NodeRef(samyama::graph::NodeId::new(1)));
+    record.bind("b", Value::Property(PropertyValue::Integer(2)));
+    assert_eq!(record.bindings().len(), 2);
+}


### PR DESCRIPTION
Refs #570 — the main part of it. One follow-up left, noted below.

## Measured

```
size_of::<Value>()   144 -> 56
```

| | before | after | |
|---|---:|---:|---:|
| clone a 3-binding record | 76.6 ns | **53.1 ns** | −31% |
| clone a `Vec<Value>` of 3 | 67.7 ns | **32.4 ns** | −52% |

LDBC SF1, same host, calibration matching at 43 ms:

| | before | after |
|---|---:|---:|
| IC5 New Forum Members | 1028 ms | **926 ms** |
| IC12 Expert Reply | 86.3 ms | **76.9 ms** |
| IC13 Single Shortest Path | 44.9 ms | **40.5 ms** |
| **whole suite** | **14.9 s** | **14.4 s** |

## Why it was 144 bytes

`Value` is the executor's **universal cell** — every binding in every record is one, and every hash table that groups or joins on one is at least that wide per entry.

```rust
Node(NodeId, Node),   // 8 + 128
```

`Node` is 128 bytes: a `HashSet<Label>` (48) and a `PropertyMap` (48) held **inline**, plus id, version and two timestamps.

Late materialization (ADR-012) exists precisely so a scan produces `NodeRef` and this variant stays rare. It was still setting the size of the type for everything else — which is what makes the indirection cheap and the saving broad.

## Risk, and where the test is

The change is **mechanical**: 18 construction sites gain a `Box::new`, and every pattern match is unchanged. So the risk is not in any one site — it is the size quietly drifting back, which no other test in the repository would notice.

`tests/value_size.rs` asserts a ceiling, that `Value` is no wider than `PropertyValue` (the smallest it can be without shrinking `PropertyValue` itself), that a boxed node value still answers for its id and still compares equal to a `NodeRef` with the same id, and that a record binding fits in 80 bytes where it used to take 160.

Suite on a dedicated box: **exit 0, 2,787 tests, 0 failures.**

## Left on #570

`PropertyValue` is 56 bytes because of `Map(HashMap<String, PropertyValue>)` — a 48-byte field that sets the size of **every integer and boolean in the engine**. Boxing it should take `PropertyValue` to 40 (set by `Duration`) and `Value` with it. `EdgeRef` also carries an `EdgeType` `String` where the store already has an interned `u16` (#536).

## Cumulative

With #538, #521, #557, #559, #562, #564, #568 and #574, SF1 has gone from **24.2 s to 14.4 s** on the same host at the same derived parameters — **−40%**, all of it in per-row constants rather than algorithms.