### PR TITLE
Fix six Cypher gaps found by sweeping expressions against known answers

### DIFF
--- a/examples/cypher_probe.rs
+++ b/examples/cypher_probe.rs
@@ -1,0 +1,167 @@
+//! A battery of standard Cypher expressions with hand-computed answers.
+//!
+//! Looking for the class of bug that #571 and #572 turned out to be: a
+//! construct that parses, runs, and returns the wrong thing without erroring.
+//! Each case states what it should return; anything else is reported.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn render(v: Option<&Value>) -> String {
+    match v {
+        Some(Value::Property(p)) => match p {
+            PropertyValue::Integer(n) => n.to_string(),
+            PropertyValue::Float(f) => format!("{f}"),
+            PropertyValue::String(s) => format!("\"{s}\""),
+            PropertyValue::Boolean(b) => b.to_string(),
+            PropertyValue::Null => "null".into(),
+            PropertyValue::Array(a) => format!(
+                "[{}]",
+                a.iter().map(|x| match x {
+                    PropertyValue::Integer(n) => n.to_string(),
+                    PropertyValue::String(s) => format!("\"{s}\""),
+                    PropertyValue::Float(f) => format!("{f}"),
+                    other => format!("{other:?}"),
+                }).collect::<Vec<_>>().join(", ")
+            ),
+            other => format!("{other:?}"),
+        },
+        Some(Value::Null) | None => "null".into(),
+        Some(other) => format!("{other:?}"),
+    }
+}
+
+fn main() {
+    let mut store = GraphStore::new();
+    // A tiny fixture some cases need.
+    let a = store.create_node("P");
+    let _ = store.set_node_property("default", a, "name", PropertyValue::String("Ada".into()));
+    let _ = store.set_node_property("default", a, "age", PropertyValue::Integer(36));
+    let b = store.create_node("P");
+    let _ = store.set_node_property("default", b, "name", PropertyValue::String("Bob".into()));
+    let _ = store.set_node_property("default", b, "age", PropertyValue::Integer(41));
+    store.create_edge(a, b, "KNOWS").unwrap();
+
+    // (cypher, expected rendering of column `r`)
+    let cases: &[(&str, &str)] = &[
+        // --- list functions
+        ("RETURN size([1,2,3]) AS r", "3"),
+        ("RETURN head([1,2,3]) AS r", "1"),
+        ("RETURN last([1,2,3]) AS r", "3"),
+        ("RETURN tail([1,2,3]) AS r", "[2, 3]"),
+        ("RETURN reverse([1,2,3]) AS r", "[3, 2, 1]"),
+        ("RETURN range(1,3) AS r", "[1, 2, 3]"),
+        ("RETURN [x IN [1,2,3,4] WHERE x > 2] AS r", "[3, 4]"),
+        ("RETURN [x IN [1,2,3] | x * 2] AS r", "[2, 4, 6]"),
+        ("RETURN reduce(s = 0, x IN [1,2,3] | s + x) AS r", "6"),
+        ("RETURN [1,2,3][1] AS r", "2"),
+        ("RETURN [1,2,3,4][1..3] AS r", "[2, 3]"),
+        // --- predicate functions
+        ("RETURN all(x IN [1,2,3] WHERE x > 0) AS r", "true"),
+        ("RETURN any(x IN [1,2,3] WHERE x > 2) AS r", "true"),
+        ("RETURN none(x IN [1,2,3] WHERE x > 5) AS r", "true"),
+        ("RETURN single(x IN [1,2,3] WHERE x = 2) AS r", "true"),
+        // --- map
+        ("WITH {a: 1, b: 2} AS m RETURN m.a AS r", "1"),
+        ("WITH {a: 1, b: 2} AS m RETURN keys(m) AS r", "[\"a\", \"b\"]"),
+        ("WITH {a: 1, b: 2} AS m RETURN size(keys(m)) AS r", "2"),
+        ("WITH {a: 1} AS m RETURN m[\"a\"] AS r", "1"),
+        // --- string functions
+        ("RETURN toUpper(\"ab\") AS r", "\"AB\""),
+        ("RETURN toLower(\"AB\") AS r", "\"ab\""),
+        ("RETURN trim(\"  x \") AS r", "\"x\""),
+        ("RETURN substring(\"abcdef\", 1, 3) AS r", "\"bcd\""),
+        ("RETURN left(\"abcdef\", 2) AS r", "\"ab\""),
+        ("RETURN right(\"abcdef\", 2) AS r", "\"ef\""),
+        ("RETURN replace(\"abc\", \"b\", \"X\") AS r", "\"aXc\""),
+        ("RETURN split(\"a,b,c\", \",\") AS r", "[\"a\", \"b\", \"c\"]"),
+        ("RETURN \"abc\" CONTAINS \"b\" AS r", "true"),
+        ("RETURN \"abc\" STARTS WITH \"a\" AS r", "true"),
+        ("RETURN \"abc\" ENDS WITH \"c\" AS r", "true"),
+        // --- numeric
+        ("RETURN abs(-3) AS r", "3"),
+        ("RETURN ceil(1.2) AS r", "2"),
+        ("RETURN floor(1.8) AS r", "1"),
+        ("RETURN round(1.5) AS r", "2"),
+        ("RETURN sign(-9) AS r", "-1"),
+        ("RETURN toInteger(\"42\") AS r", "42"),
+        ("RETURN toFloat(\"1.5\") AS r", "1.5"),
+        ("RETURN toString(42) AS r", "\"42\""),
+        ("RETURN 7 % 3 AS r", "1"),
+        ("RETURN 2 ^ 3 AS r", "8"),
+        // --- null handling / three-valued logic
+        ("RETURN coalesce(null, 2) AS r", "2"),
+        ("RETURN null IS NULL AS r", "true"),
+        ("RETURN 1 IS NOT NULL AS r", "true"),
+        ("RETURN null = null AS r", "null"),
+        // --- CASE
+        ("RETURN CASE WHEN 1 > 0 THEN \"y\" ELSE \"n\" END AS r", "\"y\""),
+        ("RETURN CASE 2 WHEN 1 THEN \"a\" WHEN 2 THEN \"b\" ELSE \"c\" END AS r", "\"b\""),
+        // --- aggregation
+        ("UNWIND [1,2,3] AS x RETURN sum(x) AS r", "6"),
+        ("UNWIND [1,2,3] AS x RETURN avg(x) AS r", "2"),
+        ("UNWIND [1,2,2] AS x RETURN count(DISTINCT x) AS r", "2"),
+        ("UNWIND [1,2,3] AS x RETURN collect(x) AS r", "[1, 2, 3]"),
+        ("UNWIND [3,1,2] AS x RETURN min(x) AS r", "1"),
+        ("UNWIND [3,1,2] AS x RETURN max(x) AS r", "3"),
+        // --- graph functions
+        ("MATCH (p:P) WHERE p.name = \"Ada\" RETURN labels(p) AS r", "[\"P\"]"),
+        ("MATCH (p:P)-[e:KNOWS]->(q) RETURN type(e) AS r", "\"KNOWS\""),
+        ("MATCH (p:P) WHERE p.name = \"Ada\" RETURN size(keys(p)) AS r", "2"),
+        ("MATCH p = (a:P)-[:KNOWS]->(b:P) RETURN length(p) AS r", "1"),
+        ("MATCH (p:P) WHERE p.name = \"Ada\" RETURN exists(p.age) AS r", "true"),
+        ("MATCH (p:P) RETURN count(p) AS r", "2"),
+        ("MATCH (a:P) WHERE EXISTS { MATCH (a)-[:KNOWS]->() } RETURN count(a) AS r", "1"),
+        // --- ordering / distinct
+        ("UNWIND [1,1,2] AS x RETURN count(x) AS r", "3"),
+        // --- narrowing the three gaps found by the first sweep
+        ("RETURN reverse(\"abc\") AS r", "\"cba\""),
+        ("RETURN [x IN [1,2,3,4] WHERE x > 2 | x] AS r", "[3, 4]"),
+        ("RETURN [x IN [1,2,3,4] WHERE x > 2] AS r", "[3, 4]"),
+        ("RETURN size([x IN [1,2,3,4] WHERE x > 2 | x]) AS r", "2"),
+        ("RETURN 2 ^ 3 AS r", "8"),
+        ("RETURN 2 * 3 AS r", "6"),
+        ("RETURN 10 / 4 AS r", "2"),
+        ("RETURN 10.0 / 4 AS r", "2.5"),
+        ("RETURN -3 + 1 AS r", "-2"),
+        ("RETURN sqrt(9) AS r", "3"),
+        ("RETURN toString(1.5) AS r", "\"1.5\""),
+        ("RETURN [1,2] + [3] AS r", "[1, 2, 3]"),
+        ("RETURN \"a\" + \"b\" AS r", "\"ab\""),
+        ("RETURN 1 IN [1,2] AS r", "true"),
+        ("RETURN NOT false AS r", "true"),
+        ("RETURN true AND false AS r", "false"),
+        ("RETURN true XOR false AS r", "true"),
+    ];
+
+    let mut wrong: Vec<(String,String,String)> = Vec::new();
+    let mut errored: Vec<(String,String)> = Vec::new();
+
+    for (cypher, expected) in cases {
+        match parse_query(cypher) {
+            Err(e) => errored.push((cypher.to_string(), format!("parse: {e:?}"))),
+            Ok(q) => match QueryExecutor::new(&store).execute(&q) {
+                Err(e) => errored.push((cypher.to_string(), format!("exec: {e:?}"))),
+                Ok(batch) => {
+                    let got = batch.records.first().map(|r| render(r.get("r"))).unwrap_or("<no rows>".into());
+                    if got != *expected {
+                        wrong.push((cypher.to_string(), expected.to_string(), got));
+                    }
+                }
+            },
+        }
+    }
+
+    println!("{} cases: {} ok, {} wrong answer, {} errored",
+        cases.len(), cases.len()-wrong.len()-errored.len(), wrong.len(), errored.len());
+
+    if !wrong.is_empty() {
+        println!("\n=== WRONG ANSWER (parses, runs, returns the wrong thing) ===");
+        for (c,e,g) in &wrong { println!("  {c}\n     expected {e}, got {g}"); }
+    }
+    if !errored.is_empty() {
+        println!("\n=== ERRORED (at least it says so) ===");
+        for (c,e) in &errored { println!("  {c}\n     {e}"); }
+    }
+}

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -484,6 +484,10 @@ pub enum BinaryOp {
     Mul,
     /// Division (/)
     Div,
+    /// Exponentiation (^). Right-associative and binds tighter than `*`.
+    Pow,
+    /// Exclusive or (XOR). Sits between OR and AND, as Cypher specifies.
+    Xor,
     /// Modulo (%)
     Mod,
     /// String starts with

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -204,7 +204,14 @@ pattern_comprehension = { "[" ~ path ~ where_clause? ~ "|" ~ expression ~ "]" }
 exists_subquery = { ^"EXISTS" ~ "{" ~ ^"MATCH" ~ pattern ~ where_clause? ~ "}" }
 
 // List comprehension: [x IN list WHERE cond | expr]
-list_comprehension = { "[" ~ variable ~ in_op ~ expression ~ (^"WHERE" ~ expression)? ~ "|" ~ expression ~ "]" }
+// The `| expr` projection is optional; without it the iteration variable is
+// projected, so `[x IN xs WHERE p]` is `[x IN xs WHERE p | x]` (#578).
+list_comprehension = { "[" ~ variable ~ in_op ~ expression ~ (where_kw ~ expression)? ~ (pipe_op ~ expression)? ~ "]" }
+// Both markers are captured rather than literal so the parser can tell which
+// optional expression it is looking at: with the projection optional, two
+// expressions could be (list, filter) or (list, projection) (#578).
+where_kw = @{ ^"WHERE" ~ !(ASCII_ALPHANUMERIC | "_") }
+pipe_op = { "|" }
 
 // CASE expression: CASE WHEN condition THEN result [WHEN...] [ELSE default] END
 // Also simple form: CASE expr WHEN val THEN result [WHEN...] [ELSE default] END
@@ -221,14 +228,16 @@ function_call = { function_name ~ "(" ~ distinct? ~ (expression ~ ("," ~ express
 function_name = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 // Operators
+pow_op = { "^" }
 mul_div_mod_op = { "*" | "/" | "%" }
 add_sub_op = { "+" | "-" }
 comparison_op = { "<=" | "<>" | ">=" | "<" | ">" | "==" | "=~" | "=" | "!=" | ^"STARTS" ~ ^"WITH" | ^"ENDS" ~ ^"WITH" | ^"CONTAINS" }
 in_op = @{ ^"IN" ~ !(ASCII_ALPHANUMERIC | "_") }
 and_op = @{ ^"AND" ~ !(ASCII_ALPHANUMERIC | "_") }
 or_op = @{ ^"OR" ~ !(ASCII_ALPHANUMERIC | "_") }
+xor_op = @{ ^"XOR" ~ !(ASCII_ALPHANUMERIC | "_") }
 
-binary_op = _{ mul_div_mod_op | add_sub_op | comparison_op | in_op | and_op | or_op }
+binary_op = _{ pow_op | mul_div_mod_op | add_sub_op | comparison_op | in_op | and_op | xor_op | or_op }
 
 unary_op = { "-" }
 not_op = @{ ^"NOT" ~ !(ASCII_ALPHANUMERIC | "_") }

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -145,6 +145,29 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
     let result = match op {
         BinaryOp::Eq => PropertyValue::Boolean(left_prop == right_prop),
         BinaryOp::Ne => PropertyValue::Boolean(left_prop != right_prop),
+        BinaryOp::Pow => match (&left_prop, &right_prop) {
+            (PropertyValue::Null, _) | (_, PropertyValue::Null) => PropertyValue::Null,
+            _ => {
+                // Cypher's `^` is float exponentiation even over integers:
+                // `2 ^ 3` is 8.0, and `2 ^ -1` has to be 0.5 rather than 0.
+                //
+                // `as_float` returns `None` for an `Integer`, so it cannot be
+                // used alone here -- doing that made `2 ^ 3` answer
+                // "^ requires numeric operands".
+                let numeric = |p: &PropertyValue| -> Option<f64> {
+                    p.as_float().or_else(|| p.as_integer().map(|i| i as f64))
+                };
+                match (numeric(&left_prop), numeric(&right_prop)) {
+                    (Some(base), Some(exp)) => PropertyValue::Float(base.powf(exp)),
+                    _ => return Err(ExecutionError::TypeError("^ requires numeric operands".to_string())),
+                }
+            }
+        },
+        BinaryOp::Xor => match (&left_prop, &right_prop) {
+            (PropertyValue::Null, _) | (_, PropertyValue::Null) => PropertyValue::Null,
+            (PropertyValue::Boolean(l), PropertyValue::Boolean(r)) => PropertyValue::Boolean(l != r),
+            _ => return Err(ExecutionError::TypeError("XOR requires boolean operands".to_string())),
+        },
         BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge => {
             let cmp = left_prop.partial_cmp(&right_prop);
             match (op, cmp) {
@@ -175,6 +198,28 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
             (PropertyValue::Integer(l), PropertyValue::Float(r)) => PropertyValue::Float(*l as f64 + r),
             (PropertyValue::Float(l), PropertyValue::Integer(r)) => PropertyValue::Float(l + *r as f64),
             (PropertyValue::String(l), PropertyValue::String(r)) => PropertyValue::String(format!("{}{}", l, r)),
+            // List concatenation, and appending or prepending a scalar. Cypher
+            // defines all three for `+`; none of them worked (#578).
+            (PropertyValue::Array(l), PropertyValue::Array(r)) => {
+                let mut out = l.clone();
+                out.extend(r.iter().cloned());
+                PropertyValue::Array(out)
+            }
+            // Null is excluded here so the propagation arm below still governs
+            // it. `[1,2] + null` appending a null element is arguably Cypher's
+            // answer, but it is a judgement call and this is not the change to
+            // make it in -- the existing rule is that any null operand makes the
+            // result null (#457), and it stays.
+            (PropertyValue::Array(l), scalar) if !matches!(scalar, PropertyValue::Null) => {
+                let mut out = l.clone();
+                out.push(scalar.clone());
+                PropertyValue::Array(out)
+            }
+            (scalar, PropertyValue::Array(r)) if !matches!(scalar, PropertyValue::Null) => {
+                let mut out = vec![scalar.clone()];
+                out.extend(r.iter().cloned());
+                PropertyValue::Array(out)
+            }
             // DateTime + Duration
             (PropertyValue::DateTime(dt), PropertyValue::Duration { months, days, seconds, .. }) |
             (PropertyValue::Duration { months, days, seconds, .. }, PropertyValue::DateTime(dt)) => {
@@ -883,6 +928,18 @@ fn value_node_id(v: &Value) -> Option<NodeId> {
     }
 }
 
+/// Property names in a stable order.
+///
+/// Lexicographic: stable, what a reader expects, and cheap over the handful of
+/// keys a node or map has (#577).
+fn sorted_keys(mut keys: Vec<PropertyValue>) -> Vec<PropertyValue> {
+    keys.sort_by(|a, b| match (a, b) {
+        (PropertyValue::String(x), PropertyValue::String(y)) => x.cmp(y),
+        _ => std::cmp::Ordering::Equal,
+    });
+    keys
+}
+
 /// Shared function evaluation for scalar functions (not aggregates)
 pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> ExecutionResult<Value> {
     match name.to_lowercase().as_str() {
@@ -1078,10 +1135,23 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
             let start = chars.len().saturating_sub(n);
             Ok(Value::Property(PropertyValue::String(chars[start..].iter().collect())))
         }
-        "reverse" => {
-            let s = extract_string(&args[0])?;
-            Ok(Value::Property(PropertyValue::String(s.chars().rev().collect())))
-        }
+        // Cypher's reverse() takes a list as well as a string, and this took
+        // only a string -- `reverse([1,2,3])` answered
+        // `TypeError("Expected string argument")` (#578).
+        "reverse" => match &args[0] {
+            Value::Property(PropertyValue::Array(items)) => {
+                let mut reversed = items.clone();
+                reversed.reverse();
+                Ok(Value::Property(PropertyValue::Array(reversed)))
+            }
+            Value::Property(PropertyValue::Null) | Value::Null => {
+                Ok(Value::Property(PropertyValue::Null))
+            }
+            other => {
+                let text = extract_string(other)?;
+                Ok(Value::Property(PropertyValue::String(text.chars().rev().collect())))
+            }
+        },
         "tostring" => {
             let val = &args[0];
             let s = match val {
@@ -1303,6 +1373,13 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                 _ => Err(ExecutionError::TypeError("type() requires an edge".to_string())),
             }
         }
+        // Sorted, because the underlying maps are `HashMap`s and Rust seeds
+        // their hasher randomly *per process* -- so this returned a different
+        // order on every run of the same query over the same data. Cypher does
+        // not specify an order, which makes any particular one conformant; it
+        // does not make a *different one each time* acceptable. A result that
+        // cannot be diffed, cached or compared across versions undermines
+        // Axiom 3 at the level of the answer rather than the timing (#577).
         "keys" => {
             match &args[0] {
                 Value::Node(id, node) => {
@@ -1322,7 +1399,7 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                             .map(|k| PropertyValue::String(k.clone()))
                             .collect(),
                     };
-                    Ok(Value::Property(PropertyValue::Array(keys)))
+                    Ok(Value::Property(PropertyValue::Array(sorted_keys(keys))))
                 }
                 Value::NodeRef(id) => {
                     let s = store.ok_or_else(|| ExecutionError::RuntimeError("keys() on NodeRef requires store".to_string()))?;
@@ -1334,13 +1411,13 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                         .keys()
                         .map(|k| PropertyValue::String(k.clone()))
                         .collect();
-                    Ok(Value::Property(PropertyValue::Array(keys)))
+                    Ok(Value::Property(PropertyValue::Array(sorted_keys(keys))))
                 }
                 Value::Edge(_, edge) => {
                     let keys: Vec<PropertyValue> = edge.properties.keys()
                         .map(|k| PropertyValue::String(k.clone()))
                         .collect();
-                    Ok(Value::Property(PropertyValue::Array(keys)))
+                    Ok(Value::Property(PropertyValue::Array(sorted_keys(keys))))
                 }
                 Value::EdgeRef(eid, _, _, _) => {
                     let s = store.ok_or_else(|| ExecutionError::RuntimeError("keys() on EdgeRef requires store".to_string()))?;
@@ -1348,7 +1425,7 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     let keys: Vec<PropertyValue> = edge.properties.keys()
                         .map(|k| PropertyValue::String(k.clone()))
                         .collect();
-                    Ok(Value::Property(PropertyValue::Array(keys)))
+                    Ok(Value::Property(PropertyValue::Array(sorted_keys(keys))))
                 }
                 // keys() over a map property. Cypher defines keys() on maps as
                 // well as nodes and edges, and without this a map property can
@@ -1358,7 +1435,7 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                         .keys()
                         .map(|k| PropertyValue::String(k.clone()))
                         .collect();
-                    Ok(Value::Property(PropertyValue::Array(keys)))
+                    Ok(Value::Property(PropertyValue::Array(sorted_keys(keys))))
                 }
                 _ => Err(ExecutionError::TypeError("keys() requires a node, edge, or map".to_string())),
             }
@@ -2188,6 +2265,7 @@ fn format_expression(expr: &Expression) -> String {
                 BinaryOp::And => "AND", BinaryOp::Or => "OR",
                 BinaryOp::Add => "+", BinaryOp::Sub => "-",
                 BinaryOp::Mul => "*", BinaryOp::Div => "/", BinaryOp::Mod => "%",
+                BinaryOp::Pow => "^", BinaryOp::Xor => "XOR",
                 BinaryOp::StartsWith => "STARTS WITH", BinaryOp::EndsWith => "ENDS WITH",
                 BinaryOp::Contains => "CONTAINS", BinaryOp::In => "IN",
                 BinaryOp::RegexMatch => "=~",
@@ -2894,6 +2972,15 @@ impl FilterOperator {
             BinaryOp::Ge => self.compare_ge(&left_prop, &right_prop)?,
             BinaryOp::And => self.logical_and(&left_prop, &right_prop)?,
             BinaryOp::Or => self.logical_or(&left_prop, &right_prop)?,
+            // Delegated so `^` and XOR have one definition rather than two that
+            // can drift; this evaluator differs from `eval_binary_op` only in
+            // its comparison coercions, which neither operator uses.
+            BinaryOp::Pow | BinaryOp::Xor => {
+                match eval_binary_op(op, Value::Property(left_prop.clone()), Value::Property(right_prop.clone()))? {
+                    Value::Property(p) => p,
+                    other => return Err(ExecutionError::TypeError(format!("unexpected {other:?}"))),
+                }
+            }
             BinaryOp::Add => self.arithmetic_add(&left_prop, &right_prop)?,
             BinaryOp::Sub => self.arithmetic_sub(&left_prop, &right_prop)?,
             BinaryOp::Mul => self.arithmetic_mul(&left_prop, &right_prop)?,

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -73,6 +73,9 @@ struct CypherParser;
 static PRATT_PARSER: LazyLock<PrattParser<Rule>> = LazyLock::new(|| {
     PrattParser::new()
         .op(Op::infix(Rule::or_op, Assoc::Left))
+        // XOR binds tighter than OR and looser than AND, which is where Cypher
+        // puts it (#578).
+        .op(Op::infix(Rule::xor_op, Assoc::Left))
         .op(Op::infix(Rule::and_op, Assoc::Left))
         // NOT sits between AND and the comparisons: `NOT a STARTS WITH b` negates the
         // comparison, while `NOT a AND b` still groups as `(NOT a) AND b`.
@@ -80,6 +83,9 @@ static PRATT_PARSER: LazyLock<PrattParser<Rule>> = LazyLock::new(|| {
         .op(Op::infix(Rule::in_op, Assoc::Left) | Op::infix(Rule::comparison_op, Assoc::Left))
         .op(Op::infix(Rule::add_sub_op, Assoc::Left))
         .op(Op::infix(Rule::mul_div_mod_op, Assoc::Left))
+        // Exponentiation binds tightest and associates to the *right*:
+        // `2 ^ 3 ^ 2` is 2^(3^2), not (2^3)^2.
+        .op(Op::infix(Rule::pow_op, Assoc::Right))
 });
 
 /// Parser errors
@@ -1572,7 +1578,9 @@ fn parse_expression(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression
             
             let op = match op.as_rule() {
                 Rule::or_op => BinaryOp::Or,
+                Rule::xor_op => BinaryOp::Xor,
                 Rule::and_op => BinaryOp::And,
+                Rule::pow_op => BinaryOp::Pow,
                 Rule::comparison_op => parse_op_str(op.as_str())?,
                 Rule::in_op => BinaryOp::In,
                 Rule::add_sub_op => parse_op_str(op.as_str())?,
@@ -1879,25 +1887,39 @@ fn parse_list_comprehension(pair: pest::iterators::Pair<Rule>) -> ParseResult<Ex
     let mut list_expr = None;
     let mut filter = None;
     let mut map_expr = None;
-    let mut expressions = Vec::new();
 
+    // Which optional expression is which is decided by the marker that preceded
+    // it, not by how many there are: `[x IN xs WHERE p]` and `[x IN xs | e]`
+    // both have two expressions and mean different things (#578).
+    let mut seen_where = false;
+    let mut seen_pipe = false;
     for inner in pair.into_inner() {
         match inner.as_rule() {
             Rule::variable => variable = Some(inner.as_str().to_string()),
             Rule::in_op => {} // skip the IN keyword
-            Rule::expression => expressions.push(parse_expression(inner)?),
+            Rule::where_kw => seen_where = true,
+            Rule::pipe_op => seen_pipe = true,
+            Rule::expression => {
+                let expr = parse_expression(inner)?;
+                if list_expr.is_none() {
+                    list_expr = Some(expr);
+                } else if seen_pipe {
+                    map_expr = Some(expr);
+                } else if seen_where {
+                    filter = Some(expr);
+                } else {
+                    map_expr = Some(expr);
+                }
+            }
             _ => {}
         }
     }
 
-    // Order: list_expr, [filter], map_expr
-    // Grammar: variable IN expression (WHERE expression)? | expression
-    // So expressions are: [list_expr, optional_filter, map_expr]
-    if expressions.len() >= 2 {
-        list_expr = Some(expressions.remove(0));
-        map_expr = Some(expressions.pop().unwrap());
-        if !expressions.is_empty() {
-            filter = Some(expressions.remove(0));
+    // Cypher defaults the projection to the iteration variable, so
+    // `[x IN xs WHERE p]` means `[x IN xs WHERE p | x]`.
+    if map_expr.is_none() {
+        if let Some(var) = &variable {
+            map_expr = Some(Expression::Variable(var.clone()));
         }
     }
 

--- a/tests/cypher_sweep_gaps.rs
+++ b/tests/cypher_sweep_gaps.rs
@@ -1,0 +1,206 @@
+//! Gaps found by sweeping standard Cypher expressions against hand-computed
+//! answers (#577, #578).
+//!
+//! The sweep exists because #571 (map property access returning `Null`) and
+//! #572 (`UNWIND … WITH` failing) were both found *by accident*, while writing
+//! tests for something else. Both were in constructs nothing exercised.
+//!
+//! `examples/cypher_probe.rs` runs the whole battery and reports wrong answers
+//! and errors separately, because those are different problems. These are the
+//! cases that were failing, pinned.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn one(cypher: &str) -> PropertyValue {
+    let store = GraphStore::new();
+    let query = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: parse {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&query)
+        .unwrap_or_else(|e| panic!("{cypher}: exec {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.clone(),
+        Some(Value::Null) | None => PropertyValue::Null,
+        other => panic!("{cypher}: {other:?}"),
+    }
+}
+
+fn ints(cypher: &str) -> Vec<i64> {
+    match one(cypher) {
+        PropertyValue::Array(items) => items
+            .iter()
+            .map(|p| match p {
+                PropertyValue::Integer(n) => *n,
+                other => panic!("{other:?}"),
+            })
+            .collect(),
+        other => panic!("{cypher}: expected a list, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------- #577
+
+/// The one that matters: not the order, but that it is the *same* order.
+#[test]
+fn keys_is_the_same_on_every_call() {
+    let cypher = "WITH {gamma: 1, alpha: 2, delta: 3, beta: 4} AS m RETURN keys(m) AS r";
+    let first = one(cypher);
+    for _ in 0..20 {
+        assert_eq!(one(cypher), first, "keys() varies between calls");
+    }
+}
+
+#[test]
+fn keys_over_a_map_is_sorted() {
+    // A `HashMap` seeds its hasher randomly *per process*, so before this the
+    // order differed on every run of the binary — which is why an exact
+    // assertion is the right one. An "unspecified but stable" order would pass
+    // the test above and still fail across processes.
+    match one("WITH {gamma: 1, alpha: 2, delta: 3, beta: 4} AS m RETURN keys(m) AS r") {
+        PropertyValue::Array(items) => {
+            let names: Vec<String> = items
+                .iter()
+                .map(|p| match p {
+                    PropertyValue::String(s) => s.clone(),
+                    other => panic!("{other:?}"),
+                })
+                .collect();
+            assert_eq!(names, vec!["alpha", "beta", "delta", "gamma"]);
+        }
+        other => panic!("{other:?}"),
+    }
+}
+
+#[test]
+fn keys_over_a_node_is_sorted() {
+    let mut store = GraphStore::new();
+    let id = store.create_node("N");
+    for k in ["zeta", "alpha", "mu"] {
+        let _ = store.set_node_property("default", id, k.to_string(), PropertyValue::Integer(1));
+    }
+    let query = parse_query("MATCH (n:N) RETURN keys(n) AS r").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    match batch.records[0].get("r") {
+        Some(Value::Property(PropertyValue::Array(items))) => {
+            let names: Vec<String> = items
+                .iter()
+                .map(|p| match p {
+                    PropertyValue::String(s) => s.clone(),
+                    other => panic!("{other:?}"),
+                })
+                .collect();
+            assert_eq!(names, vec!["alpha", "mu", "zeta"]);
+        }
+        other => panic!("{other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------- #578
+
+#[test]
+fn reverse_takes_a_list_as_well_as_a_string() {
+    assert_eq!(ints("RETURN reverse([1,2,3]) AS r"), vec![3, 2, 1]);
+    assert_eq!(one("RETURN reverse(\"abc\") AS r"), PropertyValue::String("cba".into()));
+    assert_eq!(ints("RETURN reverse([]) AS r"), Vec::<i64>::new());
+    assert_eq!(one("RETURN reverse(null) AS r"), PropertyValue::Null);
+}
+
+#[test]
+fn a_list_comprehension_may_omit_its_projection() {
+    // `[x IN xs WHERE p]` means `[x IN xs WHERE p | x]`. It is the more
+    // commonly written form and it did not parse.
+    assert_eq!(ints("RETURN [x IN [1,2,3,4] WHERE x > 2] AS r"), vec![3, 4]);
+    // The explicit form still works, and agrees.
+    assert_eq!(ints("RETURN [x IN [1,2,3,4] WHERE x > 2 | x] AS r"), vec![3, 4]);
+}
+
+#[test]
+fn a_list_comprehension_may_omit_its_filter() {
+    // The other optional half, which must not have been broken by making the
+    // projection optional: with two expressions and no `WHERE`, the second is
+    // the projection, not a filter.
+    assert_eq!(ints("RETURN [x IN [1,2,3] | x * 2] AS r"), vec![2, 4, 6]);
+}
+
+#[test]
+fn a_list_comprehension_with_neither_is_the_list_itself() {
+    assert_eq!(ints("RETURN [x IN [1,2,3]] AS r"), vec![1, 2, 3]);
+}
+
+#[test]
+fn the_power_operator_works() {
+    assert_eq!(one("RETURN 2 ^ 3 AS r"), PropertyValue::Float(8.0));
+    // Float even over integers, which is why `2 ^ -1` must not truncate.
+    assert_eq!(one("RETURN 2 ^ -1 AS r"), PropertyValue::Float(0.5));
+    assert_eq!(one("RETURN 2.0 ^ 0.5 AS r"), PropertyValue::Float(2.0f64.sqrt()));
+    assert_eq!(one("RETURN null ^ 2 AS r"), PropertyValue::Null);
+}
+
+#[test]
+fn the_power_operator_binds_tightest_and_associates_right() {
+    // `2 + 3 ^ 2` is 11, not 25 — it binds tighter than `+`.
+    assert_eq!(one("RETURN 2 + 3 ^ 2 AS r"), PropertyValue::Float(11.0));
+    // `2 * 3 ^ 2` is 18, not 36 — tighter than `*` too.
+    assert_eq!(one("RETURN 2 * 3 ^ 2 AS r"), PropertyValue::Float(18.0));
+    // `2 ^ 3 ^ 2` is 2^(3^2) = 512, not (2^3)^2 = 64.
+    assert_eq!(one("RETURN 2 ^ 3 ^ 2 AS r"), PropertyValue::Float(512.0));
+}
+
+#[test]
+fn plus_concatenates_lists() {
+    assert_eq!(ints("RETURN [1,2] + [3] AS r"), vec![1, 2, 3]);
+    assert_eq!(ints("RETURN [1,2] + 3 AS r"), vec![1, 2, 3], "appending a scalar");
+    assert_eq!(ints("RETURN 1 + [2,3] AS r"), vec![1, 2, 3], "prepending a scalar");
+    assert_eq!(ints("RETURN [] + [1] AS r"), vec![1]);
+}
+
+#[test]
+fn plus_still_adds_numbers_and_joins_strings() {
+    // The arms added for lists sit above the existing ones, so the ordinary
+    // cases are the thing most at risk.
+    assert_eq!(one("RETURN 1 + 2 AS r"), PropertyValue::Integer(3));
+    assert_eq!(one("RETURN 1.5 + 1 AS r"), PropertyValue::Float(2.5));
+    assert_eq!(one("RETURN \"a\" + \"b\" AS r"), PropertyValue::String("ab".into()));
+    // And a null operand still makes the result null (#457), rather than being
+    // appended to a list.
+    assert_eq!(one("RETURN [1,2] + null AS r"), PropertyValue::Null);
+    assert_eq!(one("RETURN 1 + null AS r"), PropertyValue::Null);
+}
+
+#[test]
+fn xor_works_and_sits_between_or_and_and() {
+    assert_eq!(one("RETURN true XOR false AS r"), PropertyValue::Boolean(true));
+    assert_eq!(one("RETURN true XOR true AS r"), PropertyValue::Boolean(false));
+    assert_eq!(one("RETURN false XOR false AS r"), PropertyValue::Boolean(false));
+    assert_eq!(one("RETURN null XOR true AS r"), PropertyValue::Null);
+
+    // AND binds tighter: `true XOR true AND false` is `true XOR (true AND false)`
+    // = true. Grouped the other way it would be false.
+    assert_eq!(one("RETURN true XOR true AND false AS r"), PropertyValue::Boolean(true));
+    // OR binds looser: `false OR true XOR true` is `false OR (true XOR true)`
+    // = false. Grouped the other way it would be true.
+    assert_eq!(one("RETURN false OR true XOR true AS r"), PropertyValue::Boolean(false));
+}
+
+#[test]
+fn explain_renders_the_new_operators() {
+    // The plan is the contract, and a missing arm in the formatter would print
+    // a predicate that reads as a different one.
+    let mut store = GraphStore::new();
+    let id = store.create_node("N");
+    let _ = store.set_node_property("default", id, "v".to_string(), PropertyValue::Integer(1));
+
+    for (cypher, expected) in [
+        ("EXPLAIN MATCH (n:N) WHERE n.v ^ 2 > 3 RETURN n", "^"),
+        ("EXPLAIN MATCH (n:N) WHERE n.v > 1 XOR n.v < 0 RETURN n", "XOR"),
+    ] {
+        let query = parse_query(cypher).unwrap();
+        let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+        let text = match batch.records[0].get("plan") {
+            Some(Value::Property(PropertyValue::String(t))) => t.clone(),
+            other => panic!("{other:?}"),
+        };
+        assert!(text.contains(expected), "{cypher} should render {expected}:\n{text}");
+    }
+}


### PR DESCRIPTION
Closes #577, closes #578.

## Why a sweep

#571 (map property access returning `Null`) and #572 (`UNWIND … WITH` failing) were both found **by accident**, while writing tests for something else, in constructs nothing exercised. So this ran **77 standard Cypher expressions against hand-computed answers** to find the rest.

**68 were already correct.** Six were not.

`examples/cypher_probe.rs` ships it, and reports wrong answers and errors *separately* — one is a hazard, the other a gap.

## The one that is a hazard

**`keys()` returned a different order on every run.** Four consecutive runs of the same binary, same query, same data:

```
["gamma", "delta", "beta",  "alpha"]
["alpha", "delta", "beta",  "gamma"]
["gamma", "delta", "alpha", "beta" ]
["alpha", "delta", "gamma", "beta" ]
```

It iterates a `HashMap`, and Rust seeds that hasher **randomly per process**. Cypher not specifying an order makes any *particular* order conformant; it does not make a **different one each time** acceptable. A result that cannot be diffed, cached or compared across versions undermines **Axiom 3** at the level of the answer rather than the timing. Now sorted — maps, nodes and relationships.

## The five gaps

| expression | was | now |
|---|---|---|
| `reverse([1,2,3])` | `TypeError("Expected string argument")` | `[3,2,1]` |
| `[x IN [1,2,3,4] WHERE x > 2]` | parse error | `[3,4]` |
| `2 ^ 3` | parse error | `8.0` |
| `[1,2] + [3]` | `TypeError` | `[1,2,3]` |
| `true XOR false` | parse error | `true` |

Three points worth stating:

- **The comprehension markers are now captured rules**, not literals. With both halves optional, two expressions could be `(list, filter)` or `(list, projection)` — the parser has to be able to tell which.
- **`^` binds tightest and associates right**: `2 + 3 ^ 2` is 11, `2 * 3 ^ 2` is 18, `2 ^ 3 ^ 2` is 512. It is float exponentiation even over integers, so `2 ^ -1` is 0.5 — `as_float` returns `None` for an `Integer`, which the first attempt did not allow for and which made `2 ^ 3` answer "requires numeric operands".
- **The new `+` arms exclude null explicitly**, so the existing propagation rule (#457) still governs `[1,2] + null`. Whether Cypher would rather append the null is a judgement call and not one to make in passing.

## Testing

13 tests in `tests/cypher_sweep_gaps.rs`. The ones carrying weight:

- `keys_is_the_same_on_every_call` — 20 calls compared, since the *stability* is the point, not the order;
- `keys_over_a_map_is_sorted` — an exact assertion, because "unspecified but stable" would pass the first test and still differ across processes;
- `a_list_comprehension_may_omit_its_filter` and `…_with_neither` — the other optional half, which making the projection optional could easily have broken;
- `plus_still_adds_numbers_and_joins_strings` — the new arms sit above the existing ones, so the ordinary cases are what is most at risk, null included;
- `the_power_operator_binds_tightest_and_associates_right` and `xor_works_and_sits_between_or_and_and` — precedence, which a grammar change gets wrong silently;
- `explain_renders_the_new_operators` — a missing formatter arm prints a predicate that reads as a different one.

Suite on a dedicated box: **exit 0, 2,812 tests, 0 failures.** Sweep: **77/77.** LDBC SF1 unchanged at **21/21 in 14.1 s**.