### PR TITLE
Count what the pattern matches, not what the adjacency index knows

### DIFF
--- a/examples/cypher_probe3.rs
+++ b/examples/cypher_probe3.rs
@@ -1,0 +1,129 @@
+//! A third sweep: MERGE, FOREACH, UNION, OPTIONAL MATCH, CALL, subqueries.
+//!
+//! Sweep 1 (`cypher_probe.rs`) covered scalar expressions and found five gaps
+//! plus a nondeterminism bug. Sweep 2 (`cypher_probe2.rs`) covered writes,
+//! paths, temporal and aggregate corners and found three *silent wrong
+//! answers*. Both now pass 100%, so this covers the clause-level surface
+//! neither touched.
+//!
+//! Same method: every case states its own expected answer, and wrong answers
+//! are reported separately from errors — one is a hazard, the other a gap.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn render(v: Option<&Value>) -> String {
+    match v {
+        Some(Value::Property(p)) => match p {
+            PropertyValue::Integer(n) => n.to_string(),
+            PropertyValue::Float(f) => format!("{f}"),
+            PropertyValue::String(s) => format!("\"{s}\""),
+            PropertyValue::Boolean(b) => b.to_string(),
+            PropertyValue::Null => "null".into(),
+            PropertyValue::Array(a) => format!(
+                "[{}]",
+                a.iter().map(|x| match x {
+                    PropertyValue::Integer(n) => n.to_string(),
+                    PropertyValue::String(s) => format!("\"{s}\""),
+                    other => format!("{other:?}"),
+                }).collect::<Vec<_>>().join(", ")
+            ),
+            other => format!("{other:?}"),
+        },
+        Some(Value::Null) | None => "null".into(),
+        Some(Value::NodeRef(_)) | Some(Value::Node(..)) => "<node>".into(),
+        Some(Value::EdgeRef(..)) | Some(Value::Edge(..)) => "<edge>".into(),
+        Some(Value::Path { nodes, edges }) => format!("<path {} {}>", nodes.len(), edges.len()),
+    }
+}
+
+/// Ada -knows-> Bob -knows-> Cy. Cy has no age; Ada has no email.
+fn fresh() -> GraphStore {
+    let mut store = GraphStore::new();
+    let a = store.create_node("P");
+    let _ = store.set_node_property("default", a, "name", PropertyValue::String("Ada".into()));
+    let _ = store.set_node_property("default", a, "age", PropertyValue::Integer(36));
+    let b = store.create_node("P");
+    let _ = store.set_node_property("default", b, "name", PropertyValue::String("Bob".into()));
+    let _ = store.set_node_property("default", b, "age", PropertyValue::Integer(41));
+    let c = store.create_node("P");
+    let _ = store.set_node_property("default", c, "name", PropertyValue::String("Cy".into()));
+    store.create_edge(a, b, "KNOWS").unwrap();
+    store.create_edge(b, c, "KNOWS").unwrap();
+    store
+}
+
+fn run(setup: &[&str], read: &str) -> Result<String, String> {
+    let mut store = fresh();
+    for stmt in setup {
+        let q = parse_query(stmt).map_err(|e| format!("parse `{stmt}`: {e:?}"))?;
+        let mut m = MutQueryExecutor::new(&mut store, "default".to_string());
+        m.execute(&q).map_err(|e| format!("exec `{stmt}`: {e:?}"))?;
+    }
+    let q = parse_query(read).map_err(|e| format!("parse: {e:?}"))?;
+    let batch = QueryExecutor::new(&store).execute(&q).map_err(|e| format!("exec: {e:?}"))?;
+    Ok(batch.records.first().map(|r| render(r.get("r"))).unwrap_or("<no rows>".into()))
+}
+
+fn main() {
+    let cases: &[(&str, &[&str], &str, &str)] = &[
+        // ---- OPTIONAL MATCH
+        ("OPTIONAL MATCH keeps unmatched rows", &[], "MATCH (p:P) OPTIONAL MATCH (p)-[:KNOWS]->(f:P) RETURN count(p) AS r", "3"),
+        ("OPTIONAL MATCH yields null", &[], "MATCH (p:P) WHERE p.name = \"Cy\" OPTIONAL MATCH (p)-[:KNOWS]->(f:P) RETURN f.name AS r", "null"),
+        ("OPTIONAL MATCH that matches", &[], "MATCH (p:P) WHERE p.name = \"Ada\" OPTIONAL MATCH (p)-[:KNOWS]->(f:P) RETURN f.name AS r", "\"Bob\""),
+        ("count over an optional null", &[], "MATCH (p:P) OPTIONAL MATCH (p)-[:KNOWS]->(f:P) RETURN count(f) AS r", "2"),
+        // ---- MERGE
+        ("MERGE ON CREATE fires", &["MERGE (p:P {name: \"Zed\"}) ON CREATE SET p.made = 1"], "MATCH (p:P) WHERE p.name = \"Zed\" RETURN p.made AS r", "1"),
+        ("MERGE ON MATCH fires", &["MERGE (p:P {name: \"Ada\"}) ON MATCH SET p.seen = 1"], "MATCH (p:P) WHERE p.name = \"Ada\" RETURN p.seen AS r", "1"),
+        ("MERGE ON CREATE skipped on match", &["MERGE (p:P {name: \"Ada\"}) ON CREATE SET p.made = 1"], "MATCH (p:P) WHERE p.name = \"Ada\" RETURN p.made AS r", "null"),
+        ("MERGE ON MATCH skipped on create", &["MERGE (p:P {name: \"Zed\"}) ON MATCH SET p.seen = 1"], "MATCH (p:P) WHERE p.name = \"Zed\" RETURN p.seen AS r", "null"),
+        ("MERGE twice creates once", &["MERGE (p:P {name: \"Zed\"})", "MERGE (p:P {name: \"Zed\"})"], "MATCH (p:P) RETURN count(p) AS r", "4"),
+        ("MERGE a relationship", &["MATCH (a:P), (c:P) WHERE a.name = \"Ada\" AND c.name = \"Cy\" MERGE (a)-[:LIKES]->(c)"], "MATCH ()-[e:LIKES]->() RETURN count(e) AS r", "1"),
+        ("MERGE a relationship twice", &["MATCH (a:P), (c:P) WHERE a.name = \"Ada\" AND c.name = \"Cy\" MERGE (a)-[:LIKES]->(c)", "MATCH (a:P), (c:P) WHERE a.name = \"Ada\" AND c.name = \"Cy\" MERGE (a)-[:LIKES]->(c)"], "MATCH ()-[e:LIKES]->() RETURN count(e) AS r", "1"),
+        // ---- UNION
+        ("UNION deduplicates", &[], "MATCH (p:P) WHERE p.name = \"Ada\" RETURN p.name AS r UNION MATCH (p:P) WHERE p.name = \"Ada\" RETURN p.name AS r", "\"Ada\""),
+        ("UNION ALL keeps duplicates", &[], "MATCH (p:P) WHERE p.name = \"Ada\" RETURN p.name AS r UNION ALL MATCH (p:P) WHERE p.name = \"Ada\" RETURN p.name AS r", "\"Ada\""),
+        // ---- FOREACH
+        ("FOREACH sets over a list", &["MATCH (p:P) WHERE p.name = \"Ada\" FOREACH (x IN [1] | SET p.touched = x)"], "MATCH (p:P) WHERE p.name = \"Ada\" RETURN p.touched AS r", "1"),
+        // ---- WITH / aggregation pipelines
+        ("WITH then filter on an aggregate", &[], "MATCH (p:P)-[:KNOWS]->(f:P) WITH p, count(f) AS n WHERE n > 0 RETURN count(p) AS r", "2"),
+        ("WITH DISTINCT", &[], "MATCH (p:P)-[:KNOWS]->(f:P) WITH DISTINCT f RETURN count(f) AS r", "2"),
+        ("WITH ORDER BY LIMIT then match", &[], "MATCH (p:P) WITH p ORDER BY p.name LIMIT 1 RETURN p.name AS r", "\"Ada\""),
+        // ---- EXISTS subquery
+        ("EXISTS positive", &[], "MATCH (p:P) WHERE EXISTS { MATCH (p)-[:KNOWS]->() } RETURN count(p) AS r", "2"),
+        ("NOT EXISTS", &[], "MATCH (p:P) WHERE NOT EXISTS { MATCH (p)-[:KNOWS]->() } RETURN count(p) AS r", "1"),
+        // ---- pattern shapes
+        ("undirected matches both ways", &[], "MATCH (p:P)-[:KNOWS]-(f:P) RETURN count(f) AS r", "4"),
+        ("variable length 1..2", &[], "MATCH (a:P)-[:KNOWS*1..2]->(x:P) WHERE a.name = \"Ada\" RETURN count(x) AS r", "2"),
+        ("zero-length allowed", &[], "MATCH (a:P)-[:KNOWS*0..1]->(x:P) WHERE a.name = \"Ada\" RETURN count(x) AS r", "2"),
+        ("a self-referencing pattern", &[], "MATCH (a:P)-[:KNOWS]->(b:P)-[:KNOWS]->(c:P) RETURN count(c) AS r", "1"),
+        ("anonymous nodes", &[], "MATCH (:P)-[:KNOWS]->(:P) RETURN count(*) AS r", "2"),
+        // ---- DELETE semantics
+        ("DELETE a node with edges errors or detaches", &["MATCH (p:P) WHERE p.name = \"Cy\" DELETE p"], "MATCH (p:P) RETURN count(p) AS r", "2"),
+        // ---- CALL
+        ("CALL pageRank YIELD", &[], "CALL algo.pageRank() YIELD nodeId, score RETURN count(score) AS r", "3"),
+    ];
+
+    let mut wrong = Vec::new();
+    let mut errored = Vec::new();
+    for (label, setup, read, expected) in cases {
+        match run(setup, read) {
+            Err(e) => errored.push((label.to_string(), read.to_string(), e)),
+            Ok(got) if got != *expected => {
+                wrong.push((label.to_string(), read.to_string(), expected.to_string(), got))
+            }
+            Ok(_) => {}
+        }
+    }
+    println!("{} cases: {} ok, {} wrong answer, {} errored",
+        cases.len(), cases.len()-wrong.len()-errored.len(), wrong.len(), errored.len());
+    if !wrong.is_empty() {
+        println!("\n=== WRONG ANSWER (parses, runs, returns the wrong thing) ===");
+        for (l,q,e,g) in &wrong { println!("  {l}\n     {q}\n     expected {e}, got {g}"); }
+    }
+    if !errored.is_empty() {
+        println!("\n=== ERRORED (at least it says so) ===");
+        for (l,q,e) in &errored { println!("  {l}\n     {q}\n     {e}"); }
+    }
+}

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -4810,15 +4810,22 @@ impl AggregateOperator {
     /// True when every aggregate can be satisfied by counting rows, so the
     /// argument expressions never have to be evaluated.
     ///
-    /// Valid only when the argument cannot be null per row — `count(*)` (a
-    /// literal) or `count(var)` for a bound node or edge. `count(x.prop)`
-    /// counts *non-null values*, so skipping the evaluation there counts rows
-    /// instead and reports every row as a value (#358).
+    /// Only `count(*)` qualifies — a literal, which is never null.
+    ///
+    /// `count(var)` used to qualify too, on the reasoning that a bound node or
+    /// edge cannot be null per row. `OPTIONAL MATCH` breaks exactly that: it
+    /// binds the variable to `Null` on a row that did not match, so
+    /// `MATCH (p) OPTIONAL MATCH (p)-[:KNOWS]->(f) RETURN count(f)` counted the
+    /// unmatched rows and reported 1 friend for a person with none (#600).
+    ///
+    /// Giving up the variable case costs little: evaluating one is
+    /// `record.get(var)` at ~4 ns, against a property read at ~17 ns. The fast
+    /// path exists to avoid *property* evaluation (#358), and it still does.
     fn all_simple_count(aggregates: &[AggregateFunction]) -> bool {
         aggregates.iter().all(|a| {
             matches!(a.func, AggregateType::Count)
                 && !a.distinct
-                && matches!(a.expr, Expression::Literal(_) | Expression::Variable(_))
+                && matches!(a.expr, Expression::Literal(_))
         })
     }
 
@@ -5146,6 +5153,13 @@ pub struct AdjacencyCountAggregateOperator {
     /// and emit one record per distinct property-value combination —
     /// avoids the planner-side post-aggregate hash-group entirely.
     group_by_props: Vec<String>,
+    /// The label the pattern requires of the *neighbour*, if any.
+    ///
+    /// A degree is not the number of pattern matches: it counts every edge of
+    /// the type whatever sits at the far end. Without this the operator
+    /// answered `MATCH (p:P)-[:KNOWS]->(f:P) RETURN p.name, count(f)` by
+    /// counting Ada's edge to an `:Animal` as well (#601).
+    neighbor_label: Option<Label>,
     /// `count(DISTINCT neighbor)` semantics. When true, build_grouped_iter
     /// accumulates a HashSet of neighbor NodeIds per group instead of
     /// summing degrees — required when the same neighbor may appear under
@@ -5186,8 +5200,15 @@ impl AdjacencyCountAggregateOperator {
             direction,
             group_by_props: Vec::new(),
             count_distinct: false,
+            neighbor_label: None,
             grouped_iter: None,
         }
+    }
+
+    /// Require the counted neighbour to carry this label.
+    pub fn with_neighbor_label(mut self, label: Option<Label>) -> Self {
+        self.neighbor_label = label;
+        self
     }
 
     /// Enable the in-operator group-by path. When non-empty, the operator
@@ -5245,6 +5266,11 @@ impl AdjacencyCountAggregateOperator {
 
         let rows: Vec<GroupedRow> = groups
             .into_iter()
+            // A required MATCH yields no row for a node the pattern does not
+            // match, so a group whose count is zero must not be emitted. The
+            // detector rejects OPTIONAL MATCH, where the zeros would be
+            // wanted, so this is unconditional (#601).
+            .filter(|(_, (_, count))| *count > 0)
             .map(|(prop_values, (sample_node, count))| GroupedRow {
                 prop_values,
                 count,
@@ -5333,14 +5359,63 @@ impl AdjacencyCountAggregateOperator {
     /// helpers (`incoming_degree_for_type` / `outgoing_degree_for_type`)
     /// which avoid Vec alloc + per-edge EdgeType clone.
     fn degree_filtered(&self, store: &GraphStore, node_id: NodeId) -> usize {
+        let Some(label) = &self.neighbor_label else {
+            // No constraint on the far end, so the degree *is* the match count
+            // and the adjacency index answers in O(1). This is the shape the
+            // operator exists for.
+            return match self.direction {
+                Direction::Outgoing => store.outgoing_degree_for_type(node_id, &self.edge_type),
+                Direction::Incoming => store.incoming_degree_for_type(node_id, &self.edge_type),
+                Direction::Both => {
+                    store.outgoing_degree_for_type(node_id, &self.edge_type)
+                        + store.incoming_degree_for_type(node_id, &self.edge_type)
+                }
+            };
+        };
+
+        // Constrained: walk and count the neighbours that carry the label.
+        // O(degree) rather than O(1), which is what a correct answer costs --
+        // and still cheaper than materialising a row per edge. The membership
+        // probe is one hash of a `NodeId` (#592).
+        let Some(members) = store.nodes_with_label(label) else {
+            // No node carries the label, so nothing matches.
+            return 0;
+        };
+        // `Some(&[])` matches no edge; a wildcard would be `None`, which is not
+        // what an unknown edge type means (#520).
+        let type_ids: Vec<u16> = store.edge_type_id(&self.edge_type).into_iter().collect();
+        let filter = Some(type_ids.as_slice());
+
+        let mut count = 0usize;
         match self.direction {
-            Direction::Outgoing => store.outgoing_degree_for_type(node_id, &self.edge_type),
-            Direction::Incoming => store.incoming_degree_for_type(node_id, &self.edge_type),
+            Direction::Outgoing => {
+                store.for_each_outgoing_neighbor(node_id, filter, |target, _| {
+                    if members.contains(&target) {
+                        count += 1;
+                    }
+                });
+            }
+            Direction::Incoming => {
+                store.for_each_incoming_neighbor(node_id, filter, |source, _| {
+                    if members.contains(&source) {
+                        count += 1;
+                    }
+                });
+            }
             Direction::Both => {
-                store.outgoing_degree_for_type(node_id, &self.edge_type)
-                    + store.incoming_degree_for_type(node_id, &self.edge_type)
+                store.for_each_outgoing_neighbor(node_id, filter, |target, _| {
+                    if members.contains(&target) {
+                        count += 1;
+                    }
+                });
+                store.for_each_incoming_neighbor(node_id, filter, |source, _| {
+                    if members.contains(&source) {
+                        count += 1;
+                    }
+                });
             }
         }
+        count
     }
 }
 
@@ -5393,6 +5468,12 @@ impl PhysicalOperator for AdjacencyCountAggregateOperator {
             };
 
             let count = self.degree_filtered(store, node_id);
+            if count == 0 {
+                // A required MATCH yields no row for a node the pattern does
+                // not match. The detector rejects OPTIONAL MATCH, where the
+                // zero would be wanted (#601).
+                continue;
+            }
 
             let mut out = input_record;
             out.bind(

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -3037,7 +3037,11 @@ impl QueryPlanner {
             pat.count_alias.clone(),
             pat.edge_type.clone(),
             physical_direction,
-        );
+        )
+        // A degree counts every edge of the type whatever sits at the far end,
+        // so a pattern that labels the neighbour needs the label applied while
+        // counting (#601).
+        .with_neighbor_label(pat.neighbor_label.clone());
         if !group_by_props.is_empty() {
             adj_op = adj_op.with_group_by_props(group_by_props);
         }
@@ -3216,7 +3220,8 @@ impl QueryPlanner {
             pat.core.count_alias.clone(),
             pat.core.edge_type.clone(),
             physical_direction,
-        );
+        )
+        .with_neighbor_label(pat.core.neighbor_label.clone());
         if !group_by_props.is_empty() {
             adj_op = adj_op.with_group_by_props(group_by_props);
         }
@@ -3346,7 +3351,8 @@ impl QueryPlanner {
             pat.core.count_alias.clone(),
             pat.core.edge_type.clone(),
             physical_direction,
-        );
+        )
+        .with_neighbor_label(pat.core.neighbor_label.clone());
         if !group_by_props.is_empty() {
             adj_op = adj_op.with_group_by_props(group_by_props);
         }

--- a/tests/adjacency_count_semantics.rs
+++ b/tests/adjacency_count_semantics.rs
@@ -1,0 +1,191 @@
+//! The degree-counting rewrite answers the query that was asked (#601).
+//!
+//! `RETURN n.prop, count(neighbour)` over an expand is rewritten to
+//! `AdjacencyCountAggregate`, which reads each source's **degree** off the
+//! adjacency index. That is a good optimisation — it is why this shape does not
+//! appear in profiles — but a degree is not a match count, and it was wrong two
+//! ways at once:
+//!
+//! * it **ignored the neighbour's label**, because a degree counts every edge
+//!   of the type whatever sits at the far end;
+//! * it **emitted a row per scanned source**, so sources matching the pattern
+//!   zero times appeared with count 0 — turning a required match into an
+//!   optional one.
+//!
+//! The tell was that the same query grouped and ungrouped disagreed: `RETURN
+//! count(f)` said 1 while `RETURN p.name, count(f)` said 2.
+//!
+//! These tests assert **the answer and that the rewrite is still taken**. Only
+//! the first would let a future correctness fix silently disable the
+//! optimisation; only the second would let it stay fast and wrong.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// Ada KNOWS Bob (a `:P`) and Rex (an `:Animal`). Bob and Cy know nobody.
+///
+/// Built so the two defects give different wrong answers: ignoring the label
+/// makes Ada 2 instead of 1, and keeping zero rows adds Bob and Cy.
+fn fixture() -> GraphStore {
+    let mut store = GraphStore::new();
+    let mut mk = |store: &mut GraphStore, label: &str, name: &str| {
+        let id = store.create_node(label);
+        let _ = store.set_node_property(
+            "default",
+            id,
+            "name".to_string(),
+            PropertyValue::String(name.to_string()),
+        );
+        id
+    };
+    let ada = mk(&mut store, "P", "Ada");
+    let bob = mk(&mut store, "P", "Bob");
+    let _cy = mk(&mut store, "P", "Cy");
+    let rex = mk(&mut store, "Animal", "Rex");
+    store.create_edge(ada, bob, "KNOWS").unwrap();
+    store.create_edge(ada, rex, "KNOWS").unwrap();
+    store
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> Vec<(String, i64)> {
+    let query = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let batch = QueryExecutor::new(store).execute(&query).unwrap();
+    let mut out: Vec<(String, i64)> = batch
+        .records
+        .iter()
+        .map(|r| {
+            let g = match r.get("g") {
+                Some(Value::Property(PropertyValue::String(s))) => s.clone(),
+                other => panic!("{other:?}"),
+            };
+            let n = match r.get("c") {
+                Some(Value::Property(PropertyValue::Integer(n))) => *n,
+                other => panic!("{other:?}"),
+            };
+            (g, n)
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+fn plan(store: &GraphStore, cypher: &str) -> String {
+    let query = parse_query(&format!("EXPLAIN {cypher}")).unwrap();
+    let batch = QueryExecutor::new(store).execute(&query).unwrap();
+    match batch.records[0].get("plan") {
+        Some(Value::Property(PropertyValue::String(t))) => t.clone(),
+        other => panic!("{other:?}"),
+    }
+}
+
+#[test]
+fn the_neighbours_label_is_honoured() {
+    let store = fixture();
+    assert_eq!(
+        rows(&store, "MATCH (p:P)-[:KNOWS]->(f:P) RETURN p.name AS g, count(f) AS c"),
+        vec![("Ada".to_string(), 1)],
+        "Rex is an :Animal and must not be counted for (f:P)"
+    );
+}
+
+#[test]
+fn an_unlabelled_neighbour_counts_everything() {
+    // The shape the optimisation exists for, and the one it was always right
+    // about. It must not have been broken by making the label case correct.
+    let store = fixture();
+    assert_eq!(
+        rows(&store, "MATCH (p:P)-[:KNOWS]->(f) RETURN p.name AS g, count(f) AS c"),
+        vec![("Ada".to_string(), 2)]
+    );
+}
+
+#[test]
+fn a_source_matching_zero_times_yields_no_row() {
+    // Bob and Cy know nobody. A *required* MATCH drops them; only
+    // OPTIONAL MATCH would keep them with a zero.
+    let store = fixture();
+    let got = rows(&store, "MATCH (p:P)-[:KNOWS]->(f) RETURN p.name AS g, count(f) AS c");
+    assert!(!got.iter().any(|(n, _)| n == "Bob" || n == "Cy"), "{got:?}");
+}
+
+#[test]
+fn the_grouped_and_ungrouped_forms_agree() {
+    // The tell that found this. Two ways of asking the same question must not
+    // give different totals.
+    let store = fixture();
+    let grouped: i64 = rows(&store, "MATCH (p:P)-[:KNOWS]->(f:P) RETURN p.name AS g, count(f) AS c")
+        .iter()
+        .map(|(_, n)| n)
+        .sum();
+
+    let query = parse_query("MATCH (p:P)-[:KNOWS]->(f:P) RETURN count(f) AS c").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    let ungrouped = match batch.records[0].get("c") {
+        Some(Value::Property(PropertyValue::Integer(n))) => *n,
+        other => panic!("{other:?}"),
+    };
+
+    assert_eq!(grouped, ungrouped, "grouped {grouped} vs ungrouped {ungrouped}");
+    assert_eq!(grouped, 1);
+}
+
+#[test]
+fn the_rewrite_is_still_taken() {
+    // Correctness without this would be easy: disable the rewrite. Asserted so
+    // a future fix cannot quietly trade the optimisation away.
+    let store = fixture();
+    for cypher in [
+        "MATCH (p:P)-[:KNOWS]->(f) RETURN p.name AS g, count(f) AS c",
+        "MATCH (p:P)-[:KNOWS]->(f:P) RETURN p.name AS g, count(f) AS c",
+    ] {
+        let text = plan(&store, cypher);
+        assert!(
+            text.contains("AdjacencyCountAggregate"),
+            "the rewrite was lost for `{cypher}`:\n{text}"
+        );
+    }
+}
+
+#[test]
+fn an_incoming_pattern_is_filtered_too() {
+    let store = fixture();
+    assert_eq!(
+        rows(&store, "MATCH (f:P)<-[:KNOWS]-(p:P) RETURN f.name AS g, count(p) AS c"),
+        vec![("Bob".to_string(), 1)],
+        "Rex is not a :P, and Ada has no incoming KNOWS"
+    );
+}
+
+#[test]
+fn an_undirected_pattern_is_filtered_too() {
+    let store = fixture();
+    let got = rows(&store, "MATCH (p:P)-[:KNOWS]-(f:P) RETURN p.name AS g, count(f) AS c");
+    assert_eq!(
+        got,
+        vec![("Ada".to_string(), 1), ("Bob".to_string(), 1)],
+        "Ada-Bob counts once from each end; Rex and Cy never: {got:?}"
+    );
+}
+
+#[test]
+fn a_label_no_node_carries_counts_nothing() {
+    // `label_index` has no entry, which is not the same as an empty one.
+    let store = fixture();
+    let got = rows(&store, "MATCH (p:P)-[:KNOWS]->(f:Ghost) RETURN p.name AS g, count(f) AS c");
+    assert!(got.is_empty(), "{got:?}");
+}
+
+#[test]
+fn the_answer_matches_expanding_the_pattern_by_hand() {
+    // A differential check against the unrewritten form. `count(f.name)` is not
+    // eligible for the rewrite, so it goes through the ordinary aggregate and
+    // is the independent answer.
+    let store = fixture();
+    let by_rewrite = rows(&store, "MATCH (p:P)-[:KNOWS]->(f:P) RETURN p.name AS g, count(f) AS c");
+    let by_aggregate = rows(
+        &store,
+        "MATCH (p:P)-[:KNOWS]->(f:P) RETURN p.name AS g, count(f.name) AS c",
+    );
+    assert_eq!(by_rewrite, by_aggregate);
+}

--- a/tests/optional_match_count.rs
+++ b/tests/optional_match_count.rs
@@ -1,0 +1,167 @@
+//! `count(var)` counts non-null bindings, including under OPTIONAL MATCH
+//! (#600).
+//!
+//! `AggregateOperator` had a fast path that skipped evaluating a `count`
+//! argument and just counted rows. Its precondition was "the argument cannot be
+//! null per row — `count(*)`, or `count(var)` for a bound node or edge".
+//!
+//! `OPTIONAL MATCH` is precisely the case that breaks it: it binds the variable
+//! to `Null` on a row that did not match. So
+//! `MATCH (p) OPTIONAL MATCH (p)-[:KNOWS]->(f) RETURN p, count(f)` reported
+//! **one friend for a person with none** — the natural way to write "how many
+//! friends does each person have", answered wrongly and silently.
+//!
+//! The contrast that pinned it: `count(f.name)` was already correct at 2, and
+//! `count(f)` said 3. Both should say 2.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// Ada -> Bob -> Cy. Cy has no outgoing KNOWS, so it is the row that goes null.
+fn graph() -> GraphStore {
+    let mut store = GraphStore::new();
+    let a = store.create_node("P");
+    let _ = store.set_node_property("default", a, "name".to_string(), PropertyValue::String("Ada".into()));
+    let b = store.create_node("P");
+    let _ = store.set_node_property("default", b, "name".to_string(), PropertyValue::String("Bob".into()));
+    let c = store.create_node("P");
+    let _ = store.set_node_property("default", c, "name".to_string(), PropertyValue::String("Cy".into()));
+    store.create_edge(a, b, "KNOWS").unwrap();
+    store.create_edge(b, c, "KNOWS").unwrap();
+    store
+}
+
+fn scalar(store: &GraphStore, cypher: &str) -> i64 {
+    let query = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let batch = QueryExecutor::new(store).execute(&query).unwrap();
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(PropertyValue::Integer(n))) => *n,
+        other => panic!("{cypher}: {other:?}"),
+    }
+}
+
+/// `(name, count)` pairs, sorted, for a grouped query.
+fn grouped(store: &GraphStore, cypher: &str) -> Vec<(String, i64)> {
+    let query = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let batch = QueryExecutor::new(store).execute(&query).unwrap();
+    let mut out: Vec<(String, i64)> = batch
+        .records
+        .iter()
+        .map(|r| {
+            let name = match r.get("g") {
+                Some(Value::Property(PropertyValue::String(s))) => s.clone(),
+                other => panic!("{other:?}"),
+            };
+            let n = match r.get("r") {
+                Some(Value::Property(PropertyValue::Integer(n))) => *n,
+                other => panic!("{other:?}"),
+            };
+            (name, n)
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn count_of_a_variable_ignores_the_unmatched_row() {
+    let store = graph();
+    assert_eq!(
+        scalar(&store, "MATCH (p:P) OPTIONAL MATCH (p)-[:KNOWS]->(f:P) RETURN count(f) AS r"),
+        2,
+        "Cy matched nothing, so f is null on that row and must not be counted"
+    );
+}
+
+#[test]
+fn count_of_a_property_was_already_right_and_stays_right() {
+    // The contrast that located the bug. If these two ever disagree again, the
+    // fast path has been widened back.
+    let store = graph();
+    assert_eq!(
+        scalar(&store, "MATCH (p:P) OPTIONAL MATCH (p)-[:KNOWS]->(f:P) RETURN count(f.name) AS r"),
+        2
+    );
+}
+
+#[test]
+fn count_star_still_counts_rows() {
+    // `count(*)` is the case the fast path is *for*, and it must keep counting
+    // every row including the unmatched one.
+    let store = graph();
+    assert_eq!(
+        scalar(&store, "MATCH (p:P) OPTIONAL MATCH (p)-[:KNOWS]->(f:P) RETURN count(*) AS r"),
+        3
+    );
+}
+
+#[test]
+fn the_grouped_form_reports_zero_for_the_person_with_none() {
+    // The shape that matters in practice: "how many friends does each person
+    // have". Cy has none and was being reported as having one.
+    let store = graph();
+    assert_eq!(
+        grouped(
+            &store,
+            "MATCH (p:P) OPTIONAL MATCH (p)-[:KNOWS]->(f:P) RETURN p.name AS g, count(f) AS r"
+        ),
+        vec![("Ada".to_string(), 1), ("Bob".to_string(), 1), ("Cy".to_string(), 0)]
+    );
+}
+
+#[test]
+fn count_distinct_over_an_optional_null() {
+    let store = graph();
+    assert_eq!(
+        scalar(
+            &store,
+            "MATCH (p:P) OPTIONAL MATCH (p)-[:KNOWS]->(f:P) RETURN count(DISTINCT f) AS r"
+        ),
+        2
+    );
+}
+
+#[test]
+fn a_required_match_is_unaffected() {
+    // The common case, where no binding can be null. This is IC5's shape and
+    // the one the fast path was introduced for, so it must not have changed
+    // answer.
+    let store = graph();
+    assert_eq!(
+        scalar(&store, "MATCH (p:P)-[:KNOWS]->(f:P) RETURN count(f) AS r"),
+        2
+    );
+    assert_eq!(
+        grouped(&store, "MATCH (p:P)-[:KNOWS]->(f:P) RETURN p.name AS g, count(f) AS r"),
+        vec![("Ada".to_string(), 1), ("Bob".to_string(), 1)],
+        "a required match drops the unmatched row entirely, rather than nulling it"
+    );
+}
+
+#[test]
+fn counting_an_edge_variable_behaves_the_same_way() {
+    let store = graph();
+    assert_eq!(
+        scalar(&store, "MATCH (p:P) OPTIONAL MATCH (p)-[e:KNOWS]->(:P) RETURN count(e) AS r"),
+        2
+    );
+}
+
+#[test]
+fn two_counts_in_one_aggregate() {
+    // Mixed arguments in one aggregate: the fast path is all-or-nothing, so a
+    // `count(*)` beside a `count(var)` must not drag the variable back onto it.
+    let store = graph();
+    let query = parse_query(
+        "MATCH (p:P) OPTIONAL MATCH (p)-[:KNOWS]->(f:P) RETURN count(*) AS a, count(f) AS b",
+    )
+    .unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    let get = |k: &str| match batch.records[0].get(k) {
+        Some(Value::Property(PropertyValue::Integer(n))) => *n,
+        other => panic!("{other:?}"),
+    };
+    assert_eq!(get("a"), 3, "count(*) counts rows");
+    assert_eq!(get("b"), 2, "count(f) counts non-null bindings");
+}


### PR DESCRIPTION
Closes #600, closes #601.

A third Cypher sweep — `MERGE`, `FOREACH`, `UNION`, `OPTIONAL MATCH`, `WITH` pipelines, `EXISTS`, `CALL`; 26 cases against hand-computed answers — found two **silent wrong answers**. The second was found by writing a control for the first.

## count(var) over an OPTIONAL MATCH counted the unmatched rows

The aggregate's fast path skips evaluating a `count` argument and counts rows, on the stated precondition that the argument cannot be null. `OPTIONAL MATCH` binds the variable to `Null` on a row that did not match — exactly that case.

```cypher
MATCH (p:P) OPTIONAL MATCH (p)-[:KNOWS]->(f:P) RETURN p.name, count(f)
-- Ada 1, Bob 1, Cy 1     ← Cy knows nobody
```

**"How many friends does each person have" reported 1 for someone with none.**

Now `count(*)` only. Giving up the variable case costs little — evaluating one is `record.get(var)` at ~4 ns against a property read at ~17 ns, and the path exists to avoid *property* evaluation, which it still does. Measured on SF1, whose IC5 `count(friend)` is the shape it was written for:

| | suite | IC3 | IC5 | IC9 |
|---|---:|---:|---:|---:|
| main | 10.1 s | 453 ms | 753 ms | 698 ms |
| this branch | 9.9 s | 456 ms | **730 ms** | 704 ms |

No regression.

## AdjacencyCountAggregate ignored the label and invented rows

```cypher
MATCH (p:P)-[:KNOWS]->(f:P) RETURN p.name, count(f)
```
Ada KNOWS Bob (a `:P`) and Rex (an `:Animal`); Bob and Cy know nobody.

| | |
|---|---|
| correct | `Ada 1` |
| actual | **`Cy 0`, `Ada 2`, `Bob 0`** |

It reads each source's **degree**, and a degree is not a match count: it counts every edge of the type whatever sits at the far end, and it produces a row per scanned source. Two errors compounding — one inflating Ada by counting an edge to an `:Animal`, the other inventing rows for nodes the pattern does not match, turning a required match into an optional one.

**The tell:** the same query grouped and ungrouped disagreed, 2 against 1.

The detector already captured the neighbour label; **the planner dropped it**. It is now applied while counting — O(degree) rather than O(1), which is what a correct answer costs, and the membership probe is one hash of a `NodeId` thanks to #592. The unlabelled shape the optimisation exists for keeps the O(1) degree. Zero counts are skipped unconditionally, because the detector already rejects `OPTIONAL MATCH`, where the zeros would be wanted.

## Testing

17 tests. The two carrying most weight:

- **the rewrite is still taken** — correctness without it would be easy (disable it) and wrong to trade away, so both the answer and the plan are asserted;
- a **differential check against `count(f.name)`**, which is not eligible for the rewrite and so answers independently.

Plus: incoming and undirected patterns, a label no node carries, the grouped/ungrouped agreement that found it, `count(DISTINCT var)`, `count(*)` still counting rows, and a required match as the control.

## Verification

| | |
|---|---|
| HEAD verified | `145c92b` |
| new test files present | 2 of 2 |
| new binaries ran | 2 of 2 |
| debug (what CI runs) | exit 0, **2,886 tests**, 0 failed |
| release | exit 0, 0 failed |
| sweeps | **77/77, 35/35, 26/26** |

The explicit HEAD and binary-ran assertions are there because an earlier run of this verification silently executed against `main` — the branch had not been pushed where I thought — and reported green for code that was not being tested.