### PR TITLE
Sync the version of record, fix two nondeterministic wrong answers, and add the conformance harness's first findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Samyama is a high-performance distributed graph database written in Rust with ~90% OpenCypher query support, Redis protocol (RESP) compatibility, multi-tenancy, vector search, NLQ, and graph algorithms. Currently at Phase 4 (High Availability Foundation), version v0.9.0.
+Samyama is a high-performance distributed graph database written in Rust with ~90% OpenCypher query support, Redis protocol (RESP) compatibility, multi-tenancy, vector search, NLQ, and graph algorithms. Currently at Phase 4 (High Availability Foundation), version v1.7.0.
 
 ## Build & Development Commands
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Samyama Graph Database API
-  version: 0.7.0
+  version: 1.7.0
   description: |
     HTTP API for the Samyama high-performance distributed graph database.
     Supports OpenCypher queries, graph status, and CRUD operations.
@@ -170,7 +170,7 @@ paths:
                 $ref: '#/components/schemas/StatusResponse'
               example:
                 status: healthy
-                version: 0.7.0
+                version: 1.7.0
                 storage:
                   nodes: 2000
                   edges: 11000
@@ -414,7 +414,7 @@ components:
           type: string
           description: Server version
           examples:
-            - 0.7.0
+            - 1.7.0
         storage:
           type: object
           properties:

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -38,6 +38,14 @@ The split follows from where a reader can act: a number you can reproduce
 belongs next to the code that produces it; a number that required another
 vendor's licensed software to obtain does not.
 
+**Not on this page either: the scorecard.** Every figure here is one suite's
+result. The single file that says where the product stands against all 254
+requirements — measured, unmeasured, or measured only by proxy — is
+`SCORECARD.json`, assembled by the conformance harness from run envelopes. It
+lives with the cross-engine results for the same reason they do. This page
+stays the reproducible own-engine record; the scorecard is what a claim gets
+checked against.
+
 ## Comparing two numbers
 
 **A before/after claim requires both figures from one back-to-back session on
@@ -123,13 +131,27 @@ cargo run --release --example tck_runner -- --features <openCypher>/tck/features
 |---|---:|
 | scenarios in the TCK | 1,615 |
 | **evaluated** by the harness | **1,049** (65.0%) |
-| pass | 486 |
-| wrong result | 285 |
+| pass | 489 |
+| wrong result | 282 |
 | errored | 278 |
 | skipped | 566 |
-| **pass rate, of evaluated** | **46.3%** |
-| pass rate, of all 1,615 | 30.1% |
+| **pass rate, of evaluated** | **46.6%** |
+| pass rate, of all 1,615 | 30.3% |
 | gate `CH-TCK ≥ 85%` | **not met** |
+
+Measured at `f295b73` on `vultr-bench-16c-32g-blr`, via the conformance
+harness's `CH-TCK` suite; the envelope is in
+`samyama-graph-competitor-benchmarks/harness/runs/`.
+
+**This number was nondeterministic until 2026-08-18.** Running the TCK five
+times at a fixed commit gave 484, 485, 486 and 487 passes while `errored`
+stayed constant — three scenarios were changing their *answer* between
+processes, because `RandomState` seeds each process's hash maps differently
+and that order was reaching results. Any single figure published before then,
+including the 486 previously on this page, was one sample of a distribution.
+The three defects behind it are fixed (#610); the count is stable now, and
+`--failures-manifest` exists so the check is one diff rather than an
+inference.
 
 **Both numbers have to be quoted together.** The pass rate says what the engine
 gets right among the scenarios this harness can judge; the coverage says how
@@ -158,7 +180,7 @@ Weakest areas, among features with at least 5 evaluated scenarios — all at 0%:
 ### How this relates to the hand-written sweeps
 
 Four hand-written sweeps in `examples/cypher_probe*.rs` (168 cases) pass
-100%, 100%, 100% and 29/30. That is not in tension with 46.3% — those sweeps
+100%, 100%, 100% and 29/30. That is not in tension with 46.6% — those sweeps
 were written to probe areas suspected of being wrong, and every case in them was
 either already correct or has since been fixed. They found seven silent
 wrong answers; they were never a coverage measurement. **The TCK is the coverage

--- a/examples/tck_runner.rs
+++ b/examples/tck_runner.rs
@@ -34,6 +34,7 @@
 //!
 //!   cargo run --release --example tck_runner -- --features /path/to/tck/features
 //!   cargo run --release --example tck_runner -- --features PATH --json /tmp/tck.json
+//!   cargo run --release --example tck_runner -- --features PATH --failures-manifest /tmp/f.tsv
 
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
@@ -98,6 +99,30 @@ impl Tck {
                 s
             }
             Tck::Opaque(raw) => raw.clone(),
+        }
+    }
+
+    /// `render`, with the elements of every list sorted.
+    ///
+    /// Used only for scenarios that say `(ignoring element order for lists)`.
+    /// Sorting the *rendered* elements rather than the values is deliberate:
+    /// it needs a total order over mixed-type lists, and the rendering
+    /// already has one.
+    fn render_sorted_lists(&self) -> String {
+        match self {
+            Tck::List(items) => {
+                let mut inner: Vec<String> = items.iter().map(|i| i.render_sorted_lists()).collect();
+                inner.sort();
+                format!("[{}]", inner.join(", "))
+            }
+            Tck::Map(m) => {
+                let inner: Vec<String> = m
+                    .iter()
+                    .map(|(k, v)| format!("{k}: {}", v.render_sorted_lists()))
+                    .collect();
+                format!("{{{}}}", inner.join(", "))
+            }
+            other => other.render(),
         }
     }
 }
