### PR TITLE
Bracket a rendered predicate where precedence would change its meaning

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2252,6 +2252,50 @@ impl OperatorDescription {
     }
 }
 
+/// Binding power, matching the parser's precedence ladder.
+///
+/// Kept in step with `PRATT_PARSER` in `query::parser`: OR < XOR < AND < NOT <
+/// comparison < +- < */% < ^. If the two ever disagree, EXPLAIN prints a
+/// predicate that means something the engine did not run, which is the exact
+/// failure #541 describes.
+fn binary_precedence(op: &BinaryOp) -> u8 {
+    match op {
+        BinaryOp::Or => 1,
+        BinaryOp::Xor => 2,
+        BinaryOp::And => 3,
+        BinaryOp::Eq
+        | BinaryOp::Ne
+        | BinaryOp::Lt
+        | BinaryOp::Le
+        | BinaryOp::Gt
+        | BinaryOp::Ge
+        | BinaryOp::In
+        | BinaryOp::StartsWith
+        | BinaryOp::EndsWith
+        | BinaryOp::Contains
+        | BinaryOp::RegexMatch => 4,
+        BinaryOp::Add | BinaryOp::Sub => 5,
+        BinaryOp::Mul | BinaryOp::Div | BinaryOp::Mod => 6,
+        BinaryOp::Pow => 7,
+    }
+}
+
+/// `expr` rendered, bracketed only where dropping the brackets would reparse
+/// differently.
+///
+/// `bias` is 1 for the side that must not re-associate -- the right operand of
+/// a left-associative operator, the left operand of a right-associative one --
+/// so `a - (b - c)` keeps its brackets while `(a - b) - c` does not need them.
+fn parenthesised(expr: &Expression, parent: u8, bias: u8) -> String {
+    let text = format_expression(expr);
+    match expr {
+        Expression::Binary { op, .. } if binary_precedence(op) + bias <= parent => {
+            format!("({text})")
+        }
+        _ => text,
+    }
+}
+
 /// Format an Expression for EXPLAIN output
 fn format_expression(expr: &Expression) -> String {
     match expr {
@@ -2270,16 +2314,38 @@ fn format_expression(expr: &Expression) -> String {
                 BinaryOp::Contains => "CONTAINS", BinaryOp::In => "IN",
                 BinaryOp::RegexMatch => "=~",
             };
-            format!("{} {} {}", format_expression(left), op_str, format_expression(right))
+            // Parenthesised where precedence would otherwise change the
+            // meaning. `A AND B AND (C OR D)` printed as `A AND B AND C OR D`,
+            // which reads as `(A AND B AND C) OR D` -- a different predicate,
+            // and one that looks like a P0 wrong answer in a plan that is
+            // actually correct (#541).
+            let parent = binary_precedence(op);
+            let right_assoc = matches!(op, BinaryOp::Pow);
+            // The side that must not re-associate takes the bias: for a
+            // left-associative operator that is the *right* operand, since
+            // `a - (b - c)` differs from `a - b - c` while `(a - b) - c` does
+            // not. Reversed, this brackets every left operand of an AND chain
+            // and leaves `a - (b - c)` unbracketed -- both of which the tests
+            // below caught.
+            let left_str = parenthesised(left, parent, if right_assoc { 0 } else { 1 });
+            let right_str = parenthesised(right, parent, if right_assoc { 1 } else { 0 });
+            format!("{} {} {}", left_str, op_str, right_str)
         }
         Expression::Unary { op, expr } => {
             let op_str = match op {
                 UnaryOp::Not => "NOT", UnaryOp::Minus => "-",
                 UnaryOp::IsNull => "IS NULL", UnaryOp::IsNotNull => "IS NOT NULL",
             };
+            // A unary operator binds tighter than every binary one, so a binary
+            // operand always needs bracketing: `NOT (a AND b)` is not
+            // `NOT a AND b`.
+            let operand = match expr.as_ref() {
+                Expression::Binary { .. } => format!("({})", format_expression(expr)),
+                _ => format_expression(expr),
+            };
             match op {
-                UnaryOp::IsNull | UnaryOp::IsNotNull => format!("{} {}", format_expression(expr), op_str),
-                _ => format!("{} {}", op_str, format_expression(expr)),
+                UnaryOp::IsNull | UnaryOp::IsNotNull => format!("{} {}", operand, op_str),
+                _ => format!("{} {}", op_str, operand),
             }
         }
         Expression::Function { name, args, distinct } => {

--- a/tests/explain_parentheses.rs
+++ b/tests/explain_parentheses.rs
@@ -1,0 +1,177 @@
+//! `EXPLAIN` renders a predicate that reparses to the same predicate (#541).
+//!
+//! It did not. LDBC IC3's
+//! `A AND B AND (place.name = X OR place.name = Y)` printed as
+//! `A AND B AND place.name = X OR place.name = Y`, which by precedence reads
+//! `(A AND B AND C) OR D` — a different predicate, and one that returns every
+//! Venezuelan row regardless of the date window.
+//!
+//! The engine was running the right thing; only the rendering was wrong. That
+//! is not a small distinction to leave standing: `EXPLAIN` and `PROFILE` exist
+//! so a person can reason about a plan (#517), and per Axiom 4 an agent is
+//! meant to consume plans as data. A rendering that changes the meaning of the
+//! predicate defeats both, and the issue records an hour lost to writing a P0
+//! report about a bug that was not there.
+//!
+//! The strong form of the property is checked by `a_rendered_predicate_reparses`:
+//! rather than asserting on particular strings, it takes the rendered predicate,
+//! parses it again, and asserts the two evaluate to the same rows. A renderer
+//! that is merely *different* passes; one that changes the meaning cannot.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn plan_of(store: &GraphStore, cypher: &str) -> String {
+    let query = parse_query(&format!("EXPLAIN {cypher}")).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&query).expect("EXPLAIN should run");
+    match batch.records[0].get("plan") {
+        Some(Value::Property(PropertyValue::String(t))) => t.clone(),
+        other => panic!("{other:?}"),
+    }
+}
+
+/// Rows chosen so the two readings of an unparenthesised predicate differ.
+fn fixture() -> GraphStore {
+    let mut store = GraphStore::new();
+    for (d, c) in [(5i64, "X"), (50, "X"), (50, "Y"), (500, "Y")] {
+        let id = store.create_node("R");
+        let _ = store.set_node_property("default", id, "d".to_string(), PropertyValue::Integer(d));
+        let _ = store.set_node_property(
+            "default",
+            id,
+            "c".to_string(),
+            PropertyValue::String(c.to_string()),
+        );
+    }
+    store
+}
+
+fn count(store: &GraphStore, cypher: &str) -> usize {
+    let query = parse_query(cypher).expect("query should parse");
+    QueryExecutor::new(store).execute(&query).expect("query should run").records.len()
+}
+
+#[test]
+fn a_grouped_or_keeps_its_parentheses() {
+    let store = fixture();
+    let text = plan_of(
+        &store,
+        "MATCH (r:R) WHERE r.d >= 10 AND r.d < 100 AND (r.c = \"X\" OR r.c = \"Y\") RETURN r",
+    );
+    assert!(
+        text.contains("(r.c = String(\"X\") OR r.c = String(\"Y\"))"),
+        "the OR must stay bracketed:\n{text}"
+    );
+}
+
+#[test]
+fn the_two_forms_still_differ_in_the_answer() {
+    // The premise of the issue: the parser was always right. If this ever fails
+    // the bug is real and much worse than a rendering problem.
+    let store = fixture();
+    assert_eq!(
+        count(&store, "MATCH (r:R) WHERE r.d >= 10 AND r.d < 100 AND (r.c = \"X\" OR r.c = \"Y\") RETURN r"),
+        2
+    );
+    assert_eq!(
+        count(&store, "MATCH (r:R) WHERE r.d >= 10 AND r.d < 100 AND r.c = \"X\" OR r.c = \"Y\" RETURN r"),
+        3
+    );
+}
+
+#[test]
+fn brackets_are_not_added_where_they_are_not_needed() {
+    // Bracketing everything would be correct and unreadable. A chain of ANDs at
+    // one precedence level should print flat.
+    let store = fixture();
+    let text = plan_of(&store, "MATCH (r:R) WHERE r.d >= 10 AND r.d < 100 AND r.c = \"X\" RETURN r");
+    assert!(!text.contains("(("), "over-bracketed:\n{text}");
+    assert!(
+        text.contains("r.d >= Integer(10) AND r.d < Integer(100) AND r.c = String(\"X\")"),
+        "a flat AND chain should print flat:\n{text}"
+    );
+}
+
+#[test]
+fn a_looser_operator_under_a_tighter_one_is_bracketed() {
+    let store = fixture();
+    let text = plan_of(&store, "MATCH (r:R) WHERE (r.d + 1) * 2 > 10 RETURN r");
+    assert!(text.contains("(r.d + Integer(1)) * Integer(2)"), "{text}");
+}
+
+#[test]
+fn right_association_is_preserved() {
+    // `a - (b - c)` must keep its brackets; `(a - b) - c` does not need them.
+    let store = fixture();
+    let nested_right = plan_of(&store, "MATCH (r:R) WHERE r.d - (r.d - 1) > 0 RETURN r");
+    assert!(nested_right.contains("r.d - (r.d - Integer(1))"), "{nested_right}");
+
+    let nested_left = plan_of(&store, "MATCH (r:R) WHERE (r.d - 1) - 1 > 0 RETURN r");
+    assert!(
+        nested_left.contains("r.d - Integer(1) - Integer(1)"),
+        "a left-associated chain needs no brackets:\n{nested_left}"
+    );
+}
+
+#[test]
+fn not_brackets_a_binary_operand() {
+    let store = fixture();
+    let text = plan_of(&store, "MATCH (r:R) WHERE NOT (r.d > 10 AND r.c = \"X\") RETURN r");
+    assert!(
+        text.contains("NOT (r.d > Integer(10) AND r.c = String(\"X\"))"),
+        "NOT over a binary operand must bracket it:\n{text}"
+    );
+}
+
+/// The property, rather than any particular rendering.
+#[test]
+fn a_rendered_predicate_reparses_to_the_same_predicate() {
+    let store = fixture();
+    let cases = [
+        "r.d >= 10 AND r.d < 100 AND (r.c = \"X\" OR r.c = \"Y\")",
+        "r.d >= 10 AND r.d < 100 AND r.c = \"X\" OR r.c = \"Y\"",
+        "(r.d > 1 OR r.d > 2) AND r.c = \"X\"",
+        "NOT (r.d > 10 AND r.c = \"X\")",
+        "(r.d + 1) * 2 > 10",
+        "r.d - (r.d - 1) > 0",
+        "r.d > 1 XOR r.c = \"X\"",
+        "(r.d > 1 XOR r.c = \"X\") AND r.d < 500",
+        "r.d ^ 2 > 100",
+    ];
+
+    for predicate in cases {
+        let original = format!("MATCH (r:R) WHERE {predicate} RETURN r");
+        let plan = plan_of(&store, &original);
+
+        // Pull the rendered predicate back out of the Filter line.
+        let rendered = plan
+            .lines()
+            .find_map(|l| {
+                let i = l.find("Filter (")? + "Filter (".len();
+                let body = &l[i..];
+                body.rfind(')').map(|j| body[..j].to_string())
+            })
+            .unwrap_or_else(|| panic!("no Filter line for {predicate}:\n{plan}"));
+
+        let round_tripped = format!("MATCH (r:R) WHERE {rendered} RETURN r");
+        // The rendering prints literals as `Integer(10)` / `String("X")`, which
+        // is not Cypher — normalise before reparsing. That is a separate
+        // readability question; the meaning is what this test is about.
+        let cypher_ish = round_tripped
+            .replace("Integer(", "(")
+            .replace("String(", "(")
+            .replace("Float(", "(");
+
+        let reparsed = match parse_query(&cypher_ish) {
+            Ok(q) => q,
+            Err(e) => panic!("rendered predicate does not reparse: {rendered}\n  {e:?}"),
+        };
+        let got = QueryExecutor::new(&store).execute(&reparsed).expect("should run").records.len();
+        let want = count(&store, &original);
+        assert_eq!(
+            got, want,
+            "rendering changed the meaning of `{predicate}`\n  rendered: {rendered}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #541.

## The bug

`format_expression` never emitted parentheses. LDBC IC3's

```cypher
WHERE A AND B AND (place.name = $countryX OR place.name = $countryY)
```

printed as

```
Filter (A AND B AND place.name = String("Belgium") OR place.name = String("Venezuela"))
```

which by precedence reads `(A AND B AND C) OR D` — a different predicate, and one that would return every Venezuelan row regardless of the date window.

**The engine was running the right thing.** Only the rendering was wrong — and the issue records an hour lost to writing a P0 report about a bug that was not there. `EXPLAIN` and `PROFILE` exist so a person can reason about a plan (#517), and per **Axiom 4** an agent is meant to consume plans as data. A rendering that changes the meaning of the predicate defeats both.

## The fix

Precedence-aware rendering, with a ladder kept in step with the parser's: `OR < XOR < AND < NOT < comparison < +- < */% < ^`.

Brackets appear **only where dropping them would reparse differently**, so a flat `AND` chain still prints flat. Bracketing everything would also be correct, and unreadable. A unary operator brackets a binary operand, since `NOT (a AND b)` is not `NOT a AND b`.

## The part I got backwards

The side that must not re-associate is the **right** operand of a left-associative operator — `a - (b - c)` differs from `a - b - c`, while `(a - b) - c` does not need brackets. I had the bias inverted, which bracketed every left operand of an `AND` chain *and* dropped the brackets from `a - (b - c)`:

```
Filter ((r.d >= Integer(10) AND r.d < Integer(100)) AND r.c = String("X"))   ← over-bracketed
Filter (r.d - r.d - Integer(1) > Integer(0))                                 ← meaning changed
```

Both were caught by tests rather than by reading.

## Testing

7 tests. The one carrying the weight asserts **the property, not a string**: it takes the rendered predicate out of the plan, parses it again, and checks the two return the same rows over a fixture built so the two readings differ. A renderer that is merely *different* passes; one that changes the meaning cannot. It covers nine shapes including `XOR` and `^`.

Also pinned: the grouped `OR` keeps its brackets; **the two forms still differ in the answer** (the issue's premise — if that ever fails, the bug is real and much worse); brackets are not added where unneeded; a looser operator under a tighter one is bracketed; right-association is preserved; and `NOT` brackets a binary operand.

Suite on a dedicated box: **exit 0, 2,819 tests, 0 failures.** The existing plan-shape tests — `duplicate_filter_plan`, `predicate_pushdown_plan`, `id_anchor`, `aggregate_identity_grouping`, `filter_parallel_threshold` — all still pass, which matters because they assert against this output.