### PR TITLE
Make REMOVE remove, and datetime read the epoch it was given

### DIFF
--- a/examples/cypher_probe2.rs
+++ b/examples/cypher_probe2.rs
@@ -1,0 +1,152 @@
+//! A second sweep: mutations, paths, temporal, and aggregate edge cases.
+//!
+//! `examples/cypher_probe.rs` covers scalar expressions and found five gaps
+//! plus a nondeterminism bug (#577, #578). This covers the surface it does not:
+//! writes, path functions, date handling, and the corners of aggregation —
+//! looking for the same class, a construct that parses, runs, and returns the
+//! wrong thing without erroring.
+//!
+//! Each case states its own expected answer. Wrong answers and errors are
+//! reported separately, because one is a hazard and the other a gap.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn render(v: Option<&Value>) -> String {
+    match v {
+        Some(Value::Property(p)) => match p {
+            PropertyValue::Integer(n) => n.to_string(),
+            PropertyValue::Float(f) => format!("{f}"),
+            PropertyValue::String(s) => format!("\"{s}\""),
+            PropertyValue::Boolean(b) => b.to_string(),
+            PropertyValue::Null => "null".into(),
+            PropertyValue::Array(a) => format!(
+                "[{}]",
+                a.iter().map(|x| match x {
+                    PropertyValue::Integer(n) => n.to_string(),
+                    PropertyValue::String(s) => format!("\"{s}\""),
+                    PropertyValue::Float(f) => format!("{f}"),
+                    PropertyValue::Boolean(b) => b.to_string(),
+                    PropertyValue::Null => "null".into(),
+                    other => format!("{other:?}"),
+                }).collect::<Vec<_>>().join(", ")
+            ),
+            other => format!("{other:?}"),
+        },
+        Some(Value::Null) | None => "null".into(),
+        Some(Value::NodeRef(_)) | Some(Value::Node(..)) => "<node>".into(),
+        Some(Value::EdgeRef(..)) | Some(Value::Edge(..)) => "<edge>".into(),
+        Some(Value::Path { nodes, edges }) => format!("<path {} nodes {} edges>", nodes.len(), edges.len()),
+    }
+}
+
+/// A small graph rebuilt per case, so a mutation cannot leak into the next.
+fn fresh() -> GraphStore {
+    let mut store = GraphStore::new();
+    let a = store.create_node("P");
+    let _ = store.set_node_property("default", a, "name", PropertyValue::String("Ada".into()));
+    let _ = store.set_node_property("default", a, "age", PropertyValue::Integer(36));
+    let b = store.create_node("P");
+    let _ = store.set_node_property("default", b, "name", PropertyValue::String("Bob".into()));
+    let _ = store.set_node_property("default", b, "age", PropertyValue::Integer(41));
+    let c = store.create_node("P");
+    let _ = store.set_node_property("default", c, "name", PropertyValue::String("Cy".into()));
+    let e = store.create_edge(a, b, "KNOWS").unwrap();
+    let _ = store.set_edge_property(e, "since", PropertyValue::Integer(2020));
+    store.create_edge(b, c, "KNOWS").unwrap();
+    store
+}
+
+/// Runs a script of write statements, then one read, returning column `r`.
+fn run(setup: &[&str], read: &str) -> Result<String, String> {
+    let mut store = fresh();
+    for stmt in setup {
+        let q = parse_query(stmt).map_err(|e| format!("parse `{stmt}`: {e:?}"))?;
+        let mut m = MutQueryExecutor::new(&mut store, "default".to_string());
+        m.execute(&q).map_err(|e| format!("exec `{stmt}`: {e:?}"))?;
+    }
+    let q = parse_query(read).map_err(|e| format!("parse: {e:?}"))?;
+    let batch = QueryExecutor::new(&store).execute(&q).map_err(|e| format!("exec: {e:?}"))?;
+    Ok(batch.records.first().map(|r| render(r.get("r"))).unwrap_or("<no rows>".into()))
+}
+
+fn main() {
+    // (label, setup statements, read query, expected `r`)
+    let cases: &[(&str, &[&str], &str, &str)] = &[
+        // ---- writes
+        ("CREATE a node", &["CREATE (:P {name: \"Dee\", age: 1})"], "MATCH (p:P) RETURN count(p) AS r", "4"),
+        ("CREATE reads back", &["CREATE (:P {name: \"Dee\"})"], "MATCH (p:P) WHERE p.name = \"Dee\" RETURN p.name AS r", "\"Dee\""),
+        ("SET a property", &["MATCH (p:P) WHERE p.name = \"Ada\" SET p.age = 99"], "MATCH (p:P) WHERE p.name = \"Ada\" RETURN p.age AS r", "99"),
+        ("SET a new property", &["MATCH (p:P) WHERE p.name = \"Ada\" SET p.city = \"Pune\""], "MATCH (p:P) WHERE p.name = \"Ada\" RETURN p.city AS r", "\"Pune\""),
+        ("SET to null removes", &["MATCH (p:P) WHERE p.name = \"Ada\" SET p.age = null"], "MATCH (p:P) WHERE p.name = \"Ada\" RETURN p.age AS r", "null"),
+        ("REMOVE a property", &["MATCH (p:P) WHERE p.name = \"Ada\" REMOVE p.age"], "MATCH (p:P) WHERE p.name = \"Ada\" RETURN p.age AS r", "null"),
+        ("DELETE a node", &["MATCH (p:P) WHERE p.name = \"Cy\" DELETE p"], "MATCH (p:P) RETURN count(p) AS r", "2"),
+        ("DETACH DELETE", &["MATCH (p:P) WHERE p.name = \"Bob\" DETACH DELETE p"], "MATCH (p:P) RETURN count(p) AS r", "2"),
+        ("DETACH DELETE drops edges", &["MATCH (p:P) WHERE p.name = \"Bob\" DETACH DELETE p"], "MATCH ()-[e:KNOWS]->() RETURN count(e) AS r", "0"),
+        ("MERGE matches existing", &["MERGE (p:P {name: \"Ada\"})"], "MATCH (p:P) RETURN count(p) AS r", "3"),
+        ("MERGE creates missing", &["MERGE (p:P {name: \"Zed\"})"], "MATCH (p:P) RETURN count(p) AS r", "4"),
+        ("CREATE an edge", &["MATCH (a:P), (b:P) WHERE a.name = \"Ada\" AND b.name = \"Cy\" CREATE (a)-[:LIKES]->(b)"], "MATCH ()-[e:LIKES]->() RETURN count(e) AS r", "1"),
+        ("SET an edge property", &["MATCH ()-[e:KNOWS]->() WHERE e.since = 2020 SET e.since = 2021"], "MATCH ()-[e:KNOWS]->() WHERE e.since = 2021 RETURN count(e) AS r", "1"),
+        ("SET a label", &["MATCH (p:P) WHERE p.name = \"Ada\" SET p:Admin"], "MATCH (p:Admin) RETURN count(p) AS r", "1"),
+        ("REMOVE a label", &["MATCH (p:P) WHERE p.name = \"Ada\" SET p:Admin", "MATCH (p:Admin) REMOVE p:Admin"], "MATCH (p:Admin) RETURN count(p) AS r", "0"),
+        // ---- paths
+        ("nodes(p)", &[], "MATCH p = (a:P)-[:KNOWS]->(b:P) WHERE a.name = \"Ada\" RETURN size(nodes(p)) AS r", "2"),
+        ("relationships(p)", &[], "MATCH p = (a:P)-[:KNOWS]->(b:P) WHERE a.name = \"Ada\" RETURN size(relationships(p)) AS r", "1"),
+        ("length of a 2-hop path", &[], "MATCH p = (a:P)-[:KNOWS*2]->(c:P) WHERE a.name = \"Ada\" RETURN length(p) AS r", "2"),
+        ("a path value round-trips", &[], "MATCH p = (a:P)-[:KNOWS]->(b:P) WHERE a.name = \"Ada\" RETURN p AS r", "<path 2 nodes 1 edges>"),
+        // ---- aggregation corners
+        ("count over no rows", &[], "MATCH (p:Nonexistent) RETURN count(p) AS r", "0"),
+        ("sum over no rows", &[], "MATCH (p:Nonexistent) RETURN sum(p.age) AS r", "0"),
+        ("avg over no rows", &[], "MATCH (p:Nonexistent) RETURN avg(p.age) AS r", "null"),
+        ("min over no rows", &[], "MATCH (p:Nonexistent) RETURN min(p.age) AS r", "null"),
+        ("collect over no rows", &[], "MATCH (p:Nonexistent) RETURN collect(p.age) AS r", "[]"),
+        ("count ignores nulls", &[], "MATCH (p:P) RETURN count(p.age) AS r", "2"),
+        ("count(*) does not", &[], "MATCH (p:P) RETURN count(*) AS r", "3"),
+        ("avg ignores nulls", &[], "MATCH (p:P) RETURN avg(p.age) AS r", "38.5"),
+        ("collect drops nulls", &[], "MATCH (p:P) RETURN size(collect(p.age)) AS r", "2"),
+        ("count DISTINCT over nodes", &[], "MATCH (a:P)-[:KNOWS]->(b:P) RETURN count(DISTINCT a) AS r", "2"),
+        ("aggregate with no group key", &[], "MATCH (p:P) RETURN max(p.age) AS r", "41"),
+        // ---- DISTINCT / ordering
+        ("RETURN DISTINCT", &[], "MATCH (p:P) RETURN count(DISTINCT p.age) AS r", "2"),
+        // collect() drops nulls by design (#358), so Cy's absent age is absent here
+        // too. Asserted as the documented behaviour rather than as a surprise.
+        ("collect drops the null, ordered", &[], "MATCH (p:P) RETURN collect(p.age) AS r ORDER BY p.age ASC", "[36, 41]"),
+        ("SKIP and LIMIT", &[], "MATCH (p:P) RETURN p.name AS r ORDER BY p.name SKIP 1 LIMIT 1", "\"Bob\""),
+        // ---- temporal
+        ("datetime from millis", &[], "WITH datetime({epochMillis: 1700000000000}) AS d RETURN d.year AS r", "2023"),
+        ("duration component", &[], "WITH duration({days: 3}) AS d RETURN d.days AS r", "3"),
+    ];
+
+    let mut wrong = Vec::new();
+    let mut errored = Vec::new();
+    for (label, setup, read, expected) in cases {
+        match run(setup, read) {
+            Err(e) => errored.push((label.to_string(), read.to_string(), e)),
+            Ok(got) if got != *expected => {
+                wrong.push((label.to_string(), read.to_string(), expected.to_string(), got))
+            }
+            Ok(_) => {}
+        }
+    }
+
+    println!(
+        "{} cases: {} ok, {} wrong answer, {} errored",
+        cases.len(),
+        cases.len() - wrong.len() - errored.len(),
+        wrong.len(),
+        errored.len()
+    );
+    if !wrong.is_empty() {
+        println!("\n=== WRONG ANSWER (parses, runs, returns the wrong thing) ===");
+        for (l, q, e, g) in &wrong {
+            println!("  {l}\n     {q}\n     expected {e}, got {g}");
+        }
+    }
+    if !errored.is_empty() {
+        println!("\n=== ERRORED (at least it says so) ===");
+        for (l, q, e) in &errored {
+            println!("  {l}\n     {q}\n     {e}");
+        }
+    }
+}

