### PR TITLE
Correct a note that generalised from a one-row measurement

### DIFF
--- a/tests/anchor_coverage.rs
+++ b/tests/anchor_coverage.rs
@@ -27,10 +27,19 @@
 //! `MATCH (a)-[:KNOWS*1..3]->(b) WHERE id(a) = … AND id(b) = …` expands to
 //! depth 3 and filters the target afterwards, so the constraint does no work.
 //! Measured on a 20,000-node graph of degree 20: **2.4 ms with the target
-//! pinned against 2.3 ms with it free** — the constraint is indeed ignored, and
-//! exploiting it would save nothing worth the change. (`shortestPath` answers
-//! the same question in 9.6 ms, so this is already the fast path.) Recorded
-//! here so the next reader does not re-derive it.
+//! pinned against 2.3 ms with it free** — the constraint is indeed ignored.
+//!
+//! **That measurement does not generalise, and an earlier version of this note
+//! wrongly concluded from it that the shape was not worth acting on.** It has
+//! *one* input row, so there is nothing to amortise. LDBC IC6 has the same
+//! shape with **18** input rows sharing one pinned target, and there the
+//! var-length expansion produces 87,834 rows to keep 7 — **96% of the query**.
+//! The win scales with the input-row count, which the synthetic case set to
+//! one. Filed as #590.
+//!
+//! Still not asserted here, because it is a cost question rather than a
+//! plan-shape one: the plan is not *wrong*, it repeats work. This file is about
+//! scans that a predicate could have replaced.
 
 use samyama::graph::{GraphStore, PropertyValue};
 use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};


### PR DESCRIPTION
Refs #590. Comment-only.

`tests/anchor_coverage.rs` recorded that a var-length segment with a pinned far end was not worth acting on, citing **2.4 ms pinned against 2.3 ms free** on a 20,000-node graph of degree 20.

The measurement is right. **The conclusion drawn from it was not** — that case has *one* input row, so there is nothing to amortise.

LDBC IC6 is the same shape with **18** input rows sharing one pinned target, and there the var-length expansion produces **87,834 rows to keep 7** — 96% of the query. The win scales with the input-row count, which the synthetic case had set to one.

Filed as #590, together with the negative result that belongs beside it: **expanding from the pinned end instead is 5× worse** on IC6 (819 ms against 155 ms), because the pinned person's 2-hop neighbourhood has ~610,000 posts hanging off it. The planner's anchor choice is correct — the waste is *repetition*, not direction.

Correcting it here rather than only on the issue, because the note is what a future reader of this file will act on, and as written it says "measured, not worth it".