### PR TITLE
Apply a pattern's target labels during the walk, not by a retain after it

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -173,22 +173,22 @@ Samyama Graph's own results on the [LDBC Social Network Benchmark (SNB) Interact
 
 | Query | Name | SF1 | previous SF1 | SF10 |
 |---|---|---|---|---|
-| IC1 | Transitive Friends by Name | **57.8 ms** | 61.6 ms | 14.0 s |
-| IC2 | Recent Friend Posts | **9.3 ms** | 7.8 ms | 306 ms |
-| IC3 | Friends in Countries | **905 ms** | 866 ms | 15.7 s |
-| IC4 | Popular Tags in Period | **16.9 ms** | 13.5 ms | 527 ms |
-| IC5 | New Forum Members | **926 ms** | 1028 ms | 31.1 s |
-| IC6 | Tag Co-occurrence | **162 ms** | 177 ms | 31.5 s |
-| IC7 | Recent Likers | **0.05 ms** | 0.05 ms | 1.70 ms |
-| IC8 | Recent Replies | **0.15 ms** | 0.15 ms | 4.00 ms |
-| IC9 | Recent FoF Posts | **1141 ms** | 1170 ms | 26.3 s |
-| IC10 | Friend Recommendation | **94.8 ms** | 99.9 ms | 2.3 s |
-| IC11 | Job Referral | **30.2 ms** | 31.5 ms | 4.5 s |
-| IC12 | Expert Reply | **76.9 ms** | 86.3 ms | 3.2 s |
-| IC13 | Single Shortest Path | **40.5 ms** | 44.9 ms | 37.00 ms |
-| IC14 | Trusted Connection Paths | **47.4 ms** | 49.9 ms | 696 ms |
+| IC1 | Transitive Friends by Name | **56.0 ms** | 58.9 ms | 14.0 s |
+| IC2 | Recent Friend Posts | **5.6 ms** | 8.1 ms | 306 ms |
+| IC3 | Friends in Countries | **443 ms** | 862 ms | 15.7 s |
+| IC4 | Popular Tags in Period | **8.8 ms** | 13.9 ms | 527 ms |
+| IC5 | New Forum Members | **713 ms** | 1203 ms | 31.1 s |
+| IC6 | Tag Co-occurrence | **161 ms** | 185 ms | 31.5 s |
+| IC7 | Recent Likers | **0.04 ms** | 0.09 ms | 1.70 ms |
+| IC8 | Recent Replies | **0.12 ms** | 0.16 ms | 4.00 ms |
+| IC9 | Recent FoF Posts | **673 ms** | 1131 ms | 26.3 s |
+| IC10 | Friend Recommendation | **85.9 ms** | 104 ms | 2.3 s |
+| IC11 | Job Referral | **30.9 ms** | 32.2 ms | 4.5 s |
+| IC12 | Expert Reply | **56.0 ms** | 84.7 ms | 3.2 s |
+| IC13 | Single Shortest Path | **42.6 ms** | 43.4 ms | 37.00 ms |
+| IC14 | Trusted Connection Paths | **49.4 ms** | 49.8 ms | 696 ms |
 
-**Whole suite: 14.4 s, 21/21 passed, 0 empty, 0 errors.**
+**Whole suite: 9.7 s, 21/21 passed, 0 empty, 0 errors.**
 
 ### What the "previous SF1" column is
 
