### PR TITLE
Anchor a shortestPath target on an indexed property too

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2448,10 +2448,29 @@ impl QueryPlanner {
                         }
                         Box::new(op) as OperatorBox
                     }
-                    None => Box::new(NodeScanOperator::new(
-                        target_var.clone(),
-                        last_segment.node.labels.clone(),
-                    )),
+                    // Then an indexed property, for the same reason and by the
+                    // same argument. `WHERE a.seq = 0 AND b.seq = 5` planned as
+                    // `IndexScan(a) x NodeScan(b)` -- the WHERE form of what the
+                    // inline form `(b:N {seq: 5})` already got right, which is
+                    // why this went unnoticed (#584).
+                    None => match find_index_predicate(
+                        &target_var,
+                        &last_segment.node.labels,
+                        &deferred_predicates,
+                        store,
+                    ) {
+                        Some((_, label, property, op, val)) => Box::new(IndexScanOperator::new(
+                            target_var.clone(),
+                            label,
+                            property,
+                            op,
+                            val,
+                        )),
+                        None => Box::new(NodeScanOperator::new(
+                            target_var.clone(),
+                            last_segment.node.labels.clone(),
+                        )),
+                    },
                 };
                 // Add property filter for target node
                 let target_op = if let Some(ref props) = last_segment.node.properties {

--- a/tests/id_anchor.rs
+++ b/tests/id_anchor.rs
@@ -199,6 +199,96 @@ fn both_shortest_path_endpoints_reach_a_node_by_id() {
     );
 }
 
+/// A chain of `N` nodes with a `seq` property and an index on it.
+fn indexed_chain(n: i64) -> (GraphStore, Vec<NodeId>) {
+    let mut store = GraphStore::new();
+    let ids: Vec<NodeId> = (0..n)
+        .map(|i| {
+            let id = store.create_node("N");
+            let _ = store.set_node_property("default", id, "seq".to_string(), PropertyValue::Integer(i));
+            id
+        })
+        .collect();
+    for w in ids.windows(2) {
+        store.create_edge(w[0], w[1], "KNOWS").unwrap();
+    }
+    let create = parse_query("CREATE INDEX ON :N(seq)").unwrap();
+    let mut mutating =
+        samyama::query::executor::MutQueryExecutor::new(&mut store, "default".to_string());
+    let _ = mutating.execute(&create);
+    (store, ids)
+}
+
+#[test]
+fn all_shortest_paths_pins_both_endpoints_too() {
+    // It shares the branch, so it should — asserted rather than assumed.
+    let (mut store, _) = (GraphStore::new(), ());
+    let ids: Vec<NodeId> = (0..50).map(|_| store.create_node("N")).collect();
+    for w in ids.windows(2) {
+        store.create_edge(w[0], w[1], "KNOWS").unwrap();
+    }
+    let (a, b) = (ids[0].as_u64(), ids[5].as_u64());
+    let text = plan(
+        &store,
+        &format!(
+            "MATCH p = allShortestPaths((a:N)-[:KNOWS*]-(b:N)) WHERE id(a) = {a} AND id(b) = {b} \
+             RETURN length(p) AS v"
+        ),
+    );
+    assert_eq!(text.matches("NodeById").count(), 2, "{text}");
+    assert!(!text.contains("NodeScan"), "{text}");
+}
+
+#[test]
+fn an_indexed_property_pins_both_endpoints_too() {
+    // The same defect for `find_index_predicate`, and the more common form:
+    // `WHERE a.seq = 0 AND b.seq = 5` planned as `IndexScan(a) x NodeScan(b)`.
+    let (store, _) = indexed_chain(50);
+    let text = plan(
+        &store,
+        "MATCH p = shortestPath((a:N)-[:KNOWS*]-(b:N)) WHERE a.seq = 0 AND b.seq = 5 \
+         RETURN length(p) AS v",
+    );
+    assert_eq!(
+        text.matches("IndexScan").count(),
+        2,
+        "both endpoints should reach the index:\n{text}"
+    );
+    assert!(!text.contains("NodeScan"), "{text}");
+}
+
+#[test]
+fn the_indexed_form_still_answers() {
+    // A plan-shape change on a path operator is exactly where an answer can go
+    // missing quietly, so the rows are checked as well as the plan.
+    let (store, _) = indexed_chain(50);
+    let query = parse_query(
+        "MATCH p = shortestPath((a:N)-[:KNOWS*]-(b:N)) WHERE a.seq = 0 AND b.seq = 5 \
+         RETURN length(p) AS v",
+    )
+    .unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    assert_eq!(batch.records.len(), 1);
+    assert_eq!(
+        batch.records[0].get("v"),
+        Some(&Value::Property(PropertyValue::Integer(5))),
+        "five hops from seq 0 to seq 5"
+    );
+}
+
+#[test]
+fn an_unanchored_endpoint_still_works() {
+    // Only one endpoint constrained: the other genuinely has to scan, and the
+    // query must still answer rather than returning nothing.
+    let (store, _) = indexed_chain(20);
+    let query = parse_query(
+        "MATCH p = shortestPath((a:N)-[:KNOWS*]-(b:N)) WHERE a.seq = 0 RETURN length(p) AS v",
+    )
+    .unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    assert!(!batch.records.is_empty(), "an unpinned target must still be searched");
+}
+
 #[test]
 fn both_endpoints_of_a_path_can_be_pinned_by_id() {
     // #538's original shape, and what motivated the issue: written with


### PR DESCRIPTION
Refs #584. The half that #585 described but did not contain.

## What happened

#585 fixed the `id()` half and its description claimed this one with it. It did not: **a bash parse error killed the `git add` that would have staged it** — the shell failed to parse a heredoc later on the same command line, so nothing in that chain ran, silently. Correction posted on #585 and #584.

## The defect

Same one, for `find_index_predicate`:

```cypher
MATCH p = shortestPath((a:N)-[:KNOWS*]-(b:N)) WHERE a.seq = 0 AND b.seq = 5
```

```
ShortestPath ((a)-[:KNOWS*]-(b), Both)
  CartesianProduct
    IndexScan (var=a, N.seq = Integer(0))   ← anchored
    NodeScan (var=b, labels=["N"])          ← every node
```

The BFS runs once per node in the label. It is the **`WHERE` form of what the inline form `(b:N {seq: 5})` already got right**, which is why it went unnoticed — and it is the more common of the two ways to write this.

## Testing

Five tests, four asserting **plan shape** rather than a clock — because a clock is exactly what let the `id()` version of this hide for a whole PR:

- two `IndexScan`, no `NodeScan`;
- `allShortestPaths` pinning both ends (it shares the branch — asserted, not assumed);
- the answer still being five hops;
- an endpoint left **deliberately unconstrained**, since that one genuinely has to scan and must still find a path.

Verified on a dedicated box in both profiles:

| | exit | tests | failed |
|---|---|---:|---:|
| debug (what CI runs) | 0 | 2,829 | 0 |
| release | 0 | 2,829 | 0 |

LDBC SF1: **21/21 in 14.0 s**.