### PR TITLE
Treat a list of floats as a list, and coerce numbers in IN

### DIFF
--- a/examples/cypher_probe4.rs
+++ b/examples/cypher_probe4.rs
@@ -1,0 +1,119 @@
+//! A fourth sweep: type coercion, comparison and ordering across types.
+//!
+//! Sweeps 1–3 covered scalar expressions, writes/paths/temporal, and
+//! clause-level surface; all three pass. This covers where values of different
+//! types meet — a classic source of *silently empty* results, and the subject
+//! of a standing note that "float-vs-int WHERE silently returns nothing".
+//!
+//! A query that returns no rows looks like a true negative. That is what makes
+//! this class worth sweeping deliberately rather than waiting to trip over it.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn render(v: Option<&Value>) -> String {
+    match v {
+        Some(Value::Property(p)) => match p {
+            PropertyValue::Integer(n) => n.to_string(),
+            PropertyValue::Float(f) => format!("{f}"),
+            PropertyValue::String(s) => format!("\"{s}\""),
+            PropertyValue::Boolean(b) => b.to_string(),
+            PropertyValue::Null => "null".into(),
+            PropertyValue::Array(a) => format!("[{}]", a.iter().map(|x| match x {
+                PropertyValue::Integer(n) => n.to_string(),
+                PropertyValue::Float(f) => format!("{f}"),
+                PropertyValue::String(s) => format!("\"{s}\""),
+                other => format!("{other:?}"),
+            }).collect::<Vec<_>>().join(", ")),
+            other => format!("{other:?}"),
+        },
+        Some(Value::Null) | None => "null".into(),
+        other => format!("{other:?}"),
+    }
+}
+
+/// Nodes carrying the same logical numbers stored as Integer and as Float,
+/// so a comparison that fails to coerce shows up as a missing row.
+fn fixture() -> GraphStore {
+    let mut store = GraphStore::new();
+    for (name, age_i, score_f) in [("Ada", 36i64, 9.5f64), ("Bob", 41, 7.0), ("Cy", 20, 10.0)] {
+        let id = store.create_node("P");
+        let _ = store.set_node_property("default", id, "name", PropertyValue::String(name.into()));
+        let _ = store.set_node_property("default", id, "age", PropertyValue::Integer(age_i));
+        let _ = store.set_node_property("default", id, "score", PropertyValue::Float(score_f));
+    }
+    store
+}
+
+fn main() {
+    let store = fixture();
+    let cases: &[(&str, &str, &str)] = &[
+        // --- int property against a float literal, and the reverse
+        ("int prop = float literal", "MATCH (p:P) WHERE p.age = 36.0 RETURN count(p) AS r", "1"),
+        ("int prop > float literal", "MATCH (p:P) WHERE p.age > 35.5 RETURN count(p) AS r", "2"),
+        ("int prop < float literal", "MATCH (p:P) WHERE p.age < 36.5 RETURN count(p) AS r", "2"),
+        ("float prop = int literal", "MATCH (p:P) WHERE p.score = 7 RETURN count(p) AS r", "1"),
+        ("float prop > int literal", "MATCH (p:P) WHERE p.score > 9 RETURN count(p) AS r", "2"),
+        ("float prop <= int literal", "MATCH (p:P) WHERE p.score <= 10 RETURN count(p) AS r", "3"),
+        // --- arithmetic mixing
+        ("int + float", "RETURN 1 + 1.5 AS r", "2.5"),
+        ("int / int truncates", "RETURN 7 / 2 AS r", "3"),
+        ("int / float", "RETURN 7 / 2.0 AS r", "3.5"),
+        ("float compared after arithmetic", "MATCH (p:P) WHERE p.age * 1.0 = 36.0 RETURN count(p) AS r", "1"),
+        // --- comparison across incompatible types (Cypher: null, not error)
+        ("int vs string is null", "RETURN 1 = \"1\" AS r", "false"),
+        ("int < string", "RETURN (1 < \"a\") IS NULL AS r", "true"),
+        ("null comparison", "RETURN (1 < null) IS NULL AS r", "true"),
+        // --- IN with mixed numeric types
+        ("int IN a float list", "MATCH (p:P) WHERE p.age IN [36.0, 99.0] RETURN count(p) AS r", "1"),
+        ("float IN an int list", "MATCH (p:P) WHERE p.score IN [7, 99] RETURN count(p) AS r", "1"),
+        // --- ordering across types
+        ("ORDER BY an int property", "MATCH (p:P) RETURN p.name AS r ORDER BY p.age ASC LIMIT 1", "\"Cy\""),
+        ("ORDER BY a float property", "MATCH (p:P) RETURN p.name AS r ORDER BY p.score DESC LIMIT 1", "\"Cy\""),
+        // --- boundary values
+        ("large integer round-trips", "RETURN 9007199254740993 AS r", "9007199254740993"),
+        ("negative zero float", "RETURN -0.0 = 0.0 AS r", "true"),
+        ("integer overflow-ish literal", "RETURN 9223372036854775807 AS r", "9223372036854775807"),
+        // --- string/number conversion
+        ("toInteger of a float", "RETURN toInteger(3.9) AS r", "3"),
+        ("toInteger of a bad string", "RETURN toInteger(\"abc\") IS NULL AS r", "true"),
+        ("toFloat of an int", "RETURN toFloat(3) AS r", "3"),
+        ("toString of a float", "RETURN toString(1.5) AS r", "\"1.5\""),
+        // --- aggregate typing
+        ("sum of ints stays int", "MATCH (p:P) RETURN sum(p.age) AS r", "97"),
+        ("sum of floats is float", "MATCH (p:P) RETURN sum(p.score) AS r", "26.5"),
+        ("avg of ints is float", "MATCH (p:P) RETURN avg(p.age) AS r", "32.333333333333336"),
+        ("min across ints", "MATCH (p:P) RETURN min(p.age) AS r", "20"),
+        ("max across floats", "MATCH (p:P) RETURN max(p.score) AS r", "10"),
+        // --- boolean coercion
+        ("boolean property filter", "RETURN true AND (1 < 2) AS r", "true"),
+    ];
+
+    let mut wrong = Vec::new();
+    let mut errored = Vec::new();
+    for (label, cypher, expected) in cases {
+        match parse_query(cypher) {
+            Err(e) => errored.push((label.to_string(), cypher.to_string(), format!("parse: {e:?}"))),
+            Ok(q) => match QueryExecutor::new(&store).execute(&q) {
+                Err(e) => errored.push((label.to_string(), cypher.to_string(), format!("exec: {e:?}"))),
+                Ok(b) => {
+                    let got = b.records.first().map(|r| render(r.get("r"))).unwrap_or("<no rows>".into());
+                    if got != *expected {
+                        wrong.push((label.to_string(), cypher.to_string(), expected.to_string(), got));
+                    }
+                }
+            },
+        }
+    }
+    println!("{} cases: {} ok, {} wrong answer, {} errored",
+        cases.len(), cases.len()-wrong.len()-errored.len(), wrong.len(), errored.len());
+    if !wrong.is_empty() {
+        println!("\n=== WRONG ANSWER (parses, runs, returns the wrong thing) ===");
+        for (l,q,e,g) in &wrong { println!("  {l}\n     {q}\n     expected {e}, got {g}"); }
+    }
+    if !errored.is_empty() {
+        println!("\n=== ERRORED (at least it says so) ===");
+        for (l,q,e) in &errored { println!("  {l}\n     {q}\n     {e}"); }
+    }
+}

