### PR TITLE
Let a demo say "I need data that is not here" without saying "I failed"

### DIFF
--- a/examples/amr_stewardship_demo.rs
+++ b/examples/amr_stewardship_demo.rs
@@ -44,6 +44,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
+#[path = "common/missing_data.rs"]
+mod missing_data;
+
 #[derive(Debug)]
 struct Args {
     catalog: PathBuf,
@@ -88,6 +91,9 @@ fn parse_args() -> Args {
             "--out" => { a.out = PathBuf::from(&argv[i + 1]); i += 2; }
             "--export-spec" => { a.export_spec = Some(PathBuf::from(&argv[i + 1])); i += 2; }
             "--export-snapshot" => { a.export_snapshot = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            // Consumed by `missing_data::skip`, which reads it straight from
+            // `env::args`. Accepted here so the parser does not reject it (#566).
+            "--require-data" => { i += 1; }
             other => { eprintln!("unknown arg: {}", other); std::process::exit(2); }
         }
     }
@@ -100,11 +106,7 @@ fn build_amr_kg(catalog: &std::path::Path)
 {
     let mut store = GraphStore::new();
     let f = File::open(catalog).unwrap_or_else(|e| {
-        eprintln!("Error: cannot read the NCBI Reference Gene Catalog: {}", catalog.display());
-        eprintln!("       {e}");
-        eprintln!("       this example needs data that is not part of this repository;");
-        eprintln!("       pass --catalog PATH to point at your own copy.");
-        std::process::exit(1);
+        missing_data::skip("NCBI Reference Gene Catalog", &catalog, &e, "--catalog")
     });
     let mut header: Vec<String> = Vec::new();
     let mut rows = Vec::new();

--- a/examples/clinical_trial_sites_demo.rs
+++ b/examples/clinical_trial_sites_demo.rs
@@ -34,6 +34,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
+#[path = "common/missing_data.rs"]
+mod missing_data;
+
 #[derive(Debug)]
 struct Args {
     snapshot: PathBuf,
@@ -72,6 +75,9 @@ fn parse_args() -> Args {
             "--diversity-weight" => { a.diversity_weight = argv[i + 1].parse().unwrap(); i += 2; }
             "--out" => { a.out = PathBuf::from(&argv[i + 1]); i += 2; }
             "--export-spec" => { a.export_spec = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            // Consumed by `missing_data::skip`, which reads it straight from
+            // `env::args`. Accepted here so the parser does not reject it (#566).
+            "--require-data" => { i += 1; }
             other => { eprintln!("unknown arg: {}", other); std::process::exit(2); }
         }
     }
@@ -118,11 +124,7 @@ fn main() {
     let mut store = GraphStore::new();
     let t0 = Instant::now();
     let f = File::open(&a.snapshot).unwrap_or_else(|e| {
-        eprintln!("Error: cannot read the clinical-trials snapshot: {}", &a.snapshot.display());
-        eprintln!("       {e}");
-        eprintln!("       this example needs data that is not part of this repository;");
-        eprintln!("       pass --snapshot PATH to point at your own copy.");
-        std::process::exit(1);
+        missing_data::skip("clinical-trials snapshot", &a.snapshot, &e, "--snapshot")
     });
     let stats = samyama::snapshot::import_tenant(&mut store, f).expect("import");
     let load_ms = t0.elapsed().as_millis();

--- a/examples/common/missing_data.rs
+++ b/examples/common/missing_data.rs
@@ -1,0 +1,46 @@
+//! What an example does when the data it needs is not in this repository.
+//!
+//! Several demos read a `.sgsnap` snapshot or a CSV from a sibling repository.
+//! Each of them printed a clear message and then `exit(1)` — indistinguishable
+//! from a genuine failure. So a CI job over every example could not be written
+//! without a skip-list, a skip-list rots as demos are added, and **a demo that
+//! actually breaks among them is invisible**, because its exit code already
+//! says failure (#566).
+//!
+//! `case_studies/_lib/run_case_study.sh` already had the answer, and this is it
+//! in Rust: report the absence, say plainly that nothing is broken, and exit
+//! with a code a runner can tell apart. A CI job then reads
+//! `0 = ok, 2 = skipped, anything else = fails`, and stays correct as demos are
+//! added.
+//!
+//! `--require-data` turns the skip back into a failure, which is what the KG
+//! repositories — where the data *is* present — should pass to assert that
+//! these demos really run.
+
+/// Exit code for "this example needs data that is not here".
+///
+/// Distinct from 1 so a runner can tell a skip from a break.
+pub const SKIP: i32 = 2;
+
+/// Report absent input data and exit.
+///
+/// `what` names the data in prose, `flag` is the option that points at a local
+/// copy — both appear in the message, so a reader knows what is missing and how
+/// to supply it without opening the source.
+pub fn skip(what: &str, path: &std::path::Path, error: &std::io::Error, flag: &str) -> ! {
+    let required = std::env::args().any(|a| a == "--require-data");
+    let label = if required { "Error" } else { "SKIP" };
+
+    eprintln!("{label}: cannot read the {what}: {}", path.display());
+    eprintln!("       {error}");
+    eprintln!("       this example needs data that is not part of this repository;");
+    eprintln!("       pass {flag} PATH to point at your own copy.");
+
+    if required {
+        eprintln!("       --require-data was given, so this is a failure.");
+        std::process::exit(1);
+    }
+    eprintln!("       Skipping rather than failing: nothing here is broken.");
+    eprintln!("       (exit {SKIP}; pass --require-data to make this a failure.)");
+    std::process::exit(SKIP)
+}

--- a/examples/drug_repurposing_demo.rs
+++ b/examples/drug_repurposing_demo.rs
@@ -31,6 +31,9 @@ use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
+#[path = "common/missing_data.rs"]
+mod missing_data;
+
 #[derive(Debug)]
 struct Args {
     snapshot: PathBuf,
@@ -72,6 +75,9 @@ fn parse_args() -> Args {
             "--out" => { a.out = PathBuf::from(&argv[i + 1]); i += 2; }
             "--sider-weight" => { a.sider_weight = argv[i + 1].parse().unwrap(); i += 2; }
             "--export-edges" => { a.export_edges = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            // Consumed by `missing_data::skip`, which reads it straight from
+            // `env::args`. Accepted here so the parser does not reject it (#566).
+            "--require-data" => { i += 1; }
             other => { eprintln!("unknown arg: {}", other); std::process::exit(2); }
         }
     }
@@ -124,11 +130,7 @@ fn main() {
     let mut store = GraphStore::new();
     let t0 = Instant::now();
     let f = File::open(&a.snapshot).unwrap_or_else(|e| {
-        eprintln!("Error: cannot read the drug-interactions snapshot: {}", &a.snapshot.display());
-        eprintln!("       {e}");
-        eprintln!("       this example needs data that is not part of this repository;");
-        eprintln!("       pass --snapshot PATH to point at your own copy.");
-        std::process::exit(1);
+        missing_data::skip("drug-interactions snapshot", &a.snapshot, &e, "--snapshot")
     });
     let stats = samyama::snapshot::import_tenant(&mut store, f).expect("import");
     let load_ms = t0.elapsed().as_millis();

--- a/examples/grid_dispatch_demo.rs
+++ b/examples/grid_dispatch_demo.rs
@@ -38,6 +38,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
+#[path = "common/missing_data.rs"]
+mod missing_data;
+
 #[derive(Debug)]
 struct Args {
     data_dir: PathBuf,
@@ -79,6 +82,9 @@ fn parse_args() -> Args {
             "--out" => { a.out = PathBuf::from(&argv[i + 1]); i += 2; }
             "--export-spec" => { a.export_spec = Some(PathBuf::from(&argv[i + 1])); i += 2; }
             "--export-snapshot" => { a.export_snapshot = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            // Consumed by `missing_data::skip`, which reads it straight from
+            // `env::args`. Accepted here so the parser does not reject it (#566).
+            "--require-data" => { i += 1; }
             other => { eprintln!("unknown arg: {}", other); std::process::exit(2); }
         }
     }
@@ -111,11 +117,7 @@ fn build_grid_kg(data_dir: &std::path::Path) -> (GraphStore, Vec<Generator>, Vec
     let gen_csv = data_dir.join("sample_generators.csv");
     let mut gens = Vec::new();
     let f = File::open(&gen_csv).unwrap_or_else(|e| {
-        eprintln!("Error: cannot read the smart-grid sample data: {}", &gen_csv.display());
-        eprintln!("       {e}");
-        eprintln!("       this example needs data that is not part of this repository;");
-        eprintln!("       pass --data-dir PATH to point at your own copy.");
-        std::process::exit(1);
+        missing_data::skip("smart-grid sample data", &gen_csv, &e, "--data-dir")
     });
     for (i, line) in BufReader::new(f).lines().enumerate() {
         let line = line.unwrap();

--- a/examples/healthcare_allocation_demo.rs
+++ b/examples/healthcare_allocation_demo.rs
@@ -33,6 +33,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
+#[path = "common/missing_data.rs"]
+mod missing_data;
+
 #[derive(Debug)]
 struct Args {
     snapshot: PathBuf,
@@ -70,6 +73,9 @@ fn parse_args() -> Args {
             "--threshold" => { a.threshold = argv[i + 1].parse().unwrap(); i += 2; }
             "--out" => { a.out = PathBuf::from(&argv[i + 1]); i += 2; }
             "--export-spec" => { a.export_spec = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            // Consumed by `missing_data::skip`, which reads it straight from
+            // `env::args`. Accepted here so the parser does not reject it (#566).
+            "--require-data" => { i += 1; }
             other => { eprintln!("unknown arg: {}", other); std::process::exit(2); }
         }
     }
@@ -114,11 +120,7 @@ fn main() {
     let mut store = GraphStore::new();
     let t0 = Instant::now();
     let f = File::open(&a.snapshot).unwrap_or_else(|e| {
-        eprintln!("Error: cannot read the health-systems snapshot: {}", &a.snapshot.display());
-        eprintln!("       {e}");
-        eprintln!("       this example needs data that is not part of this repository;");
-        eprintln!("       pass --snapshot PATH to point at your own copy.");
-        std::process::exit(1);
+        missing_data::skip("health-systems snapshot", &a.snapshot, &e, "--snapshot")
     });
     let stats = samyama::snapshot::import_tenant(&mut store, f).expect("import");
     let load_ms = t0.elapsed().as_millis();

--- a/examples/supply_chain_snapshot.rs
+++ b/examples/supply_chain_snapshot.rs
@@ -19,6 +19,9 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::time::Instant;
 
+#[path = "common/missing_data.rs"]
+mod missing_data;
+
 fn arg(argv: &[String], name: &str) -> Option<String> {
     argv.iter().position(|a| a == name).and_then(|i| argv.get(i + 1)).cloned()
 }
@@ -37,11 +40,7 @@ fn main() {
     let mut s = String::new();
     File::open(&nodes_path)
         .unwrap_or_else(|e| {
-            eprintln!("Error: cannot read the supply-chain nodes file: {}", nodes_path.display());
-            eprintln!("       {e}");
-            eprintln!("       this example needs data that is not part of this repository;");
-            eprintln!("       pass --nodes PATH to point at your own copy.");
-            std::process::exit(1);
+            missing_data::skip("supply-chain nodes file", &nodes_path, &e, "--nodes")
         })
         .read_to_string(&mut s)
         .unwrap();

--- a/scripts/run_all_examples.sh
+++ b/scripts/run_all_examples.sh
@@ -8,6 +8,7 @@ SERVER_PID=""
 BATCH_MODE=false
 TOTAL_TIME=0
 EXAMPLE_RESULTS=()
+EXIT_STATUS=0
 
 # Colors
 GREEN='\033[0;32m'
@@ -117,9 +118,16 @@ function run_rust_example() {
     local EXIT_CODE=$?
     local ELAPSED=$(( SECONDS - START_TIME ))
 
+    # Exit 2 means "this example needs data that is not in this repository"
+    # (#566). It is deliberately distinct from 1 so this loop can tell a skip
+    # from a break -- before that, a demo whose sibling-repo data was absent
+    # exited 1, and a demo that actually broke among them was invisible.
     if [ $EXIT_CODE -eq 0 ]; then
         echo -e "${GREEN}$DESCRIPTION completed in ${ELAPSED}s${NC}"
         EXAMPLE_RESULTS+=("PASS  ${ELAPSED}s  $DESCRIPTION")
+    elif [ $EXIT_CODE -eq 2 ]; then
+        echo -e "${YELLOW}$DESCRIPTION skipped after ${ELAPSED}s — needs data not in this repository${NC}"
+        EXAMPLE_RESULTS+=("SKIP  ${ELAPSED}s  $DESCRIPTION (needs external data)")
     else
         echo -e "${RED}$DESCRIPTION FAILED (exit code: $EXIT_CODE) after ${ELAPSED}s${NC}"
         EXAMPLE_RESULTS+=("FAIL  ${ELAPSED}s  $DESCRIPTION")
@@ -231,6 +239,14 @@ function run_all_batch() {
 function cleanup_exit() {
     stop_server
     cleanup_data
+    # A gate needs an exit code, not only a table. Skips do not fail it: that
+    # is the whole point of separating them from failures (#566).
+    local FAILURES
+    FAILURES=$(printf '%s\n' "${EXAMPLE_RESULTS[@]}" | grep -c '^FAIL' || true)
+    if [ "${FAILURES:-0}" -gt 0 ]; then
+        EXIT_STATUS=1
+    fi
+
     if [ ${#EXAMPLE_RESULTS[@]} -gt 0 ]; then
         print_summary
     fi
@@ -246,7 +262,10 @@ build_project
 if [ "$BATCH_MODE" = true ]; then
     start_server
     run_all_batch
-    cleanup_exit
+    # Batch mode is the CI entry point, so it has to carry the verdict in its
+    # exit code. Skips do not fail it (#566).
+    stop_server 2>/dev/null || true
+    exit "$EXIT_STATUS"
 fi
 
 # Interactive menu mode


### PR DESCRIPTION
Closes #566.

## The problem

Five demos read a snapshot or CSV from a sibling repository. Each printed a clear message and then **exited 1** — indistinguishable from a genuine failure. So:

- a CI job over the examples could not be written without a skip-list;
- a skip-list rots as demos are added;
- **a demo that actually broke among the five was invisible**, because its exit code already said failure.

## The fix, copied rather than designed

`case_studies/_lib/run_case_study.sh` had already solved this, and its message is the argument:

```
SKIP: legal-judgments — its snapshot has not been published yet.
      Skipping rather than failing: nothing here is broken.
```

`examples/common/missing_data.rs` is that convention in Rust: **exit 2** for "needs data", message unchanged apart from saying plainly that nothing is broken. A runner reads `0 = ok, 2 = skipped, anything else = fails`.

`--require-data` turns the skip back into a failure. The KG repositories, where the data *is* present, should pass it — that is how these demos get **asserted** rather than merely tolerated.

## Verified on a dedicated box

| demo | default | `--require-data` |
|---|---:|---:|
| `amr_stewardship_demo` | 2 | 1 |
| `drug_repurposing_demo` | 2 | 1 |
| `healthcare_allocation_demo` | 2 | 1 |
| `clinical_trial_sites_demo` | 2 | 1 |
| `grid_dispatch_demo` | 2 | 1 |
| `supply_chain_snapshot` | 2 | 1 |

Each demo's **own argument parser** had to learn the flag — without that they rejected it as unknown and exited 2 for the wrong reason, which is how I found they parse arguments themselves rather than sharing a parser.

## The runner

`scripts/run_all_examples.sh` now reports `SKIP` separately from `FAIL`, and **its batch mode exits non-zero on a real failure**. It previously exited 0 whatever happened, so it could report a failure and still pass a gate.

Batch run on the box: **8 pass, 1 skip, 0 fail, exit 0** — the skip being the agentic-enrichment demo, which needs the `claude` CLI.

## Scope, stated plainly

The runner covers its existing curated list, not every example — loaders take required arguments and are exercised by the case studies instead. Extending it to all of `examples/` is a separate job. What this PR guarantees is that the five data-needing demos now report a skip **wherever they are run**, so any runner can tell them apart.