@@ -197,10 +197,17 @@ derived parameters (#505), so the two columns differ only by engine changes.
 Both were taken with the host calibration reported and matching, which is what
 makes them comparable at all (#529).
 
-This round: `Value` is **56 bytes instead of 144**. `Value::Node` and
-`Value::Edge` carried a whole `Node`/`Edge` inline; boxing them shrinks every
-binding in every record, since `Value` is the executor's universal cell.
-Cloning a three-binding record drops from 76.6 ns to 53.1 ns (#570).
+This round: `Expand` applies a pattern's target labels **during** the adjacency
+walk, by probing the label index with the target's id, instead of collecting
+every incident edge and then `retain`-ing the ones that match. The old test was
+`get_node(id).has_label(label)` per edge — a `Vec` index, a version-chain walk,
+a 128-byte `Node`, and a `HashSet<Label>` probe that hashes a *string* — and at
+2.22M edges visited per IC9 run it was **26.7% of a CPU profile**, the largest
+single symbol, ahead of every property read (#592). IC3, IC5 and IC9 each drop
+about 40%.
+
+Before that: `Value` became **56 bytes instead of 144** by boxing the
+`Node`/`Edge` payloads, shrinking every binding in every record (#570).
 
 Before that: the aggregate's group table stopped storing a `Value` per group,
 taking an entry from ~320 bytes to ~40 and IC5's `Aggregate` down 23%.
@@ -220,9 +227,10 @@ columns located once per query rather than once per row (#557); and `Filter`
 deciding whether to go parallel from the predicate's cost rather than the batch
 size (#559).
 
-Together, over this sequence, the suite went from **24.2 s to 14.4 s** on the
-same host at the same derived parameters — a 40% reduction, all of it in
-per-row constants rather than in algorithms.
+Together, over this sequence, the suite went from **24.2 s to 9.7 s** on the
+same host at the same derived parameters — a **60% reduction**, almost all of it
+in per-row constants rather than in algorithms. The one exception is the last:
+moving the label test into the walk removes work rather than making it cheaper.
 
 Nothing here is a parameter change. The parameter shift that made several
 queries look slower — deriving substitution parameters from the dataset at the

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -2322,6 +2322,20 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
     }
 
     /// Get all nodes with a specific label
+    /// The set of nodes carrying a label, for membership tests.
+    ///
+    /// Exists so a caller testing many nodes against the same label resolves
+    /// the set once and then probes by `NodeId`. The alternative --
+    /// `get_node(id).has_label(label)` -- costs a `Vec` index, a version-chain
+    /// walk, a 128-byte `Node`, and a `HashSet<Label>` probe that hashes a
+    /// *string*, all per node tested. `ExpandOperator` was doing that once per
+    /// edge visited, and it was 26.7% of a profiled LDBC IC9 run (#592).
+    ///
+    /// `None` means no node carries the label, which matches nothing.
+    pub fn nodes_with_label(&self, label: &Label) -> Option<&HashSet<NodeId>> {
+        self.label_index.get(label)
+    }
+
     pub fn get_nodes_by_label(&self, label: &Label) -> Vec<&Node> {
         self.label_index
             .get(label)

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3464,47 +3464,79 @@ impl ExpandOperator {
         let mut collected = std::mem::take(&mut self.current_edges);
         collected.clear();
         let type_filter = self.type_ids.as_deref();
+
+        // Target-label sets, resolved once per source record rather than per
+        // edge, and applied *during* the walk rather than by a `retain`
+        // afterwards.
+        //
+        // The old code collected every incident edge and then retained the ones
+        // whose target carried the labels, testing each with
+        // `get_node(id).has_label(label)` -- a `Vec` index, a version-chain
+        // walk, a 128-byte `Node`, and a `HashSet<Label>` probe hashing a
+        // *string*. At 2.22M edges visited per LDBC IC9 run that was **26.7% of
+        // the profile**, the single largest symbol, ahead of every property
+        // read. Probing `label_index` by `NodeId` instead is one hash of a u64
+        // (#592).
+        //
+        // A label no node carries yields `None`, which matches nothing -- so
+        // the whole expansion is empty, which is correct and is why the empty
+        // case is distinguished from "no labels required".
+        let label_sets: Option<Vec<&std::collections::HashSet<NodeId>>> =
+            if self.target_labels.is_empty() {
+                None
+            } else {
+                Some(
+                    self.target_labels
+                        .iter()
+                        .map(|l| store.nodes_with_label(l))
+                        .collect::<Option<Vec<_>>>()
+                        .unwrap_or_default(),
+                )
+            };
+        let keeps = |target: NodeId| -> bool {
+            match &label_sets {
+                None => true,
+                // `Some(empty)` means a required label exists on no node.
+                Some(sets) if sets.len() < self.target_labels.len() => false,
+                Some(sets) => sets.iter().all(|s| s.contains(&target)),
+            }
+        };
+
         match self.direction {
             Direction::Outgoing => {
                 store.for_each_outgoing_neighbor(node_id, type_filter, |target, eid| {
-                    collected.push((eid, node_id, target));
+                    if keeps(target) {
+                        collected.push((eid, node_id, target));
+                    }
                 });
             }
             Direction::Incoming => {
                 store.for_each_incoming_neighbor(node_id, type_filter, |source, eid| {
-                    collected.push((eid, source, node_id));
+                    if keeps(source) {
+                        collected.push((eid, source, node_id));
+                    }
                 });
             }
             Direction::Both => {
                 store.for_each_outgoing_neighbor(node_id, type_filter, |target, eid| {
-                    collected.push((eid, node_id, target));
+                    if keeps(target) {
+                        collected.push((eid, node_id, target));
+                    }
                 });
                 store.for_each_incoming_neighbor(node_id, type_filter, |source, eid| {
-                    collected.push((eid, source, node_id));
+                    if keeps(source) {
+                        collected.push((eid, source, node_id));
+                    }
                 });
             }
         }
 
+        // No `retain` here any more: the labels were applied during the walk
+        // above, so a non-matching edge was never pushed. The retain also
+        // compacted the vector, and its `Direction::Both` arm ran
+        // `store.get_node(node_id)` per edge purely to recover a value it
+        // already had (#592).
         self.current_edges = collected;
-
-        // Filter by target node labels if specified
-        if !self.target_labels.is_empty() {
-            self.current_edges.retain(|(_, src, tgt)| {
-                let target_id = match self.direction {
-                    Direction::Outgoing => *tgt,
-                    Direction::Incoming => *src,
-                    Direction::Both => {
-                        let source_id = store.get_node(node_id).map(|_| node_id);
-                        if source_id == Some(*src) { *tgt } else { *src }
-                    }
-                };
-                if let Some(node) = store.get_node(target_id) {
-                    self.target_labels.iter().all(|l| node.has_label(l))
-                } else {
-                    false
-                }
-            });
-        }
 
         self.edge_index = 0;
         Ok(())

--- a/tests/expand_target_labels.rs
+++ b/tests/expand_target_labels.rs
@@ -1,0 +1,149 @@
+//! Filtering an expansion's target by label (#592).
+//!
+//! `ExpandOperator` used to collect every incident edge and then `retain` the
+//! ones whose target carried the pattern's labels, testing each with
+//! `get_node(id).has_label(label)` — a `Vec` index, a version-chain walk, a
+//! 128-byte `Node`, and a `HashSet<Label>` probe that hashes a **string**. At
+//! 2.22M edges visited per LDBC IC9 run that was **26.7% of the profile**, the
+//! largest single symbol, ahead of every property read.
+//!
+//! The labels are now applied during the walk, by probing `label_index` with
+//! the target's `NodeId`. These tests are about the cases where "during" and
+//! "afterwards" could differ, and where a set-membership test could differ from
+//! asking the node:
+//!
+//! * **a label no node carries** — the set is absent, not empty, and the
+//!   expansion must match nothing rather than everything;
+//! * **more than one label** — every one must hold, not any;
+//! * **`Direction::Both`** — the old code recovered the far end with an
+//!   expression that consulted the store; getting the near/far end backwards
+//!   here filters on the wrong node and is invisible on a symmetric fixture;
+//! * **multi-label nodes**, since a node satisfying one required label and not
+//!   another must be excluded.
+
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// A hub with three kinds of neighbour, so a label filter has something to
+/// exclude in both directions.
+fn fixture() -> GraphStore {
+    let mut store = GraphStore::new();
+    let hub = store.create_node("Hub");
+    let _ = store.set_node_property("default", hub, "name".to_string(), PropertyValue::String("h".into()));
+
+    for i in 0..10i64 {
+        // Outgoing: hub -> Post
+        let post = store.create_node("Post");
+        let _ = store.set_node_property("default", post, "n".to_string(), PropertyValue::Integer(i));
+        store.create_edge(hub, post, "WROTE").unwrap();
+
+        // Outgoing: hub -> Comment, same edge type
+        let comment = store.create_node("Comment");
+        let _ = store.set_node_property("default", comment, "n".to_string(), PropertyValue::Integer(i));
+        store.create_edge(hub, comment, "WROTE").unwrap();
+
+        // Incoming: Person -> hub
+        let person = store.create_node("Person");
+        let _ = store.set_node_property("default", person, "n".to_string(), PropertyValue::Integer(i));
+        store.create_edge(person, hub, "LIKES").unwrap();
+    }
+    store
+}
+
+fn count(store: &GraphStore, cypher: &str) -> i64 {
+    let query = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&query).expect("query should run");
+    match batch.records.first().and_then(|r| r.get("c")) {
+        Some(Value::Property(PropertyValue::Integer(n))) => *n,
+        None => 0,
+        other => panic!("{other:?}"),
+    }
+}
+
+#[test]
+fn an_outgoing_expansion_keeps_only_the_labelled_targets() {
+    let store = fixture();
+    // 20 WROTE edges, half to Post and half to Comment.
+    assert_eq!(count(&store, "MATCH (h:Hub)-[:WROTE]->(x) RETURN count(x) AS c"), 20);
+    assert_eq!(count(&store, "MATCH (h:Hub)-[:WROTE]->(x:Post) RETURN count(x) AS c"), 10);
+    assert_eq!(count(&store, "MATCH (h:Hub)-[:WROTE]->(x:Comment) RETURN count(x) AS c"), 10);
+}
+
+#[test]
+fn an_incoming_expansion_filters_the_source_end() {
+    let store = fixture();
+    assert_eq!(count(&store, "MATCH (h:Hub)<-[:LIKES]-(x:Person) RETURN count(x) AS c"), 10);
+    assert_eq!(count(&store, "MATCH (h:Hub)<-[:LIKES]-(x:Post) RETURN count(x) AS c"), 0);
+}
+
+#[test]
+fn an_undirected_expansion_filters_the_far_end_not_the_near_one() {
+    // The case that would be invisible on a symmetric fixture: `Both` walks
+    // out-edges and in-edges, and the node to test is the *other* end each
+    // time. Testing the hub instead would return everything.
+    let store = fixture();
+    assert_eq!(count(&store, "MATCH (h:Hub)-[:WROTE]-(x:Post) RETURN count(x) AS c"), 10);
+    assert_eq!(count(&store, "MATCH (h:Hub)-[:LIKES]-(x:Person) RETURN count(x) AS c"), 10);
+    // And a label that only the *hub* carries must match nothing, which is what
+    // filtering the near end by mistake would get wrong.
+    assert_eq!(count(&store, "MATCH (h:Hub)-[:WROTE]-(x:Hub) RETURN count(x) AS c"), 0);
+}
+
+#[test]
+fn a_label_no_node_carries_matches_nothing() {
+    // `label_index` has no entry, so the set is *absent* rather than empty.
+    // Treating absent as "no constraint" would return every edge — the same
+    // class of bug as an unknown edge type matching everything (#520).
+    let store = fixture();
+    assert_eq!(count(&store, "MATCH (h:Hub)-[:WROTE]->(x:NoSuchLabel) RETURN count(x) AS c"), 0);
+    assert_eq!(count(&store, "MATCH (h:Hub)-[:WROTE]-(x:NoSuchLabel) RETURN count(x) AS c"), 0);
+}
+
+#[test]
+fn every_required_label_must_hold_not_any() {
+    let mut store = GraphStore::new();
+    let hub = store.create_node("Hub");
+
+    // One node with both labels, one with each.
+    let both = store.create_node("Post");
+    // Through the store, so `label_index` is maintained -- which is what the
+    // expansion now probes.
+    store.add_label_to_node("default", both, Label::new("Archived")).expect("add label");
+    let only_post = store.create_node("Post");
+    let only_archived = store.create_node("Archived");
+    for t in [both, only_post, only_archived] {
+        store.create_edge(hub, t, "WROTE").unwrap();
+    }
+
+    assert_eq!(count(&store, "MATCH (h:Hub)-[:WROTE]->(x:Post) RETURN count(x) AS c"), 2);
+    assert_eq!(count(&store, "MATCH (h:Hub)-[:WROTE]->(x:Archived) RETURN count(x) AS c"), 2);
+    assert_eq!(
+        count(&store, "MATCH (h:Hub)-[:WROTE]->(x:Post:Archived) RETURN count(x) AS c"),
+        1,
+        "only the node carrying both"
+    );
+}
+
+#[test]
+fn an_unlabelled_pattern_keeps_everything() {
+    let store = fixture();
+    assert_eq!(count(&store, "MATCH (h:Hub)-[]-(x) RETURN count(x) AS c"), 30);
+}
+
+#[test]
+fn a_multi_hop_pattern_filters_at_each_hop() {
+    let mut store = GraphStore::new();
+    let a = store.create_node("A");
+    for i in 0..5 {
+        let b = store.create_node("B");
+        store.create_edge(a, b, "R").unwrap();
+        for j in 0..3 {
+            let c = store.create_node(if j == 0 { "C" } else { "D" });
+            store.create_edge(b, c, "R").unwrap();
+        }
+    }
+    assert_eq!(count(&store, "MATCH (a:A)-[:R]->(b:B)-[:R]->(c:C) RETURN count(c) AS c"), 5);
+    assert_eq!(count(&store, "MATCH (a:A)-[:R]->(b:B)-[:R]->(d:D) RETURN count(d) AS c"), 10);
+    assert_eq!(count(&store, "MATCH (a:A)-[:R]->(b:D)-[:R]->(c) RETURN count(c) AS c"), 0);
+}


### PR DESCRIPTION
Closes #592.

## Measured

LDBC SNB Interactive SF1, same host, calibration matching at 43 ms:

| | before | after | |
|---|---:|---:|---:|
| IC2 Recent Friend Posts | 8.1 ms | **5.6 ms** | −31% |
| IC3 Friends in Countries | 862 ms | **443 ms** | −49% |
| IC4 Popular Tags in Period | 13.9 ms | **8.8 ms** | −37% |
| IC5 New Forum Members | 1203 ms | **713 ms** | −41% |
| IC9 Recent FoF Posts | 1131 ms | **673 ms** | −40% |
| IC12 Expert Reply | 84.7 ms | **56.0 ms** | −34% |
| **whole suite** | **14.2 s** | **9.7 s** | **−32%** |

IC9's `Expand` alone: **681 ms → 258 ms**.

## What it was

`ExpandOperator` collected **every** incident edge and then `retain`-ed the ones whose target carried the pattern's labels:

```rust
store.get_node(target_id).has_label(label)   // per edge
```

That is a `Vec` index, a version-chain walk, a 128-byte `Node`, and a `HashSet<Label>` probe **that hashes a string** — per edge visited. At 2.22M edges per IC9 run it was **26.7% of a CPU profile**, the largest single symbol, ahead of every property read.

Found by profiling with the *query* dominating rather than the load: 120 IC9 runs against one import. An earlier profile of a single run showed only ingestion symbols and said nothing about this.

## What it is now

`label_index: HashMap<Label, HashSet<NodeId>>` already exists, is maintained by the store, and is what `MATCH (n:Label)` already depends on — so this introduces no new consistency assumption, it uses the one the engine already has. Resolving the set **once per source record** and probing by `NodeId` is one hash of a `u64`.

Doing it inside the walk means a non-matching edge is never pushed, so the `retain` and its compaction go too — along with its `Direction::Both` arm, which called `store.get_node(node_id)` per edge to recover a value it already had.

## The case to get right

**A label no node carries.** `label_index` has no entry, so the set is *absent* rather than empty — and treating absent as "no constraint" would return **every** edge. That is the same class of bug as an unknown edge type matching everything (#520). Distinguished explicitly, with a test.

## Testing

7 tests in `tests/expand_target_labels.rs`, chosen for where "during" and "afterwards" could differ:

- outgoing, incoming, and **undirected** expansion — `Direction::Both` tests the *far* end of each edge, and getting near and far backwards is invisible on a symmetric fixture, so there is a case where only the hub carries the label;
- a label no node carries, in both directions;
- **multi-label** patterns, where every label must hold rather than any;
- an unlabelled pattern keeping everything;
- a multi-hop pattern filtering at each hop.

Both profiles on a dedicated box: **debug exit 0 / 2,838 tests / 0 failed; release exit 0 / 0 failed.** `docs/BENCHMARKS.md` updated.

## Cumulative

SF1 has now gone from **24.2 s to 9.7 s** on the same host at the same derived parameters — **−60%**. Almost all of it was per-row constants; this last one is the exception, removing work rather than making it cheaper.