@@ -405,7 +430,19 @@ fn value_to_tck(v: &Value, store: &GraphStore) -> Tck {
 
 #[derive(Debug, Clone)]
 enum Expect {
-    Rows { header: Vec<String>, rows: Vec<Vec<String>>, ordered: bool },
+    Rows {
+        header: Vec<String>,
+        rows: Vec<Vec<String>>,
+        ordered: bool,
+        /// Set by `the result should be (ignoring element order for lists)`.
+        ///
+        /// That phrase relaxes the order of elements *inside a list value*,
+        /// not the order of rows — `labels(n)` may answer `['L','B']` or
+        /// `['B','L']` and both satisfy the scenario. Treating it as a
+        /// row-order relaxation only, which is what this runner did, reports
+        /// a correct engine as wrong.
+        list_order_insensitive: bool,
+    },
     Empty,
     Error(String),
 }
@@ -492,10 +529,22 @@ fn parse_feature(path: &Path, text: &str) -> Vec<Scenario> {
             } else if body.starts_with("the result should be, in any order")
                 || body.starts_with("the result should be (ignoring element order for lists)")
             {
-                s.expect = Some(Expect::Rows { header: vec![], rows: vec![], ordered: false });
+                let list_order_insensitive =
+                    body.starts_with("the result should be (ignoring element order for lists)");
+                s.expect = Some(Expect::Rows {
+                    header: vec![],
+                    rows: vec![],
+                    ordered: false,
+                    list_order_insensitive,
+                });
                 pending = Pending::Result(false);
             } else if body.starts_with("the result should be, in order") {
-                s.expect = Some(Expect::Rows { header: vec![], rows: vec![], ordered: true });
+                s.expect = Some(Expect::Rows {
+                    header: vec![],
+                    rows: vec![],
+                    ordered: true,
+                    list_order_insensitive: false,
+                });
                 pending = Pending::Result(true);
             } else if body.starts_with("the result should be empty") {
                 s.expect = Some(Expect::Empty);
@@ -638,7 +687,7 @@ fn run_scenario(s: &Scenario) -> (Outcome, String) {
                 (Outcome::WrongResult, format!("expected empty, got {} rows", batch.records.len()))
             }
         }
-        Expect::Rows { header, rows, ordered } => {
+        Expect::Rows { header, rows, ordered, list_order_insensitive } => {
             if header.is_empty() {
                 return (Outcome::Skipped, "no header".into());
             }
@@ -647,13 +696,28 @@ fn run_scenario(s: &Scenario) -> (Outcome, String) {
                 let mut row = Vec::new();
                 for col in header {
                     let v = rec.get(col).map(|v| value_to_tck(v, &store)).unwrap_or(Tck::Null);
-                    row.push(v.render());
+                    row.push(if *list_order_insensitive {
+                        v.render_sorted_lists()
+                    } else {
+                        v.render()
+                    });
                 }
                 actual.push(row);
             }
             let mut expected: Vec<Vec<String>> = rows
                 .iter()
-                .map(|r| r.iter().map(|c| parse_expected(c).render()).collect())
+                .map(|r| {
+                    r.iter()
+                        .map(|c| {
+                            let v = parse_expected(c);
+                            if *list_order_insensitive {
+                                v.render_sorted_lists()
+                            } else {
+                                v.render()
+                            }
+                        })
+                        .collect()
+                })
                 .collect();
 
             if !*ordered {
@@ -721,7 +785,10 @@ fn main() {
 
     let (mut pass, mut wrong, mut err, mut skip) = (0usize, 0usize, 0usize, 0usize);
     let mut skip_reasons: BTreeMap<String, usize> = BTreeMap::new();
-    let mut failures: Vec<(String, String, String)> = Vec::new();
+    // (feature, scenario, outcome, detail). The outcome is carried so a
+    // manifest can distinguish a wrong answer from an error — they are
+    // different bugs and only one of them is dangerous.
+    let mut failures: Vec<(String, String, &'static str, String)> = Vec::new();
     let mut per_feature: BTreeMap<String, (usize, usize)> = BTreeMap::new();
 
     for s in &scenarios {
@@ -731,9 +798,9 @@ fn main() {
         match outcome {
             Outcome::Pass => { pass += 1; entry.0 += 1; entry.1 += 1; }
             Outcome::WrongResult => { wrong += 1; entry.1 += 1;
-                failures.push((s.feature.clone(), s.name.clone(), detail)); }
+                failures.push((s.feature.clone(), s.name.clone(), "wrong_result", detail)); }
             Outcome::Errored => { err += 1; entry.1 += 1;
-                failures.push((s.feature.clone(), s.name.clone(), detail)); }
+                failures.push((s.feature.clone(), s.name.clone(), "errored", detail)); }
             Outcome::Skipped => { skip += 1; *skip_reasons.entry(detail).or_insert(0) += 1; }
         }
     }
@@ -793,10 +860,29 @@ fn main() {
         println!("\nwrote {path}");
     }
 
+    // A sorted, one-line-per-scenario manifest of everything that did not
+    // pass. Two of these can be diffed, which is how the pass count was shown
+    // to vary by up to 3 scenarios between processes at a fixed commit: the
+    // totals moved while `errored` did not, so the drift was between pass and
+    // wrong-answer and no summary number could localise it.
+    if let Some(path) = arg("--failures-manifest") {
+        let mut lines: Vec<String> = failures
+            .iter()
+            .map(|(f, n, o, _)| format!("{o}\t{f}\t{n}"))
+            .collect();
+        lines.sort();
+        let _ = std::fs::write(&path, lines.join("\n") + "\n");
+        println!("wrote failure manifest ({} scenarios): {path}", lines.len());
+    }
+
     if arg("--show-failures").is_some() {
         println!("\nFailures:");
-        for (f, n, d) in failures.iter().take(60) {
-            println!("  [{f}] {n}\n      {d}");
+        for (f, n, o, d) in failures.iter().take(60) {
+            println!("  [{f}] {n} ({o})\n      {d}");
+        }
+        if failures.len() > 60 {
+            println!("  ... and {} more; use --failures-manifest for the full list",
+                     failures.len() - 60);
         }
     }
 }

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "samyama"
-version = "0.7.0"
+version = "1.7.0"
 description = "Python SDK for the Samyama Graph Database"
 requires-python = ">=3.8"
 license = {text = "Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "samyama-sdk",
-  "version": "0.7.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "samyama-sdk",
-      "version": "0.7.0",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samyama-sdk",
-  "version": "0.7.0",
+  "version": "1.7.0",
   "description": "TypeScript SDK for the Samyama Graph Database",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! A high-performance graph database written in Rust with ~90% OpenCypher query support,
 //! RESP (Redis protocol) compatibility, multi-tenancy, HNSW vector search, natural language
-//! queries, and graph algorithms. Currently at v0.7.0.
+//! queries, and graph algorithms. Currently at v1.7.0.
 //!
 //! ## How a Graph Database Works
 //!

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -970,6 +970,26 @@ fn eval_in_list(left: &PropertyValue, right: &PropertyValue) -> Option<PropertyV
 ///
 /// Lexicographic: stable, what a reader expects, and cheap over the handful of
 /// keys a node or map has (#577).
+/// Labels, sorted, as a list of strings.
+///
+/// `Node::labels` is a `HashSet`, whose iteration order varies per process
+/// because `RandomState` seeds each one differently. Returning it raw made
+/// `labels(n)` answer `['L','B']` on one run and `['B','L']` on the next for
+/// the same node — two identical queries over identical data producing
+/// different rows, which is the determinism requirement (LANG-14) failing in
+/// the smallest possible way. It surfaced as a TCK scenario that passed or
+/// failed depending on the run.
+///
+/// Sorted rather than insertion-ordered because insertion order is not
+/// recorded anywhere: a set has no order to preserve, and inventing one that
+/// survives a snapshot round trip would be a storage change. Sorted is
+/// deterministic, and it is the same contract `keys()` already offers.
+fn sorted_labels(node: &crate::graph::Node) -> Vec<PropertyValue> {
+    let mut labels: Vec<&str> = node.labels.iter().map(|l| l.as_str()).collect();
+    labels.sort_unstable();
+    labels.into_iter().map(|l| PropertyValue::String(l.to_string())).collect()
+}
+
 fn sorted_keys(mut keys: Vec<PropertyValue>) -> Vec<PropertyValue> {
     keys.sort_by(|a, b| match (a, b) {
         (PropertyValue::String(x), PropertyValue::String(y)) => x.cmp(y),
@@ -1403,18 +1423,12 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
         "labels" => {
             match &args[0] {
                 Value::Node(_, node) => {
-                    let labels: Vec<PropertyValue> = node.labels.iter()
-                        .map(|l| PropertyValue::String(l.as_str().to_string()))
-                        .collect();
-                    Ok(Value::Property(PropertyValue::Array(labels)))
+                    Ok(Value::Property(PropertyValue::Array(sorted_labels(node))))
                 }
                 Value::NodeRef(id) => {
                     let s = store.ok_or_else(|| ExecutionError::RuntimeError("labels() on NodeRef requires store".to_string()))?;
                     let node = s.get_node(*id).ok_or_else(|| ExecutionError::RuntimeError(format!("Node {} not found", id.as_u64())))?;
-                    let labels: Vec<PropertyValue> = node.labels.iter()
-                        .map(|l| PropertyValue::String(l.as_str().to_string()))
-                        .collect();
-                    Ok(Value::Property(PropertyValue::Array(labels)))
+                    Ok(Value::Property(PropertyValue::Array(sorted_labels(node))))
                 }
                 _ => Err(ExecutionError::TypeError("labels() requires a node".to_string())),
             }

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -87,6 +87,46 @@ thread_local! {
 /// Returns the rewritten expression and the list of extracted aggregates.
 /// This enables expressions like `round(sum(b.runs) * 100 / sum(b.balls))` where
 /// aggregate calls are nested inside arithmetic or scalar function calls.
+/// Rewrite an `ORDER BY` expression so it refers to the projection's aliases.
+///
+/// Cypher lets a sort key be written either as the alias or as a repeat of the
+/// projected expression:
+///
+/// ```cypher
+/// WITH a.num2 % 3 AS mod, sum(a.num) AS total ORDER BY sum(a.num)   -- this
+/// WITH a.num2 % 3 AS mod, sum(a.num) AS total ORDER BY total        -- and this
+/// ```
+///
+/// are the same query. The second worked; the first did not, and failed in the
+/// worst available way. After the aggregation barrier the rows hold `mod` and
+/// `total` — there is no `a` to evaluate `sum(a.num)` against — so the sort key
+/// evaluated to null for every row, the sort became a no-op, and any `LIMIT`
+/// then took an arbitrary prefix of whatever order the group hash map happened
+/// to produce. Not a stable wrong answer: the same query over the same data
+/// returned **five different results across 100 runs**, of which 36 were right.
+///
+/// The rewrite is by structural equality against the projected expressions,
+/// recursing through compound keys so `ORDER BY sum(x) + 1` resolves too. An
+/// expression that matches nothing is left alone — it may legitimately name a
+/// grouping key that is still in scope, and rewriting it would break that.
+fn rewrite_sort_key(expr: &Expression, projections: &[(Expression, String)]) -> Expression {
+    if let Some((_, alias)) = projections.iter().find(|(projected, _)| projected == expr) {
+        return Expression::Variable(alias.clone());
+    }
+    match expr {
+        Expression::Binary { left, op, right } => Expression::Binary {
+            left: Box::new(rewrite_sort_key(left, projections)),
+            op: op.clone(),
+            right: Box::new(rewrite_sort_key(right, projections)),
+        },
+        Expression::Unary { op, expr } => Expression::Unary {
+            op: op.clone(),
+            expr: Box::new(rewrite_sort_key(expr, projections)),
+        },
+        other => other.clone(),
+    }
+}
+
 fn extract_nested_aggregates(
     expr: &Expression,
     counter: &mut usize,
@@ -4161,6 +4201,13 @@ impl QueryPlanner {
             });
         }
 
+        // Captured before `item_infos` is consumed: ORDER BY may restate any
+        // projected expression instead of naming its alias.
+        let projections: Vec<(Expression, String)> = item_infos
+            .iter()
+            .map(|i| (i.original_expr.clone(), i.alias.clone()))
+            .collect();
+
         for info in item_infos {
             if has_aggregation {
                 if !info.extracted_aggs.is_empty() {
@@ -4175,8 +4222,15 @@ impl QueryPlanner {
             }
         }
 
-        let sort_items: Vec<(Expression, bool)> = with_clause.order_by.as_ref()
-            .map(|ob| ob.items.iter().map(|i| (i.expression.clone(), i.ascending)).collect())
+        let sort_items: Vec<(Expression, bool)> = with_clause
+            .order_by
+            .as_ref()
+            .map(|ob| {
+                ob.items
+                    .iter()
+                    .map(|i| (rewrite_sort_key(&i.expression, &projections), i.ascending))
+                    .collect()
+            })
             .unwrap_or_default();
 
         let where_predicate = with_clause.where_clause.as_ref()

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -245,20 +245,71 @@ enum SortPosition {
 ///
 /// A key that matches nothing is returned unchanged: it may legitimately reference a
 /// variable that is still in scope, and rewriting it would be worse than leaving it.
+/// Replace RETURN aliases in a sort key with the expressions they name.
+///
+/// A sort placed *below* the projection sees the pre-projection record, where
+/// the alias does not exist yet — only the expression behind it does. Handling
+/// the bare `ORDER BY alias` case but not `ORDER BY alias.property` made this
+/// silently wrong:
+///
+/// ```cypher
+/// MATCH (a)-[r]->(b) RETURN r AS rel ORDER BY rel.id DESC
+/// ```
+///
+/// `rel` was unbound at sort time, so the key was null on every row, the sort
+/// was a no-op, and the rows came back in scan order — which for a small
+/// fixture is often *already* the ascending order, so the bug reads as a
+/// correct answer until you ask for `DESC` and get the same rows back.
+///
+/// It surfaced through the TCK as a scenario that passed or failed depending
+/// on the process, because after a `WITH` that aggregates, "scan order"
+/// becomes hash order.
+///
+/// Only aliases naming a variable can be substituted into a property access:
+/// if `rel` aliases `count(*)` then `rel.id` means nothing and is left alone
+/// for the executor to reject rather than silently rewritten into something
+/// else.
+fn substitute_aliases(key: &Expression, return_items: &[(Expression, String)]) -> Expression {
+    let aliased = |name: &str| -> Option<&Expression> {
+        return_items.iter().find(|(_, alias)| alias == name).map(|(expr, _)| expr)
+    };
+    match key {
+        Expression::Variable(name) => match aliased(name) {
+            Some(expr) => expr.clone(),
+            None => key.clone(),
+        },
+        Expression::Property { variable, property } => match aliased(variable) {
+            Some(Expression::Variable(underlying)) => Expression::Property {
+                variable: underlying.clone(),
+                property: property.clone(),
+            },
+            _ => key.clone(),
+        },
+        Expression::Binary { left, op, right } => Expression::Binary {
+            left: Box::new(substitute_aliases(left, return_items)),
+            op: op.clone(),
+            right: Box::new(substitute_aliases(right, return_items)),
+        },
+        Expression::Unary { op, expr } => Expression::Unary {
+            op: op.clone(),
+            expr: Box::new(substitute_aliases(expr, return_items)),
+        },
+        Expression::Function { name, args, distinct } => Expression::Function {
+            name: name.clone(),
+            args: args.iter().map(|a| substitute_aliases(a, return_items)).collect(),
+            distinct: *distinct,
+        },
+        other => other.clone(),
+    }
+}
+
 fn resolve_sort_key(
     key: &Expression,
     return_items: &[(Expression, String)],
     position: SortPosition,
 ) -> Expression {
     match position {
-        SortPosition::BeforeProjection => {
-            if let Expression::Variable(name) = key {
-                if let Some((expr, _)) = return_items.iter().find(|(_, alias)| alias == name) {
-                    return expr.clone();
-                }
-            }
-            key.clone()
-        }
+        SortPosition::BeforeProjection => substitute_aliases(key, return_items),
         SortPosition::AfterProjection => {
             if let Some((_, alias)) = return_items.iter().find(|(expr, _)| expr == key) {
                 return Expression::Variable(alias.clone());

--- a/tests/result_determinism.rs
+++ b/tests/result_determinism.rs
@@ -1,0 +1,205 @@
+//! The same query, over the same data, must return the same rows.
+//!
+//! Both defects here were found by running the openCypher TCK five times and
+//! diffing the failure manifests. The pass count moved between 484 and 487 at
+//! a fixed commit while `errored` stayed constant, so two or three scenarios
+//! were changing their *answer* between processes — which no summary number
+//! could localise, and which a single run would have reported as a stable
+//! 46%.
+//!
+//! The common cause is a `HashSet`/`HashMap` iteration order reaching a
+//! result. `RandomState` seeds every process differently, so this class of
+//! bug is invisible to a test that runs once and to a developer who reruns
+//! the same failing case.
+//!
+//! Each test below runs its query many times **in one process**, which does
+//! not vary the hash seed — so a single-process loop cannot catch the
+//! original bug on its own. They pin the fix instead: the sorted contract and
+//! the rewritten sort key are properties of the output that hold regardless
+//! of iteration order, and each test is written to fail against the old
+//! behaviour for a reason that has nothing to do with luck.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+use samyama::graph::PropertyValue;
+
+fn write(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).expect("query should parse");
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .expect("query should run");
+}
+
+/// Rows rendered as sorted `key=value` strings, in result order.
+fn rows(store: &GraphStore, cypher: &str) -> Vec<String> {
+    let q = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&q).expect("query should run");
+    batch
+        .records
+        .iter()
+        .map(|r| {
+            let mut cells: Vec<String> =
+                r.bindings().iter().map(|(k, v)| format!("{k}={v:?}")).collect();
+            cells.sort();
+            cells.join(",")
+        })
+        .collect()
+}
+
+fn aggregate_fixture() -> GraphStore {
+    // Three groups by `num2 % 3`, with distinct sums 7, 13 and 15, so a sort
+    // has an unambiguous order and a LIMIT has an unambiguous answer.
+    let mut store = GraphStore::new();
+    write(
+        &mut store,
+        "CREATE (:A {num: 1, num2: 4}), (:A {num: 5, num2: 2}), (:A {num: 9, num2: 0}), \
+         (:A {num: 3, num2: 3}), (:A {num: 7, num2: 1})",
+    );
+    store
+}
+
+#[test]
+fn order_by_restating_an_aggregate_sorts_the_same_as_ordering_by_its_alias() {
+    // The two spellings are the same query. `ORDER BY sum(...)` evaluated to
+    // null after the aggregation barrier — there is no `a` left to evaluate
+    // it against — so the sort silently became a no-op.
+    let store = aggregate_fixture();
+    let by_expression = rows(
+        &store,
+        "MATCH (a:A) WITH a.num2 % 3 AS m, sum(a.num + a.num2) AS s ORDER BY sum(a.num + a.num2) \
+         RETURN m, s",
+    );
+    let by_alias = rows(
+        &store,
+        "MATCH (a:A) WITH a.num2 % 3 AS m, sum(a.num + a.num2) AS s ORDER BY s RETURN m, s",
+    );
+    assert_eq!(by_expression, by_alias);
+    assert_eq!(by_expression.len(), 3);
+}
+
+#[test]
+fn a_limit_after_ordering_by_an_aggregate_takes_the_smallest_groups() {
+    // The TCK scenario (WithOrderBy4 [11]) that exposed this. With the sort a
+    // no-op, LIMIT 2 took two arbitrary groups of three: the same query
+    // returned five different answers across 100 processes, 36 of them right.
+    let store = aggregate_fixture();
+    let out = rows(
+        &store,
+        "MATCH (a:A) WITH a.num2 % 3 AS m, sum(a.num + a.num2) AS s ORDER BY sum(a.num + a.num2) \
+         LIMIT 2 RETURN m, s",
+    );
+    assert_eq!(
+        out,
+        vec![
+            "m=Property(Integer(2)),s=Property(Integer(7))".to_string(),
+            "m=Property(Integer(1)),s=Property(Integer(13))".to_string(),
+        ],
+        "sums are 7, 13, 15 — the two smallest are 7 and 13, in that order"
+    );
+}
+
+#[test]
+fn descending_order_by_an_aggregate_takes_the_largest_group() {
+    // The mirror of the above: if the sort were still a no-op, this would
+    // agree with the ascending case some of the time, which is how a weak
+    // assertion would let the bug back in.
+    let store = aggregate_fixture();
+    let out = rows(
+        &store,
+        "MATCH (a:A) WITH a.num2 % 3 AS m, sum(a.num + a.num2) AS s ORDER BY sum(a.num + a.num2) \
+         DESC LIMIT 1 RETURN m, s",
+    );
+    assert_eq!(out, vec!["m=Property(Integer(0)),s=Property(Integer(15))".to_string()]);
+}
+
+#[test]
+fn an_aggregate_inside_a_compound_sort_key_is_resolved_too() {
+    // The rewrite recurses, so a key that merely *contains* a projected
+    // expression resolves as well.
+    let store = aggregate_fixture();
+    let compound = rows(
+        &store,
+        "MATCH (a:A) WITH a.num2 % 3 AS m, sum(a.num + a.num2) AS s ORDER BY sum(a.num + a.num2) * -1 \
+         RETURN m, s",
+    );
+    let descending = rows(
+        &store,
+        "MATCH (a:A) WITH a.num2 % 3 AS m, sum(a.num + a.num2) AS s ORDER BY s DESC RETURN m, s",
+    );
+    assert_eq!(compound, descending, "multiplying the key by -1 reverses the order");
+}
+
+#[test]
+fn ordering_by_a_grouping_key_still_works() {
+    // The guard on the rewrite: a sort key naming a grouping expression must
+    // keep working. Rewriting too eagerly would break this, and it is the
+    // more common spelling of the two.
+    let store = aggregate_fixture();
+    let out = rows(
+        &store,
+        "MATCH (a:A) WITH a.num2 % 3 AS m, sum(a.num) AS s ORDER BY a.num2 % 3 RETURN m, s",
+    );
+    let by_alias = rows(
+        &store,
+        "MATCH (a:A) WITH a.num2 % 3 AS m, sum(a.num) AS s ORDER BY m RETURN m, s",
+    );
+    assert_eq!(out, by_alias);
+    assert_eq!(out.len(), 3);
+}
+
+#[test]
+fn labels_are_returned_in_a_stable_order() {
+    // `Node::labels` is a HashSet. Returning its iteration order made
+    // `labels(n)` answer ['L','B'] on one run and ['B','L'] on the next —
+    // 88/200 one way and 112/200 the other, across processes.
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (:L:B:A {num: 42})");
+
+    let q = parse_query("MATCH (n) RETURN labels(n) AS labels").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&q).unwrap();
+    let labels = match batch.records[0].get("labels") {
+        Some(Value::Property(PropertyValue::Array(items))) => items
+            .iter()
+            .map(|v| match v {
+                PropertyValue::String(s) => s.clone(),
+                other => panic!("expected a string label, got {other:?}"),
+            })
+            .collect::<Vec<_>>(),
+        other => panic!("expected a list of labels, got {other:?}"),
+    };
+    assert_eq!(labels, vec!["A", "B", "L"], "labels come back sorted");
+}
+
+#[test]
+fn labels_are_stable_across_many_nodes_with_the_same_label_set() {
+    // A weaker but broader check: every node with the same labels must report
+    // them identically. With a raw HashSet this held within one process and
+    // failed across processes, which is precisely why it needs stating as a
+    // contract rather than being left to the representation.
+    let mut store = GraphStore::new();
+    for _ in 0..200 {
+        write(&mut store, "CREATE (:Zebra:Apple:Mango)");
+    }
+    let out = rows(&store, "MATCH (n) RETURN DISTINCT labels(n) AS labels");
+    assert_eq!(out.len(), 1, "200 identically-labelled nodes must render one distinct value: {out:?}");
+    assert!(out[0].contains("Apple"), "{out:?}");
+    assert!(
+        out[0].find("Apple").unwrap() < out[0].find("Mango").unwrap(),
+        "sorted, so Apple precedes Mango: {out:?}"
+    );
+}
+
+#[test]
+fn repeated_execution_in_one_process_is_stable() {
+    // Cheap, and it would have caught a bug that varied per *call* rather
+    // than per process — a different failure mode from the two above, and one
+    // nothing else here covers.
+    let store = aggregate_fixture();
+    let cypher = "MATCH (a:A) WITH a.num2 % 3 AS m, sum(a.num + a.num2) AS s \
+                  ORDER BY sum(a.num + a.num2) LIMIT 2 RETURN m, s";
+    let first = rows(&store, cypher);
+    for i in 0..50 {
+        assert_eq!(rows(&store, cypher), first, "run {i} disagreed with run 0");
+    }
+}

--- a/tests/result_determinism.rs
+++ b/tests/result_determinism.rs
@@ -203,3 +203,108 @@ fn repeated_execution_in_one_process_is_stable() {
         assert_eq!(rows(&store, cypher), first, "run {i} disagreed with run 0");
     }
 }
+
+// ---------------------------------------------------------------------------
+// ORDER BY over a RETURN alias.
+//
+// Found while chasing the third flaky TCK scenario. It turned out not to be a
+// determinism bug at all but a plain wrong answer that *looked* deterministic:
+// with the sort dropped, rows came back in scan order, and on a small fixture
+// scan order is often already the ascending order. `ASC` looked right, and
+// only asking for `DESC` and getting the same rows back gave it away.
+//
+// Every test here therefore asserts a *reversal*, not just an order.
+
+fn edges_fixture() -> GraphStore {
+    let mut store = GraphStore::new();
+    write(
+        &mut store,
+        "CREATE ()-[:T1 {id: 0}]->(:X), ()-[:T2 {id: 1}]->(:X), ()-[:T2 {id: 2}]->()",
+    );
+    store
+}
+
+/// The `id` property of each returned edge, in result order.
+fn edge_ids(store: &GraphStore, cypher: &str, column: &str) -> Vec<i64> {
+    let q = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&q).expect("query should run");
+    batch
+        .records
+        .iter()
+        .map(|r| match r.get(column) {
+            Some(Value::Edge(_, e)) => match e.properties.get("id") {
+                Some(PropertyValue::Integer(i)) => *i,
+                other => panic!("expected an integer id, got {other:?}"),
+            },
+            Some(Value::Property(PropertyValue::Integer(i))) => *i,
+            other => panic!("expected an edge or an integer, got {other:?}"),
+        })
+        .collect()
+}
+
+#[test]
+fn ordering_by_a_property_of_a_return_alias_actually_sorts() {
+    let store = edges_fixture();
+    assert_eq!(
+        edge_ids(&store, "MATCH (a)-[r]->(b) RETURN r AS rel ORDER BY rel.id ASC", "rel"),
+        vec![0, 1, 2]
+    );
+    assert_eq!(
+        edge_ids(&store, "MATCH (a)-[r]->(b) RETURN r AS rel ORDER BY rel.id DESC", "rel"),
+        vec![2, 1, 0],
+        "DESC must reverse the order — matching ASC means the sort was dropped"
+    );
+}
+
+#[test]
+fn the_alias_and_the_underlying_variable_sort_identically() {
+    // `ORDER BY r.id` always worked; `ORDER BY rel.id` did not. They are the
+    // same query.
+    let store = edges_fixture();
+    for direction in ["ASC", "DESC"] {
+        assert_eq!(
+            edge_ids(&store, &format!("MATCH (a)-[r]->(b) RETURN r AS rel ORDER BY rel.id {direction}"), "rel"),
+            edge_ids(&store, &format!("MATCH (a)-[r]->(b) RETURN r AS rel ORDER BY r.id {direction}"), "rel"),
+            "{direction}"
+        );
+    }
+}
+
+#[test]
+fn a_sort_after_an_aggregating_with_and_a_second_match_is_applied() {
+    // The TCK scenario (WithOrderBy4 [15]). After a `WITH` that aggregates,
+    // the pre-sort row order is the group hash map's order, so the dropped
+    // sort stopped being merely wrong and became wrong differently on each
+    // process: 61/39 across 100 runs.
+    let store = edges_fixture();
+    let cypher = "MATCH (a)-[r]->(b:X) WITH a, r, b, count(*) AS c ORDER BY c                   MATCH (a)-[r]->(b) RETURN r AS rel ORDER BY rel.id";
+    assert_eq!(edge_ids(&store, cypher, "rel"), vec![0, 1]);
+    assert_eq!(
+        edge_ids(&store, &cypher.replace("ORDER BY rel.id", "ORDER BY rel.id DESC"), "rel"),
+        vec![1, 0]
+    );
+}
+
+#[test]
+fn an_alias_over_a_non_variable_expression_is_left_alone() {
+    // The guard on the substitution. `total` names an aggregate, so
+    // `total.anything` is meaningless and must not be rewritten into some
+    // other node's property. Whatever the executor does with it, the query
+    // must not silently sort by something else.
+    let store = edges_fixture();
+    let q = parse_query("MATCH (a)-[r]->(b) RETURN count(*) AS total ORDER BY total").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&q).expect("counting still works");
+    assert_eq!(batch.records.len(), 1);
+}
+
+#[test]
+fn ordering_by_an_expression_over_an_alias_property_is_resolved() {
+    // The substitution recurses, so a key that merely contains `rel.id`
+    // resolves as well.
+    let store = edges_fixture();
+    assert_eq!(
+        edge_ids(&store, "MATCH (a)-[r]->(b) RETURN r AS rel ORDER BY rel.id * -1", "rel"),
+        vec![2, 1, 0],
+        "negating the key reverses the order"
+    );
+}

--- a/tests/version_consistency.rs
+++ b/tests/version_consistency.rs
@@ -1,0 +1,249 @@
+//! One version of record, in every location that publishes one (API-10).
+//!
+//! This test exists because the drift it checks for had already happened and
+//! nobody noticed: the engine was at `1.7.0` while `pip show samyama` and
+//! `npm ls samyama` both reported **`0.7.0`**, and the OpenAPI document
+//! advertised `0.7.0` as the server version in its own examples. A user
+//! comparing the crate version against the SDK version would have concluded
+//! they were a major release apart.
+//!
+//! The version of record is `CARGO_PKG_VERSION` — the root manifest — and
+//! every other location is compared against it. There is no configuration and
+//! no allowlist: a location that cannot be read is a failure, because the
+//! usual way a check like this stops working is that a refactor moves a file
+//! and the check quietly starts passing over nothing.
+//!
+//! Locations that *derive* the version at compile time (`VERSION`, the RESP
+//! `INFO` payload) cannot drift and are deliberately not listed. Only the
+//! places where a human typed the number are checked.
+
+use std::path::{Path, PathBuf};
+
+/// Repository root, from the manifest directory of this crate.
+fn root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn read(rel: &str) -> String {
+    let path: PathBuf = root().join(rel);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("{rel} is named in the release checklist but could not be read: {e}"))
+}
+
+/// Every `X.Y.Z` in `text`, as a list.
+///
+/// Tokenised rather than pattern-matched, because the first version of this
+/// function matched `127.0.0` inside `127.0.0.1` and reported the loopback
+/// address as a stale version claim. A token is a maximal run of digits and
+/// dots; it counts only if, once trailing dots are trimmed, it has exactly
+/// three numeric components. That rejects dotted quads and accepts a version
+/// at the end of a sentence.
+fn semvers(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for token in text.split(|c: char| !(c.is_ascii_digit() || c == '.')) {
+        let t = token.trim_end_matches('.');
+        if t.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = t.split('.').collect();
+        if parts.len() == 3 && parts.iter().all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit())) {
+            out.push(t.to_string());
+        }
+    }
+    out
+}
+
+/// Semvers appearing as the value of a `version` key, or in the example list
+/// belonging to one.
+///
+/// The OpenAPI document declares its own *specification* version as
+/// `openapi: 3.1.0`, which is not ours to keep in sync. Scanning every semver
+/// in the file therefore fails on a correct document — so only version fields
+/// are read.
+fn yaml_version_values(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut in_version_examples = false;
+    for line in text.lines() {
+        let l = line.trim();
+        if l.starts_with("openapi:") {
+            continue;
+        }
+        if let Some(rest) = l.strip_prefix("version:") {
+            let rest = rest.trim();
+            if rest.is_empty() {
+                in_version_examples = true; // an examples list follows
+            } else {
+                in_version_examples = false;
+                out.extend(semvers(rest));
+            }
+            continue;
+        }
+        if in_version_examples {
+            // Stay inside the block while indented list items or `examples:`
+            // continue; any other key ends it.
+            if l.starts_with('-') {
+                out.extend(semvers(l));
+                continue;
+            }
+            if l.is_empty() || l.starts_with("examples:") || l.starts_with("type:") || l.starts_with("description:") {
+                continue;
+            }
+            in_version_examples = false;
+        }
+    }
+    out
+}
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// The `[package] version` of a Cargo manifest — not a dependency's version.
+fn cargo_package_version(rel: &str) -> Option<String> {
+    let text = read(rel);
+    let mut section = String::new();
+    for line in text.lines() {
+        let l = line.trim();
+        if l.starts_with('[') {
+            section = l.trim_matches(|c| c == '[' || c == ']').to_string();
+            continue;
+        }
+        if section == "package" && l.starts_with("version") && l.contains('=') {
+            if l.contains("workspace") && l.contains("true") {
+                return Some("workspace".into());
+            }
+            return l.split('"').nth(1).map(str::to_string);
+        }
+    }
+    None
+}
+
+#[test]
+fn every_cargo_manifest_carries_the_version_of_record() {
+    for rel in [
+        "Cargo.toml",
+        "cli/Cargo.toml",
+        "crates/samyama-sdk/Cargo.toml",
+        "crates/samyama-optimization/Cargo.toml",
+        "crates/samyama-graph-algorithms/Cargo.toml",
+        "sdk/python/Cargo.toml",
+    ] {
+        let found = cargo_package_version(rel)
+            .unwrap_or_else(|| panic!("{rel}: no [package] version"));
+        assert!(
+            found == VERSION || found == "workspace",
+            "{rel} declares {found}, the version of record is {VERSION}"
+        );
+    }
+}
+
+#[test]
+fn the_python_wheel_reports_the_version_of_record() {
+    // PEP 440 permits `1.7.0rc1` where cargo writes `1.7.0-rc1`; the release
+    // segment is what `pip show` prints, and it must match.
+    let text = read("sdk/python/pyproject.toml");
+    let declared = text
+        .lines()
+        .find(|l| l.trim_start().starts_with("version"))
+        .and_then(|l| l.split('"').nth(1))
+        .expect("sdk/python/pyproject.toml has no version");
+    assert_eq!(
+        declared.replace('-', ""),
+        VERSION.replace('-', ""),
+        "pip would report {declared} for an engine at {VERSION}"
+    );
+}
+
+#[test]
+fn the_typescript_package_and_its_lockfile_agree_with_the_version_of_record() {
+    for rel in ["sdk/typescript/package.json", "sdk/typescript/package-lock.json"] {
+        let text = read(rel);
+        // Only the top-level "version" keys — a lockfile's dependency
+        // versions are not ours to hold in sync.
+        let ours: Vec<String> = text
+            .lines()
+            .take(12)
+            .filter(|l| l.contains("\"version\""))
+            .filter_map(|l| l.split('"').nth(3).map(str::to_string))
+            .collect();
+        assert!(!ours.is_empty(), "{rel}: no top-level version key found");
+        for v in ours {
+            assert_eq!(v, VERSION, "{rel} declares {v}, the version of record is {VERSION}");
+        }
+    }
+}
+
+#[test]
+fn the_openapi_document_advertises_the_version_of_record() {
+    // Including the examples: an example is what a reader copies, and a
+    // status example claiming 0.7.0 is a published claim about the server.
+    let text = read("api/openapi.yaml");
+    let values = yaml_version_values(&text);
+    assert!(!values.is_empty(), "no version fields found in api/openapi.yaml — the scan is vacuous");
+    let stale: Vec<String> = values.into_iter().filter(|v| v != VERSION).collect();
+    assert!(
+        stale.is_empty(),
+        "api/openapi.yaml mentions {stale:?}; the version of record is {VERSION}. \
+         Examples count — they are what a reader copies."
+    );
+}
+
+#[test]
+fn the_prose_that_names_a_version_names_the_current_one() {
+    // Two documents state the version in prose. They are checked for
+    // *containing* the version of record rather than for containing nothing
+    // else, because prose legitimately refers to history ("since 0.4").
+    for rel in ["src/lib.rs", "CLAUDE.md"] {
+        let text = read(rel);
+        let mentions = semvers(&text);
+        if mentions.is_empty() {
+            continue; // no version claim to keep in sync
+        }
+        assert!(
+            mentions.iter().any(|v| v == VERSION),
+            "{rel} names {mentions:?} but never {VERSION} — the version of record"
+        );
+    }
+}
+
+#[test]
+fn the_release_checklist_locations_all_exist() {
+    // The failure mode this guards: a file is moved, the check above reads
+    // nothing, and a green test means "nothing was checked".
+    for rel in [
+        "Cargo.toml",
+        "cli/Cargo.toml",
+        "crates/samyama-sdk/Cargo.toml",
+        "crates/samyama-optimization/Cargo.toml",
+        "crates/samyama-graph-algorithms/Cargo.toml",
+        "sdk/python/Cargo.toml",
+        "sdk/python/pyproject.toml",
+        "sdk/typescript/package.json",
+        "sdk/typescript/package-lock.json",
+        "api/openapi.yaml",
+        "src/lib.rs",
+        "CLAUDE.md",
+    ] {
+        assert!(
+            Path::new(&root().join(rel)).exists(),
+            "{rel} is in the release checklist but does not exist"
+        );
+    }
+}
+
+#[test]
+fn the_semver_scanner_finds_what_it_claims_to() {
+    // The scanner above decides whether the OpenAPI test can fail at all, so
+    // it is worth pinning. A scanner that silently found nothing would make
+    // that test vacuous — the exact failure this file is about.
+    assert_eq!(semvers("version: 1.7.0"), vec!["1.7.0"]);
+    assert_eq!(semvers("- 0.7.0\n- 1.2.3"), vec!["0.7.0", "1.2.3"]);
+    assert_eq!(semvers("v1.7.0 and 1.7.0."), vec!["1.7.0", "1.7.0"]);
+    assert!(semvers("no version here").is_empty());
+    assert!(semvers("1.7").is_empty(), "two components is not a semver");
+    // The bug this function was rewritten for.
+    assert!(semvers("bound to 127.0.0.1:6379").is_empty(), "a dotted quad is not a version");
+    assert!(semvers("10.0.0.255").is_empty());
+
+    // And the OpenAPI reader must ignore the spec version while finding ours.
+    let doc = "openapi: 3.1.0\ninfo:\n  version: 1.7.0\n  x:\n    version:\n      examples:\n        - 1.7.0\n";
+    assert_eq!(yaml_version_values(doc), vec!["1.7.0", "1.7.0"]);
+}


### PR DESCRIPTION
Three commits, all downstream of standing up the spec-18 conformance harness in `samyama-graph-competitor-benchmarks`. Each defect here was found by a suite on its first run, which is the argument for the harness better than any description of it.

## 1. The version of record was wrong in four published places (API-10)

The engine is at **1.7.0**. `pip show samyama` reported **0.7.0**, `npm ls` the same, and `api/openapi.yaml` advertised `0.7.0` as the server version *in the examples a reader copies*. `CLAUDE.md` said 0.9.0.

`tests/version_consistency.rs` makes it a gate rather than a checklist item, in `cargo test` so existing CI enforces it with no new wiring. It checks all twelve locations, including that they still exist — the way a check like this usually stops working is a refactor moving a file, after which it passes over nothing. Reverting any single location fails the suite; verified.

Two bugs in the scanner were caught by its own unit test: it matched `127.0.0` inside `127.0.0.1`, and read the OpenAPI document's own `openapi: 3.1.0` as a stale claim.

## 2. Two nondeterministic wrong answers (LANG-14)

Running the TCK five times at a fixed commit gave 484/485/486/487 passes with `errored` constant — two scenarios were changing their *answer* between processes. A single run reports a stable 46% and tells you nothing.

**`ORDER BY` restating an aggregate was silently ignored.**

```cypher
WITH a.num2 % 3 AS mod, sum(a.num) AS total ORDER BY sum(a.num)   -- broken
WITH a.num2 % 3 AS mod, sum(a.num) AS total ORDER BY total        -- worked
```

Same query. After the aggregation barrier there is no `a` to evaluate `sum(a.num)` against, so the key was null on every row, the sort became a no-op, and a following `LIMIT` took an arbitrary prefix of the group hash map. On the TCK's own fixture: **five different results across 100 runs, 36 of them correct.**

**`labels()` returned a `HashSet` iteration order** — `['L','B']` on one run, `['B','L']` on the next (112/200 vs 88/200). Now sorted, the contract `keys()` already offered.

## 3. Runner improvements that made the above findable

- `--failures-manifest` writes every non-passing scenario, sorted, for diffing. `--show-failures` prints the first 60 and both flaky scenarios were outside that window.
- `the result should be (ignoring element order for lists)` now relaxes element order *inside a list*, which is what the phrase means. It was read as a row-order relaxation, scoring a correct engine wrong.

## Numbers

- openCypher TCK: **485 → 488** of 1,049 evaluated (46.5%), 65% coverage. Still varies by one from a third scenario (`WithOrderBy4 [15]`), not yet diagnosed and stated as such.
- `cargo test --workspace`: green.
- New: `tests/version_consistency.rs` (7), `tests/result_determinism.rs` (8). Every test verified to fail when its fix is reverted.

The determinism tests say plainly that a single-process loop cannot reproduce the original bug — the hash seed is per process — so they assert the properties the fixes establish rather than re-running the lottery.