### PR TITLE
Assert a ratio, not a clock, in the last wall-clock test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,24 @@ graph.create_edge(source_id, target_id, "KNOWS")?;
 
 ## Testing
 
+**CI runs `cargo test --workspace --no-fail-fast` — a debug build, not `--release`.**
+A suite that passes in release can still fail the gate: the engine is more than
+an order of magnitude slower in debug. Run the profile CI runs before claiming a
+suite is green, and say which profile a claim was measured in.
+
+**Do not assert wall-clock times in tests.** An absolute bound encodes the speed
+of the machine and the build profile that wrote it. Assert a **ratio** against a
+baseline measured in the same process instead — a scan against an anchored
+lookup, a small graph against a large one, a query against a single hop. See
+`tests/id_anchor.rs`, `tests/aggregate_identity_grouping.rs`,
+`tests/bounded_sort_semantics.rs` and `tests/shortest_path_semantics.rs` for the
+pattern, and #587 for what it cost to learn. A weak timing assertion is worse
+than none: the one in `id_anchor` passed for a whole PR over a plan that was
+running 329x too slow (#584).
+
+Benchmarks are the opposite — always `--release`, on a quiet host, with the
+calibration line compared before the timings (#529).
+
 - **1814 unit tests** across all modules (87.8% coverage)
 - **10 benchmark binaries** in `benches/` (Criterion micro-benchmarks + domain benchmarks)
 - **Integration tests**: Python scripts in `tests/integration/`

--- a/tests/shortest_path_semantics.rs
+++ b/tests/shortest_path_semantics.rs
@@ -235,9 +235,9 @@ fn a_wide_graph_three_hops_apart_finishes_quickly() {
     }
 
     // Anchored by inline properties, which is the form LDBC IC14 uses. The
-    // `WHERE id(a) = …` form is 1000x slower because the planner does not use
-    // the predicate to anchor the source — a separate defect, filed as #538,
-    // and not what this test is about.
+    // `WHERE id(a) = …` form used to be ~1000x slower because the planner did
+    // not use the predicate to anchor either endpoint — #538 fixed the start,
+    // #584 the target. Both forms are anchored now.
     for (label, cypher) in [
         (
             "shortestPath",
@@ -254,9 +254,26 @@ fn a_wide_graph_three_hops_apart_finishes_quickly() {
         let elapsed = started.elapsed();
 
         assert!(!batch.records.is_empty(), "{label}: the graph is dense enough to be connected");
+
+        // Compared against a one-hop expansion over the same graph rather than
+        // against a clock. The old shape enumerated walks, so it was
+        // ~degree³ where this is one pass; a bound expressed as a multiple of
+        // a single hop states that, and does not encode the speed of the
+        // machine or the build profile.
+        //
+        // An absolute bound here would be the same mistake that made CI red
+        // in #584: 5 ms asserted from a `--release` run, failing in CI, which
+        // builds in debug.
+        let hop_started = std::time::Instant::now();
+        let hop = parse_query("MATCH (a:N {seq: 1})-[:KNOWS]-(b:N) RETURN count(b) AS len").unwrap();
+        let _ = QueryExecutor::new(&store).execute(&hop).unwrap();
+        let hop_elapsed = hop_started.elapsed();
+
+        let ratio = elapsed.as_secs_f64() / hop_elapsed.as_secs_f64().max(1e-9);
         assert!(
-            elapsed < std::time::Duration::from_secs(5),
-            "{label} took {elapsed:?} on a 4,000-node graph — this is the shape that timed out"
+            ratio < 400.0,
+            "{label} cost {ratio:.0}x a single hop ({hop_elapsed:?} -> {elapsed:?}) \
+             on a 4,000-node graph — this is the shape that timed out"
         );
     }
 }


### PR DESCRIPTION
Refs #587.

## The change

`shortest_path_semantics` asserted *"under 5 seconds on a 4,000-node graph"*. Generous enough to pass in both profiles — but the same shape as the two assertions that made CI red in #584: **an absolute bound encodes the speed of the machine and the build profile that wrote it.**

It now compares the search against **a single hop over the same graph, in the same run**. That states what the test is actually about — the old implementation enumerated walks, so it was ~degree³ where this is one pass — and is invariant to CPU speed and build profile.

That was the last absolute *performance* assertion in the suite. The remaining `Duration` uses are async timeouts and sleeps, which are a different thing: generous upper bounds on waiting, not claims about speed.

## The two rules, written down

`CLAUDE.md` gains what this cost a day to learn:

- **CI runs `cargo test --workspace` — debug, not release.** A suite that passes in release can still fail the gate; the engine is more than an order of magnitude slower in debug. Seventeen PRs went in verified only in `--release`.
- **Tests assert ratios; benchmarks assert times.** With the four files that now demonstrate the pattern, and the reason it matters: a weak timing assertion is *worse than none*, because it reads as coverage. The one in `id_anchor` passed for a whole PR over a plan running **329× too slow** (#584).

## Verification

Both profiles on a dedicated box:

| | exit | tests | failed |
|---|---|---:|---:|
| debug (what CI runs) | 0 | 2,829 | 0 |
| release | 0 | 2,829 | 0 |

LDBC SF1: **21/21 in 14.2 s**.