--- a/src/graph/storage/columnar.rs
+++ b/src/graph/storage/columnar.rs
@@ -553,6 +553,18 @@ impl ColumnStore {
         }
     }
 
+    /// Drop one property of one row.
+    ///
+    /// The single-property counterpart of `clear_row`. Its absence is why
+    /// `REMOVE n.prop` reported success and left the value readable: the
+    /// operator cleared the per-node row map, the column kept its copy, and
+    /// `resolve_property` reads the column first (#594).
+    pub fn remove_property(&mut self, idx: usize, key: &str) {
+        if let Some(&ColumnId(slot)) = self.index.get(key) {
+            self.columns[slot as usize].remove(idx);
+        }
+    }
+
     /// Drop every property stored for one row.
     ///
     /// Node ids are recycled through a free list, so a deleted node's slot is handed to the

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -2322,6 +2322,30 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
     }
 
     /// Get all nodes with a specific label
+    /// Remove one property of a node from **both** stores.
+    ///
+    /// A node's properties live in the columnar store and in the per-node row
+    /// map, and reads consult the column first. So removing from one alone
+    /// leaves the value readable, which is what `REMOVE n.prop` was doing
+    /// (#594). Anything that removes a property has to go through here.
+    pub fn remove_node_property(&mut self, node_id: NodeId, key: &str) {
+        self.node_columns.remove_property(node_id.as_u64() as usize, key);
+        if let Some(node) = self.get_node_mut(node_id) {
+            node.remove_property(key);
+        }
+        self.invalidate_statistics_cache();
+    }
+
+    /// Remove one property of an edge from both stores. See
+    /// `remove_node_property`.
+    pub fn remove_edge_property(&mut self, edge_id: EdgeId, key: &str) {
+        self.edge_columns.remove_property(edge_id.as_u64() as usize, key);
+        if let Some(props) = self.get_edge_properties_mut(edge_id) {
+            props.remove(key);
+        }
+        self.invalidate_statistics_cache();
+    }
+
     /// The set of nodes carrying a label, for membership tests.
     ///
     /// Exists so a caller testing many nodes against the same label resolves

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1530,6 +1530,38 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     }
                     Value::Property(PropertyValue::Map(map)) => {
                         use chrono::TimeZone;
+
+                        // An epoch, which is what a machine caller has (Axiom 4).
+                        // Handled before the calendar components because it is a
+                        // complete specification on its own -- and because
+                        // without it the map fell through to the defaults below
+                        // and returned 1970-01-01 *silently*, which reads as a
+                        // plausible date rather than a failure (#595).
+                        if let Some(millis) = map.get("epochMillis").and_then(|v| v.as_integer()) {
+                            return Ok(Value::Property(PropertyValue::DateTime(millis)));
+                        }
+                        if let Some(seconds) = map.get("epochSeconds").and_then(|v| v.as_integer()) {
+                            return Ok(Value::Property(PropertyValue::DateTime(seconds * 1000)));
+                        }
+
+                        // A map naming none of the understood keys is a mistake,
+                        // not a request for the epoch. Answering 1970-01-01 for
+                        // it is how the missing `epochMillis` arm stayed
+                        // invisible.
+                        const KNOWN: [&str; 8] = [
+                            "year", "month", "day", "hour", "minute", "second",
+                            "epochMillis", "epochSeconds",
+                        ];
+                        if !map.keys().any(|k| KNOWN.contains(&k.as_str())) {
+                            let mut given: Vec<String> = map.keys().cloned().collect();
+                            given.sort();
+                            return Err(ExecutionError::RuntimeError(format!(
+                                "datetime() understands none of the keys given ({}); expected one of {}",
+                                given.join(", "),
+                                KNOWN.join(", ")
+                            )));
+                        }
+
                         let year = map.get("year").and_then(|v| v.as_integer()).unwrap_or(1970) as i32;
                         let month = map.get("month").and_then(|v| v.as_integer()).unwrap_or(1) as u32;
                         let day = map.get("day").and_then(|v| v.as_integer()).unwrap_or(1) as u32;
@@ -8824,16 +8856,19 @@ impl PhysicalOperator for RemovePropertyOperator {
         if let Some(record) = self.input.next_mut(store, tenant_id)? {
             for (var, prop) in &self.items {
                 if let Some(node_val) = record.get(var) {
+                    // Through the store, so *both* the column and the row are
+                    // cleared. Removing from the row alone left the value
+                    // readable, because `resolve_property` reads the column
+                    // first -- so REMOVE reported success and did nothing
+                    // (#594).
                     match node_val {
                         Value::NodeRef(id) | Value::Node(id, _) => {
-                            if let Some(node) = store.get_node_mut(*id) {
-                                node.remove_property(prop);
-                            }
+                            let id = *id;
+                            store.remove_node_property(id, prop);
                         }
                         Value::EdgeRef(id, ..) | Value::Edge(id, _) => {
-                            if let Some(props) = store.get_edge_properties_mut(*id) {
-                                props.remove(prop);
-                            }
+                            let id = *id;
+                            store.remove_edge_property(id, prop);
                         }
                         _ => {}
                     }

--- a/tests/datetime_construction.rs
+++ b/tests/datetime_construction.rs
@@ -1,0 +1,125 @@
+//! Building a `datetime` from a map (#595).
+//!
+//! `datetime({epochMillis: 1700000000000})` returned the **epoch**. The map
+//! form handled `year`/`month`/`day`/`hour`/`minute`/`second` and nothing else,
+//! so a map naming only `epochMillis` matched no branch, fell through to the
+//! defaults, and produced `1970-01-01T00:00:00`.
+//!
+//! Silent, and in a value type where wrongness hides: `1970` reads as a
+//! plausible date rather than a failure, and every comparison against it is
+//! quietly wrong. A millisecond epoch is also what a machine caller has
+//! (`Axiom 4`), so it is the natural way to construct a timestamp.
+//!
+//! The second half of the fix matters as much as the first: a map naming
+//! **none** of the understood keys now errors. Returning the epoch for it is
+//! exactly how the missing arm stayed invisible.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn one(cypher: &str) -> Result<PropertyValue, String> {
+    let store = GraphStore::new();
+    let query = parse_query(cypher).map_err(|e| format!("parse: {e:?}"))?;
+    let batch = QueryExecutor::new(&store)
+        .execute(&query)
+        .map_err(|e| format!("exec: {e:?}"))?;
+    Ok(match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.clone(),
+        _ => PropertyValue::Null,
+    })
+}
+
+const NOV_2023: i64 = 1_700_000_000_000;
+
+#[test]
+fn epoch_millis_yields_that_instant() {
+    assert_eq!(
+        one("RETURN datetime({epochMillis: 1700000000000}) AS r").unwrap(),
+        PropertyValue::DateTime(NOV_2023)
+    );
+}
+
+#[test]
+fn it_round_trips() {
+    // The property that makes the value usable rather than merely non-1970.
+    assert_eq!(
+        one("WITH datetime({epochMillis: 1700000000000}) AS d RETURN d.epochMillis AS r").unwrap(),
+        PropertyValue::Integer(NOV_2023)
+    );
+}
+
+#[test]
+fn its_components_are_right() {
+    // 1700000000000 is 2023-11-14T22:13:20Z.
+    for (expr, expected) in [
+        ("d.year", 2023),
+        ("d.month", 11),
+        ("d.day", 14),
+        ("d.hour", 22),
+        ("d.minute", 13),
+        ("d.second", 20),
+    ] {
+        let cypher = format!("WITH datetime({{epochMillis: 1700000000000}}) AS d RETURN {expr} AS r");
+        assert_eq!(one(&cypher).unwrap(), PropertyValue::Integer(expected), "{expr}");
+    }
+}
+
+#[test]
+fn epoch_seconds_works_too() {
+    assert_eq!(
+        one("RETURN datetime({epochSeconds: 1700000000}) AS r").unwrap(),
+        PropertyValue::DateTime(NOV_2023)
+    );
+}
+
+#[test]
+fn the_calendar_form_still_works() {
+    // The branch that already existed, and which the new arms sit in front of.
+    let got = one("WITH datetime({year: 2020, month: 2, day: 29}) AS d RETURN d.year AS r").unwrap();
+    assert_eq!(got, PropertyValue::Integer(2020));
+    let day = one("WITH datetime({year: 2020, month: 2, day: 29}) AS d RETURN d.day AS r").unwrap();
+    assert_eq!(day, PropertyValue::Integer(29));
+}
+
+#[test]
+fn the_string_form_still_works() {
+    let got = one("WITH datetime(\"2023-11-14T22:13:20Z\") AS d RETURN d.year AS r").unwrap();
+    assert_eq!(got, PropertyValue::Integer(2023));
+}
+
+#[test]
+fn a_map_of_unknown_keys_errors_rather_than_returning_1970() {
+    // This is the half that keeps the first half honest. Before, *any*
+    // unrecognised map produced the epoch, which is why a missing `epochMillis`
+    // arm could go unnoticed.
+    let err = one("RETURN datetime({nonsense: 1}) AS r").unwrap_err();
+    assert!(err.contains("understands none of the keys"), "{err}");
+    assert!(err.contains("nonsense"), "the message should name what was given: {err}");
+}
+
+#[test]
+fn an_empty_map_errors() {
+    let err = one("RETURN datetime({}) AS r").unwrap_err();
+    assert!(err.contains("understands none of the keys"), "{err}");
+}
+
+#[test]
+fn a_partial_calendar_map_is_still_accepted() {
+    // `{year: 2020}` names a key the constructor understands, so the remaining
+    // components default. That behaviour predates this change and stays.
+    assert_eq!(
+        one("WITH datetime({year: 2020}) AS d RETURN d.year AS r").unwrap(),
+        PropertyValue::Integer(2020)
+    );
+}
+
+#[test]
+fn epoch_millis_wins_over_calendar_components() {
+    // Both given: the epoch is a complete specification, so it decides. Stated
+    // as a test because the precedence is a choice, not an accident.
+    assert_eq!(
+        one("RETURN datetime({epochMillis: 1700000000000, year: 1999}) AS r").unwrap(),
+        PropertyValue::DateTime(NOV_2023)
+    );
+}

--- a/tests/remove_property.rs
+++ b/tests/remove_property.rs
@@ -1,0 +1,199 @@
+//! `REMOVE n.prop` actually removes the property (#594).
+//!
+//! It reported success and left the value readable. A node's properties live
+//! in the columnar store **and** in the per-node row map, and
+//! `Value::resolve_property` reads the column first — `REMOVE` cleared only the
+//! row, so the column's copy answered every subsequent read.
+//!
+//! That is the worst shape a bug can take here: a write that returns success,
+//! changes nothing observable, and reports no problem. Someone removing a
+//! property to correct bad data or clear a flag has every reason to believe it
+//! worked.
+//!
+//! So these tests assert against **both stores**, not only against what a read
+//! returns. A read-only assertion would have passed the moment the row was
+//! cleared, if the column happened to be empty — which is exactly the case the
+//! original code got right by accident.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn graph() -> (GraphStore, samyama::graph::NodeId, samyama::graph::EdgeId) {
+    let mut store = GraphStore::new();
+    let a = store.create_node("P");
+    let _ = store.set_node_property("default", a, "name".to_string(), PropertyValue::String("Ada".into()));
+    let _ = store.set_node_property("default", a, "age".to_string(), PropertyValue::Integer(36));
+    let b = store.create_node("P");
+    let _ = store.set_node_property("default", b, "name".to_string(), PropertyValue::String("Bob".into()));
+    let e = store.create_edge(a, b, "KNOWS").unwrap();
+    let _ = store.set_edge_property(e, "since", PropertyValue::Integer(2020));
+    (store, a, e)
+}
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let query = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let mut mutating = MutQueryExecutor::new(store, "default".to_string());
+    mutating.execute(&query).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+}
+
+fn read(store: &GraphStore, cypher: &str) -> PropertyValue {
+    let query = parse_query(cypher).unwrap();
+    let batch = QueryExecutor::new(store).execute(&query).unwrap();
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.clone(),
+        _ => PropertyValue::Null,
+    }
+}
+
+#[test]
+fn removing_a_node_property_clears_both_stores() {
+    let (mut store, a, _) = graph();
+    run(&mut store, "MATCH (p:P) WHERE p.name = \"Ada\" REMOVE p.age");
+
+    assert_eq!(
+        store.node_columns.get_property(a.as_u64() as usize, "age"),
+        PropertyValue::Null,
+        "the column still holds the value — this is the bug"
+    );
+    assert!(
+        store.get_node(a).and_then(|n| n.get_property("age")).is_none(),
+        "the row still holds the value"
+    );
+    assert_eq!(
+        read(&store, "MATCH (p:P) WHERE p.name = \"Ada\" RETURN p.age AS r"),
+        PropertyValue::Null
+    );
+}
+
+#[test]
+fn the_removed_property_disappears_from_keys() {
+    // `keys()` reads the merged view, so it is the user-visible symptom that
+    // does not depend on which store answered.
+    let (mut store, _, _) = graph();
+    run(&mut store, "MATCH (p:P) WHERE p.name = \"Ada\" REMOVE p.age");
+
+    match read(&store, "MATCH (p:P) WHERE p.name = \"Ada\" RETURN keys(p) AS r") {
+        PropertyValue::Array(keys) => {
+            let names: Vec<String> = keys
+                .iter()
+                .map(|k| match k {
+                    PropertyValue::String(s) => s.clone(),
+                    other => panic!("{other:?}"),
+                })
+                .collect();
+            assert_eq!(names, vec!["name"], "age should be gone");
+        }
+        other => panic!("{other:?}"),
+    }
+}
+
+#[test]
+fn other_properties_survive() {
+    let (mut store, a, _) = graph();
+    run(&mut store, "MATCH (p:P) WHERE p.name = \"Ada\" REMOVE p.age");
+    assert_eq!(
+        store.node_columns.get_property(a.as_u64() as usize, "name"),
+        PropertyValue::String("Ada".into()),
+        "removing one property must not disturb another"
+    );
+}
+
+#[test]
+fn other_nodes_survive() {
+    // The column is shared across nodes, so clearing a slot must clear exactly
+    // one row of it.
+    let (mut store, _, _) = graph();
+    let c = store.create_node("P");
+    let _ = store.set_node_property("default", c, "age".to_string(), PropertyValue::Integer(7));
+
+    run(&mut store, "MATCH (p:P) WHERE p.name = \"Ada\" REMOVE p.age");
+    assert_eq!(
+        store.node_columns.get_property(c.as_u64() as usize, "age"),
+        PropertyValue::Integer(7),
+        "another node's value in the same column was cleared"
+    );
+}
+
+#[test]
+fn removing_an_edge_property_clears_both_stores() {
+    let (mut store, _, e) = graph();
+    run(&mut store, "MATCH ()-[r:KNOWS]->() REMOVE r.since");
+
+    assert_eq!(
+        store.edge_columns.get_property(e.as_u64() as usize, "since"),
+        PropertyValue::Null
+    );
+    assert_eq!(
+        read(&store, "MATCH ()-[r:KNOWS]->() RETURN r.since AS r"),
+        PropertyValue::Null
+    );
+}
+
+#[test]
+fn removing_a_property_that_was_never_set_is_a_no_op() {
+    let (mut store, a, _) = graph();
+    run(&mut store, "MATCH (p:P) WHERE p.name = \"Ada\" REMOVE p.nonexistent");
+    // And nothing else was disturbed.
+    assert_eq!(
+        store.node_columns.get_property(a.as_u64() as usize, "age"),
+        PropertyValue::Integer(36)
+    );
+}
+
+#[test]
+fn removing_twice_is_a_no_op() {
+    let (mut store, _, _) = graph();
+    run(&mut store, "MATCH (p:P) WHERE p.name = \"Ada\" REMOVE p.age");
+    run(&mut store, "MATCH (p:P) WHERE p.name = \"Ada\" REMOVE p.age");
+    assert_eq!(
+        read(&store, "MATCH (p:P) WHERE p.name = \"Ada\" RETURN p.age AS r"),
+        PropertyValue::Null
+    );
+}
+
+#[test]
+fn a_removed_property_can_be_set_again() {
+    let (mut store, a, _) = graph();
+    run(&mut store, "MATCH (p:P) WHERE p.name = \"Ada\" REMOVE p.age");
+    run(&mut store, "MATCH (p:P) WHERE p.name = \"Ada\" SET p.age = 40");
+    assert_eq!(
+        store.node_columns.get_property(a.as_u64() as usize, "age"),
+        PropertyValue::Integer(40)
+    );
+    assert_eq!(
+        read(&store, "MATCH (p:P) WHERE p.name = \"Ada\" RETURN p.age AS r"),
+        PropertyValue::Integer(40)
+    );
+}
+
+#[test]
+fn a_removed_property_no_longer_matches_a_filter() {
+    // The consequence that matters in practice: a query selecting on the
+    // property must stop finding the node.
+    let (mut store, _, _) = graph();
+    assert_eq!(
+        read(&store, "MATCH (p:P) WHERE p.age = 36 RETURN count(p) AS r"),
+        PropertyValue::Integer(1)
+    );
+    run(&mut store, "MATCH (p:P) WHERE p.name = \"Ada\" REMOVE p.age");
+    assert_eq!(
+        read(&store, "MATCH (p:P) WHERE p.age = 36 RETURN count(p) AS r"),
+        PropertyValue::Integer(0),
+        "the node still matches on a property that was removed"
+    );
+}
+
+#[test]
+fn set_to_null_still_behaves_as_before() {
+    // The contrast that revealed the bug. `SET p.age = null` already worked and
+    // must keep working; it leaves an explicit null rather than removing the
+    // key, which is a different thing from REMOVE and stays different.
+    let (mut store, a, _) = graph();
+    run(&mut store, "MATCH (p:P) WHERE p.name = \"Ada\" SET p.age = null");
+    assert_eq!(
+        read(&store, "MATCH (p:P) WHERE p.name = \"Ada\" RETURN p.age AS r"),
+        PropertyValue::Null
+    );
+    assert_eq!(store.node_columns.get_property(a.as_u64() as usize, "age"), PropertyValue::Null);
+}


