### PR TITLE
openCypher TCK: 46.6% → 53.2%, and the eight defects found getting there

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,25 @@ jobs:
         # The sweep runs these; here we only prove they still build, which is
         # what actually breaks when a signature changes.
         run: cargo check --workspace --all-targets
+
+      # ---- Conformance gates (spec 18 §5: these block commits, not releases,
+      # because they are fast and catch the most damaging classes).
+      #
+      # Each is an ordinary example that exits non-zero on failure, so it
+      # gates without any bespoke CI machinery. `--release` because both are
+      # seconds either way and the debug build of the engine is slow enough
+      # that the dev profile dominates.
+
+      - name: CH-IMPORT — the same graph by different paths is the same graph
+        # REL-06. Builds one fixture via Cypher, a snapshot round
+        # trip, and the store API, then compares 11 invariants through Cypher.
+        # Carries its own canary: a deliberately-wrong graph must be detected,
+        # so the suite cannot pass by comparing nothing.
+        run: cargo run --release --example import_invariants
+
+      - name: CH-DOC-EXEC — the Cypher in our documentation parses
+        # DX-04. Every fenced ```cypher block in every markdown file. Blocks
+        # showing clause syntax rather than whole queries opt out with
+        # ```cypher,ignore, and the opt-out count is printed so it cannot grow
+        # unnoticed.
+        run: cargo run --release --example doc_check

--- a/README.md
+++ b/README.md
@@ -351,8 +351,9 @@ RETURN nodeId, score ORDER BY score DESC LIMIT 10
 **Vector search** — HNSW indexing for semantic search and Graph RAG.
 
 ```cypher
-CREATE VECTOR INDEX ON :Paper(embedding) OPTIONS {dimensions: 384, similarity: 'cosine'}
-CALL vector.search('Paper', 'embedding', [0.1, 0.2, ...], 10) YIELD node, score
+CREATE VECTOR INDEX paper_idx FOR (p:Paper) ON (p.embedding) OPTIONS {dimensions: 384, similarity: 'cosine'}
+
+CALL vector.search('Paper', 'embedding', [0.1, 0.2, 0.3], 10) YIELD node, score
 ```
 
 **Natural language** — Ask questions in English. The LLM translates to Cypher.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -298,31 +298,151 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /api/tenants/{id}/usage:
-    parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-        description: Tenant ID
-    get:
-      operationId: getTenantUsage
-      summary: Get tenant resource usage
-      description: Returns current resource usage for a tenant (nodes, edges, memory, storage, connections).
+  /api/sample:
+    post:
+      operationId: sampleSubgraph
+      summary: Sample a representative subgraph
+      description: >
+        Returns a label-stratified, size-capped subgraph intended for
+        visualization. One call replaces the `1 + <edge types>` sequential
+        queries a client would otherwise issue to draw an overview, and the
+        default of 200 nodes is the point past which a node-link diagram stops
+        being legible.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                max_nodes:
+                  type: integer
+                  default: 200
+                  description: Upper bound on returned nodes. Capped server-side at 1000.
+                labels:
+                  type: array
+                  items:
+                    type: string
+                  description: Restrict sampling to these labels. Empty means all labels.
+                graph:
+                  type: string
+                  description: Tenant/graph name.
       responses:
         '200':
-          description: Resource usage
+          description: A sampled subgraph
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UsageResponse'
-        '404':
-          description: Tenant not found
+                type: object
+
+  /api/vector/indexes:
+    get:
+      operationId: listVectorIndexes
+      summary: List vector indexes
+      responses:
+        '200':
+          description: The configured vector indexes
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: object
+    post:
+      operationId: createVectorIndex
+      summary: Create a vector index
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - label
+                - property_key
+                - dimensions
+              properties:
+                label:
+                  type: string
+                property_key:
+                  type: string
+                dimensions:
+                  type: integer
+                metric:
+                  type: string
+                  description: Distance metric, e.g. cosine or euclidean.
+      responses:
+        '200':
+          description: The index was created
+
+  /api/vector-search:
+    post:
+      operationId: vectorSearch
+      summary: k-nearest-neighbour search over a vector index
+      description: >
+        Supply either `query_vector` or `query_text`; supplying text requires an
+        embedding provider to be configured.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                query_text:
+                  type: string
+                query_vector:
+                  type: array
+                  items:
+                    type: number
+                    format: float
+                label:
+                  type: string
+                property_key:
+                  type: string
+                k:
+                  type: integer
+                  description: Number of neighbours to return.
+      responses:
+        '200':
+          description: The nearest neighbours, closest first
+          content:
+            application/json:
+              schema:
+                type: object
+
+  /api/snapshot/export:
+    post:
+      operationId: exportSnapshot
+      summary: Export a tenant as a portable .sgsnap snapshot
+      responses:
+        '200':
+          description: The snapshot bytes
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+
+  /api/snapshot/import:
+    post:
+      operationId: importSnapshot
+      summary: Import a .sgsnap snapshot into a tenant
+      description: >
+        The body is **multipart/form-data**, not a raw octet stream — posting the
+        bytes directly is the mistake this description exists to prevent. Import
+        merges into the target tenant rather than replacing it.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: The snapshot was imported
 
 components:
   schemas:

--- a/docs/ADR/ADR-011-cypher-crud-operations.md
+++ b/docs/ADR/ADR-011-cypher-crud-operations.md
@@ -32,7 +32,7 @@ This significantly limits Samyama's utility as a production graph database.
 
 ### Phase 1: DELETE Operations
 
-```cypher
+```cypher,ignore
 -- Strict delete (fails if node has edges)
 DELETE n
 
@@ -44,7 +44,7 @@ DETACH DELETE n
 
 ### Phase 2: SET Operations
 
-```cypher
+```cypher,ignore
 -- Individual property
 SET n.prop = value
 
@@ -59,7 +59,7 @@ SET n += {props}
 
 ### Phase 3: REMOVE Operations
 
-```cypher
+```cypher,ignore
 -- Remove properties
 REMOVE n.prop1, n.prop2
 ```

--- a/docs/ADR/ADR-017-adjacency-aware-aggregation-planning.md
+++ b/docs/ADR/ADR-017-adjacency-aware-aggregation-planning.md
@@ -40,7 +40,7 @@ The fundamental insight: when the aggregate is `count(neighbor)` grouped by a bo
 
 The v1.0 planner has a narrow `EdgeTypeCountOperator` (planner.rs:1321-1339) that handles:
 
-```cypher
+```cypher,ignore
 MATCH ()-[r]->() RETURN type(r), count(*)
 ```
 
@@ -59,7 +59,7 @@ MB049 does not qualify because both endpoints have labels. The degree informatio
 
 The planner will detect this shape during logical-plan construction:
 
-```cypher
+```cypher,ignore
 MATCH (a[:LabelA])-[r:EdgeType]-(b:LabelB)
 RETURN b.prop [, ...], count(a) AS n  -- or count(*), count(r), count(DISTINCT a)
 [ORDER BY n DESC | ASC] [LIMIT N]

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -38,6 +38,14 @@ The split follows from where a reader can act: a number you can reproduce
 belongs next to the code that produces it; a number that required another
 vendor's licensed software to obtain does not.
 
+**LDBC SNB Interactive at SF10, against Neo4j on the same host** (2026-08-19,
+AWS r6a.8xlarge): 12 of 14 complex reads within 5× of Neo4j and **6 faster**,
+with IC6 timing out and IC11 at 11.5×. That is a cross-engine result, so it
+lives in the private repo with the competitor configs it depends on —
+`benchmarks/ldbc-snb-interactive/SF10-2026-08-19-SAME-HOST.md`. It supersedes
+the "85–170× slower on complex reads" figure, which came from a run whose
+Samyama and competitor columns were measured on *different machines*.
+
 **Not on this page either: the scorecard.** Every figure here is one suite's
 result. The single file that says where the product stands against all 254
 requirements — measured, unmeasured, or measured only by proxy — is
@@ -130,18 +138,25 @@ cargo run --release --example tck_runner -- --features <openCypher>/tck/features
 | | |
 |---|---:|
 | scenarios in the TCK | 1,615 |
-| **evaluated** by the harness | **1,049** (65.0%) |
-| pass | 489 |
-| wrong result | 282 |
-| errored | 278 |
-| skipped | 566 |
-| **pass rate, of evaluated** | **46.6%** |
-| pass rate, of all 1,615 | 30.3% |
+| **evaluated** by the harness | **1,239** (76.7%) |
+| pass | 663 |
+| wrong result | 320 |
+| errored | 256 |
+| skipped | 376 |
+| **pass rate, of evaluated** | **53.5%** |
+| pass rate, of all 1,615 | 41.1% |
 | gate `CH-TCK ≥ 85%` | **not met** |
 
-Measured at `f295b73` on `vultr-bench-16c-32g-blr`, via the conformance
-harness's `CH-TCK` suite; the envelope is in
-`samyama-graph-competitor-benchmarks/harness/runs/`.
+Measured at `ab4ae61` via the conformance harness's `CH-TCK` suite; the
+envelope is in `samyama-graph-competitor-benchmarks/harness/runs/`.
+
+**Coverage moved further than the rate.** 65.0% → 76.7% of scenarios are now
+judged rather than skipped, because 197 of them were being skipped for
+"setup did not parse" — every TCK fixture is written as a run of `CREATE`
+clauses, which did not parse. Making them parse then exposed a worse bug:
+`CREATE (a), (b), (a)-[:R]->(b)` created **four** nodes instead of two. The
+rate rising from 46.6% to 53.5% *while* 190 harder scenarios joined the
+denominator is the more useful way to read this.
 
 **This number was nondeterministic until 2026-08-18.** Running the TCK five
 times at a fixed commit gave 484, 485, 486 and 487 passes while `errored`
@@ -163,14 +178,16 @@ published:
 | skipped | reason |
 |---:|---|
 | 274 | `Scenario Outline` — the harness does not expand `Examples` tables |
-| 197 | the scenario's setup Cypher did not parse |
 | 39 | user-defined procedures |
 | 34 | query parameters |
 | 19 | named fixture graphs (`binary-tree-N`) |
+| 3 | the scenario's setup did not run |
 
-The 197 setup failures are a **result, not only a harness gap**: those are
-ordinary `CREATE` statements the parser rejects, so they measure the same thing
-the TCK is measuring.
+The 197 "setup did not parse" skips are **gone**: they were ordinary `CREATE`
+statements the parser rejected, and fixing that moved them into the judged set
+— which is where most of the coverage gain came from. `Scenario Outline`
+expansion is now the single largest remaining skip category and is a harness
+gap rather than an engine one.
 
 Weakest areas, among features with at least 5 evaluated scenarios — all at 0%:
 `Boolean5`, `Comparison3`, `Create3`, `Create6`, `Match6`, `Merge6`, `Set4`,
@@ -180,7 +197,7 @@ Weakest areas, among features with at least 5 evaluated scenarios — all at 0%:
 ### How this relates to the hand-written sweeps
 
 Four hand-written sweeps in `examples/cypher_probe*.rs` (168 cases) pass
-100%, 100%, 100% and 29/30. That is not in tension with 46.6% — those sweeps
+100%, 100%, 100% and 29/30. That is not in tension with 53.5% — those sweeps
 were written to probe areas suspected of being wrong, and every case in them was
 either already correct or has since been fixed. They found seven silent
 wrong answers; they were never a coverage measurement. **The TCK is the coverage

--- a/examples/doc_check.rs
+++ b/examples/doc_check.rs
@@ -1,0 +1,212 @@
+//! CH-DOC-EXEC — the Cypher in our documentation actually parses (DX-04).
+//!
+//! Documentation drifts silently. A query in a README keeps its syntax
+//! highlighting long after the grammar has moved, and the first person to
+//! notice is a new user copying it. This walks the repo's markdown, pulls out
+//! every fenced `cypher` block, and parses each statement.
+//!
+//! Parsing, not executing, is the bar — deliberately. Most documented queries
+//! need a specific graph to return anything, and demanding one would mean
+//! maintaining a fixture per document, which is how executable-documentation
+//! efforts die. A query that does not parse is unambiguously broken; a query
+//! that parses and returns nothing may be perfectly fine.
+//!
+//! Blocks can opt out with `cypher,ignore` — for deliberately invalid examples
+//! showing what *not* to write. That marker is counted and reported, so opting
+//! out stays visible rather than becoming a quiet way to pass.
+//!
+//!   cargo run --release --example doc_check
+//!   cargo run --release --example doc_check -- --json out.json --root .
+
+use samyama::query::parser::parse_query;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+struct Block {
+    file: String,
+    line: usize,
+    query: String,
+    ignored: bool,
+}
+
+/// Fenced blocks tagged `cypher` (optionally `cypher,ignore`).
+fn blocks_in(path: &Path, text: &str) -> Vec<Block> {
+    let mut out = Vec::new();
+    let mut current: Option<(usize, bool, String)> = None;
+    for (i, line) in text.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if let Some((start, ignored, body)) = current.take() {
+            if trimmed.starts_with("```") {
+                out.push(Block {
+                    file: path.display().to_string(),
+                    line: start + 1,
+                    query: body,
+                    ignored,
+                });
+            } else {
+                let mut body = body;
+                body.push_str(line);
+                body.push('\n');
+                current = Some((start, ignored, body));
+            }
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("```") {
+            let tag = rest.trim().to_ascii_lowercase();
+            if tag == "cypher" || tag.starts_with("cypher,") || tag.starts_with("cypher ") {
+                current = Some((i, tag.contains("ignore"), String::new()));
+            }
+        }
+    }
+    out
+}
+
+fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    for e in entries.flatten() {
+        let p = e.path();
+        let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        // Build output, dependencies and vendored checkouts are not our docs.
+        if p.is_dir() {
+            if matches!(name, "target" | ".git" | "node_modules" | ".harness-cache" | "data") {
+                continue;
+            }
+            walk(&p, out);
+        } else if name.ends_with(".md") {
+            out.push(p);
+        }
+    }
+}
+
+/// Whether a line is a comment. Cypher's own comment marker is `//`, but our
+/// documentation also uses `--` and `#` to annotate example blocks. Treating
+/// those as queries produced a dozen "failures" that were prose, which is the
+/// fastest way to get a check like this ignored.
+fn is_comment(line: &str) -> bool {
+    let t = line.trim_start();
+    t.starts_with("//") || t.starts_with("--") || t.starts_with('#')
+}
+
+/// Split a block into statements. A documented block often shows several
+/// queries separated by blank lines; each is parsed on its own, because one
+/// failure should name one query. Comment lines are stripped rather than
+/// skipped-if-all-comments, so an annotated query is still checked.
+fn statements(block: &str) -> Vec<String> {
+    block
+        .split("\n\n")
+        .map(|chunk| {
+            chunk
+                .lines()
+                .filter(|l| !is_comment(l))
+                .collect::<Vec<_>>()
+                .join("\n")
+                .trim()
+                .trim_end_matches(';')
+                .trim()
+                .to_string()
+        })
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let arg = |flag: &str| -> Option<String> {
+        args.iter().position(|a| a == flag).and_then(|i| args.get(i + 1)).cloned()
+    };
+    let root = arg("--root").unwrap_or_else(|| ".".into());
+
+    let mut files = Vec::new();
+    walk(Path::new(&root), &mut files);
+    files.sort();
+
+    let mut checked = 0usize;
+    let mut failed: Vec<(String, usize, String, String)> = Vec::new();
+    let mut ignored = 0usize;
+    let mut docs_with_cypher = 0usize;
+
+    for file in &files {
+        let Ok(text) = std::fs::read_to_string(file) else { continue };
+        let blocks = blocks_in(file, &text);
+        if !blocks.is_empty() {
+            docs_with_cypher += 1;
+        }
+        for b in blocks {
+            if b.ignored {
+                ignored += 1;
+                continue;
+            }
+            for stmt in statements(&b.query) {
+                checked += 1;
+                if let Err(e) = parse_query(&stmt) {
+                    let short: String = e.to_string().lines().next().unwrap_or("").chars().take(90).collect();
+                    failed.push((b.file.clone(), b.line, stmt.lines().next().unwrap_or("").chars().take(90).collect(), short));
+                }
+            }
+        }
+    }
+
+    println!("CH-DOC-EXEC — Cypher in documentation");
+    println!("{}", "=".repeat(78));
+    println!("markdown files scanned : {}", files.len());
+    println!("files containing cypher: {docs_with_cypher}");
+    println!("statements parsed      : {checked}");
+    println!("blocks marked ignore   : {ignored}");
+    println!("failures               : {}", failed.len());
+    if !failed.is_empty() {
+        println!("\nFailures:");
+        for (f, l, q, e) in failed.iter().take(40) {
+            println!("  {f}:{l}\n      {q}\n      {e}");
+        }
+        if failed.len() > 40 {
+            println!("  … and {} more", failed.len() - 40);
+        }
+    }
+
+    if let Some(path) = arg("--json") {
+        let commit = std::process::Command::new("git")
+            .args(["rev-parse", "--short", "HEAD"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .unwrap_or_else(|| "unknown".into());
+        let mut cases = String::new();
+        for (f, l, q, e) in failed.iter().take(200) {
+            if !cases.is_empty() {
+                cases.push_str(",\n      ");
+            }
+            let esc = |s: &str| s.replace('\\', "\\\\").replace('"', "\\\"");
+            let _ = write!(
+                cases,
+                "{{\"file\": \"{}\", \"line\": {l}, \"query\": \"{}\", \"error\": \"{}\"}}",
+                esc(f), esc(q), esc(e)
+            );
+        }
+        let envelope = format!(
+            "{{
+  \"suite\": \"doc-exec\",
+  \"requirement_ids\": [\"DX-04\"],
+  \"run_id\": \"docexec-{commit}\",
+  \"engine\": {{\"name\": \"samyama\", \"version\": \"{}\", \"commit\": \"{commit}\"}},
+  \"dataset\": {{\"name\": \"repo-markdown\", \"files\": {}, \"files_with_cypher\": {docs_with_cypher}}},
+  \"measurements\": {{\"checked\": {checked}, \"failed\": {}, \"ignored\": {ignored}, \"cases\": [
+      {cases}
+  ]}},
+  \"status\": \"{}\",
+  \"artifacts\": [\"examples/doc_check.rs\"]
+}}
+",
+            env!("CARGO_PKG_VERSION"),
+            files.len(),
+            failed.len(),
+            if failed.is_empty() { "pass" } else { "fail" }
+        );
+        std::fs::write(&path, envelope).expect("could not write JSON");
+        println!("\nwrote {path}");
+    }
+
+    if !failed.is_empty() {
+        std::process::exit(1);
+    }
+}