--- a/src/graph/property.rs
+++ b/src/graph/property.rs
@@ -314,6 +314,32 @@ impl PropertyValue {
         }
     }
 
+    /// The elements of this value viewed as a list.
+    ///
+    /// `Array` is a list. So is `Vector`, in every sense a query can observe:
+    /// a list literal whose numeric elements include a float is parsed as a
+    /// `Vector` because the type is inferred from the values, and nothing in
+    /// `[1.0, 2.0]` distinguishes an embedding from a list of numbers.
+    ///
+    /// Without this, `size`, `head`, `last`, `reverse`, `IN` and `+` rejected
+    /// such a literal, and indexing, list comprehension and `reduce` returned
+    /// null, `[]` and the seed respectively — silently (#605).
+    ///
+    /// The inference itself is the deeper problem, but it cannot simply be
+    /// removed: the `Vector` type is what marks a property as an embedding for
+    /// the vector index, so making literals `Array` would stop
+    /// `{embedding: [0.1, 0.2]}` being indexed. That needs a way to declare an
+    /// embedding, and is left on #605.
+    pub fn as_list_items(&self) -> Option<Vec<PropertyValue>> {
+        match self {
+            PropertyValue::Array(items) => Some(items.clone()),
+            PropertyValue::Vector(floats) => {
+                Some(floats.iter().map(|f| PropertyValue::Float(*f as f64)).collect())
+            }
+            _ => None,
+        }
+    }
+
     /// Get boolean value if this is a boolean
     pub fn as_boolean(&self) -> Option<bool> {
         match self {

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -5825,20 +5825,32 @@ mod tests {
 
     #[test]
     fn test_cov_tointeger_bad() {
+        // Null, not an error: Cypher's `toInteger` yields null for a string it
+        // cannot parse, and erroring made the function unusable for checking
+        // whether input is a number at all (#606).
         let mut store = GraphStore::new();
         let id = store.create_node("I");
         store.set_node_property("default", id, "v", "bad").unwrap();
         let q = parse_query("MATCH (n:I) RETURN toInteger(n.v) AS i").unwrap();
-        assert!(QueryExecutor::new(&store).execute(&q).is_err());
+        let batch = QueryExecutor::new(&store).execute(&q).expect("must not fail the query");
+        assert_eq!(
+            batch.records[0].get("i"),
+            Some(&Value::Property(PropertyValue::Null))
+        );
     }
 
     #[test]
     fn test_cov_tofloat_bad() {
+        // See `test_cov_tointeger_bad` (#606).
         let mut store = GraphStore::new();
         let id = store.create_node("I");
         store.set_node_property("default", id, "v", "xyz").unwrap();
         let q = parse_query("MATCH (n:I) RETURN toFloat(n.v) AS f").unwrap();
-        assert!(QueryExecutor::new(&store).execute(&q).is_err());
+        let batch = QueryExecutor::new(&store).execute(&q).expect("must not fail the query");
+        assert_eq!(
+            batch.records[0].get("f"),
+            Some(&Value::Property(PropertyValue::Null))
+        );
     }
 
     // --- 10. Math: log, exp, rand ---

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -302,9 +302,9 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
             (PropertyValue::Null, _) | (_, PropertyValue::Null) => PropertyValue::Null,
             _ => return Err(ExecutionError::TypeError("CONTAINS requires string operands".to_string())),
         },
-        BinaryOp::In => match &right_prop {
-            PropertyValue::Array(arr) => PropertyValue::Boolean(arr.contains(&left_prop)),
-            _ => return Err(ExecutionError::TypeError("IN requires a list on the right".to_string())),
+        BinaryOp::In => match eval_in_list(&left_prop, &right_prop) {
+            Some(v) => v,
+            None => return Err(ExecutionError::TypeError("IN requires a list on the right".to_string())),
         },
         BinaryOp::RegexMatch => match (&left_prop, &right_prop) {
             (PropertyValue::String(text), PropertyValue::String(pattern)) => {
@@ -347,7 +347,12 @@ fn eval_unary_op(op: &UnaryOp, val: Value) -> ExecutionResult<Value> {
 /// Shared list/map indexing evaluation
 fn eval_index(collection: Value, index: Value) -> ExecutionResult<Value> {
     match (&collection, &index) {
-        (Value::Property(PropertyValue::Array(arr)), Value::Property(PropertyValue::Integer(i))) => {
+        // Any value that reads as a list, so an all-float literal -- which
+        // parses as a `Vector` -- indexes rather than returning null (#605).
+        (Value::Property(p), Value::Property(PropertyValue::Integer(i)))
+            if p.as_list_items().is_some() =>
+        {
+            let arr = p.as_list_items().unwrap();
             let idx = if *i < 0 { (arr.len() as i64 + *i) as usize } else { *i as usize };
             Ok(arr.get(idx).map(|v| Value::Property(v.clone())).unwrap_or(Value::Null))
         }
@@ -708,8 +713,11 @@ fn eval_list_comprehension(
 ) -> ExecutionResult<Value> {
     let list_val = eval_expression(list_expr, record, store)?;
 
+    // `as_list_items` rather than an `Array` match: an all-float list literal
+    // parses as a `Vector`, and returning the empty list for it made a
+    // comprehension over one silently produce nothing (#605).
     let items = match list_val {
-        Value::Property(PropertyValue::Array(arr)) => arr,
+        Value::Property(ref p) if p.as_list_items().is_some() => p.as_list_items().unwrap(),
         _ => return Ok(Value::Property(PropertyValue::Array(vec![]))),
     };
 
@@ -748,7 +756,7 @@ fn eval_predicate_function(
 ) -> ExecutionResult<Value> {
     let list_val = eval_expression(list_expr, record, store)?;
     let items = match list_val {
-        Value::Property(PropertyValue::Array(arr)) => arr,
+        Value::Property(ref p) if p.as_list_items().is_some() => p.as_list_items().unwrap(),
         _ => return Ok(Value::Property(PropertyValue::Boolean(false))),
     };
 
@@ -784,8 +792,10 @@ fn eval_reduce(
 ) -> ExecutionResult<Value> {
     let init_val = eval_expression(init, record, store)?;
     let list_val = eval_expression(list_expr, record, store)?;
+    // See the note in `eval_list_comprehension`: an all-float list literal is a
+    // `Vector`, and giving up here returned the seed unchanged (#605).
     let items = match list_val {
-        Value::Property(PropertyValue::Array(arr)) => arr,
+        Value::Property(ref p) if p.as_list_items().is_some() => p.as_list_items().unwrap(),
         _ => return Ok(init_val),
     };
 
@@ -926,6 +936,34 @@ fn value_node_id(v: &Value) -> Option<NodeId> {
         Value::NodeRef(id) => Some(*id),
         _ => None,
     }
+}
+
+/// `left IN right`, where `right` is any value that reads as a list.
+///
+/// Two things the previous `arr.contains(&left)` got wrong. It rejected a
+/// `Vector`, which is what an all-float list literal parses as (#605). And it
+/// compared with `PartialEq`, so `7.0 IN [7, 99]` was false even though
+/// `p.score = 7` matches a float 7.0 -- `IN` disagreed with `=` about whether
+/// an integer and a float can be equal.
+fn eval_in_list(left: &PropertyValue, right: &PropertyValue) -> Option<PropertyValue> {
+    let items = right.as_list_items()?;
+    let numeric = |p: &PropertyValue| -> Option<f64> {
+        match p {
+            PropertyValue::Integer(i) => Some(*i as f64),
+            PropertyValue::Float(f) => Some(*f),
+            _ => None,
+        }
+    };
+    let found = items.iter().any(|item| {
+        if item == left {
+            return true;
+        }
+        match (numeric(left), numeric(item)) {
+            (Some(a), Some(b)) => a == b,
+            _ => false,
+        }
+    });
+    Some(PropertyValue::Boolean(found))
 }
 
 /// Property names in a stable order.
@@ -1139,8 +1177,8 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
         // only a string -- `reverse([1,2,3])` answered
         // `TypeError("Expected string argument")` (#578).
         "reverse" => match &args[0] {
-            Value::Property(PropertyValue::Array(items)) => {
-                let mut reversed = items.clone();
+            Value::Property(p) if p.as_list_items().is_some() => {
+                let mut reversed = p.as_list_items().unwrap();
                 reversed.reverse();
                 Ok(Value::Property(PropertyValue::Array(reversed)))
             }
@@ -1177,9 +1215,17 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
             match &args[0] {
                 Value::Property(PropertyValue::Integer(i)) => Ok(Value::Property(PropertyValue::Integer(*i))),
                 Value::Property(PropertyValue::Float(f)) => Ok(Value::Property(PropertyValue::Integer(*f as i64))),
-                Value::Property(PropertyValue::String(s)) => {
-                    let i = s.parse::<i64>().map_err(|_| ExecutionError::TypeError(format!("Cannot convert '{}' to integer", s)))?;
-                    Ok(Value::Property(PropertyValue::Integer(i)))
+                // Cypher yields null for a string it cannot parse, rather than
+                // failing the query. Erroring made `toInteger` unusable for the
+                // thing it is mostly used for -- checking whether input is a
+                // number at all (#606).
+                Value::Property(PropertyValue::String(s)) => Ok(Value::Property(
+                    s.parse::<i64>()
+                        .map(PropertyValue::Integer)
+                        .unwrap_or(PropertyValue::Null),
+                )),
+                Value::Null | Value::Property(PropertyValue::Null) => {
+                    Ok(Value::Property(PropertyValue::Null))
                 }
                 _ => Err(ExecutionError::TypeError("Cannot convert to integer".to_string())),
             }
@@ -1188,9 +1234,12 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
             match &args[0] {
                 Value::Property(PropertyValue::Float(f)) => Ok(Value::Property(PropertyValue::Float(*f))),
                 Value::Property(PropertyValue::Integer(i)) => Ok(Value::Property(PropertyValue::Float(*i as f64))),
-                Value::Property(PropertyValue::String(s)) => {
-                    let f = s.parse::<f64>().map_err(|_| ExecutionError::TypeError(format!("Cannot convert '{}' to float", s)))?;
-                    Ok(Value::Property(PropertyValue::Float(f)))
+                // Null rather than an error, as with `toInteger` (#606).
+                Value::Property(PropertyValue::String(s)) => Ok(Value::Property(
+                    s.parse::<f64>().map(PropertyValue::Float).unwrap_or(PropertyValue::Null),
+                )),
+                Value::Null | Value::Property(PropertyValue::Null) => {
+                    Ok(Value::Property(PropertyValue::Null))
                 }
                 _ => Err(ExecutionError::TypeError("Cannot convert to float".to_string())),
             }
@@ -1199,8 +1248,10 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
         "size" | "length" => {
             match &args[0] {
                 Value::Property(PropertyValue::String(s)) => Ok(Value::Property(PropertyValue::Integer(s.len() as i64))),
-                Value::Property(PropertyValue::Array(a)) => Ok(Value::Property(PropertyValue::Integer(a.len() as i64))),
                 Value::Path { edges, .. } => Ok(Value::Property(PropertyValue::Integer(edges.len() as i64))),
+                Value::Property(p) if p.as_list_items().is_some() => Ok(Value::Property(
+                    PropertyValue::Integer(p.as_list_items().unwrap().len() as i64),
+                )),
                 _ => Err(ExecutionError::TypeError("size() requires string, list, or path".to_string())),
             }
         }
@@ -1312,17 +1363,23 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
         }
         "head" => {
             match &args[0] {
-                Value::Property(PropertyValue::Array(arr)) => {
-                    Ok(arr.first().map(|v| Value::Property(v.clone())).unwrap_or(Value::Null))
-                }
+                Value::Property(p) if p.as_list_items().is_some() => Ok(p
+                    .as_list_items()
+                    .unwrap()
+                    .first()
+                    .map(|v| Value::Property(v.clone()))
+                    .unwrap_or(Value::Null)),
                 _ => Err(ExecutionError::TypeError("head() requires list".to_string())),
             }
         }
         "last" => {
             match &args[0] {
-                Value::Property(PropertyValue::Array(arr)) => {
-                    Ok(arr.last().map(|v| Value::Property(v.clone())).unwrap_or(Value::Null))
-                }
+                Value::Property(p) if p.as_list_items().is_some() => Ok(p
+                    .as_list_items()
+                    .unwrap()
+                    .last()
+                    .map(|v| Value::Property(v.clone()))
+                    .unwrap_or(Value::Null)),
                 _ => Err(ExecutionError::TypeError("last() requires list".to_string())),
             }
         }
@@ -3283,10 +3340,8 @@ impl FilterOperator {
     }
 
     fn eval_in(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        match right {
-            PropertyValue::Array(arr) => Ok(PropertyValue::Boolean(arr.contains(left))),
-            _ => Err(ExecutionError::TypeError("IN requires a list on the right side".to_string())),
-        }
+        eval_in_list(left, right)
+            .ok_or_else(|| ExecutionError::TypeError("IN requires a list on the right side".to_string()))
     }
 
     fn regex_match(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
@@ -11206,8 +11261,9 @@ mod tests {
 
     #[test]
     fn test_eval_function_tointeger_bad_string() {
+        // Null rather than an error, matching Cypher (#606).
         let result = eval_function("tointeger", &[Value::Property(PropertyValue::String("bad".to_string()))], None);
-        assert!(result.is_err());
+        assert_eq!(result.unwrap(), Value::Property(PropertyValue::Null));
     }
 
     #[test]
@@ -11239,8 +11295,9 @@ mod tests {
 
     #[test]
     fn test_eval_function_tofloat_bad_string() {
+        // Null rather than an error, matching Cypher (#606).
         let result = eval_function("tofloat", &[Value::Property(PropertyValue::String("bad".to_string()))], None);
-        assert!(result.is_err());
+        assert_eq!(result.unwrap(), Value::Property(PropertyValue::Null));
     }
 
     #[test]

--- a/tests/list_and_numeric_coercion.rs
+++ b/tests/list_and_numeric_coercion.rs
@@ -1,0 +1,206 @@
+//! Lists of floats behave as lists, and `IN` coerces numbers (#605, #606).
+//!
+//! A list literal whose numeric elements include a float parses as
+//! `PropertyValue::Vector` — the embedding type — because the type is inferred
+//! from the values, and nothing in `[1.0, 2.0]` distinguishes an embedding from
+//! a list of numbers. Every list operation then failed, and **three failed
+//! silently**: indexing returned null, a list comprehension returned `[]`, and
+//! `reduce` returned its seed. Those read as true negatives.
+//!
+//! The inference is not removed here, and the reason is worth stating: the
+//! `Vector` *type* is what marks a property as an embedding for the vector
+//! index, so making literals `Array` would stop `{embedding: [0.1, 0.2]}` being
+//! indexed. Declaring an embedding some other way is a design question, left on
+//! #605. What changes is that anything expecting a list accepts a `Vector` as
+//! one.
+//!
+//! Separately, `IN` compared with `PartialEq`, so `7.0 IN [7, 99]` was false
+//! while `p.score = 7` matched a float 7.0 — `IN` disagreed with `=` about
+//! whether an integer and a float can be equal.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn one(cypher: &str) -> PropertyValue {
+    let store = GraphStore::new();
+    let query = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&query)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.clone(),
+        _ => PropertyValue::Null,
+    }
+}
+
+fn floats(cypher: &str) -> Vec<f64> {
+    match one(cypher) {
+        PropertyValue::Array(items) => items
+            .iter()
+            .map(|p| match p {
+                PropertyValue::Float(f) => *f,
+                PropertyValue::Integer(i) => *i as f64,
+                other => panic!("{other:?}"),
+            })
+            .collect(),
+        PropertyValue::Vector(v) => v.iter().map(|f| *f as f64).collect(),
+        other => panic!("{cypher}: {other:?}"),
+    }
+}
+
+// ------------------------------------------------------- the silent three
+
+#[test]
+fn indexing_a_float_list_returns_the_element() {
+    assert_eq!(one("RETURN [1.0, 2.0][0] AS r"), PropertyValue::Float(1.0));
+    assert_eq!(one("RETURN [1.0, 2.0][1] AS r"), PropertyValue::Float(2.0));
+    assert_eq!(one("RETURN [1.0, 2.0][-1] AS r"), PropertyValue::Float(2.0));
+    assert_eq!(one("RETURN [1.0, 2.0][9] AS r"), PropertyValue::Null, "out of range is null");
+}
+
+#[test]
+fn a_comprehension_over_a_float_list_filters_rather_than_emptying() {
+    assert_eq!(floats("RETURN [x IN [1.0, 2.0, 3.0] WHERE x > 1.5] AS r"), vec![2.0, 3.0]);
+    assert_eq!(floats("RETURN [x IN [1.0, 2.0] | x * 2] AS r"), vec![2.0, 4.0]);
+}
+
+#[test]
+fn reduce_over_a_float_list_accumulates_rather_than_returning_the_seed() {
+    assert_eq!(one("RETURN reduce(s = 0.0, x IN [1.0, 2.0] | s + x) AS r"), PropertyValue::Float(3.0));
+}
+
+// ------------------------------------------------------- the loud ones
+
+#[test]
+fn the_list_functions_accept_a_float_list() {
+    assert_eq!(one("RETURN size([1.0, 2.0]) AS r"), PropertyValue::Integer(2));
+    assert_eq!(one("RETURN head([1.0, 2.0]) AS r"), PropertyValue::Float(1.0));
+    assert_eq!(one("RETURN last([1.0, 2.0]) AS r"), PropertyValue::Float(2.0));
+    assert_eq!(floats("RETURN reverse([1.0, 2.0]) AS r"), vec![2.0, 1.0]);
+}
+
+#[test]
+fn predicate_functions_accept_a_float_list() {
+    assert_eq!(one("RETURN all(x IN [1.0, 2.0] WHERE x > 0) AS r"), PropertyValue::Boolean(true));
+    assert_eq!(one("RETURN any(x IN [1.0, 2.0] WHERE x > 1.5) AS r"), PropertyValue::Boolean(true));
+    assert_eq!(one("RETURN none(x IN [1.0, 2.0] WHERE x > 9) AS r"), PropertyValue::Boolean(true));
+}
+
+// ------------------------------------------------------- IN coercion
+
+#[test]
+fn in_matches_a_float_against_an_integer_list() {
+    assert_eq!(one("RETURN 7.0 IN [7, 99] AS r"), PropertyValue::Boolean(true));
+    assert_eq!(one("RETURN 7 IN [7.0, 99.0] AS r"), PropertyValue::Boolean(true));
+    assert_eq!(one("RETURN 7.5 IN [7, 99] AS r"), PropertyValue::Boolean(false));
+}
+
+#[test]
+fn in_agrees_with_equality() {
+    // The inconsistency that made this a surprise: `=` coerced and `IN` did not.
+    let mut store = GraphStore::new();
+    let id = store.create_node("P");
+    let _ = store.set_node_property("default", id, "score".to_string(), PropertyValue::Float(7.0));
+
+    let count = |cypher: &str| -> i64 {
+        let query = parse_query(cypher).unwrap();
+        let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+        match batch.records[0].get("r") {
+            Some(Value::Property(PropertyValue::Integer(n))) => *n,
+            other => panic!("{other:?}"),
+        }
+    };
+    assert_eq!(count("MATCH (p:P) WHERE p.score = 7 RETURN count(p) AS r"), 1);
+    assert_eq!(
+        count("MATCH (p:P) WHERE p.score IN [7, 99] RETURN count(p) AS r"),
+        1,
+        "IN must agree with ="
+    );
+}
+
+#[test]
+fn in_still_works_on_ordinary_lists() {
+    assert_eq!(one("RETURN 1 IN [1, 2] AS r"), PropertyValue::Boolean(true));
+    assert_eq!(one("RETURN 3 IN [1, 2] AS r"), PropertyValue::Boolean(false));
+    assert_eq!(one("RETURN \"a\" IN [\"a\", \"b\"] AS r"), PropertyValue::Boolean(true));
+    assert_eq!(one("RETURN \"a\" IN [1, 2] AS r"), PropertyValue::Boolean(false));
+}
+
+// ------------------------------------------------------- #606
+
+#[test]
+fn to_integer_yields_null_rather_than_failing() {
+    assert_eq!(one("RETURN toInteger(\"abc\") AS r"), PropertyValue::Null);
+    assert_eq!(one("RETURN toFloat(\"abc\") AS r"), PropertyValue::Null);
+    assert_eq!(one("RETURN toInteger(null) AS r"), PropertyValue::Null);
+    assert_eq!(one("RETURN toFloat(null) AS r"), PropertyValue::Null);
+}
+
+#[test]
+fn to_integer_still_converts_what_it_can() {
+    assert_eq!(one("RETURN toInteger(\"42\") AS r"), PropertyValue::Integer(42));
+    assert_eq!(one("RETURN toInteger(3.9) AS r"), PropertyValue::Integer(3), "truncates");
+    assert_eq!(one("RETURN toInteger(7) AS r"), PropertyValue::Integer(7));
+    assert_eq!(one("RETURN toFloat(\"1.5\") AS r"), PropertyValue::Float(1.5));
+    assert_eq!(one("RETURN toFloat(3) AS r"), PropertyValue::Float(3.0));
+}
+
+#[test]
+fn the_filtering_idiom_to_integer_exists_for_now_works() {
+    // The query the error made impossible: parse a list of inputs and keep the
+    // ones that are numbers.
+    match one("RETURN [x IN [\"1\", \"nope\", \"3\"] | toInteger(x)] AS r") {
+        PropertyValue::Array(items) => {
+            assert_eq!(
+                items,
+                vec![
+                    PropertyValue::Integer(1),
+                    PropertyValue::Null,
+                    PropertyValue::Integer(3)
+                ],
+                "one element per input, with the unparseable one null rather than \
+                 the whole query failing"
+            );
+        }
+        other => panic!("{other:?}"),
+    }
+    assert_eq!(one("RETURN toInteger(\"nope\") IS NULL AS r"), PropertyValue::Boolean(true));
+}
+
+// ------------------------------------------------------- unchanged
+
+#[test]
+fn an_integer_list_is_still_an_array() {
+    // The `Vector` inference only fires when a float is present, and integer
+    // lists must be unaffected.
+    match one("RETURN [1, 2] AS r") {
+        PropertyValue::Array(items) => assert_eq!(items.len(), 2),
+        other => panic!("an all-integer list should stay an Array, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_vector_property_is_still_a_vector() {
+    // The behaviour the inference exists for: a stored embedding keeps its type,
+    // which is what marks it for the vector index.
+    let mut store = GraphStore::new();
+    let id = store.create_node("Doc");
+    let _ = store.set_node_property(
+        "default",
+        id,
+        "embedding".to_string(),
+        PropertyValue::Vector(vec![0.1, 0.2, 0.3]),
+    );
+    assert!(matches!(
+        store.node_columns.get_property(id.as_u64() as usize, "embedding"),
+        PropertyValue::Vector(_)
+    ));
+    // And it reads as a list too, which is the point of the change.
+    let query = parse_query("MATCH (d:Doc) RETURN size(d.embedding) AS r").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    assert_eq!(
+        batch.records[0].get("r"),
+        Some(&Value::Property(PropertyValue::Integer(3)))
+    );
+}


### PR DESCRIPTION
Closes #605, closes #606.

## The find

A list literal whose numeric elements include a float parses as `PropertyValue::Vector` — the embedding type. The type is inferred from the values, and **nothing in `[1.0, 2.0]` distinguishes an embedding from a list of numbers**.

Everything expecting a list then failed, and **three failed silently**:

| | expected | was |
|---|---|---|
| `[1.0, 2.0][0]` | `1.0` | **`null`** |
| `[x IN [1.0, 2.0] WHERE x > 1.5]` | `[2.0]` | **`[]`** |
| `reduce(s = 0.0, x IN [1.0, 2.0] \| s + x)` | `3.0` | **`0.0`** |

with `size`, `head`, `last`, `reverse`, `+` and `IN` erroring outright. A comprehension returning nothing and a `reduce` returning its seed **read as true negatives**.

## What is deliberately *not* changed

The inference stays, and the reason belongs in the record: the `Vector` type is what marks a property as an embedding for the vector index — `store.rs` calls `add_vector` for any property that is one, ungated. Making literals `Array` would silently stop `{embedding: [0.1, 0.2]}` being indexed.

Declaring an embedding some other way is a design question, left on #605. What changes here is that **anything expecting a list accepts a `Vector` as one**, via `PropertyValue::as_list_items`. A test asserts a stored embedding still keeps its type *and* now reads as a list.

## IN disagreed with =

```cypher
RETURN 7.0 IN [7, 99]                  -- was false
MATCH (p) WHERE p.score = 7            -- matches a float 7.0
```

`IN` compared with `PartialEq`; `=` coerces. It now coerces too, with a test asserting the two agree.

## toInteger / toFloat

They errored on a string they cannot parse where Cypher returns null — which makes them unusable for what they are mostly used for, checking whether input *is* a number:

```cypher
RETURN [x IN ["1", "nope", "3"] | toInteger(x)]   -- now [1, null, 3]
```

**Four existing unit tests pinned the old contract.** They are updated rather than deleted, each carrying a line saying why — this is an intentional contract change, not a test that got in the way.

## Verification

| | |
|---|---|
| HEAD verified | `c4193f9` |
| new test file / binary ran | 1 of 1 / 1 of 1 |
| debug (what CI runs) | exit 0, **2,899 tests**, 0 failed |
| release | exit 0, 0 failed |
| sweeps | 77/77, 35/35, 26/26, **29/30** |
| LDBC SF1 | 21/21 in **9.6 s** |

Sweep 4 goes 26/30 → 29/30. The one left is **#607** — an ordering comparison between incompatible types yields `false` where Cypher yields `null`. Not folded in: comparison semantics reach into ordering, filters and three-valued logic, and #369 already moved null's sort position once. It wants its own pass.

Also confirmed by this sweep, worth recording: the standing **"float-vs-int `WHERE` silently empty" quirk is fixed** for `=`, `>`, `<`, `<=` — those all coerce. `IN` was the one still carrying it.