### PR DESCRIPTION
Closes #594, closes #595.

A second Cypher sweep — writes, paths, temporal, aggregate corners; 35 cases against hand-computed answers — found two **silent wrong answers**. The third finding (#596, `SET n:Label` unsupported) errors honestly and is left filed.

## REMOVE reported success and left the value readable

```
REMOVE p.age   ->   column = Integer(36)   row = None   p.age reads 36
```

A node's properties live in the columnar store **and** in the per-node row map, and `resolve_property` consults the column first. The operator cleared only the row.

That is the worst shape available: a write that returns success, changes nothing observable, and reports no problem. Someone removing a property to correct bad data or clear a flag has every reason to believe it worked.

`SET p.age = null` reached both stores and worked — that contrast is what showed where to look:

| | column | row | `p.age` reads |
|---|---|---|---|
| `SET p.age = null` | `Null` | `Null` | `null` ✓ |
| `REMOVE p.age` (before) | **`Integer(36)`** | `None` | **`36`** ✗ |

Removal now goes through `GraphStore::remove_node_property` / `remove_edge_property`, which clear both.

## datetime({epochMillis: N}) ignored its argument

It returned **the epoch** — `1970`. The map form handled `year`/`month`/`day`/`hour`/`minute`/`second` and nothing else, so a map naming only `epochMillis` matched no branch and fell through to the defaults. `1970-01-01` reads as a plausible date rather than a failure, and a millisecond epoch is what a machine caller has (`Axiom 4`).

`epochMillis` and `epochSeconds` are handled now, **ahead** of the calendar components since an epoch is a complete specification on its own.

**The second half matters as much as the first:** a map naming *none* of the understood keys now errors. Returning 1970 for it is precisely how the missing arm stayed invisible.

`date` and `localdatetime` share the calendar code and have the same silent-default shape; left alone and noted on #595 rather than changed without tests.

## Testing

20 tests. The REMOVE ones assert against **both stores**, not only against what a read returns — a read-only assertion would have passed the moment the row was cleared, which is the case the original code got right by accident.

Verified load-bearing: with the column-side removal reverted, **4 fail**, including `a_removed_property_no_longer_matches_a_filter` — the consequence that matters in practice.

Also covered: other properties and other nodes in the same column surviving; edge properties; removing twice; removing something never set; setting again after removal; and `SET … = null` keeping its distinct meaning.

For datetime: round-trip, every component, `epochSeconds`, the calendar and string forms still working, precedence when both are given, and the unknown-key error naming what it was given.

## Verification

| | exit | tests | failed |
|---|---|---:|---:|
| debug (what CI runs) | 0 | 2,858 | 0 |
| release | 0 | — | 0 |

Sweeps: **77/77** and **33/35 with zero wrong answers** (the two remaining are #596, which errors). LDBC SF1 **21/21 at 9.6 s**.