--- a/examples/import_invariants.rs
+++ b/examples/import_invariants.rs
@@ -1,0 +1,301 @@
+//! CH-IMPORT — the same graph, built by different paths, must be the same graph
+//! (LANG-15, REL-06).
+//!
+//! A graph can enter this engine three ways: written by Cypher, restored from a
+//! `.sgsnap` snapshot, or built through the store API that loaders use. Each
+//! path writes properties, labels and adjacency through different code, and the
+//! failure they share is *partial* agreement — the nodes match, the counts
+//! match, and one representation has quietly dropped something the others kept.
+//!
+//! That is not hypothetical here. `node.properties` is empty after a snapshot
+//! import because properties live in the columnar store, so a check that reads
+//! only row storage reports a restored graph as having none. Dense property
+//! columns had to be taught to keep a gap rather than answer `T::default()`,
+//! or an absent property would come back as `0`. Both were found by comparing
+//! paths, not by testing one.
+//!
+//! Invariants compared, in increasing order of how easy they are to get wrong:
+//!
+//!   1. node and edge counts;
+//!   2. the label histogram and the edge-type histogram;
+//!   3. every property of every node, read back through Cypher — which is the
+//!      only reader a user has;
+//!   4. degree distribution, so adjacency is compared and not just endpoints;
+//!   5. absent properties stay absent, checked with `IS NULL`.
+//!
+//!   cargo run --release --example import_invariants -- --json out.json
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+use samyama::snapshot::{export_tenant, import_tenant};
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+/// The fixture, deliberately awkward: several labels, a node missing a
+/// property, an empty string, a stored zero, a float, a bool and a list.
+const CYPHER_BUILD: &str = "\
+CREATE (a:Person:Employee {name: 'Alice', age: 30, score: 0.5, active: true, tags: ['x','y']}) \
+CREATE (b:Person {name: 'Bob', age: 0, note: ''}) \
+CREATE (c:Company {name: 'Acme'}) \
+CREATE (a)-[:WORKS_AT {since: 2019}]->(c) \
+CREATE (b)-[:WORKS_AT {since: 2021}]->(c) \
+CREATE (a)-[:KNOWS]->(b)";
+
+fn write(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).expect("fixture should parse");
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .expect("fixture should run");
+}
+
+/// Every row of a query, rendered canonically and sorted, so two graphs can be
+/// compared as text without depending on row order.
+fn rows(store: &GraphStore, cypher: &str) -> Vec<String> {
+    let q = parse_query(cypher).expect("probe should parse");
+    let batch = QueryExecutor::new(store).execute(&q).expect("probe should run");
+    let mut out: Vec<String> = batch
+        .records
+        .iter()
+        .map(|r| {
+            let mut cells: Vec<String> = r
+                .bindings()
+                .iter()
+                .map(|(k, v)| format!("{k}={}", render(v)))
+                .collect();
+            cells.sort();
+            cells.join(",")
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+/// Render a value without its node id, which legitimately differs between
+/// paths — a snapshot restores ids, a rebuild allocates fresh ones. Comparing
+/// ids would report every run as a mismatch.
+fn render(v: &Value) -> String {
+    match v {
+        Value::Property(p) => render_prop(p),
+        Value::Node(_, n) => {
+            let mut labels: Vec<&str> = n.labels.iter().map(|l| l.as_str()).collect();
+            labels.sort_unstable();
+            format!("node[{}]", labels.join(":"))
+        }
+        Value::NodeRef(_) => "noderef".to_string(),
+        other => format!("{other:?}"),
+    }
+}
+
+fn render_prop(p: &PropertyValue) -> String {
+    match p {
+        PropertyValue::Null => "null".into(),
+        PropertyValue::String(s) => format!("'{s}'"),
+        PropertyValue::Integer(i) => i.to_string(),
+        PropertyValue::Float(f) => format!("{f:?}"),
+        PropertyValue::Boolean(b) => b.to_string(),
+        PropertyValue::Array(items) => {
+            let inner: Vec<String> = items.iter().map(render_prop).collect();
+            format!("[{}]", inner.join(","))
+        }
+        other => format!("{other:?}"),
+    }
+}
+
+/// The probes that define "the same graph". Each is a Cypher query, because
+/// Cypher is the only reader a user has — an invariant checked through a
+/// back door can hold while the front door is broken (#333).
+fn probes() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("node_count", "MATCH (n) RETURN count(n) AS c"),
+        ("edge_count", "MATCH ()-[r]->() RETURN count(r) AS c"),
+        ("label_histogram", "MATCH (n) UNWIND labels(n) AS l RETURN l, count(*) AS c"),
+        ("edge_type_histogram", "MATCH ()-[r]->() RETURN type(r) AS t, count(*) AS c"),
+        ("all_node_properties", "MATCH (n) RETURN n.name AS name, n.age AS age, n.score AS score, n.active AS active, n.note AS note, n.tags AS tags"),
+        ("keys_per_node", "MATCH (n) RETURN n.name AS name, keys(n) AS k"),
+        ("edge_properties", "MATCH ()-[r]->() RETURN type(r) AS t, r.since AS since"),
+        ("out_degree", "MATCH (n) RETURN n.name AS name, size([(n)-->() | 1]) AS d"),
+        ("absent_property_is_null", "MATCH (n) WHERE n.note IS NULL RETURN count(*) AS c"),
+        ("stored_zero_is_present", "MATCH (n) WHERE n.age = 0 RETURN count(*) AS c"),
+        ("empty_string_is_present", "MATCH (n) WHERE n.note = '' RETURN count(*) AS c"),
+    ]
+}
+
+struct Built {
+    name: &'static str,
+    store: GraphStore,
+}
+
+fn main() {
+    let json_path = {
+        let args: Vec<String> = std::env::args().collect();
+        args.iter().position(|a| a == "--json").and_then(|i| args.get(i + 1).cloned())
+    };
+
+    // ---- Path 1: written by Cypher.
+    let mut cypher_store = GraphStore::new();
+    write(&mut cypher_store, CYPHER_BUILD);
+
+    // ---- Path 2: exported and re-imported as a snapshot.
+    let mut bytes = Vec::new();
+    export_tenant(&cypher_store, &mut bytes).expect("export should succeed");
+    let mut snapshot_store = GraphStore::new();
+    import_tenant(&mut snapshot_store, bytes.as_slice()).expect("import should succeed");
+
+    // ---- Path 3: built through the store API, the way loaders do.
+    let mut api_store = GraphStore::new();
+    {
+        let s = &mut api_store;
+        let a = s.create_node("Person");
+        let _ = s.add_label_to_node("default", a, "Employee");
+        let _ = s.set_node_property("default", a, "name".to_string(), PropertyValue::String("Alice".into()));
+        let _ = s.set_node_property("default", a, "age".to_string(), PropertyValue::Integer(30));
+        let _ = s.set_node_property("default", a, "score".to_string(), PropertyValue::Float(0.5));
+        let _ = s.set_node_property("default", a, "active".to_string(), PropertyValue::Boolean(true));
+        let _ = s.set_node_property("default", a, "tags".to_string(), PropertyValue::Array(vec![
+            PropertyValue::String("x".into()),
+            PropertyValue::String("y".into()),
+        ]));
+
+        let b = s.create_node("Person");
+        let _ = s.set_node_property("default", b, "name".to_string(), PropertyValue::String("Bob".into()));
+        let _ = s.set_node_property("default", b, "age".to_string(), PropertyValue::Integer(0));
+        let _ = s.set_node_property("default", b, "note".to_string(), PropertyValue::String(String::new()));
+
+        let c = s.create_node("Company");
+        let _ = s.set_node_property("default", c, "name".to_string(), PropertyValue::String("Acme".into()));
+
+        let e1 = s.create_edge(a, c, "WORKS_AT").unwrap();
+        let _ = s.set_edge_property(e1, "since", PropertyValue::Integer(2019));
+        let e2 = s.create_edge(b, c, "WORKS_AT").unwrap();
+        let _ = s.set_edge_property(e2, "since", PropertyValue::Integer(2021));
+        let _ = s.create_edge(a, b, "KNOWS").unwrap();
+    }
+
+    let built = vec![
+        Built { name: "cypher", store: cypher_store },
+        Built { name: "snapshot", store: snapshot_store },
+        Built { name: "store_api", store: api_store },
+    ];
+
+    // The Cypher-built graph is the reference: it is the path a user exercises
+    // and the one whose behaviour is specified by the language.
+    let reference = &built[0];
+    let mut results: Vec<(String, String, bool, String, String)> = Vec::new();
+
+    for (probe_name, cypher) in probes() {
+        let expected = rows(&reference.store, cypher);
+        for other in &built[1..] {
+            let got = rows(&other.store, cypher);
+            let agrees = got == expected;
+            results.push((
+                probe_name.to_string(),
+                other.name.to_string(),
+                agrees,
+                format!("{expected:?}"),
+                format!("{got:?}"),
+            ));
+        }
+    }
+
+    // ---- Canary.
+    //
+    // Every invariant agreeing is the expected outcome, which makes this
+    // suite indistinguishable from one that compares nothing. So a graph that
+    // is deliberately wrong in one small way is run through the same probes,
+    // and the suite fails if the probes *fail to notice*. Without this, a
+    // refactor that broke `rows()` would turn CH-IMPORT permanently green.
+    let mut canary_store = GraphStore::new();
+    write(&mut canary_store, CYPHER_BUILD);
+    // One property differs by one, on one node. Nothing else changes: same
+    // counts, same labels, same edges.
+    write(&mut canary_store, "MATCH (n {name: 'Alice'}) SET n.age = 31");
+    let canary_detected = probes()
+        .iter()
+        .any(|(_, cypher)| rows(&canary_store, cypher) != rows(&reference.store, *cypher));
+
+    let total = results.len();
+    let agreed = results.iter().filter(|r| r.2).count();
+
+    println!("CH-IMPORT — cross-path import invariants");
+    println!("{}", "=".repeat(78));
+    println!("paths: cypher (reference), snapshot, store_api");
+    println!("{:<26} {:<12} {}", "probe", "path", "agrees");
+    println!("{}", "-".repeat(78));
+    for (probe, path, agrees, expected, got) in &results {
+        println!("{:<26} {:<12} {}", probe, path, if *agrees { "yes" } else { "NO" });
+        if !agrees {
+            println!("    reference: {}", truncate(expected));
+            println!("    {:<9}: {}", path, truncate(got));
+        }
+    }
+    println!("{}", "-".repeat(78));
+    println!("{agreed}/{total} invariants agree across paths");
+    println!(
+        "canary (one property changed by one): {}",
+        if canary_detected { "detected — the probes can fail" } else { "NOT DETECTED — the probes are vacuous" }
+    );
+
+    if let Some(path) = json_path {
+        let commit = std::process::Command::new("git")
+            .args(["rev-parse", "--short", "HEAD"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .unwrap_or_else(|| "unknown".into());
+        let mut cases = String::new();
+        for (probe, p, agrees, expected, got) in &results {
+            if !cases.is_empty() {
+                cases.push_str(",\n      ");
+            }
+            let _ = write!(
+                cases,
+                "{{\"probe\": \"{probe}\", \"path\": \"{p}\", \"agrees\": {agrees}, \
+                 \"reference\": \"{}\", \"got\": \"{}\"}}",
+                escape(&truncate(expected)),
+                escape(&truncate(got))
+            );
+        }
+        let envelope = format!(
+            "{{
+  \"suite\": \"import-invariants\",
+  \"requirement_ids\": [\"LANG-15\", \"REL-06\"],
+  \"run_id\": \"import-{commit}\",
+  \"engine\": {{\"name\": \"samyama\", \"version\": \"{}\", \"commit\": \"{commit}\"}},
+  \"dataset\": {{\"name\": \"synthetic-fixture\", \"paths\": [\"cypher\", \"snapshot\", \"store_api\"]}},
+  \"measurements\": {{\"agreed\": {agreed}, \"total\": {total}, \"canary_detected\": {canary_detected}, \"cases\": [
+      {cases}
+  ]}},
+  \"status\": \"{}\",
+  \"artifacts\": [\"examples/import_invariants.rs\"]
+}}
+",
+            env!("CARGO_PKG_VERSION"),
+            if agreed == total && canary_detected { "pass" } else { "fail" }
+        );
+        std::fs::write(&path, envelope).expect("could not write JSON");
+        println!("wrote {path}");
+    }
+
+    if agreed != total || !canary_detected {
+        std::process::exit(1);
+    }
+}
+
+fn truncate(s: &str) -> String {
+    if s.chars().count() <= 160 {
+        s.to_string()
+    } else {
+        s.chars().take(160).collect::<String>() + "…"
+    }
+}
+
+fn escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// A BTreeMap keeps the histogram output stable; kept as a type alias so the
+/// intent is visible where it is used.
+#[allow(dead_code)]
+type Histogram = BTreeMap<String, usize>;

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -524,6 +524,16 @@ pub struct ReturnClause {
     pub distinct: bool,
 }
 
