### PR TITLE
Plan a leading UNWIND before the WITH barrier that reads it

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -564,6 +564,24 @@ impl QueryPlanner {
     /// in. Assigning it to a MATCH instead puts the filter underneath the operator that
     /// binds the variable, and the query dies with "Variable not found" even though the
     /// same variable projects fine in RETURN (#429).
+    /// Whether the query has an `UNWIND` anywhere, in either slot the parser
+    /// uses for one.
+    ///
+    /// A leading `UNWIND` is `query.unwind_clause` when a single `WITH`
+    /// follows, and the *first extra stage's* unwind when two or more do. Four
+    /// early branches -- the CREATE-only path, the standalone-RETURN path, the
+    /// leading-FOREACH path and the "no clauses at all" error -- tested only
+    /// the first slot, so `UNWIND [1,2] AS x WITH x WHERE x > 1 WITH ... RETURN`
+    /// was planned as a standalone RETURN and the `UNWIND` vanished from the
+    /// plan entirely (#572).
+    fn has_any_unwind(query: &Query) -> bool {
+        query.unwind_clause.is_some()
+            || query
+                .extra_with_stages
+                .iter()
+                .any(|(_, unwind, _, _)| unwind.is_some())
+    }
+
     fn late_bound_variables(query: &Query) -> HashSet<String> {
         let mut vars = HashSet::new();
         if query.unwind_leading {
@@ -836,7 +854,7 @@ impl QueryPlanner {
         // Unwind feeds the create.
         if query.match_clauses.is_empty()
             && query.call_clause.is_none()
-            && query.unwind_clause.is_none()
+            && !Self::has_any_unwind(query)
         {
             if let Some(create_clause) = &query.create_clause {
                 let mut plan = self.plan_create_only(create_clause)?;
@@ -897,7 +915,7 @@ impl QueryPlanner {
             // A leading UNWIND also has no MATCH, but it is *not* a single-row projection --
             // it must fall through to the general pipeline so the Unwind, and any
             // aggregation over it, get planned.
-            if query.unwind_clause.is_none() {
+            if !Self::has_any_unwind(query) {
             if let Some(return_clause) = &query.return_clause {
                 // Single-row operator that emits one empty record for projection
                 use crate::query::executor::operator::SingleRowOperator;
@@ -929,7 +947,7 @@ impl QueryPlanner {
             // single empty row -- the same way a bare RETURN does. The loop
             // variable is bound per element inside ForeachOperator, so nothing
             // upstream needs to supply bindings.
-            if query.foreach_clause.is_some() && query.unwind_clause.is_none() {
+            if query.foreach_clause.is_some() && !Self::has_any_unwind(query) {
                 let foreach_clause = query.foreach_clause.as_ref().expect("checked above");
                 let mut set_items = Vec::new();
                 for set_clause in &foreach_clause.set_clauses {
@@ -959,7 +977,7 @@ impl QueryPlanner {
                 });
             }
 
-            if query.unwind_clause.is_none() {
+            if !Self::has_any_unwind(query) {
                 return Err(ExecutionError::PlanningError(
                     "Query must have at least one MATCH, CALL, CREATE, or RETURN clause".to_string()
                 ));
@@ -1011,10 +1029,20 @@ impl QueryPlanner {
         // nothing.
         let late_bound_pre = Self::late_bound_variables(query);
 
+        // Predicates deferred past match planning because they name a leading
+        // UNWIND's variable. Kept rather than dropped: the claim above -- that
+        // the top-level WHERE re-applies them -- holds only when there is no
+        // WITH, because that filter is skipped once a barrier exists. With a
+        // WITH they were being discarded, so
+        // `UNWIND [1,2,3] AS x MATCH (p) WHERE p.n = x WITH ... RETURN ...`
+        // returned a cross product instead of the join (#572).
+        let mut late_bound_predicates: Vec<Expression> = Vec::new();
+
         for pred in pre_where_preds {
             let mut pred_vars = HashSet::new();
             Self::collect_expression_variables(&pred, &mut pred_vars);
             if pred_vars.iter().any(|v| late_bound_pre.contains(v)) {
+                late_bound_predicates.push(pred);
                 continue;
             }
 
@@ -1069,6 +1097,76 @@ impl QueryPlanner {
             known_vars.extend(clause_vars);
         }
 
+        // A leading UNWIND binds its variable before anything downstream reads it,
+        // and that has to happen *before* the first WITH barrier.
+        //
+        // A barrier projects the variables the WITH names, so with the UNWIND
+        // applied after it there is nothing bound for it to project, and
+        // `UNWIND [1,2,3] AS x WITH x WHERE x > 1 RETURN x` failed with
+        // `VariableNotFound("x")` -- as did every other shape, whatever the
+        // value type. Since `WHERE` cannot follow `UNWIND` directly, that left
+        // no way to filter an unwound list at all (#572).
+        //
+        // It also has to happen before the cross-MATCH predicates below, which
+        // may reference it: `UNWIND [1,2] AS x MATCH (p) WHERE p.n = x` puts
+        // `x` in a predicate spanning the unwound variable and a match
+        // variable. Applied after that filter, the predicate was silently
+        // dropped rather than failing, and the query returned a cross product.
+        //
+        // A statement that begins with UNWIND has no MATCH to build a pipeline
+        // on, so it is seeded with a single empty row here for the same reason
+        // it was seeded further down: the rest of the planner -- filters,
+        // aggregation, ORDER BY, SKIP/LIMIT -- then applies unchanged.
+        //
+        // Which slot holds it depends on how many WITH stages follow, which is
+        // a parser detail rather than a semantic one: with a single WITH the
+        // leading UNWIND is `query.unwind_clause`, and with two or more it is
+        // the *first* extra stage's unwind. Both mean the same query.
+        let leading_unwind: Option<&UnwindClause> = if query.unwind_leading {
+            if query.extra_with_stages.is_empty() {
+                query.unwind_clause.as_ref()
+            } else {
+                query.extra_with_stages[0].1.as_ref()
+            }
+        } else {
+            None
+        };
+
+        if query.unwind_leading {
+            if let Some(unwind) = leading_unwind {
+                use crate::query::executor::operator::SingleRowOperator;
+                let base: OperatorBox = match operator.take() {
+                    Some(op) => op,
+                    None => Box::new(SingleRowOperator::new()),
+                };
+                operator = Some(Box::new(UnwindOperator::new(
+                    base,
+                    unwind.expression.clone(),
+                    unwind.variable.clone(),
+                )));
+                known_vars.insert(unwind.variable.clone());
+            }
+        }
+
+        // The predicates held back above, now that the UNWIND has bound its
+        // variable. Only when a WITH follows: without one, the top-level WHERE
+        // applies the full predicate and doing it here as well would just cost
+        // a second evaluation per row.
+        if query.with_clause.is_some() && !late_bound_predicates.is_empty() {
+            if let Some(op) = operator.take() {
+                let filter_expr = late_bound_predicates
+                    .clone()
+                    .into_iter()
+                    .reduce(|acc, pred| Expression::Binary {
+                        left: Box::new(acc),
+                        op: BinaryOp::And,
+                        right: Box::new(pred),
+                    })
+                    .unwrap();
+                operator = Some(Box::new(FilterOperator::new(op, filter_expr)));
+            }
+        }
+
         // Apply cross-MATCH predicates after all pre-WITH MATCH clauses are joined
         if !cross_match_predicates.is_empty() {
             if let Some(op) = operator {
@@ -1088,11 +1186,21 @@ impl QueryPlanner {
         // Each stage: (with_clause, unwind, post_match_clauses, post_where_clause)
         let mut all_with_stages: Vec<(&WithClause, Option<&UnwindClause>, Vec<&MatchClause>, Option<&WhereClause>)> = Vec::new();
 
-        for (wc, uw, mcs, wh) in &query.extra_with_stages {
-            all_with_stages.push((wc, uw.as_ref(), mcs.iter().collect(), wh.as_ref()));
+        for (idx, (wc, uw, mcs, wh)) in query.extra_with_stages.iter().enumerate() {
+            // Stage 0 holds the leading UNWIND when there is more than one WITH;
+            // it was applied before the barriers, above.
+            let stage_unwind = if idx == 0 && leading_unwind.is_some() { None } else { uw.as_ref() };
+            all_with_stages.push((wc, stage_unwind, mcs.iter().collect(), wh.as_ref()));
         }
         if let Some(wc) = &query.with_clause {
-            all_with_stages.push((wc, query.unwind_clause.as_ref(), post_with_clauses.iter().collect(), query.post_with_where_clause.as_ref()));
+            // A *leading* UNWIND was applied before the barriers, above. Only a
+            // trailing one belongs to this stage.
+            let stage_unwind = if query.unwind_leading && query.extra_with_stages.is_empty() {
+                None
+            } else {
+                query.unwind_clause.as_ref()
+            };
+            all_with_stages.push((wc, stage_unwind, post_with_clauses.iter().collect(), query.post_with_where_clause.as_ref()));
         }
 
         let mut anon_counter: usize = 0;
@@ -1338,26 +1446,18 @@ impl QueryPlanner {
         // aggregation, ORDER BY, SKIP/LIMIT -- apply unchanged. Hand-building a plan here
         // instead would have to re-implement all of that; the first attempt did, and
         // promptly failed on `UNWIND [...] AS x RETURN count(x)`.
-        if operator.is_none() && query.unwind_clause.is_some() {
+        if operator.is_none() && Self::has_any_unwind(query) {
             use crate::query::executor::operator::SingleRowOperator;
             operator = Some(Box::new(SingleRowOperator::new()));
         }
 
         let mut operator = operator.unwrap();
 
-        // A *leading* UNWIND binds its variable before the WHERE, because the predicate may
-        // reference it (`UNWIND [1,2] AS x MATCH (p) WHERE p.n = x`). Applied after the
-        // filter, as a trailing UNWIND is, that query fails with "Variable not found".
-        let leading_unwind = query.unwind_leading && query.with_clause.is_none();
-        if leading_unwind {
-            if let Some(unwind_clause) = &query.unwind_clause {
-                operator = Box::new(UnwindOperator::new(
-                    operator,
-                    unwind_clause.expression.clone(),
-                    unwind_clause.variable.clone(),
-                ));
-            }
-        }
+        // A *leading* UNWIND is planned before the WITH barriers, above, so that
+        // a following WITH has its variable bound. It still lands below the
+        // WHERE, which is what `UNWIND [1,2] AS x MATCH (p) WHERE p.n = x`
+        // needs -- the predicate references the unwound variable.
+        let leading_unwind = query.unwind_leading;
 
         // Add WHERE clause if present.
         // When a WITH clause exists, WHERE predicates were already decomposed and

--- a/tests/unwind_with.rs
+++ b/tests/unwind_with.rs
@@ -1,0 +1,198 @@
+//! A leading `UNWIND` followed by `WITH` (#572).
+//!
+//! `UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 RETURN x` failed with
+//! `VariableNotFound("x")`, and so did every other shape whatever the value
+//! type. A `WITH` barrier projects the variables the clause names, and the
+//! `UNWIND` was being planned *after* it — so there was nothing bound for the
+//! barrier to project.
+//!
+//! Since `WHERE` cannot follow `UNWIND` directly, that left **no way to filter
+//! an unwound list at all**, and no way to write the "unwind a list of
+//! parameters, then match on each" shape a machine caller uses for a batch.
+//!
+//! The risk in the fix is the other direction: a *trailing* `UNWIND` belongs to
+//! its stage and must still be applied there, and a leading one must not be
+//! applied twice. Both have tests below, because a double `UNWIND` multiplies
+//! rows rather than erroring.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn ints(store: &GraphStore, cypher: &str, name: &str) -> Vec<i64> {
+    let query = parse_query(cypher).expect("query should parse");
+    QueryExecutor::new(store)
+        .execute(&query)
+        .expect("query should run")
+        .records
+        .iter()
+        .map(|r| match r.get(name) {
+            Some(Value::Property(PropertyValue::Integer(n))) => *n,
+            other => panic!("{other:?}"),
+        })
+        .collect()
+}
+
+#[test]
+fn a_leading_unwind_is_visible_to_a_following_with() {
+    let store = GraphStore::new();
+    assert_eq!(
+        ints(&store, "UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 RETURN x AS a", "a"),
+        vec![2, 3]
+    );
+}
+
+#[test]
+fn the_with_may_rename_it() {
+    let store = GraphStore::new();
+    assert_eq!(
+        ints(&store, "UNWIND [1, 2, 3] AS x WITH x AS y WHERE y > 1 RETURN y AS a", "a"),
+        vec![2, 3]
+    );
+}
+
+#[test]
+fn the_with_may_project_an_expression_of_it() {
+    let store = GraphStore::new();
+    assert_eq!(
+        ints(&store, "UNWIND [1, 2, 3] AS x WITH x * 10 AS y WHERE y > 15 RETURN y AS a", "a"),
+        vec![20, 30]
+    );
+}
+
+#[test]
+fn a_map_element_works_the_same_way() {
+    let store = GraphStore::new();
+    assert_eq!(
+        ints(
+            &store,
+            "UNWIND [{a: 1}, {a: 2}, {a: 3}] AS m WITH m WHERE m.a > 1 RETURN m.a AS a",
+            "a"
+        ),
+        vec![2, 3]
+    );
+    assert_eq!(
+        ints(
+            &store,
+            "UNWIND [{a: 1}, {a: 2}, {a: 3}] AS m WITH m.a AS a WHERE a > 1 RETURN a",
+            "a"
+        ),
+        vec![2, 3]
+    );
+}
+
+#[test]
+fn every_row_survives_when_the_where_keeps_them_all() {
+    // A double UNWIND would multiply rows rather than error, so the count is
+    // the thing to assert, not just the values.
+    let store = GraphStore::new();
+    let got = ints(&store, "UNWIND [1, 2, 3] AS x WITH x RETURN x AS a", "a");
+    assert_eq!(got, vec![1, 2, 3], "three rows in, three out — not nine");
+}
+
+#[test]
+fn a_with_can_aggregate_over_the_unwound_rows() {
+    let store = GraphStore::new();
+    assert_eq!(
+        ints(&store, "UNWIND [1, 2, 3, 4] AS x WITH sum(x) AS s RETURN s AS a", "a"),
+        vec![10]
+    );
+    assert_eq!(
+        ints(&store, "UNWIND [1, 2, 3, 4] AS x WITH count(x) AS c RETURN c AS a", "a"),
+        vec![4]
+    );
+}
+
+#[test]
+fn a_leading_unwind_still_reaches_a_where_with_no_with() {
+    // The shape the old placement existed for: the predicate references the
+    // unwound variable, so the UNWIND has to sit below the filter. Moving it
+    // earlier must not have broken this.
+    let mut store = GraphStore::new();
+    for i in 1..=4i64 {
+        let id = store.create_node("N");
+        let _ = store.set_node_property("default", id, "n".to_string(), PropertyValue::Integer(i));
+    }
+    let got = ints(
+        &store,
+        "UNWIND [2, 3] AS x MATCH (p:N) WHERE p.n = x RETURN p.n AS a",
+        "a",
+    );
+    let mut got = got;
+    got.sort();
+    assert_eq!(got, vec![2, 3]);
+}
+
+#[test]
+fn a_leading_unwind_with_a_match_and_a_with() {
+    // Both at once: the UNWIND must be bound before the MATCH's predicate and
+    // before the barrier.
+    let mut store = GraphStore::new();
+    for i in 1..=4i64 {
+        let id = store.create_node("N");
+        let _ = store.set_node_property("default", id, "n".to_string(), PropertyValue::Integer(i));
+    }
+    let mut got = ints(
+        &store,
+        "UNWIND [1, 2, 3] AS x MATCH (p:N) WHERE p.n = x WITH p.n AS n WHERE n > 1 RETURN n AS a",
+        "a",
+    );
+    got.sort();
+    assert_eq!(got, vec![2, 3]);
+}
+
+#[test]
+fn a_trailing_unwind_still_belongs_to_its_stage() {
+    // The other direction. `WITH … UNWIND …` unwinds *after* the barrier, and
+    // suppressing the stage's UNWIND for the leading case must not have
+    // suppressed it here.
+    let mut store = GraphStore::new();
+    let id = store.create_node("N");
+    let _ = store.set_node_property(
+        "default",
+        id,
+        "tags".to_string(),
+        PropertyValue::Array(vec![
+            PropertyValue::Integer(7),
+            PropertyValue::Integer(8),
+            PropertyValue::Integer(9),
+        ]),
+    );
+    let got = ints(&store, "MATCH (n:N) WITH n.tags AS t UNWIND t AS x RETURN x AS a", "a");
+    assert_eq!(got, vec![7, 8, 9]);
+}
+
+#[test]
+fn a_leading_unwind_with_no_with_is_unchanged() {
+    let store = GraphStore::new();
+    assert_eq!(ints(&store, "UNWIND [5, 6] AS x RETURN x AS a", "a"), vec![5, 6]);
+    // Aggregation over a bare leading UNWIND — the case the SingleRowOperator
+    // seed was introduced for.
+    assert_eq!(ints(&store, "UNWIND [5, 6, 7] AS x RETURN count(x) AS a", "a"), vec![3]);
+}
+
+#[test]
+fn ordering_and_limiting_after_the_with_work() {
+    let store = GraphStore::new();
+    assert_eq!(
+        ints(
+            &store,
+            "UNWIND [3, 1, 4, 1, 5] AS x WITH x WHERE x > 1 RETURN x AS a ORDER BY x DESC LIMIT 2",
+            "a"
+        ),
+        vec![5, 4]
+    );
+}
+
+#[test]
+fn two_with_stages_after_a_leading_unwind() {
+    let store = GraphStore::new();
+    assert_eq!(
+        ints(
+            &store,
+            "UNWIND [1, 2, 3, 4] AS x WITH x WHERE x > 1 WITH x * 2 AS y WHERE y < 8 RETURN y AS a",
+            "a"
+        ),
+        vec![4, 6]
+    );
+}


### PR DESCRIPTION
Closes #572.

## The bug

```cypher
UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 RETURN x
-- was: VariableNotFound("x")     now: 2, 3
```

Every shape failed, whatever the value type. Since `WHERE` cannot follow `UNWIND` directly, **there was no way to filter an unwound list at all** — nor to write the "unwind a list of parameters, then match on each" shape a machine caller uses for a batch (`Axiom 4`).

## Three causes, found one behind the other

**1. The `UNWIND` was planned after the `WITH` barrier.** A barrier projects the variables the clause names, so there was nothing bound for it to project. It is now planned before the barriers, and suppressed in the stage that would re-apply it.

**2. Predicates naming the unwound variable were being *dropped*.** Match planning defers them, on the stated grounds that the top-level `WHERE` re-applies the full predicate — which holds *only when there is no `WITH`*, because that filter is skipped once a barrier exists. So:

```cypher
UNWIND [1,2,3] AS x MATCH (p:N) WHERE p.n = x WITH p.n AS n WHERE n > 1 RETURN n
-- returned [2,2,2,3,3,3,4,4,4] — a cross product, silently
```

They are now kept and applied once the `UNWIND` has bound its variable.

**3. Four early branches tested the wrong slot.** A leading `UNWIND` is `query.unwind_clause` when a single `WITH` follows, and the **first extra stage's** unwind when two or more do — a parser detail, not a semantic one. The CREATE-only path, the standalone-`RETURN` path, the leading-`FOREACH` path and the "no clauses at all" error all tested only the first. So a two-stage query was planned as a standalone `RETURN` and the `UNWIND` **vanished from the plan entirely**:

```
Project (y AS a)
+- Project (x * Integer(2) AS y)
   +- SingleRow          ← no Unwind anywhere
```

`has_any_unwind` looks in both slots.

## Testing

12 tests in `tests/unwind_with.rs`. The ones that matter are the reverse direction:

- a **trailing** `UNWIND` still belongs to its stage (`MATCH … WITH … UNWIND … RETURN`), since suppressing the leading case must not suppress that one;
- a leading one must not be applied **twice** — which multiplies rows rather than erroring, so the row count is asserted and not only the values;
- `UNWIND … MATCH … WHERE p.n = x` with **no** `WITH` still works, which is what the old placement existed for;
- a bare leading `UNWIND` with aggregation, which is what the `SingleRowOperator` seed was introduced for.

Plus: renaming in the `WITH`, projecting an expression of it, map elements, aggregating over the unwound rows, `ORDER BY … LIMIT` after the `WITH`, and two `WITH` stages.

Suite on a dedicated box: **exit 0, 2,799 tests, 0 failures.** LDBC SF1 unchanged at **21/21 in 14.4 s**.