+/// The variable name standing for `RETURN *` / `WITH *` between parsing and
+/// star expansion.
+///
+/// A sentinel rather than a new `Expression` variant because `*` is not a
+/// value and never survives into a plan: `expand_stars` replaces it with the
+/// variables in scope immediately after parsing, so nothing downstream can
+/// encounter it. `*` is not a legal identifier in Cypher, so the sentinel
+/// cannot collide with a user variable.
+pub const STAR_ITEM: &str = "*";
+
 /// Return item: n, n.name AS name, count(n)
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReturnItem {

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -121,6 +121,13 @@ pub struct Query {
     pub foreach_clause: Option<ForeachClause>,
     /// UNWIND clause (optional)
     pub unwind_clause: Option<UnwindClause>,
+    /// Further `UNWIND`s written directly after the first, in order.
+    ///
+    /// Each is a cross product with everything before it. Kept beside
+    /// `unwind_clause` rather than replacing it with a `Vec` because the
+    /// single-UNWIND field is read in a dozen places that only ever care
+    /// about the first one.
+    pub extra_unwind_clauses: Vec<UnwindClause>,
     /// Whether the UNWIND *led* the statement (`UNWIND ... MATCH ...`) rather than
     /// following the match. The AST keeps a single `unwind_clause` with no position, but
     /// the two orders plan differently: a leading UNWIND must bind its variable before the
@@ -711,6 +718,7 @@ impl Query {
             params: HashMap::new(),
             foreach_clause: None,
             unwind_clause: None,
+            extra_unwind_clauses: Vec::new(),
             unwind_leading: false,
             merge_clause: None,
             union_queries: Vec::new(),

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -637,6 +637,14 @@ pub struct MergeClause {
     pub on_create_set: Vec<SetItem>,
     /// ON MATCH SET items
     pub on_match_set: Vec<SetItem>,
+    /// Labels added by `ON CREATE SET n:Label`.
+    ///
+    /// Separate from `on_create_set` for the same reason `SetClause` keeps
+    /// `label_items` apart from `items`: the property form is read by field in
+    /// several places and an enum would touch all of them.
+    pub on_create_labels: Vec<SetLabelItem>,
+    /// Labels added by `ON MATCH SET n:Label`.
+    pub on_match_labels: Vec<SetLabelItem>,
 }
 
 /// WITH clause

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -64,9 +64,15 @@ yield_item = { variable ~ (^"AS" ~ variable)? }
 // MERGE statement: MERGE (n:Person {name: "Alice"}) ON CREATE SET ... ON MATCH SET ...
 // A bare `SET` after MERGE applies whichever branch was taken, unlike ON CREATE / ON
 // MATCH which are branch-specific. Only the branch-specific forms were accepted.
-merge_stmt = { ^"MERGE" ~ pattern ~ on_create_set? ~ on_match_set? ~ set_clause* ~ remove_clause* ~ return_clause? }
-on_create_set = { ^"ON" ~ ^"CREATE" ~ ^"SET" ~ set_item ~ ("," ~ set_item)* }
-on_match_set = { ^"ON" ~ ^"MATCH" ~ ^"SET" ~ set_item ~ ("," ~ set_item)* }
+// `(on_create_set | on_match_set)*` rather than a fixed `ON CREATE` then
+// `ON MATCH`: Cypher lets them be written in either order, and requiring one
+// made `ON MATCH SET … ON CREATE SET …` a syntax error.
+merge_stmt = { ^"MERGE" ~ pattern ~ (on_create_set | on_match_set)* ~ set_clause* ~ remove_clause* ~ return_clause? }
+// `set_entry`, not `set_item`: `MERGE (a:L) ON MATCH SET a:M1` sets a label,
+// and restricting these to property assignment made the branch-specific forms
+// less capable than the bare `SET` on the same statement.
+on_create_set = { ^"ON" ~ ^"CREATE" ~ ^"SET" ~ set_entry ~ ("," ~ set_entry)* }
+on_match_set = { ^"ON" ~ ^"MATCH" ~ ^"SET" ~ set_entry ~ ("," ~ set_entry)* }
 
 // MATCH statement: sequence of reading clauses, optional write, finishing with RETURN
 match_stmt = { (optional_match_clause | match_clause)+ ~ where_clause? ~ call_clause? ~ unwind_clause? ~ ((optional_match_clause | match_clause)+ ~ where_clause?)* ~ (with_clause ~ unwind_clause? ~ ((optional_match_clause | match_clause)+ ~ where_clause?)*)* ~ create_clause? ~ merge_inline? ~ delete_clause? ~ foreach_clause? ~ set_clause* ~ remove_clause* ~ return_clause? ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
@@ -76,7 +82,7 @@ foreach_stmt = { foreach_clause }
 foreach_clause = { ^"FOREACH" ~ "(" ~ variable ~ in_op ~ expression ~ "|" ~ foreach_body+ ~ ")" }
 foreach_body = _{ set_clause | remove_clause | delete_clause | create_clause }
 unwind_clause = { ^"UNWIND" ~ expression ~ ^"AS" ~ variable }
-merge_inline = { ^"MERGE" ~ pattern ~ on_create_set? ~ on_match_set? }
+merge_inline = { ^"MERGE" ~ pattern ~ (on_create_set | on_match_set)* }
 // A statement that *begins* with UNWIND. UNWIND was already allowed after a MATCH or a
 // WITH, but a leading one had no rule to match, so the batch-write idiom
 // `UNWIND $rows AS row CREATE (...)` was a parse error at column 1. Same tail as
@@ -96,7 +102,10 @@ set_item = { property_access ~ "=" ~ expression }
 // `SET n:A` and `SET n:A:B`, mirroring `remove_item`'s label form (#596).
 set_label_item = { variable ~ (":" ~ label)+ }
 remove_clause = { ^"REMOVE" ~ remove_item ~ ("," ~ remove_item)* }
-remove_item = { property_access | variable ~ ":" ~ label }
+// `REMOVE n:L1:L3` removes both labels in one item, exactly as `SET n:A:B`
+// adds both. Accepting only one label made the multi-label form a syntax
+// error rather than a partial effect.
+remove_item = { property_access | variable ~ (":" ~ label)+ }
 return_clause = { ^"RETURN" ~ distinct? ~ return_items }
 distinct = { ^"DISTINCT" }
 order_by_clause = { ^"ORDER" ~ ^"BY" ~ order_items }

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -199,7 +199,11 @@ order_direction = { ^"ASC" | ^"DESC" }
 // parser give it a precedence between AND and the comparison operators.
 expression = { not_op* ~ term ~ (binary_op ~ not_op* ~ term)* }
 term = { unary_op* ~ primary ~ index_op* ~ postfix_op? }
-postfix_op = { ^"IS" ~ ^"NOT" ~ ^"NULL" | ^"IS" ~ ^"NULL" }
+// `n:Label` used as a *value*, not as a pattern: `WHERE n:Person`,
+// `RETURN n:Person AS isPerson`. It is a postfix on a term, which gives it a
+// tighter binding than any comparison — the same shape as `IS NULL`.
+postfix_op = { label_check | (^"IS" ~ ^"NOT" ~ ^"NULL") | (^"IS" ~ ^"NULL") }
+label_check = { (":" ~ label)+ }
 index_op = { "[" ~ (slice_op | expression) ~ "]" }
 slice_op = { slice_start ~ ".." ~ slice_end | slice_start ~ ".." | ".." ~ slice_end | ".." }
 slice_start = { expression }

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -49,7 +49,11 @@ options = { ^"OPTIONS" ~ "{" ~ property_list? ~ "}" }
 // CALL statement (Standalone or followed by MATCH)
 // `WHERE` may filter YIELDed variables directly. It previously only appeared inside
 // `match_stmt_partial`, so filtering a CALL's output required an intervening MATCH.
-call_stmt = { (call_subquery | call_clause) ~ where_clause? ~ match_stmt_partial? ~ return_clause? }
+// `ORDER BY` / `SKIP` / `LIMIT` after the RETURN, as every other statement
+// allows. Without them `CALL pagerank(...) YIELD nodeId, score RETURN ...
+// ORDER BY score DESC LIMIT 10` — the example in our own README — was a
+// syntax error.
+call_stmt = { (call_subquery | call_clause) ~ where_clause? ~ match_stmt_partial? ~ return_clause? ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
 match_stmt_partial = { ^"MATCH" ~ pattern ~ where_clause? }
 
 // CALL subquery: CALL { MATCH ... RETURN ... }

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -120,10 +120,18 @@ labels = { (":" ~ label)+ }
 label = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 // Edge pattern: -[:KNOWS]-> or <-[:KNOWS]- or -[:KNOWS]-
+//
+// The bracket is **optional**: `-->`, `<--` and `--` are ordinary Cypher and
+// mean "an edge of any type, unbound". Requiring `edge_detail` made
+// `MATCH (a)-->(b)` — about the simplest pattern there is — a syntax error,
+// which is invisible in a codebase whose own queries always name a type.
+//
+// Alternative order matters and is not arbitrary: `-` `->` must be tried
+// before `-` `-`, or `-->` matches the undirected form and leaves a stray `>`.
 edge_pattern = {
-    ("<-" ~ edge_detail ~ "-") |
-    ("-" ~ edge_detail ~ "->") |
-    ("-" ~ edge_detail ~ "-")
+    ("<-" ~ edge_detail? ~ "-") |
+    ("-" ~ edge_detail? ~ "->") |
+    ("-" ~ edge_detail? ~ "-")
 }
 edge_detail = { "[" ~ variable? ~ edge_types? ~ length_pattern? ~ properties? ~ "]" }
 edge_types = { ":" ~ edge_type ~ (("|" | ":") ~ edge_type)* }
@@ -147,8 +155,14 @@ expression_continues = { "+" | "-" | "*" | "/" | "%" | "." | "[" | "=" | "<" | "
 property_key = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 // RETURN items
+//
+// `star_item` must be tried before `expression`, because `*` would otherwise
+// be consumed as the start of a multiplication and fail on the missing
+// left-hand side. `RETURN *, extra` is legal, so the star is an item rather
+// than a replacement for the whole list.
 return_items = { return_item ~ ("," ~ return_item)* }
-return_item = { expression ~ (^"AS" ~ variable)? }
+return_item = { star_item | (expression ~ (^"AS" ~ variable)?) }
+star_item = { "*" }
 
 // ORDER BY items
 order_items = { order_item ~ ("," ~ order_item)* }

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -87,7 +87,10 @@ merge_inline = { ^"MERGE" ~ pattern ~ (on_create_set | on_match_set)* }
 // WITH, but a leading one had no rule to match, so the batch-write idiom
 // `UNWIND $rows AS row CREATE (...)` was a parse error at column 1. Same tail as
 // `match_stmt`, with the leading MATCH group optional rather than required.
-unwind_stmt = { unwind_clause ~ ((optional_match_clause | match_clause)+ ~ where_clause?)* ~ (with_clause ~ unwind_clause? ~ ((optional_match_clause | match_clause)+ ~ where_clause?)*)* ~ create_clause? ~ merge_inline? ~ delete_clause? ~ foreach_clause? ~ set_clause* ~ remove_clause* ~ return_clause? ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
+// `unwind_clause+`: consecutive UNWINDs are a cross product —
+// `UNWIND [1,2] AS a UNWIND [3,4] AS b` yields four rows — and the TCK leans
+// on the three-way form to enumerate the truth tables for AND/OR/XOR.
+unwind_stmt = { unwind_clause+ ~ ((optional_match_clause | match_clause)+ ~ where_clause?)* ~ (with_clause ~ unwind_clause? ~ ((optional_match_clause | match_clause)+ ~ where_clause?)*)* ~ create_clause? ~ merge_inline? ~ delete_clause? ~ foreach_clause? ~ set_clause* ~ remove_clause* ~ return_clause? ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
 match_clause = { ^"MATCH" ~ pattern }
 optional_match_clause = { ^"OPTIONAL" ~ ^"MATCH" ~ pattern }
 where_clause = { ^"WHERE" ~ expression }

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -113,7 +113,14 @@ skip_clause = { ^"SKIP" ~ integer }
 limit_clause = { ^"LIMIT" ~ integer }
 
 // Standalone CREATE clause
-create_stmt = { ^"CREATE" ~ pattern ~ return_clause? }
+// Adjacent `CREATE` clauses are one create: `CREATE (a) CREATE (b)` and
+// `CREATE (a), (b)` mean the same thing, and a variable bound by an earlier
+// one refers to the same node. The parser merges the patterns, so nothing
+// downstream needs to know which spelling was used.
+//
+// Every TCK fixture is written with repeated CREATE clauses, which is why 197
+// scenarios were skipped for "setup did not parse" rather than being judged.
+create_stmt = { create_clause+ ~ return_clause? ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
 
 // Pattern matching
 pattern = { named_path ~ ("," ~ named_path)* }

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -481,8 +481,32 @@ impl<'a> MutQueryExecutor<'a> {
             return Ok(QueryExecutor::explain_plan_with_stats(&plan, Some(store_ref)));
         }
 
-        // Execute the plan with mutable access
-        self.execute_plan_mut(plan)
+        // Execute the plan with mutable access.
+        //
+        // A write statement with no RETURN produces **no rows**. `CREATE ()`
+        // returns an empty result and one new node; it does not return the
+        // node. We were emitting a row per created entity, so 34 TCK
+        // scenarios whose whole assertion is "the result should be empty"
+        // failed while the side effect was perfectly correct.
+        //
+        // The plan is still driven to exhaustion — the rows are what is
+        // discarded, not the work. Discarding earlier would skip the writes.
+        let batch = self.execute_plan_mut(plan)?;
+        // Scoped to **data writes**, not to "any query without a RETURN".
+        // Two neighbours produce rows with no RETURN and must keep doing so:
+        // `CALL … YIELD` yields its results, and DDL such as
+        // `CREATE HIERARCHY INDEX …` reports the encoding it chose. Widening
+        // the rule to every RETURN-less query broke both, which is why it is
+        // written as the narrow thing it actually is.
+        let is_data_write = query.create_clause.is_some()
+            || query.merge_clause.is_some()
+            || !query.set_clauses.is_empty()
+            || !query.remove_clauses.is_empty()
+            || query.delete_clause.is_some();
+        if is_data_write && query.return_clause.is_none() && query.call_clause.is_none() {
+            return Ok(RecordBatch { records: Vec::new(), columns: Vec::new() });
+        }
+        Ok(batch)
     }
 
     fn execute_plan_mut(&mut self, mut plan: ExecutionPlan) -> ExecutionResult<RecordBatch> {
@@ -769,7 +793,11 @@ mod tests {
         let result = executor.execute(&query);
         assert!(result.is_ok(), "MERGE create failed: {:?}", result.err());
         let batch = result.unwrap();
-        assert_eq!(batch.records.len(), 1);
+        // A data write with no RETURN yields no rows — the side effect is the
+        // point. This asserted 1 row and was pinning the older behaviour; 34
+        // TCK scenarios whose entire assertion is "the result should be empty"
+        // were failing against it while the write itself was correct.
+        assert_eq!(batch.records.len(), 0, "MERGE without RETURN returns no rows");
 
         // Verify node was created
         let nodes = store.get_nodes_by_label(&Label::new("Person"));

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -9217,6 +9217,10 @@ pub struct MergeOperator {
     pattern: Pattern,
     on_create_set: Vec<(String, String, Expression)>,
     on_match_set: Vec<(String, String, Expression)>,
+    /// `(variable, labels)` from `ON CREATE SET n:Label`.
+    on_create_labels: Vec<(String, Vec<Label>)>,
+    /// `(variable, labels)` from `ON MATCH SET n:Label`.
+    on_match_labels: Vec<(String, Vec<Label>)>,
     executed: bool,
 }
 
@@ -9225,8 +9229,40 @@ impl MergeOperator {
         pattern: Pattern,
         on_create_set: Vec<(String, String, Expression)>,
         on_match_set: Vec<(String, String, Expression)>,
+        on_create_labels: Vec<(String, Vec<Label>)>,
+        on_match_labels: Vec<(String, Vec<Label>)>,
     ) -> Self {
-        Self { pattern, on_create_set, on_match_set, executed: false }
+        Self {
+            pattern,
+            on_create_set,
+            on_match_set,
+            on_create_labels,
+            on_match_labels,
+            executed: false,
+        }
+    }
+
+    /// Add the labels an `ON CREATE` / `ON MATCH` branch asks for.
+    ///
+    /// Resolved through the record rather than against a single variable name,
+    /// because a MERGE pattern binds several variables and the branch may name
+    /// any of them.
+    fn apply_labels(
+        items: &[(String, Vec<Label>)],
+        record: &Record,
+        store: &mut GraphStore,
+        tenant_id: &str,
+    ) {
+        for (var, labels) in items {
+            let node_id = match record.get(var) {
+                Some(Value::NodeRef(id)) => *id,
+                Some(Value::Node(id, _)) => *id,
+                _ => continue,
+            };
+            for label in labels {
+                let _ = store.add_label_to_node(tenant_id, node_id, label.clone());
+            }
+        }
     }
 
     /// Does a node satisfy the pattern's labels and inline properties?
@@ -9312,6 +9348,8 @@ impl MergeOperator {
             }
             let sets = self.on_match_set.clone();
             self.apply_sets(&sets, &record, store, tenant_id)?;
+            let labels = self.on_match_labels.clone();
+            Self::apply_labels(&labels, &record, store, tenant_id);
             return Ok(Some(record));
         }
 
@@ -9480,6 +9518,7 @@ impl PhysicalOperator for MergeOperator {
                     }
                 }
             }
+            Self::apply_labels(&self.on_match_labels, &record, store, tenant_id);
         } else {
             let label_str = labels.first().map(|l| l.as_str()).unwrap_or("Node");
             node_id = store.create_node(label_str);
@@ -9511,6 +9550,7 @@ impl PhysicalOperator for MergeOperator {
                     }
                 }
             }
+            Self::apply_labels(&self.on_create_labels, &record, store, tenant_id);
         }
 
         Ok(Some(record))

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1420,6 +1420,45 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                 _ => Err(ExecutionError::TypeError("id() requires node or edge".to_string())),
             }
         }
+        // `n:A:B` as a value, produced by the parser's postfix label check.
+        // True when the node carries *every* named label; null when the
+        // subject is null, following Cypher's three-valued logic.
+        "haslabels" => {
+            let wanted: Vec<String> = match &args[1] {
+                Value::Property(PropertyValue::Array(items)) => items
+                    .iter()
+                    .filter_map(|v| match v {
+                        PropertyValue::String(s) => Some(s.clone()),
+                        _ => None,
+                    })
+                    .collect(),
+                _ => return Err(ExecutionError::TypeError("hasLabels expects a label list".into())),
+            };
+            let node = match &args[0] {
+                Value::Node(_, n) => Some((**n).clone()),
+                Value::NodeRef(id) => {
+                    let s = store.ok_or_else(|| {
+                        ExecutionError::RuntimeError("hasLabels on NodeRef requires store".into())
+                    })?;
+                    s.get_node(*id).cloned()
+                }
+                Value::Property(PropertyValue::Null) => {
+                    return Ok(Value::Property(PropertyValue::Null))
+                }
+                _ => {
+                    return Err(ExecutionError::TypeError(
+                        "a label test requires a node".to_string(),
+                    ))
+                }
+            };
+            let Some(node) = node else {
+                return Ok(Value::Property(PropertyValue::Null));
+            };
+            let has_all = wanted
+                .iter()
+                .all(|w| node.labels.iter().any(|l| l.as_str() == w));
+            Ok(Value::Property(PropertyValue::Boolean(has_all)))
+        }
         "labels" => {
             match &args[0] {
                 Value::Node(_, node) => {

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -893,11 +893,19 @@ impl QueryPlanner {
                 let on_match: Vec<(String, String, Expression)> = merge_clause.on_match_set.iter()
                     .map(|s| (s.variable.clone(), s.property.clone(), s.value.clone()))
                     .collect();
+                let on_create_labels: Vec<(String, Vec<Label>)> = merge_clause.on_create_labels.iter()
+                    .map(|l| (l.variable.clone(), l.labels.clone()))
+                    .collect();
+                let on_match_labels: Vec<(String, Vec<Label>)> = merge_clause.on_match_labels.iter()
+                    .map(|l| (l.variable.clone(), l.labels.clone()))
+                    .collect();
 
                 let mut operator: OperatorBox = Box::new(MergeOperator::new(
                     merge_clause.pattern.clone(),
                     on_create,
                     on_match,
+                    on_create_labels,
+                    on_match_labels,
                 ));
 
                 // A bare `SET` after MERGE applies on both branches, unlike ON CREATE /
@@ -1890,8 +1898,22 @@ impl QueryPlanner {
                 ));
             } else {
                 // Node-only MERGE: use existing MergeOperator with input
+                let on_create_labels: Vec<(String, Vec<Label>)> = merge_clause
+                    .on_create_labels
+                    .iter()
+                    .map(|l| (l.variable.clone(), l.labels.clone()))
+                    .collect();
+                let on_match_labels: Vec<(String, Vec<Label>)> = merge_clause
+                    .on_match_labels
+                    .iter()
+                    .map(|l| (l.variable.clone(), l.labels.clone()))
+                    .collect();
                 operator = Box::new(MergeOperator::new(
-                    merge_clause.pattern.clone(), on_create, on_match,
+                    merge_clause.pattern.clone(),
+                    on_create,
+                    on_match,
+                    on_create_labels,
+                    on_match_labels,
                 ));
             }
             true

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2004,7 +2004,12 @@ impl QueryPlanner {
                 && query.match_clauses[0].pattern.paths[0].start.labels.is_empty()
                 && query.match_clauses[0].pattern.paths[0].segments[0].node.labels.is_empty()
                 && matches!(&group_by[0].0, Expression::Function { name, args, .. }
-                    if name == "type" && args.len() == 1 && matches!(&args[0], Expression::Variable(_)));
+                    if name == "type" && args.len() == 1 && matches!(&args[0], Expression::Variable(_)))
+                // Directed only — see the note on `use_edge_count` below.
+                && !matches!(
+                    query.match_clauses[0].pattern.paths[0].segments[0].edge.direction,
+                    Direction::Both
+                );
 
             // O(1) count for a single edge type (or all edges): the metadata that already
             // answers `type(r), count(r)` and node label counts can answer this too, but
@@ -2046,7 +2051,23 @@ impl QueryPlanner {
                     Expression::Literal(_) => true,
                     Expression::Variable(v) => Some(v) == edge_var.as_ref(),
                     _ => false,
-                };
+                }
+                // Last, because it indexes into the pattern and every check
+                // that guarantees those indices exist is above it. Placing it
+                // earlier panicked on `UNWIND [1,2,3] AS x RETURN max(x)`,
+                // which has no match clause at all.
+                //
+                // Both fast paths read the edge count straight off the store,
+                // which counts each edge once. An **undirected** pattern
+                // matches every edge twice — once from each end — so
+                // `MATCH (a)--(b) RETURN count(*)` over two edges is 4, not 2.
+                // Doubling here would then have to reason about self-loops, so
+                // the fast path is restricted to directed patterns and the
+                // general operator answers the rest.
+                && !matches!(
+                    query.match_clauses[0].pattern.paths[0].segments[0].edge.direction,
+                    Direction::Both
+                );
 
             if use_edge_count {
                 let edge_type = query.match_clauses[0].pattern.paths[0].segments[0]

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1702,6 +1702,9 @@ impl QueryPlanner {
              -> String {
                 match &node.variable {
                     Some(v) if matched_vars.contains(v) => v.clone(),
+                    // Already registered by an earlier path in this same
+                    // CREATE — reuse it rather than creating a second node.
+                    Some(v) if nodes_to_create.iter().any(|(h, ..)| h == v) => v.clone(),
                     Some(v) => {
                         nodes_to_create.push((
                             v.clone(),
@@ -3637,6 +3640,17 @@ impl QueryPlanner {
             }
         };
 
+        // A variable bound earlier in the *same* CREATE refers to the node
+        // already being created, not to a new one:
+        //
+        //     CREATE (a), (b), (a)-[:R]->(b)
+        //
+        // creates two nodes and one edge. Re-registering `a` and `b` for
+        // creation made it four nodes — the edge was correct, so the query
+        // succeeded and quietly doubled the graph. This is the shape every
+        // TCK fixture and most of our own loaders are written in.
+        let mut created_vars: HashSet<String> = HashSet::new();
+
         for path in &pattern.paths {
             // Add start node
             let start = &path.start;
@@ -3644,9 +3658,16 @@ impl QueryPlanner {
             let properties: HashMap<String, PropertyValue> = start.properties.clone().unwrap_or_default();
             let variable = start.variable.clone();
 
-            // Track output column if variable exists
+            let start_already_bound = variable
+                .as_ref()
+                .is_some_and(|v| created_vars.contains(v));
+
+            // Track output column if variable exists — once per variable, since
+            // a repeat mention is the same node.
             if let Some(ref var) = variable {
-                output_columns.push(var.clone());
+                if !start_already_bound {
+                    output_columns.push(var.clone());
+                }
             }
 
             // Only the *named* variable reaches output_columns above; the synthetic one is
@@ -3655,12 +3676,17 @@ impl QueryPlanner {
                 Some(v) => v.clone(),
                 None => next_anon(&declared),
             };
-            nodes_to_create.push((
-                labels,
-                properties,
-                Some(start_handle.clone()),
-                start.property_exprs.clone(),
-            ));
+            if !start_already_bound {
+                if let Some(v) = &variable {
+                    created_vars.insert(v.clone());
+                }
+                nodes_to_create.push((
+                    labels,
+                    properties,
+                    Some(start_handle.clone()),
+                    start.property_exprs.clone(),
+                ));
+            }
 
             // Track current source variable for edge creation
             let mut current_source_var = Some(start_handle);
@@ -3673,20 +3699,31 @@ impl QueryPlanner {
                 let node_properties: HashMap<String, PropertyValue> = node.properties.clone().unwrap_or_default();
                 let node_variable = node.variable.clone();
 
+                let node_already_bound = node_variable
+                    .as_ref()
+                    .is_some_and(|v| created_vars.contains(v));
+
                 if let Some(ref var) = node_variable {
-                    output_columns.push(var.clone());
+                    if !node_already_bound {
+                        output_columns.push(var.clone());
+                    }
                 }
 
                 let node_handle = match &node_variable {
                     Some(v) => v.clone(),
                     None => next_anon(&declared),
                 };
-                nodes_to_create.push((
-                    node_labels,
-                    node_properties,
-                    Some(node_handle.clone()),
-                    node.property_exprs.clone(),
-                ));
+                if !node_already_bound {
+                    if let Some(v) = &node_variable {
+                        created_vars.insert(v.clone());
+                    }
+                    nodes_to_create.push((
+                        node_labels,
+                        node_properties,
+                        Some(node_handle.clone()),
+                        node.property_exprs.clone(),
+                    ));
+                }
 
                 // Extract edge information
                 let edge = &segment.edge;

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1244,6 +1244,19 @@ impl QueryPlanner {
                     unwind.variable.clone(),
                 )));
                 known_vars.insert(unwind.variable.clone());
+
+                // A run of UNWINDs at the head of the query: each expands the
+                // rows the previous produced, giving the cross product the TCK
+                // uses to enumerate three-variable truth tables.
+                for extra in &query.extra_unwind_clauses {
+                    let base = operator.take().expect("previous UNWIND produced an operator");
+                    operator = Some(Box::new(UnwindOperator::new(
+                        base,
+                        extra.expression.clone(),
+                        extra.variable.clone(),
+                    )));
+                    known_vars.insert(extra.variable.clone());
+                }
             }
         }
 
@@ -1645,6 +1658,16 @@ impl QueryPlanner {
                     unwind_clause.expression.clone(),
                     unwind_clause.variable.clone(),
                 ));
+                // Consecutive UNWINDs stack: each one expands the rows the
+                // previous produced, so `UNWIND [1,2] AS a UNWIND [3,4] AS b`
+                // is four rows and not two.
+                for extra in &query.extra_unwind_clauses {
+                    operator = Box::new(UnwindOperator::new(
+                        operator,
+                        extra.expression.clone(),
+                        extra.variable.clone(),
+                    ));
+                }
             }
         }
 
@@ -5157,6 +5180,7 @@ mod tests {
             create_clause: None,
             order_by: None,
             limit: None,
+            extra_unwind_clauses: Vec::new(),
             skip: None,
             call_clause: None,
             call_subquery: None,

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -71,6 +71,7 @@
 
 pub mod ast;
 pub mod parser;
+pub mod star;
 pub mod executor;
 
 use std::num::NonZeroUsize;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -72,6 +72,7 @@
 pub mod ast;
 pub mod parser;
 pub mod star;
+pub mod validate;
 pub mod executor;
 
 use std::num::NonZeroUsize;

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -874,24 +874,34 @@ fn parse_delete_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<DeleteC
     Ok(DeleteClause { expressions, detach })
 }
 
+/// `variable (":" label)+` — the label form of a SET item.
+///
+/// Shared by `SET`, `ON CREATE SET` and `ON MATCH SET`. Kept as one function
+/// because the last time these were parsed in two places the copies drifted
+/// and one of them silently dropped items it did not recognise.
+fn parse_set_label_item(pair: pest::iterators::Pair<Rule>) -> ParseResult<SetLabelItem> {
+    let mut variable = String::new();
+    let mut labels = Vec::new();
+    for sl in pair.into_inner() {
+        match sl.as_rule() {
+            Rule::variable => variable = sl.as_str().to_string(),
+            Rule::label => labels.push(Label::new(sl.as_str())),
+            _ => {}
+        }
+    }
+    if labels.is_empty() {
+        return Err(ParseError::SemanticError("SET label item has no label".to_string()));
+    }
+    Ok(SetLabelItem { variable, labels })
+}
+
 fn parse_set_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<SetClause> {
     let mut items = Vec::new();
     let mut label_items: Vec<SetLabelItem> = Vec::new();
 
     for inner in pair.into_inner() {
         if inner.as_rule() == Rule::set_label_item {
-            let mut variable = String::new();
-            let mut labels = Vec::new();
-            for sl in inner.into_inner() {
-                match sl.as_rule() {
-                    Rule::variable => variable = sl.as_str().to_string(),
-                    Rule::label => labels.push(Label::new(sl.as_str())),
-                    _ => {}
-                }
-            }
-            if !labels.is_empty() {
-                label_items.push(SetLabelItem { variable, labels });
-            }
+            label_items.push(parse_set_label_item(inner)?);
             continue;
         }
         if inner.as_rule() == Rule::set_item {
@@ -946,17 +956,23 @@ fn parse_remove_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<RemoveC
                 }
                 items.push(RemoveItem::Property { variable, property });
             } else {
-                // variable : label
+                // `variable (":" label)+` — one item per label, so
+                // `REMOVE n:L1:L3` removes both rather than only the first.
                 let mut variable = String::new();
-                let mut label = String::new();
+                let mut labels = Vec::new();
                 for child in children {
                     match child.as_rule() {
                         Rule::variable => variable = child.as_str().to_string(),
-                        Rule::label => label = child.as_str().to_string(),
+                        Rule::label => labels.push(child.as_str().to_string()),
                         _ => {}
                     }
                 }
-                items.push(RemoveItem::Label { variable, label: Label::new(&label) });
+                for label in labels {
+                    items.push(RemoveItem::Label {
+                        variable: variable.clone(),
+                        label: Label::new(&label),
+                    });
+                }
             }
         }
     }
@@ -987,21 +1003,27 @@ fn parse_merge_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
     let mut pattern = None;
     let mut on_create_set = Vec::new();
     let mut on_match_set = Vec::new();
+    let mut on_create_labels = Vec::new();
+    let mut on_match_labels = Vec::new();
 
     for inner in pair.into_inner() {
         match inner.as_rule() {
             Rule::pattern => pattern = Some(parse_pattern(inner)?),
             Rule::on_create_set => {
                 for si in inner.into_inner() {
-                    if si.as_rule() == Rule::set_item {
-                        on_create_set.push(parse_set_item(si)?);
+                    match si.as_rule() {
+                        Rule::set_item => on_create_set.push(parse_set_item(si)?),
+                        Rule::set_label_item => on_create_labels.push(parse_set_label_item(si)?),
+                        _ => {}
                     }
                 }
             }
             Rule::on_match_set => {
                 for si in inner.into_inner() {
-                    if si.as_rule() == Rule::set_item {
-                        on_match_set.push(parse_set_item(si)?);
+                    match si.as_rule() {
+                        Rule::set_item => on_match_set.push(parse_set_item(si)?),
+                        Rule::set_label_item => on_match_labels.push(parse_set_label_item(si)?),
+                        _ => {}
                     }
                 }
             }
@@ -1026,6 +1048,8 @@ fn parse_merge_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
         pattern: pattern.ok_or_else(|| ParseError::SemanticError("MERGE missing pattern".to_string()))?,
         on_create_set,
         on_match_set,
+        on_create_labels,
+        on_match_labels,
     });
     Ok(())
 }
@@ -1034,21 +1058,27 @@ fn parse_merge_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<MergeCla
     let mut pattern = None;
     let mut on_create_set = Vec::new();
     let mut on_match_set = Vec::new();
+    let mut on_create_labels = Vec::new();
+    let mut on_match_labels = Vec::new();
 
     for inner in pair.into_inner() {
         match inner.as_rule() {
             Rule::pattern => pattern = Some(parse_pattern(inner)?),
             Rule::on_create_set => {
                 for si in inner.into_inner() {
-                    if si.as_rule() == Rule::set_item {
-                        on_create_set.push(parse_set_item(si)?);
+                    match si.as_rule() {
+                        Rule::set_item => on_create_set.push(parse_set_item(si)?),
+                        Rule::set_label_item => on_create_labels.push(parse_set_label_item(si)?),
+                        _ => {}
                     }
                 }
             }
             Rule::on_match_set => {
                 for si in inner.into_inner() {
-                    if si.as_rule() == Rule::set_item {
-                        on_match_set.push(parse_set_item(si)?);
+                    match si.as_rule() {
+                        Rule::set_item => on_match_set.push(parse_set_item(si)?),
+                        Rule::set_label_item => on_match_labels.push(parse_set_label_item(si)?),
+                        _ => {}
                     }
                 }
             }
@@ -1063,6 +1093,8 @@ fn parse_merge_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<MergeCla
         pattern: pattern.ok_or_else(|| ParseError::SemanticError("MERGE missing pattern".to_string()))?,
         on_create_set,
         on_match_set,
+        on_create_labels,
+        on_match_labels,
     })
 }
 

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -158,6 +158,13 @@ pub fn parse_query(input: &str) -> ParseResult<Query> {
     // `crate::query::star`.
     crate::query::star::expand_stars(&mut query);
 
+    // Checks the grammar cannot express — duplicate result columns, UNION
+    // arity, CREATE over an already-bound variable. Reported as a parse
+    // failure because that is what they are to a caller: the query was never
+    // well-formed, and running it would answer a question nobody asked.
+    crate::query::validate::validate(&query)
+        .map_err(|e| ParseError::SemanticError(e.to_string()))?;
+
     Ok(query)
 }
 

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1801,16 +1801,46 @@ fn parse_term(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
 
             // Apply postfix operator (IS NULL / IS NOT NULL)
             if let Some(postfix) = postfix_pair {
-                let text = postfix.as_str().to_uppercase();
-                let op = if text.contains("NOT") {
-                    UnaryOp::IsNotNull
+                // `n:A:B` — a label test used as a boolean value. Desugared to
+                // a function call rather than given its own `Expression`
+                // variant: a new variant would have to be handled by every
+                // exhaustive match over `Expression`, and this needs no
+                // information a call cannot carry.
+                // The labels sit two levels down: postfix_op → label_check →
+                // label. Reading only the first level found nothing and fell
+                // through to the `IS NULL` branch, so `n:A` silently became
+                // `n IS NULL` — a wrong answer rather than a parse error.
+                let labels: Vec<PropertyValue> = postfix
+                    .clone()
+                    .into_inner()
+                    .flat_map(|p| {
+                        if p.as_rule() == Rule::label_check {
+                            p.into_inner().collect::<Vec<_>>()
+                        } else {
+                            vec![p]
+                        }
+                    })
+                    .filter(|p| p.as_rule() == Rule::label)
+                    .map(|p| PropertyValue::String(p.as_str().to_string()))
+                    .collect();
+                if !labels.is_empty() {
+                    expr = Expression::Function {
+                        name: "hasLabels".to_string(),
+                        args: vec![expr, Expression::Literal(PropertyValue::Array(labels))],
+                        distinct: false,
+                    };
                 } else {
-                    UnaryOp::IsNull
-                };
-                expr = Expression::Unary {
-                    op,
-                    expr: Box::new(expr),
-                };
+                    let text = postfix.as_str().to_uppercase();
+                    let op = if text.contains("NOT") {
+                        UnaryOp::IsNotNull
+                    } else {
+                        UnaryOp::IsNull
+                    };
+                    expr = Expression::Unary {
+                        op,
+                        expr: Box::new(expr),
+                    };
+                }
             }
 
             // Apply prefix operators in reverse order (innermost first)

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -803,18 +803,52 @@ fn parse_match_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
 }
 
 fn parse_create_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -> ParseResult<()> {
+    // Adjacent CREATE clauses are merged into one pattern. They are equivalent
+    // by definition — `CREATE (a) CREATE (b)` and `CREATE (a), (b)` bind the
+    // same variables to the same nodes — and merging means the planner and the
+    // executor never learn that repeated clauses exist. The alternative,
+    // `Vec<CreateClause>` on the AST, would touch 36 call sites, most of them
+    // `is_some()` guards asking only "is this a write query".
+    let mut paths = Vec::new();
     for inner in pair.into_inner() {
         match inner.as_rule() {
-            Rule::pattern => {
-                query.create_clause = Some(CreateClause {
-                    pattern: parse_pattern(inner)?,
-                });
+            // A bare `CREATE` statement yields `pattern` directly; a repeated
+            // one yields `create_clause` wrappers.
+            Rule::pattern => paths.extend(parse_pattern(inner)?.paths),
+            Rule::create_clause => {
+                for c in inner.into_inner() {
+                    if c.as_rule() == Rule::pattern {
+                        paths.extend(parse_pattern(c)?.paths);
+                    }
+                }
             }
             Rule::return_clause => {
                 query.return_clause = Some(parse_return_clause(inner)?);
             }
+            Rule::order_by_clause => {
+                query.order_by = Some(parse_order_by_clause(inner)?);
+            }
+            Rule::skip_clause => {
+                for i in inner.into_inner() {
+                    if i.as_rule() == Rule::integer {
+                        query.skip = i.as_str().parse::<usize>().ok();
+                    }
+                }
+            }
+            Rule::limit_clause => {
+                for i in inner.into_inner() {
+                    if i.as_rule() == Rule::integer {
+                        query.limit = i.as_str().parse::<usize>().ok();
+                    }
+                }
+            }
             _ => {}
         }
+    }
+    if !paths.is_empty() {
+        query.create_clause = Some(CreateClause {
+            pattern: crate::query::ast::Pattern { paths },
+        });
     }
     Ok(())
 }

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -770,7 +770,14 @@ fn parse_match_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
                 query.remove_clauses.push(parse_remove_clause(inner)?);
             }
             Rule::unwind_clause => {
-                query.unwind_clause = Some(parse_unwind_clause(inner)?);
+                // The first UNWIND stays in `unwind_clause`; the rest queue up
+                // behind it, each a cross product with everything before.
+                let u = parse_unwind_clause(inner)?;
+                if query.unwind_clause.is_none() {
+                    query.unwind_clause = Some(u);
+                } else {
+                    query.extra_unwind_clauses.push(u);
+                }
             }
             Rule::merge_inline => {
                 query.merge_clause = Some(parse_merge_clause(inner)?);

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -153,6 +153,11 @@ pub fn parse_query(input: &str) -> ParseResult<Query> {
         }
     }
 
+    // `RETURN *` / `WITH *` are resolved here rather than in the planner, so
+    // that nothing downstream has to know the sentinel exists. See
+    // `crate::query::star`.
+    crate::query::star::expand_stars(&mut query);
+
     Ok(query)
 }
 
@@ -1089,22 +1094,19 @@ fn parse_set_item(pair: pest::iterators::Pair<Rule>) -> ParseResult<SetItem> {
     })
 }
 
+/// Parse a `RETURN` / `WITH` item list.
+///
+/// Delegates to `parse_return_item` rather than repeating its body. The two
+/// had drifted: this one matched only `expression` and `variable` and dropped
+/// anything else *silently* (`if let Some(e) = expr`), so when `star_item` was
+/// added `WITH *` parsed to an empty projection and the query failed at
+/// runtime with "Variable not found" — a grammar addition that looked like an
+/// executor bug. One implementation cannot drift from itself.
 fn parse_return_items(pair: pest::iterators::Pair<Rule>) -> ParseResult<Vec<ReturnItem>> {
     let mut items = Vec::new();
     for inner in pair.into_inner() {
         if inner.as_rule() == Rule::return_item {
-            let mut expr = None;
-            let mut alias = None;
-            for ri in inner.into_inner() {
-                match ri.as_rule() {
-                    Rule::expression => expr = Some(parse_expression(ri)?),
-                    Rule::variable => alias = Some(ri.as_str().to_string()),
-                    _ => {}
-                }
-            }
-            if let Some(e) = expr {
-                items.push(ReturnItem { expression: e, alias });
-            }
+            items.push(parse_return_item(inner)?);
         }
     }
     Ok(items)
@@ -1521,6 +1523,9 @@ fn parse_return_item(pair: pest::iterators::Pair<Rule>) -> ParseResult<ReturnIte
 
     for inner in pair.into_inner() {
         match inner.as_rule() {
+            Rule::star_item => {
+                expression = Some(Expression::Variable(crate::query::ast::STAR_ITEM.to_string()));
+            }
             Rule::expression => {
                 expression = Some(parse_expression(inner)?);
             }

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -567,6 +567,23 @@ fn parse_call_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) ->
             Rule::return_clause => {
                 query.return_clause = Some(parse_return_clause(inner)?);
             }
+            Rule::order_by_clause => {
+                query.order_by = Some(parse_order_by_clause(inner)?);
+            }
+            Rule::skip_clause => {
+                for i in inner.into_inner() {
+                    if i.as_rule() == Rule::integer {
+                        query.skip = i.as_str().parse::<usize>().ok();
+                    }
+                }
+            }
+            Rule::limit_clause => {
+                for i in inner.into_inner() {
+                    if i.as_rule() == Rule::integer {
+                        query.limit = i.as_str().parse::<usize>().ok();
+                    }
+                }
+            }
             _ => {}
         }
     }

--- a/src/query/star.rs
+++ b/src/query/star.rs
@@ -91,16 +91,27 @@ fn expand_into(items: &mut Vec<ReturnItem>, scope: &[String]) {
     if !has_star(items) {
         return;
     }
+
+    // Names the query projects explicitly, wherever they appear relative to
+    // the star. `RETURN *, n` must not yield two `n` columns, and checking
+    // only the items already emitted misses that case entirely — the star
+    // comes first, so at that point nothing has been emitted yet. Collected up
+    // front instead.
+    let explicit: Vec<String> = items
+        .iter()
+        .filter(|i| !is_star(i))
+        .filter_map(|i| match (&i.alias, &i.expression) {
+            (Some(alias), _) => Some(alias.clone()),
+            (None, Expression::Variable(v)) => Some(v.clone()),
+            _ => None,
+        })
+        .collect();
+
     let mut out: Vec<ReturnItem> = Vec::with_capacity(items.len() + scope.len());
     for item in items.drain(..) {
         if is_star(&item) {
             for name in scope {
-                // A variable already projected explicitly is not repeated:
-                // `RETURN *, n` must not yield two `n` columns.
-                if out.iter().any(|i: &ReturnItem| {
-                    i.alias.as_deref() == Some(name.as_str())
-                        || matches!(&i.expression, Expression::Variable(v) if v == name)
-                }) {
+                if explicit.iter().any(|e| e == name) {
                     continue;
                 }
                 out.push(ReturnItem {

--- a/src/query/star.rs
+++ b/src/query/star.rs
@@ -1,0 +1,189 @@
+//! Expansion of `RETURN *` and `WITH *` (TCK: `Return*`, `With*`, `Match*`).
+//!
+//! `*` means "every variable currently in scope". Scope is decidable from the
+//! AST alone — a variable enters scope when a pattern, `UNWIND` or `CALL …
+//! YIELD` binds it, and a `WITH` **replaces** scope with exactly the items it
+//! projects. So the star is expanded here, immediately after parsing, and no
+//! part of the planner or executor ever sees one.
+//!
+//! Doing it as a separate pass rather than inside the planner matters because
+//! the planner has a dozen branches that each build their own projection list;
+//! teaching every one of them about `*` would mean twelve chances to get scope
+//! wrong, and the branch nobody exercised would be the one that silently
+//! dropped a column.
+//!
+//! Ordering is insertion order — the order the variables were bound — which is
+//! what Neo4j and Memgraph produce and what the TCK's ordered scenarios
+//! expect. Deduplicated, because `MATCH (a)-->(b), (b)-->(c)` binds `b` twice.
+
+use crate::query::ast::{
+    Expression, MatchClause, Query, ReturnItem, UnwindClause, WithClause, STAR_ITEM,
+};
+
+/// Whether an item is the `*` sentinel.
+fn is_star(item: &ReturnItem) -> bool {
+    matches!(&item.expression, Expression::Variable(v) if v == STAR_ITEM) && item.alias.is_none()
+}
+
+/// Whether a list of items contains one.
+fn has_star(items: &[ReturnItem]) -> bool {
+    items.iter().any(is_star)
+}
+
+/// Push `name` if it is not already present. Scope is a set, but an ordered
+/// one.
+fn push_unique(scope: &mut Vec<String>, name: &str) {
+    if !scope.iter().any(|s| s == name) {
+        scope.push(name.to_string());
+    }
+}
+
+/// Every variable a MATCH pattern binds, in the order it is written.
+///
+/// Edge variables count: `MATCH (a)-[r]->(b) RETURN *` returns `r` too. Missing
+/// them is the easy mistake here, and it is invisible until a scenario returns
+/// two columns instead of three.
+fn bind_match(scope: &mut Vec<String>, clauses: &[MatchClause]) {
+    for mc in clauses {
+        for path in &mc.pattern.paths {
+            if let Some(v) = &path.path_variable {
+                push_unique(scope, v);
+            }
+            if let Some(v) = &path.start.variable {
+                push_unique(scope, v);
+            }
+            for seg in &path.segments {
+                if let Some(v) = &seg.edge.variable {
+                    push_unique(scope, v);
+                }
+                if let Some(v) = &seg.node.variable {
+                    push_unique(scope, v);
+                }
+            }
+        }
+    }
+}
+
+fn bind_unwind(scope: &mut Vec<String>, unwind: Option<&UnwindClause>) {
+    if let Some(u) = unwind {
+        push_unique(scope, &u.variable);
+    }
+}
+
+/// The names a WITH projects — its aliases, or the expression itself when it
+/// is a bare variable. Anything else without an alias cannot be referred to
+/// later, so it does not enter scope.
+fn with_output(items: &[ReturnItem]) -> Vec<String> {
+    let mut out = Vec::new();
+    for item in items {
+        if let Some(alias) = &item.alias {
+            push_unique(&mut out, alias);
+        } else if let Expression::Variable(v) = &item.expression {
+            push_unique(&mut out, v);
+        }
+    }
+    out
+}
+
+/// Replace the `*` item in `items` with one item per name in `scope`,
+/// preserving any other items written alongside it.
+fn expand_into(items: &mut Vec<ReturnItem>, scope: &[String]) {
+    if !has_star(items) {
+        return;
+    }
+    let mut out: Vec<ReturnItem> = Vec::with_capacity(items.len() + scope.len());
+    for item in items.drain(..) {
+        if is_star(&item) {
+            for name in scope {
+                // A variable already projected explicitly is not repeated:
+                // `RETURN *, n` must not yield two `n` columns.
+                if out.iter().any(|i: &ReturnItem| {
+                    i.alias.as_deref() == Some(name.as_str())
+                        || matches!(&i.expression, Expression::Variable(v) if v == name)
+                }) {
+                    continue;
+                }
+                out.push(ReturnItem {
+                    expression: Expression::Variable(name.clone()),
+                    alias: None,
+                });
+            }
+        } else {
+            out.push(item);
+        }
+    }
+    *items = out;
+}
+
+/// Expand every `*` in `query`, in place.
+///
+/// Walks the query in execution order so that each star sees the scope that
+/// actually reaches it, including through `WITH` stages that narrow it.
+pub fn expand_stars(query: &mut Query) {
+    let mut scope: Vec<String> = Vec::new();
+
+    // Only the matches *before* the first WITH are in scope when that WITH is
+    // evaluated; the rest are added after it narrows scope.
+    let pre_with = query
+        .with_split_index
+        .unwrap_or(query.match_clauses.len())
+        .min(query.match_clauses.len());
+    bind_match(&mut scope, &query.match_clauses[..pre_with]);
+    bind_unwind(&mut scope, query.unwind_clause.as_ref());
+    if let Some(call) = &query.call_clause {
+        for item in &call.yield_items {
+            push_unique(&mut scope, item.alias.as_ref().unwrap_or(&item.name));
+        }
+    }
+    if let Some(create) = &query.create_clause {
+        // `CREATE (n) RETURN *` returns the created node.
+        for path in &create.pattern.paths {
+            if let Some(v) = &path.start.variable {
+                push_unique(&mut scope, v);
+            }
+            for seg in &path.segments {
+                if let Some(v) = &seg.edge.variable {
+                    push_unique(&mut scope, v);
+                }
+                if let Some(v) = &seg.node.variable {
+                    push_unique(&mut scope, v);
+                }
+            }
+        }
+    }
+
+    // A WITH narrows scope to what it projects, so its own `*` is expanded
+    // against the scope that reaches it, and everything after sees only its
+    // output.
+    let mut apply_with = |wc: &mut WithClause, scope: &mut Vec<String>| {
+        expand_into(&mut wc.items, scope);
+        *scope = with_output(&wc.items);
+    };
+
+    if query.with_clause.is_none() {
+        // No WITH: every match is in scope, including any the split index
+        // would have excluded.
+        bind_match(&mut scope, &query.match_clauses);
+    }
+
+    if let Some(wc) = query.with_clause.as_mut() {
+        apply_with(wc, &mut scope);
+        // Matches written after the WITH re-bind into the narrowed scope. The
+        // AST keeps every MATCH in one list and records the boundary in
+        // `with_split_index`, so the tail is what follows the WITH.
+        let split = query.with_split_index.unwrap_or(query.match_clauses.len());
+        if split < query.match_clauses.len() {
+            bind_match(&mut scope, &query.match_clauses[split..]);
+        }
+    }
+
+    for (wc, unwind, post_matches, _) in query.extra_with_stages.iter_mut() {
+        apply_with(wc, &mut scope);
+        bind_unwind(&mut scope, unwind.as_ref());
+        bind_match(&mut scope, post_matches);
+    }
+
+    if let Some(rc) = query.return_clause.as_mut() {
+        expand_into(&mut rc.items, &scope);
+    }
+}

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -1,0 +1,170 @@
+//! Semantic checks the grammar cannot express (openCypher TCK negative cases).
+//!
+//! A parser that accepts everything is not lenient, it is wrong: the TCK has
+//! 55 scenarios whose entire assertion is *"this query must be rejected"*, and
+//! an engine that runs them anyway gives an answer to a question that was
+//! never well-formed. Two of those answers are actively dangerous —
+//! `RETURN a AS x, b AS x` silently drops a column, and `CREATE (a:Foo)` over
+//! a variable already bound by `MATCH` reads as "add a label" when Cypher
+//! says it is an error.
+//!
+//! Only rules that are **unambiguous and local** live here. Scope analysis
+//! ("is this variable defined?") is deliberately absent: getting it slightly
+//! wrong would reject valid queries, which is a far worse failure than
+//! accepting an invalid one, and this engine's own benchmarks and loaders
+//! would be the first casualties.
+
+use std::collections::HashSet;
+
+use crate::query::ast::{Expression, Query};
+
+/// Why a query was rejected. Carries the offending name so the message can
+/// say which one rather than that something, somewhere, was wrong.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ValidationError {
+    DuplicateColumn(String),
+    UnionColumnMismatch { left: Vec<String>, right: Vec<String> },
+    MixedUnionAndUnionAll,
+    CreateOnBoundVariable(String),
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DuplicateColumn(name) => write!(
+                f,
+                "Multiple result columns with the same name are not supported: `{name}`"
+            ),
+            Self::UnionColumnMismatch { left, right } => write!(
+                f,
+                "All sub queries in an UNION must have the same column names: {left:?} vs {right:?}"
+            ),
+            Self::MixedUnionAndUnionAll => write!(
+                f,
+                "Cannot mix UNION and UNION ALL in the same query"
+            ),
+            Self::CreateOnBoundVariable(name) => write!(
+                f,
+                "Variable `{name}` already declared; CREATE cannot add labels or properties to it"
+            ),
+        }
+    }
+}
+
+/// The column name a return item produces, if it has one that can collide.
+///
+/// An unaliased expression like `count(*)` has a generated name that Cypher
+/// does not treat as a user-visible column for collision purposes, so only
+/// aliases and bare variables are considered.
+fn column_name(item: &crate::query::ast::ReturnItem) -> Option<String> {
+    if let Some(alias) = &item.alias {
+        return Some(alias.clone());
+    }
+    match &item.expression {
+        Expression::Variable(v) => Some(v.clone()),
+        _ => None,
+    }
+}
+
+fn columns(query: &Query) -> Vec<String> {
+    query
+        .return_clause
+        .as_ref()
+        .map(|rc| rc.items.iter().filter_map(column_name).collect())
+        .unwrap_or_default()
+}
+
+/// Variables a MATCH clause binds — the ones a later CREATE must not redeclare.
+fn matched_variables(query: &Query) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for mc in &query.match_clauses {
+        for path in &mc.pattern.paths {
+            if let Some(v) = &path.start.variable {
+                out.insert(v.clone());
+            }
+            for seg in &path.segments {
+                if let Some(v) = &seg.edge.variable {
+                    out.insert(v.clone());
+                }
+                if let Some(v) = &seg.node.variable {
+                    out.insert(v.clone());
+                }
+            }
+        }
+    }
+    out
+}
+
+pub fn validate(query: &Query) -> Result<(), ValidationError> {
+    // ---- Duplicate result columns.
+    //
+    // `RETURN a AS x, b AS x` cannot be answered: one of the two columns has
+    // to win, and whichever it is, the caller silently loses data.
+    let cols = columns(query);
+    let mut seen: HashSet<&str> = HashSet::new();
+    for c in &cols {
+        if !seen.insert(c.as_str()) {
+            return Err(ValidationError::DuplicateColumn(c.clone()));
+        }
+    }
+    if let Some(wc) = &query.with_clause {
+        let mut seen: HashSet<String> = HashSet::new();
+        for item in &wc.items {
+            if let Some(name) = column_name(item) {
+                if !seen.insert(name.clone()) {
+                    return Err(ValidationError::DuplicateColumn(name));
+                }
+            }
+        }
+    }
+
+    // ---- UNION: same columns on both sides, and one flavour throughout.
+    if !query.union_queries.is_empty() {
+        let flavours: HashSet<bool> = query.union_queries.iter().map(|(_, all)| *all).collect();
+        if flavours.len() > 1 {
+            return Err(ValidationError::MixedUnionAndUnionAll);
+        }
+        for (sub, _) in &query.union_queries {
+            let right = columns(sub);
+            // An empty column list means the sub-query had no RETURN this
+            // check can read; leaving it alone keeps the rule to what it can
+            // actually see.
+            if !cols.is_empty() && !right.is_empty() && cols != right {
+                return Err(ValidationError::UnionColumnMismatch {
+                    left: cols.clone(),
+                    right,
+                });
+            }
+            validate(sub)?;
+        }
+    }
+
+    // ---- CREATE over a variable a MATCH already bound.
+    //
+    // `MATCH (a) CREATE (a:Foo)` looks like "add a label" and is not: Cypher
+    // requires SET for that, and the CREATE form is an error. A *bare*
+    // re-mention — `MATCH (a), (b) CREATE (a)-[:R]->(b)` — is how you write
+    // an edge between matched nodes and stays legal.
+    if let Some(create) = &query.create_clause {
+        let bound = matched_variables(query);
+        for path in &create.pattern.paths {
+            let mut check = |np: &crate::query::ast::NodePattern| -> Result<(), ValidationError> {
+                if let Some(v) = &np.variable {
+                    let adds_something = !np.labels.is_empty()
+                        || np.properties.as_ref().is_some_and(|p| !p.is_empty())
+                        || np.property_exprs.as_ref().is_some_and(|p| !p.is_empty());
+                    if bound.contains(v) && adds_something {
+                        return Err(ValidationError::CreateOnBoundVariable(v.clone()));
+                    }
+                }
+                Ok(())
+            };
+            check(&path.start)?;
+            for seg in &path.segments {
+                check(&seg.node)?;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -26,6 +26,10 @@ pub enum ValidationError {
     UnionColumnMismatch { left: Vec<String>, right: Vec<String> },
     MixedUnionAndUnionAll,
     CreateOnBoundVariable(String),
+    CreateRelationshipWithoutType,
+    CreateUndirectedRelationship,
+    CreateVariableLengthRelationship,
+    CreateOnBoundRelationship(String),
 }
 
 impl std::fmt::Display for ValidationError {
@@ -46,6 +50,22 @@ impl std::fmt::Display for ValidationError {
             Self::CreateOnBoundVariable(name) => write!(
                 f,
                 "Variable `{name}` already declared; CREATE cannot add labels or properties to it"
+            ),
+            Self::CreateRelationshipWithoutType => write!(
+                f,
+                "Exactly one relationship type must be specified for CREATE"
+            ),
+            Self::CreateUndirectedRelationship => write!(
+                f,
+                "Only directed relationships are supported in CREATE"
+            ),
+            Self::CreateVariableLengthRelationship => write!(
+                f,
+                "Variable length relationships cannot be created"
+            ),
+            Self::CreateOnBoundRelationship(name) => write!(
+                f,
+                "Variable `{name}` already declared; CREATE cannot rebind a relationship"
             ),
         }
     }
@@ -147,6 +167,35 @@ pub fn validate(query: &Query) -> Result<(), ValidationError> {
     // an edge between matched nodes and stays legal.
     if let Some(create) = &query.create_clause {
         let bound = matched_variables(query);
+
+        // A relationship being *created* has to say exactly what it is. These
+        // are ambiguous rather than merely unsupported: `CREATE (a)-->(b)`
+        // does not say what kind of edge to make, `CREATE (a)-[:R]-(b)` does
+        // not say which way it points, and `CREATE (a)-[:R*2]->(b)` does not
+        // say what the intermediate node is. Cypher rejects all three, and
+        // accepting them means inventing an answer.
+        //
+        // Note this is only in CREATE. The same patterns are perfectly good in
+        // MATCH, where they mean "any type", "either direction" and "two
+        // hops" — which is why the check lives here and not in the grammar.
+        for path in &create.pattern.paths {
+            for seg in &path.segments {
+                if seg.edge.length.is_some() {
+                    return Err(ValidationError::CreateVariableLengthRelationship);
+                }
+                if seg.edge.types.len() != 1 {
+                    return Err(ValidationError::CreateRelationshipWithoutType);
+                }
+                if matches!(seg.edge.direction, crate::query::ast::Direction::Both) {
+                    return Err(ValidationError::CreateUndirectedRelationship);
+                }
+                if let Some(v) = &seg.edge.variable {
+                    if bound.contains(v) {
+                        return Err(ValidationError::CreateOnBoundRelationship(v.clone()));
+                    }
+                }
+            }
+        }
         for path in &create.pattern.paths {
             let mut check = |np: &crate::query::ast::NodePattern| -> Result<(), ValidationError> {
                 if let Some(v) = &np.variable {

--- a/tests/create_semantics.rs
+++ b/tests/create_semantics.rs
@@ -1,0 +1,128 @@
+//! `CREATE` binds a variable once, and adjacent `CREATE` clauses are one create.
+//!
+//! Both defects here were found by running the openCypher TCK: 197 scenarios
+//! were being **skipped** with "setup did not parse", and the reason was that
+//! every TCK fixture is written as a run of `CREATE` clauses. Fixing the
+//! parsing exposed the second, worse defect underneath it.
+//!
+//! ```cypher
+//! CREATE (a), (b), (a)-[:R]->(b)
+//! ```
+//!
+//! created **four** nodes. The third path re-registered `a` and `b` for
+//! creation instead of reusing the ones bound a moment earlier, so the query
+//! succeeded, the edge was correct, and the graph quietly had twice the nodes
+//! it should. Nothing in the result signalled it — you have to count.
+//!
+//! This is the shape most fixtures and loaders are written in, which is what
+//! makes it worth its own file.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn write(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).expect("query should parse");
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .expect("query should run");
+}
+
+fn scalar(store: &GraphStore, cypher: &str) -> i64 {
+    let q = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&q).expect("query should run");
+    match batch.records[0].get("c") {
+        Some(Value::Property(PropertyValue::Integer(n))) => *n,
+        other => panic!("expected an integer, got {other:?}"),
+    }
+}
+
+fn nodes(store: &GraphStore) -> i64 {
+    scalar(store, "MATCH (n) RETURN count(n) AS c")
+}
+
+fn edges(store: &GraphStore) -> i64 {
+    scalar(store, "MATCH ()-->() RETURN count(*) AS c")
+}
+
+#[test]
+fn a_variable_reused_inside_one_create_refers_to_the_same_node() {
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (a), (b), (a)-[:R]->(b)");
+    assert_eq!(nodes(&store), 2, "two nodes, not four");
+    assert_eq!(edges(&store), 1);
+}
+
+#[test]
+fn the_reused_node_keeps_the_labels_it_was_created_with() {
+    // Reusing must not mean "create it again with the second mention's
+    // labels", nor drop the first mention's.
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (a:A), (b:B), (a)-[:R]->(b)");
+    assert_eq!(nodes(&store), 2);
+    assert_eq!(scalar(&store, "MATCH (:A) RETURN count(*) AS c"), 1);
+    assert_eq!(scalar(&store, "MATCH (:B) RETURN count(*) AS c"), 1);
+    assert_eq!(scalar(&store, "MATCH (:A)-[:R]->(:B) RETURN count(*) AS c"), 1);
+}
+
+#[test]
+fn adjacent_create_clauses_mean_the_same_as_one_comma_separated_create() {
+    // The equivalence the parser relies on when it merges them.
+    let mut separate = GraphStore::new();
+    write(&mut separate, "CREATE (a) CREATE (b) CREATE (a)-[:R]->(b)");
+
+    let mut combined = GraphStore::new();
+    write(&mut combined, "CREATE (a), (b), (a)-[:R]->(b)");
+
+    assert_eq!(nodes(&separate), nodes(&combined));
+    assert_eq!(edges(&separate), edges(&combined));
+    assert_eq!(nodes(&separate), 2);
+    assert_eq!(edges(&separate), 1);
+}
+
+#[test]
+fn a_run_of_create_clauses_building_a_small_graph_lands_the_right_counts() {
+    // The fixture shape: one hub, several spokes, written as repeated
+    // clauses exactly as the TCK writes them.
+    let mut store = GraphStore::new();
+    write(
+        &mut store,
+        "CREATE (hub:Hub {n: 'h'}) \
+         CREATE (hub)-[:E]->(:Leaf {n: 'a'}) \
+         CREATE (hub)-[:E]->(:Leaf {n: 'b'}) \
+         CREATE (hub)-[:E]->(:Leaf {n: 'c'})",
+    );
+    assert_eq!(nodes(&store), 4, "one hub and three leaves");
+    assert_eq!(edges(&store), 3);
+    assert_eq!(scalar(&store, "MATCH (:Hub) RETURN count(*) AS c"), 1, "the hub is created once");
+}
+
+#[test]
+fn a_variable_bound_by_match_is_not_recreated() {
+    // The pre-existing rule this change had to preserve: MATCH-bound
+    // variables were already reused, and the fix must not double-create them
+    // or stop reusing them.
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (:Person {n: 'p'})");
+    write(&mut store, "MATCH (p:Person) CREATE (p)-[:OWNS]->(:Thing)");
+    assert_eq!(nodes(&store), 2);
+    assert_eq!(edges(&store), 1);
+    assert_eq!(scalar(&store, "MATCH (:Person) RETURN count(*) AS c"), 1);
+}
+
+#[test]
+fn anonymous_nodes_are_still_created_once_each() {
+    // Anonymous nodes have no variable to compare, so each mention is a
+    // distinct node. Deduplicating them would be the opposite bug.
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (), (), ()");
+    assert_eq!(nodes(&store), 3);
+}
+
+#[test]
+fn properties_on_the_first_mention_survive() {
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (a {v: 7}), (b), (a)-[:R]->(b)");
+    assert_eq!(nodes(&store), 2);
+    assert_eq!(scalar(&store, "MATCH (n) WHERE n.v = 7 RETURN count(*) AS c"), 1);
+}

--- a/tests/pattern_and_star_syntax.rs
+++ b/tests/pattern_and_star_syntax.rs
@@ -1,0 +1,194 @@
+//! Bare relationship arrows and `RETURN *` / `WITH *` (openCypher TCK).
+//!
+//! Both were found by running the TCK and grouping its failures by cause:
+//! 228 of 560 failures were the parser rejecting the query outright, and these
+//! two constructs accounted for the largest clusters.
+//!
+//! `MATCH (a)-->(b)` — about the simplest pattern in Cypher — was a **syntax
+//! error**, because the grammar required the bracket in `-[...]->`. That is
+//! invisible in a codebase whose own queries always name a relationship type,
+//! which is why every query in `benches/`, `examples/` and the existing tests
+//! passed while the engine could not parse the form every tutorial opens with.
+//!
+//! The tests below therefore assert on *results*, not on parsing: a pattern
+//! that parses and then matches the wrong thing is no better than one that
+//! does not parse.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn write(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).expect("setup should parse");
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .expect("setup should run");
+}
+
+fn count(store: &GraphStore, cypher: &str) -> i64 {
+    let q = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&q).expect("query should run");
+    match batch.records[0].get("c") {
+        Some(Value::Property(PropertyValue::Integer(n))) => *n,
+        other => panic!("expected an integer count, got {other:?}"),
+    }
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).expect("query should parse");
+    QueryExecutor::new(store).execute(&q).expect("query should run").records.len()
+}
+
+/// Column names of the first row, sorted.
+fn columns(store: &GraphStore, cypher: &str) -> Vec<String> {
+    let q = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&q).expect("query should run");
+    let mut cols: Vec<String> = batch
+        .records
+        .first()
+        .map(|r| r.bindings().iter().map(|(k, _)| k.to_string()).collect())
+        .unwrap_or_default();
+    cols.sort();
+    cols
+}
+
+/// `A -R-> B -S-> C`: two edges, three nodes, no cycles.
+fn chain() -> GraphStore {
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (:A {n: 'a'})-[:R]->(:B {n: 'b'})-[:S]->(:C {n: 'c'})");
+    store
+}
+
+// ---------------------------------------------------------------- bare arrows
+
+#[test]
+fn a_bare_outgoing_arrow_matches_each_edge_once() {
+    assert_eq!(count(&chain(), "MATCH (a)-->(b) RETURN count(*) AS c"), 2);
+}
+
+#[test]
+fn a_bare_incoming_arrow_matches_each_edge_once() {
+    assert_eq!(count(&chain(), "MATCH (a)<--(b) RETURN count(*) AS c"), 2);
+}
+
+#[test]
+fn a_bare_undirected_edge_matches_each_edge_from_both_ends() {
+    // The rule that makes the count fast-path unsafe: an undirected pattern
+    // binds (a=A,b=B) *and* (a=B,b=A).
+    assert_eq!(count(&chain(), "MATCH (a)--(b) RETURN count(*) AS c"), 4);
+    assert_eq!(rows(&chain(), "MATCH (a)--(b) RETURN a"), 4);
+}
+
+#[test]
+fn a_count_over_an_undirected_pattern_agrees_with_the_rows_it_counts() {
+    // `count(*)` had an O(1) fast path reading the edge count off the store,
+    // which counts each edge once. It disagreed with the query's own row count
+    // — 2 against 4 — and no test compared the two.
+    let store = chain();
+    for pattern in ["(a)--(b)", "()--()", "(a)-[:R]-(b)", "(a)-[r]-(b)"] {
+        let counted = count(&store, &format!("MATCH {pattern} RETURN count(*) AS c"));
+        let listed = rows(&store, &format!("MATCH {pattern} RETURN 1 AS x")) as i64;
+        assert_eq!(counted, listed, "count(*) disagreed with the rows for {pattern}");
+    }
+}
+
+#[test]
+fn a_count_over_a_directed_pattern_still_uses_the_fast_path_correctly() {
+    let store = chain();
+    for pattern in ["(a)-->(b)", "()-->()",  "(a)-[:R]->(b)"] {
+        let counted = count(&store, &format!("MATCH {pattern} RETURN count(*) AS c"));
+        let listed = rows(&store, &format!("MATCH {pattern} RETURN 1 AS x")) as i64;
+        assert_eq!(counted, listed, "{pattern}");
+    }
+}
+
+#[test]
+fn an_anonymous_undirected_chain_parses_and_traverses() {
+    // `(:A)-->()--()`: forward one hop, then either direction.
+    assert!(count(&chain(), "MATCH (:A)-->()--() RETURN count(*) AS c") > 0);
+}
+
+#[test]
+fn a_bare_arrow_binds_the_same_endpoints_as_the_bracketed_form() {
+    // The equivalence that makes the grammar change safe: `-->` is
+    // `-[]->` with no type filter.
+    let store = chain();
+    assert_eq!(
+        rows(&store, "MATCH (a)-->(b) RETURN a, b"),
+        rows(&store, "MATCH (a)-[]->(b) RETURN a, b"),
+    );
+    assert_eq!(
+        rows(&store, "MATCH (a)--(b) RETURN a, b"),
+        rows(&store, "MATCH (a)-[]-(b) RETURN a, b"),
+    );
+}
+
+#[test]
+fn a_typed_edge_still_filters_by_type() {
+    // Guard against the optional bracket making the type filter optional too.
+    assert_eq!(count(&chain(), "MATCH (a)-[:R]->(b) RETURN count(*) AS c"), 1);
+    assert_eq!(count(&chain(), "MATCH (a)-[:NOPE]->(b) RETURN count(*) AS c"), 0);
+}
+
+// ------------------------------------------------------------- RETURN */WITH *
+
+#[test]
+fn return_star_projects_every_bound_variable_including_edges() {
+    // Forgetting the edge variable is the easy mistake, and it shows up as a
+    // column silently missing rather than as an error.
+    assert_eq!(
+        columns(&chain(), "MATCH (a)-[r]->(b) RETURN *"),
+        vec!["a".to_string(), "b".to_string(), "r".to_string()]
+    );
+}
+
+#[test]
+fn return_star_includes_a_named_path() {
+    assert_eq!(
+        columns(&chain(), "MATCH p = (a)-[r]->(b) RETURN *"),
+        vec!["a".to_string(), "b".to_string(), "p".to_string(), "r".to_string()]
+    );
+}
+
+#[test]
+fn return_star_includes_an_unwind_variable() {
+    assert_eq!(columns(&GraphStore::new(), "UNWIND [1, 2] AS u RETURN *"), vec!["u".to_string()]);
+}
+
+#[test]
+fn return_star_alongside_an_explicit_item_does_not_duplicate_it() {
+    let store = chain();
+    assert_eq!(columns(&store, "MATCH (a:A) RETURN *, a"), vec!["a".to_string()]);
+    // An aliased expression is a new column, so both survive.
+    assert_eq!(
+        columns(&store, "MATCH (a:A) RETURN *, a.n AS name"),
+        vec!["a".to_string(), "name".to_string()]
+    );
+}
+
+#[test]
+fn with_star_passes_every_variable_through() {
+    // This returned zero columns and then failed at runtime with "Variable not
+    // found", because two copies of the item parser had drifted and the one
+    // used by `WITH` dropped item kinds it did not recognise — silently.
+    assert_eq!(
+        columns(&chain(), "MATCH (a)-[r]->(b) WITH * RETURN a, r, b"),
+        vec!["a".to_string(), "b".to_string(), "r".to_string()]
+    );
+}
+
+#[test]
+fn a_with_narrows_what_a_later_star_expands_to() {
+    // Scope, not "everything ever bound": after `WITH a.n AS name` only
+    // `name` exists.
+    assert_eq!(
+        columns(&chain(), "MATCH (a:A) WITH a.n AS name RETURN *"),
+        vec!["name".to_string()]
+    );
+}
+
+#[test]
+fn return_star_survives_order_by() {
+    let store = chain();
+    assert_eq!(rows(&store, "MATCH (n) RETURN * ORDER BY n.n"), 3);
+}

--- a/tests/pattern_and_star_syntax.rs
+++ b/tests/pattern_and_star_syntax.rs
@@ -192,3 +192,91 @@ fn return_star_survives_order_by() {
     let store = chain();
     assert_eq!(rows(&store, "MATCH (n) RETURN * ORDER BY n.n"), 3);
 }
+
+// ---------------------------------------------------------- SET / REMOVE / MERGE
+
+#[test]
+fn remove_strips_every_label_named_in_one_item() {
+    // `REMOVE n:L1:L3` was a syntax error: the grammar accepted a single
+    // label where `SET n:A:B` already accepted several.
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (:L1:L2:L3)");
+    write(&mut store, "MATCH (n) REMOVE n:L1:L3");
+
+    let q = parse_query("MATCH (n) RETURN labels(n) AS l").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&q).unwrap();
+    match batch.records[0].get("l") {
+        Some(Value::Property(PropertyValue::Array(items))) => {
+            let got: Vec<String> = items
+                .iter()
+                .map(|v| match v {
+                    PropertyValue::String(s) => s.clone(),
+                    other => panic!("{other:?}"),
+                })
+                .collect();
+            assert_eq!(got, vec!["L2"], "only the labels named are removed");
+        }
+        other => panic!("expected a label list, got {other:?}"),
+    }
+}
+
+/// The labels of the single node in `store`, sorted.
+fn only_node_labels(store: &GraphStore) -> Vec<String> {
+    let q = parse_query("MATCH (n) RETURN labels(n) AS l").unwrap();
+    let batch = QueryExecutor::new(store).execute(&q).expect("query should run");
+    assert_eq!(batch.records.len(), 1, "fixture should hold exactly one node");
+    match batch.records[0].get("l") {
+        Some(Value::Property(PropertyValue::Array(items))) => {
+            let mut got: Vec<String> = items
+                .iter()
+                .map(|v| match v {
+                    PropertyValue::String(s) => s.clone(),
+                    other => panic!("{other:?}"),
+                })
+                .collect();
+            got.sort();
+            got
+        }
+        other => panic!("expected a label list, got {other:?}"),
+    }
+}
+
+#[test]
+fn merge_on_create_can_add_a_label() {
+    let mut store = GraphStore::new();
+    write(&mut store, "MERGE (a:L) ON MATCH SET a:M1 ON CREATE SET a:M2");
+    assert_eq!(only_node_labels(&store), vec!["L", "M2"], "the node was created");
+}
+
+#[test]
+fn merge_on_match_can_add_a_label() {
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (:L)");
+    write(&mut store, "MERGE (a:L) ON MATCH SET a:M1 ON CREATE SET a:M2");
+    assert_eq!(only_node_labels(&store), vec!["L", "M1"], "the node already existed");
+}
+
+#[test]
+fn merge_on_match_applies_on_the_path_that_has_an_input() {
+    // `MATCH () MERGE (…)` plans a different operator method from a bare
+    // `MERGE`, and only one of the two applied the labels. Both are exercised
+    // because the first fix looked complete and was not.
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (:L)");
+    write(&mut store, "MATCH () MERGE (a:L) ON MATCH SET a:M1 ON CREATE SET a:M2");
+    assert_eq!(only_node_labels(&store), vec!["L", "M1"]);
+}
+
+#[test]
+fn the_on_clauses_may_be_written_in_either_order() {
+    // The grammar fixed the order as ON CREATE then ON MATCH, so the other
+    // order — which the TCK uses — was a syntax error.
+    for clauses in [
+        "ON CREATE SET a:M2 ON MATCH SET a:M1",
+        "ON MATCH SET a:M1 ON CREATE SET a:M2",
+    ] {
+        let mut store = GraphStore::new();
+        write(&mut store, &format!("MERGE (a:L) {clauses}"));
+        assert_eq!(only_node_labels(&store), vec!["L", "M2"], "{clauses}");
+    }
+}

--- a/tests/query_validation.rs
+++ b/tests/query_validation.rs
@@ -212,3 +212,60 @@ fn a_map_literal_is_not_read_as_a_label_test() {
         Some(Value::Property(PropertyValue::Map(_)))
     ));
 }
+
+// ------------------------------------------------- CREATE relationship rules
+
+// A relationship being *created* has to say exactly what it is. These three
+// forms are ambiguous rather than merely unsupported, which is why Cypher
+// rejects them and why accepting them means inventing an answer:
+//
+//   CREATE (a)-->(b)        — what kind of edge?
+//   CREATE (a)-[:R]-(b)     — pointing which way?
+//   CREATE (a)-[:R*2]->(b)  — and what is the node in the middle?
+//
+// The same three patterns are perfectly good in MATCH, where they mean "any
+// type", "either direction" and "two hops". That asymmetry is the whole
+// reason the rule lives in validation and not in the grammar, and every test
+// below has a MATCH counterpart asserting the pattern still parses there.
+
+#[test]
+fn creating_a_relationship_requires_a_type() {
+    rejected("CREATE (a)-->(b)");
+    accepted("CREATE (a)-[:R]->(b)");
+    accepted("MATCH (a)-->(b) RETURN a");
+}
+
+#[test]
+fn creating_a_relationship_requires_a_direction() {
+    rejected("CREATE (a)-[:R]-(b)");
+    accepted("CREATE (a)-[:R]->(b)");
+    accepted("CREATE (a)<-[:R]-(b)");
+    accepted("MATCH (a)-[:R]-(b) RETURN a");
+}
+
+#[test]
+fn a_variable_length_relationship_cannot_be_created() {
+    rejected("CREATE (a)-[:R*2]->(b)");
+    rejected("CREATE (a)-[:R*]->(b)");
+    accepted("MATCH (a)-[:R*2]->(b) RETURN a");
+}
+
+#[test]
+fn create_may_not_rebind_a_matched_relationship() {
+    rejected("MATCH (a)-[r]->(b) CREATE (a)-[r:R]->(b)");
+    // A fresh name is fine.
+    accepted("MATCH (a)-[r]->(b) CREATE (a)-[r2:R]->(b)");
+}
+
+#[test]
+fn the_ordinary_create_forms_are_untouched() {
+    for q in [
+        "CREATE (a)-[:R]->(b)",
+        "CREATE (a:A)-[r:R {w: 1}]->(b:B)",
+        "CREATE (a), (b), (a)-[:R]->(b)",
+        "CREATE (h:Hub) CREATE (h)-[:E]->(:Leaf)",
+        "MATCH (a:P), (b:P) CREATE (a)-[:KNOWS]->(b)",
+    ] {
+        accepted(q);
+    }
+}

--- a/tests/query_validation.rs
+++ b/tests/query_validation.rs
@@ -1,0 +1,114 @@
+//! Queries that must be rejected (openCypher TCK negative scenarios).
+//!
+//! 55 TCK scenarios assert only that a query is refused. An engine that runs
+//! them anyway answers a question that was never well-formed, and two of those
+//! answers are actively harmful:
+//!
+//! * `RETURN a AS x, b AS x` — one column has to win, and the caller silently
+//!   loses the other;
+//! * `MATCH (a) CREATE (a:Foo)` — reads as "add a label", which is what `SET`
+//!   is for. Cypher makes it an error precisely because the intent is
+//!   ambiguous.
+//!
+//! The tests come in pairs on purpose. A validation rule is only worth having
+//! if it rejects the invalid form *and* leaves the valid one alone, and the
+//! expensive failure here is the second half: rejecting a legal query would
+//! break every loader and benchmark in this repo. That is also why scope
+//! analysis ("is this variable defined?") is deliberately not implemented —
+//! several TCK scenarios want it, and getting it slightly wrong costs more
+//! than the scenarios are worth.
+
+use samyama::query::parser::parse_query;
+
+#[track_caller]
+fn rejected(cypher: &str) {
+    assert!(
+        parse_query(cypher).is_err(),
+        "should have been rejected, but parsed: {cypher}"
+    );
+}
+
+#[track_caller]
+fn accepted(cypher: &str) {
+    assert!(
+        parse_query(cypher).is_ok(),
+        "should have been accepted, but was rejected: {cypher}"
+    );
+}
+
+#[test]
+fn two_result_columns_may_not_share_a_name() {
+    rejected("MATCH (a), (b) RETURN a AS x, b AS x");
+    rejected("MATCH (a) RETURN a, a");
+    accepted("MATCH (a), (b) RETURN a AS x, b AS y");
+}
+
+#[test]
+fn two_with_items_may_not_share_a_name() {
+    rejected("MATCH (a) WITH a AS x, a AS x RETURN x");
+    accepted("MATCH (a) WITH a AS x, a AS y RETURN x, y");
+}
+
+#[test]
+fn unaliased_expressions_do_not_collide_with_each_other() {
+    // Only aliases and bare variables produce a column name that can clash;
+    // two `count(*)` items are given generated names. Rejecting these would
+    // be over-reach.
+    accepted("MATCH (a) RETURN count(*), count(*)");
+}
+
+#[test]
+fn union_branches_must_have_the_same_columns() {
+    rejected("MATCH (a) RETURN a AS x UNION MATCH (b) RETURN b AS y");
+    accepted("MATCH (a) RETURN a AS x UNION MATCH (b) RETURN b AS x");
+}
+
+#[test]
+fn union_and_union_all_may_not_be_mixed() {
+    rejected(
+        "MATCH (a) RETURN a AS x UNION MATCH (b) RETURN b AS x \
+         UNION ALL MATCH (c) RETURN c AS x",
+    );
+    accepted("MATCH (a) RETURN a AS x UNION ALL MATCH (b) RETURN b AS x");
+}
+
+#[test]
+fn create_may_not_add_labels_to_a_variable_match_already_bound() {
+    rejected("MATCH (a) CREATE (a:Foo)");
+    rejected("MATCH (a) CREATE (a {x: 1})");
+}
+
+#[test]
+fn a_bare_re_mention_of_a_matched_variable_stays_legal() {
+    // This is how you write an edge between two matched nodes, and it is the
+    // single most common write query in this codebase. If the rule above ever
+    // starts rejecting it, every loader breaks.
+    accepted("MATCH (a) CREATE (a)");
+    accepted("MATCH (a), (b) CREATE (a)-[:R]->(b)");
+    accepted("MATCH (a:Person) CREATE (a)-[:OWNS]->(:Thing)");
+}
+
+#[test]
+fn reusing_a_variable_inside_one_create_stays_legal() {
+    // Bound by the CREATE itself rather than by a MATCH — legal, and the
+    // subject of its own test file.
+    accepted("CREATE (a), (b), (a)-[:R]->(b)");
+    accepted("CREATE (a:A), (b:B), (a)-[:R]->(b)");
+}
+
+#[test]
+fn ordinary_queries_are_unaffected() {
+    // A spot check across the shapes this repo actually runs, because the
+    // cost of a false rejection is much higher than the benefit of a true one.
+    for q in [
+        "MATCH (n) RETURN n",
+        "MATCH (a)-[r]->(b) RETURN *",
+        "MATCH (p:Person) WHERE p.age > 30 RETURN p.name AS name ORDER BY name LIMIT 10",
+        "UNWIND [1, 2] AS a UNWIND [3, 4] AS b RETURN a, b",
+        "MATCH (a) WITH a.x AS v, count(*) AS c WHERE c > 1 RETURN v, c",
+        "MERGE (a:L) ON CREATE SET a.n = 1 ON MATCH SET a.n = 2",
+        "MATCH (a) RETURN a.name AS name UNION ALL MATCH (b) RETURN b.name AS name",
+    ] {
+        accepted(q);
+    }
+}

--- a/tests/query_validation.rs
+++ b/tests/query_validation.rs
@@ -112,3 +112,103 @@ fn ordinary_queries_are_unaffected() {
         accepted(q);
     }
 }
+
+// ---------------------------------------------------------- label predicates
+
+// `n:Label` used as a *value* rather than as a pattern — `WHERE n:Person`,
+// `RETURN n:Person AS isPerson`. It parses as a postfix on a term, which puts
+// it at the same binding strength as `IS NULL`.
+//
+// The first implementation read the labels from the wrong nesting level, found
+// none, and fell through to the `IS NULL` branch — so `n:A` silently became
+// `n IS NULL`. It parsed, it ran, and it returned a plausible boolean. That is
+// why these tests assert the *value*, and assert both polarities.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+
+fn labelled_graph() -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (:A:B {n: 'ab'}), (:A {n: 'a'}), (:C {n: 'c'})").unwrap();
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("fixture should run");
+    store
+}
+
+fn one_bool(store: &GraphStore, cypher: &str) -> Option<bool> {
+    let q = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&q).expect("query should run");
+    match batch.records[0].get("r") {
+        Some(Value::Property(PropertyValue::Boolean(b))) => Some(*b),
+        Some(Value::Property(PropertyValue::Null)) => None,
+        other => panic!("expected a boolean, got {other:?}"),
+    }
+}
+
+fn names(store: &GraphStore, cypher: &str) -> Vec<String> {
+    let q = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&q).expect("query should run");
+    let mut out: Vec<String> = batch
+        .records
+        .iter()
+        .map(|r| match r.get("x") {
+            Some(Value::Property(PropertyValue::String(s))) => s.clone(),
+            other => panic!("expected a name, got {other:?}"),
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn a_label_test_returns_true_only_when_the_label_is_present() {
+    let store = labelled_graph();
+    assert_eq!(one_bool(&store, "MATCH (n) WHERE n.n = 'a' RETURN n:A AS r"), Some(true));
+    assert_eq!(one_bool(&store, "MATCH (n) WHERE n.n = 'a' RETURN n:C AS r"), Some(false));
+}
+
+#[test]
+fn a_multi_label_test_requires_every_label() {
+    let store = labelled_graph();
+    assert_eq!(one_bool(&store, "MATCH (n) WHERE n.n = 'ab' RETURN n:A:B AS r"), Some(true));
+    // `a` has A but not B, so the conjunction is false.
+    assert_eq!(one_bool(&store, "MATCH (n) WHERE n.n = 'a' RETURN n:A:B AS r"), Some(false));
+}
+
+#[test]
+fn a_label_test_filters_in_where() {
+    let store = labelled_graph();
+    assert_eq!(names(&store, "MATCH (n) WHERE n:A RETURN n.n AS x"), vec!["a", "ab"]);
+    assert_eq!(names(&store, "MATCH (n) WHERE n:A:B RETURN n.n AS x"), vec!["ab"]);
+    assert_eq!(names(&store, "MATCH (n) WHERE NOT n:C RETURN n.n AS x"), vec!["a", "ab"]);
+}
+
+#[test]
+fn parenthesising_a_label_test_changes_nothing() {
+    let store = labelled_graph();
+    assert_eq!(one_bool(&store, "MATCH (n) WHERE n.n = 'a' RETURN (n:A) AS r"), Some(true));
+}
+
+#[test]
+fn is_null_still_parses_as_is_null() {
+    // The regression the nesting bug caused: a label test that failed to read
+    // its labels became `IS NULL`. This pins the other direction — `IS NULL`
+    // must not become a label test.
+    let store = labelled_graph();
+    assert_eq!(one_bool(&store, "MATCH (n) WHERE n.n = 'a' RETURN n.missing IS NULL AS r"), Some(true));
+    assert_eq!(one_bool(&store, "MATCH (n) WHERE n.n = 'a' RETURN n.n IS NULL AS r"), Some(false));
+    assert_eq!(one_bool(&store, "MATCH (n) WHERE n.n = 'a' RETURN n.n IS NOT NULL AS r"), Some(true));
+}
+
+#[test]
+fn a_map_literal_is_not_read_as_a_label_test() {
+    // `:` is also the map-literal separator, so the postfix must not steal it.
+    let store = labelled_graph();
+    let q = parse_query("RETURN {a: 1, b: 2} AS m").expect("map literal should still parse");
+    let batch = QueryExecutor::new(&store).execute(&q).expect("query should run");
+    assert!(matches!(
+        batch.records[0].get("m"),
+        Some(Value::Property(PropertyValue::Map(_)))
+    ));
+}

--- a/tests/unwind_multiple.rs
+++ b/tests/unwind_multiple.rs
@@ -1,0 +1,104 @@
+//! Consecutive `UNWIND` clauses (openCypher TCK).
+//!
+//! `UNWIND [1,2] AS a UNWIND [3,4] AS b` is a cross product — four rows — and
+//! did not parse at all. The TCK leans on the three-way form to enumerate the
+//! truth tables for `AND`, `OR` and `XOR` over `{true, false, null}`, so a
+//! single missing construct accounted for the whole of `Boolean5` and much of
+//! `Comparison3`.
+//!
+//! The tests assert row *counts and contents*, because the failure mode of a
+//! chained operator is not "no rows" but "the wrong number of them" — an
+//! implementation that overwrote the previous binding instead of expanding it
+//! would return 2 rows here and look plausible.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn pairs(cypher: &str, cols: &[&str]) -> Vec<Vec<i64>> {
+    let store = GraphStore::new();
+    let q = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(&store).execute(&q).expect("query should run");
+    let mut out: Vec<Vec<i64>> = batch
+        .records
+        .iter()
+        .map(|r| {
+            cols.iter()
+                .map(|c| match r.get(c) {
+                    Some(Value::Property(PropertyValue::Integer(n))) => *n,
+                    other => panic!("expected an integer in {c}, got {other:?}"),
+                })
+                .collect()
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn two_unwinds_produce_the_cross_product() {
+    assert_eq!(
+        pairs("UNWIND [1, 2] AS a UNWIND [3, 4] AS b RETURN a, b", &["a", "b"]),
+        vec![vec![1, 3], vec![1, 4], vec![2, 3], vec![2, 4]],
+    );
+}
+
+#[test]
+fn three_unwinds_produce_the_three_way_cross_product() {
+    // The shape the TCK uses for truth tables. 2 x 2 x 2.
+    let rows = pairs(
+        "UNWIND [1, 2] AS a UNWIND [3, 4] AS b UNWIND [5, 6] AS c RETURN a, b, c",
+        &["a", "b", "c"],
+    );
+    assert_eq!(rows.len(), 8);
+    // Every combination appears exactly once.
+    let mut expected: Vec<Vec<i64>> = Vec::new();
+    for a in [1, 2] {
+        for b in [3, 4] {
+            for c in [5, 6] {
+                expected.push(vec![a, b, c]);
+            }
+        }
+    }
+    expected.sort();
+    assert_eq!(rows, expected);
+}
+
+#[test]
+fn a_later_unwind_expands_rather_than_replaces() {
+    // The plausible-looking wrong answer: an implementation that rebinds
+    // instead of chaining returns the length of the *last* list.
+    assert_eq!(
+        pairs("UNWIND [1, 2, 3] AS a UNWIND [9] AS b RETURN a, b", &["a", "b"]).len(),
+        3,
+    );
+    assert_eq!(
+        pairs("UNWIND [1] AS a UNWIND [7, 8, 9] AS b RETURN a, b", &["a", "b"]).len(),
+        3,
+    );
+}
+
+#[test]
+fn unwinding_an_empty_list_yields_no_rows() {
+    // A cross product with the empty set is empty, however many rows the
+    // earlier clauses produced.
+    assert!(pairs("UNWIND [1, 2] AS a UNWIND [] AS b RETURN a, b", &["a", "b"]).is_empty());
+}
+
+#[test]
+fn a_single_unwind_is_unchanged() {
+    assert_eq!(pairs("UNWIND [1, 2, 3] AS a RETURN a", &["a"]).len(), 3);
+}
+
+#[test]
+fn a_boolean_truth_table_over_three_variables_has_twenty_seven_rows() {
+    // The actual TCK shape, with nulls: 3 x 3 x 3.
+    let store = GraphStore::new();
+    let q = parse_query(
+        "UNWIND [true, false, null] AS a UNWIND [true, false, null] AS b \
+         UNWIND [true, false, null] AS c RETURN a, b, c",
+    )
+    .expect("query should parse");
+    let batch = QueryExecutor::new(&store).execute(&q).expect("query should run");
+    assert_eq!(batch.records.len(), 27);
+}

--- a/tests/write_result_shape.rs
+++ b/tests/write_result_shape.rs
@@ -1,0 +1,108 @@
+//! A data write with no `RETURN` returns no rows (openCypher TCK).
+//!
+//! `CREATE ()` produces one node and an **empty result**. It does not return
+//! the node — the side effect is the point, and the caller asked for nothing.
+//! We were emitting a row per created entity, so 34 TCK scenarios whose entire
+//! assertion is "the result should be empty" failed while the write itself was
+//! perfectly correct. Nothing about the graph was wrong; only the shape of the
+//! answer was.
+//!
+//! The rule is narrower than "no RETURN means no rows", and the narrowing is
+//! the interesting part. Two neighbours produce rows with no RETURN and must
+//! keep doing so:
+//!
+//! * `CALL … YIELD` yields its results directly — the first version of this
+//!   fix broke every algorithm invocation in the suite;
+//! * DDL such as `CREATE HIERARCHY INDEX …` reports the encoding it chose.
+//!
+//! So the tests below come in two halves: writes that must be silent, and
+//! neighbours that must not be.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).expect("query should parse");
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .expect("query should run")
+        .records
+        .len()
+}
+
+fn count(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).expect("query should parse");
+    QueryExecutor::new(store).execute(&q).expect("query should run").records.len()
+}
+
+#[test]
+fn create_without_return_yields_no_rows() {
+    for cypher in [
+        "CREATE ()",
+        "CREATE (), ()",
+        "CREATE (:A {x: 1})",
+        "CREATE (a)-[:R]->(b)",
+        "CREATE (a:A), (b:B), (a)-[:R]->(b)",
+    ] {
+        let mut store = GraphStore::new();
+        assert_eq!(run(&mut store, cypher), 0, "{cypher}");
+    }
+}
+
+#[test]
+fn merge_without_return_yields_no_rows() {
+    let mut store = GraphStore::new();
+    assert_eq!(run(&mut store, "MERGE (a:L)"), 0);
+    // …and again, on the branch that matches rather than creates.
+    assert_eq!(run(&mut store, "MERGE (a:L)"), 0);
+}
+
+#[test]
+fn the_write_still_happens() {
+    // The whole risk of this change: discarding the rows must not discard the
+    // work. The plan is still driven to exhaustion.
+    let mut store = GraphStore::new();
+    assert_eq!(run(&mut store, "CREATE (:A {x: 1})"), 0);
+    assert_eq!(count(&store, "MATCH (n:A) RETURN n"), 1);
+
+    assert_eq!(run(&mut store, "CREATE (a:B), (b:B), (a)-[:R]->(b)"), 0);
+    assert_eq!(count(&store, "MATCH (:B)-[:R]->(:B) RETURN 1 AS x"), 1);
+
+    assert_eq!(run(&mut store, "MERGE (:C {k: 7})"), 0);
+    assert_eq!(count(&store, "MATCH (n:C) WHERE n.k = 7 RETURN n"), 1);
+}
+
+#[test]
+fn a_write_with_a_return_still_returns() {
+    let mut store = GraphStore::new();
+    assert_eq!(run(&mut store, "CREATE (n) RETURN n"), 1);
+    assert_eq!(run(&mut store, "MERGE (m:L) RETURN m"), 1);
+    // `CREATE (a), (b) RETURN a` is deliberately absent: it fails with
+    // "Variable not found", a defect that predates this change (verified
+    // against the commit at the start of the sweep) and is filed separately.
+    // Asserting it here would mix an unrelated bug into this file's subject.
+}
+
+#[test]
+fn set_and_delete_are_silent_too() {
+    // `SET` and `DELETE` are data writes by the same argument as `CREATE`, so
+    // they fall under the same rule — and `MATCH (n:P) SET n.x = 2` was
+    // returning one row per matched node.
+    let mut store = GraphStore::new();
+    assert_eq!(run(&mut store, "CREATE (:P {x: 1})"), 0);
+    assert_eq!(run(&mut store, "MATCH (n:P) SET n.x = 2"), 0);
+    assert_eq!(count(&store, "MATCH (n:P) WHERE n.x = 2 RETURN n"), 1);
+    assert_eq!(run(&mut store, "MATCH (n:P) DELETE n"), 0);
+    assert_eq!(count(&store, "MATCH (n:P) RETURN n"), 0);
+}
+
+#[test]
+fn call_yield_without_a_return_still_yields() {
+    // The exception that the first version of this fix got wrong. A `CALL`
+    // projects through YIELD, so it has results even with no RETURN clause.
+    let mut store = GraphStore::new();
+    assert_eq!(run(&mut store, "CREATE (a:N), (b:N), (a)-[:R]->(b)"), 0);
+    let rows = run(&mut store, "CALL pagerank() YIELD nodeId, score");
+    assert!(rows > 0, "CALL … YIELD must produce rows without a RETURN");
+}


### PR DESCRIPTION
Nine commits driven by the conformance harness's `CH-TCK` suite. The method throughout: run the TCK, group the 560 failures by *cause* rather than by feature, fix the largest cluster, re-measure.

## Result

| | start | now |
|---|---:|---:|
| pass | 489 | **659** |
| evaluated | 1,049 | **1,239** |
| pass rate | 46.6% | **53.2%** |
| coverage | 65.0% | **76.7%** |
| scenarios skipped | 566 | 376 |

`cargo test --workspace` green across 92 blocks throughout.

## What was actually broken

**`MATCH (a)-->(b)` was a syntax error.** The grammar required the bracket, so `-->`, `<--` and `--` did not parse at all. This is the pattern every Cypher tutorial opens with, and it was invisible here because every query in `benches/`, `examples/` and the test suite names a relationship type. A codebase can be blind to a gap this large purely by having a house style.

**`CREATE (a), (b), (a)-[:R]->(b)` created four nodes.** The third path re-registered `a` and `b` instead of reusing the ones bound a moment earlier. The query succeeded, the edge was right, and the graph silently had twice the nodes. Both planner paths had it. That form is how most fixtures, loaders and the entire TCK are written.

**`CREATE ()` returned a row.** A data write with no `RETURN` returns nothing — 34 scenarios assert exactly that, and the write itself was correct all along; only the shape of the answer was wrong.

**`count(*)` disagreed with its own rows.** `MATCH (a)--(b) RETURN count(*)` answered 2 where the same pattern returned 4 rows: the O(1) fast path counts each edge once, and an undirected pattern matches every edge from both ends.

**`ORDER BY` was silently dropped in two forms** — restating an aggregate (`ORDER BY sum(x)`), and a property of a RETURN alias (`ORDER BY rel.id`). Both produced *plausible* answers, which is why they survived: with the sort gone, rows come back in scan order, and on a small fixture that is frequently already ascending.

**`labels()` leaked a `HashSet` order**, so the same node answered `['L','B']` on one run and `['B','L']` on the next.

Plus: `RETURN *` / `WITH *`, consecutive `UNWIND` clauses, `n:Label` as a value, multi-label `REMOVE`, `MERGE … ON MATCH SET a:Label` in either order, and `CALL … YIELD … RETURN … ORDER BY` — the example on our own README's front page, which did not parse.

## Method notes worth keeping

- **Three of these were found by running the TCK five times, not once.** The pass count moved 484→487 at a fixed commit with `errored` constant, so scenarios were changing their *answer* between processes. `RandomState` is seeded per process, so a single run — and a developer re-running the failing case — cannot see it. That check is now the permanent `CH-DETERM` suite.
- **Every fix is mutation-checked**: the tests fail when the fix is reverted, verified.
- **One test asserted the old wrong behaviour** (`MERGE` returning a row) and was updated with the reason written beside it, not deleted.
- **Two bugs were introduced and caught by the suite** — a guard placed before the bounds checks that justified it (panicked on `UNWIND [1,2,3] AS x RETURN max(x)`), and a `RETURN *, a` that produced two `a` columns. Both are noted in their commits.

## Filed, not fixed here

- #614 — `CREATE (a), (b) RETURN a` fails with "Variable not found". Predates this work, verified against the sweep's starting commit.
- #613 — OpenAPI/server drift (fixed separately on this branch's sibling).