### PR TITLE
SET n = {…} / SET n += {…}, and the TCK diagnostics that found the sweep's bugs

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -181,9 +181,10 @@ published:
 | 39 | user-defined procedures |
 | 34 | query parameters |
 | 19 | named fixture graphs (`binary-tree-N`) |
+| 7 | the scenario's setup still does not parse |
 | 3 | the scenario's setup did not run |
 
-The 197 "setup did not parse" skips are **gone**: they were ordinary `CREATE`
+"setup did not parse" fell from **197 to 7**: they were ordinary `CREATE`
 statements the parser rejected, and fixing that moved them into the judged set
 — which is where most of the coverage gain came from. `Scenario Outline`
 expansion is now the single largest remaining skip category and is a harness

--- a/examples/tck_runner.rs
+++ b/examples/tck_runner.rs
@@ -35,6 +35,7 @@
 //!   cargo run --release --example tck_runner -- --features /path/to/tck/features
 //!   cargo run --release --example tck_runner -- --features PATH --json /tmp/tck.json
 //!   cargo run --release --example tck_runner -- --features PATH --failures-manifest /tmp/f.tsv
+//!   cargo run --release --example tck_runner -- --features PATH --failures-detail /tmp/d.tsv
 
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
@@ -631,7 +632,10 @@ fn run_scenario(s: &Scenario) -> (Outcome, String) {
     let mut store = GraphStore::new();
     for stmt in &s.setup {
         let Ok(q) = parse_query(stmt) else {
-            return (Outcome::Skipped, "setup did not parse".into());
+            return (
+                Outcome::Skipped,
+                format!("setup did not parse: {}", stmt.replace('\n', " ")),
+            );
         };
         let mut m = MutQueryExecutor::new(&mut store, "default".to_string());
         if m.execute(&q).is_err() {
@@ -646,7 +650,13 @@ fn run_scenario(s: &Scenario) -> (Outcome, String) {
         Err(e) => {
             return match expect {
                 Expect::Error(_) => (Outcome::Pass, String::new()),
-                _ => (Outcome::Errored, format!("parse: {}", short(&format!("{e:?}")))),
+                _ => (
+                    Outcome::Errored,
+                    // The pest error lists the grammar rules that *could* have
+                    // matched, which does not say what syntax the engine is
+                    // missing. The query does.
+                    format!("parse: {}", query.replace('\n', " ")),
+                ),
             }
         }
     };
@@ -801,7 +811,15 @@ fn main() {
                 failures.push((s.feature.clone(), s.name.clone(), "wrong_result", detail)); }
             Outcome::Errored => { err += 1; entry.1 += 1;
                 failures.push((s.feature.clone(), s.name.clone(), "errored", detail)); }
-            Outcome::Skipped => { skip += 1; *skip_reasons.entry(detail).or_insert(0) += 1; }
+            Outcome::Skipped => {
+                skip += 1;
+                // Group on the category, not the whole detail. "setup did not
+                // parse" now carries the offending query so it can be fixed,
+                // and counting those verbatim would make every row unique and
+                // the histogram useless.
+                let category = detail.split_once(": ").map_or(detail.as_str(), |(head, _)| head).to_string();
+                *skip_reasons.entry(category).or_insert(0) += 1;
+            }
         }
     }
 
@@ -873,6 +891,24 @@ fn main() {
         lines.sort();
         let _ = std::fs::write(&path, lines.join("\n") + "\n");
         println!("wrote failure manifest ({} scenarios): {path}", lines.len());
+    }
+
+    // Full detail, one scenario per line, for grouping failures by cause.
+    // Kept separate from `--failures-manifest` on purpose: the detail text
+    // embeds row dumps, which differ between runs for unordered results, and
+    // CH-DETERM compares manifests as sets. Mixing them would make the
+    // determinism suite flag its own diagnostics as nondeterminism.
+    if let Some(path) = arg("--failures-detail") {
+        let mut lines: Vec<String> = failures
+            .iter()
+            .map(|(f, n, o, d)| {
+                let one_line = d.replace('\n', " ");
+                format!("{o}\t{f}\t{n}\t{one_line}")
+            })
+            .collect();
+        lines.sort();
+        let _ = std::fs::write(&path, lines.join("\n") + "\n");
+        println!("wrote failure detail ({} scenarios): {path}", lines.len());
     }
 
     if arg("--show-failures").is_some() {

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -577,6 +577,22 @@ pub struct SetClause {
     /// struct read by field in several places, and an enum would touch all of
     /// them for no gain. `RemoveItem` is an enum because it always was.
     pub label_items: Vec<SetLabelItem>,
+    /// Whole-entity assignment: `SET n = {…}` and `SET n += {…}`.
+    pub entity_items: Vec<SetEntityItem>,
+}
+
+/// `SET n = <expr>` (replace every property) or `SET n += <expr>` (merge).
+///
+/// The right-hand side evaluates to a map, or to another node or relationship
+/// whose properties are copied.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SetEntityItem {
+    /// Variable naming the entity being assigned to.
+    pub variable: String,
+    /// `true` for `+=` (merge), `false` for `=` (replace).
+    pub merge: bool,
+    /// The map, or entity, to take properties from.
+    pub value: Expression,
 }
 
 /// SET item adding labels: `n:Admin`, `n:A:B`

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -104,10 +104,19 @@ delete_clause = { ^"DETACH"? ~ ^"DELETE" ~ expression ~ ("," ~ expression)* }
 set_clause = { ^"SET" ~ set_entry ~ ("," ~ set_entry)* }
 // `set_item` is tried first and needs a `.`, so `p:Admin` falls through to the
 // label form rather than being mistaken for a property assignment.
-set_entry = _{ set_item | set_label_item }
+// Order matters: `set_item` needs a `.`, so `n = {...}` and `n += {...}` fall
+// through to the entity form, and `p:Admin` falls through to the label form.
+// `set_entity_item` must precede `set_label_item` because both start with a
+// bare variable.
+set_entry = _{ set_item | set_entity_item | set_label_item }
 set_item = { property_access ~ "=" ~ expression }
 // `SET n:A` and `SET n:A:B`, mirroring `remove_item`'s label form (#596).
 set_label_item = { variable ~ (":" ~ label)+ }
+// Whole-entity assignment: `SET n = {a: 1}` replaces every property,
+// `SET n += {a: 1}` merges. The right-hand side may also be another entity,
+// which copies its properties (`SET a = b`).
+set_entity_item = { variable ~ set_entity_op ~ expression }
+set_entity_op = { "+=" | "=" }
 remove_clause = { ^"REMOVE" ~ remove_item ~ ("," ~ remove_item)* }
 // `REMOVE n:L1:L3` removes both labels in one item, exactly as `SET n:A:B`
 // adds both. Accepting only one label made the multi-label form a syntax

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -8942,11 +8942,45 @@ impl PhysicalOperator for DeleteOperator {
 pub struct SetPropertyOperator {
     input: OperatorBox,
     items: Vec<(String, String, Expression)>, // (variable, property, value_expr)
+    /// Whole-entity assignments: `(variable, merge, value)`. `merge` is `+=`.
+    entity_items: Vec<(String, bool, Expression)>,
 }
 
 impl SetPropertyOperator {
     pub fn new(input: OperatorBox, items: Vec<(String, String, Expression)>) -> Self {
-        Self { input, items }
+        Self { input, items, entity_items: Vec::new() }
+    }
+
+    /// With whole-entity assignments (`SET n = {…}`, `SET n += {…}`).
+    pub fn with_entity_items(
+        input: OperatorBox,
+        items: Vec<(String, String, Expression)>,
+        entity_items: Vec<(String, bool, Expression)>,
+    ) -> Self {
+        Self { input, items, entity_items }
+    }
+
+    /// The properties a right-hand side contributes.
+    ///
+    /// A map contributes its entries; a node or relationship contributes its
+    /// own properties, which is what makes `SET a = b` a copy. Anything else
+    /// is a type error rather than a silent no-op — assigning a scalar to an
+    /// entity has no sensible meaning and guessing one would hide the mistake.
+    fn source_properties(
+        value: &Value,
+        store: &GraphStore,
+    ) -> ExecutionResult<HashMap<String, PropertyValue>> {
+        match value {
+            Value::Property(PropertyValue::Map(m)) => Ok(m.clone().into_iter().collect()),
+            Value::Node(id, _) | Value::NodeRef(id) => {
+                Ok(store.node_properties_full(*id).into_iter().collect())
+            }
+            Value::Edge(_, e) => Ok(e.properties.clone().into_iter().collect()),
+            Value::Property(PropertyValue::Null) => Ok(HashMap::new()),
+            other => Err(ExecutionError::TypeError(format!(
+                "SET <entity> = expects a map or another entity, got {other:?}"
+            ))),
+        }
     }
 }
 
@@ -8994,6 +9028,54 @@ impl PhysicalOperator for SetPropertyOperator {
                     }
                 }
             }
+
+            // Whole-entity assignment. Evaluated after the per-property items
+            // so that `SET n.a = 1, n = {b: 2}` behaves as written rather than
+            // as ordered by implementation detail.
+            for (var, merge, expr) in &self.entity_items {
+                let Some(target) = record.get(var).cloned() else { continue };
+                let value = eval_expression(expr, &record, store)?;
+                let incoming = Self::source_properties(&value, store)?;
+
+                match target {
+                    Value::NodeRef(id) | Value::Node(id, _) => {
+                        if !merge {
+                            // `=` replaces: every property not in the incoming
+                            // map goes away. Removing them first, then writing,
+                            // keeps the two spellings from differing only in
+                            // leftovers.
+                            for key in store.node_properties_full(id).keys().cloned().collect::<Vec<_>>() {
+                                if !incoming.contains_key(&key) {
+                                    let _ = store.remove_node_property(id, &key);
+                                }
+                            }
+                        }
+                        for (k, v) in incoming {
+                            store
+                                .set_node_property(tenant_id, id, k, v)
+                                .map_err(|e| ExecutionError::GraphError(e.to_string()))?;
+                        }
+                    }
+                    Value::EdgeRef(id, ..) | Value::Edge(id, _) => {
+                        if !merge {
+                            let existing: Vec<String> = store
+                                .get_edge(id)
+                                .map(|e| e.properties.keys().cloned().collect())
+                                .unwrap_or_default();
+                            for key in existing {
+                                if !incoming.contains_key(&key) {
+                                    let _ = store.remove_edge_property(id, &key);
+                                }
+                            }
+                        }
+                        for (k, v) in incoming {
+                            let _ = store.set_edge_property(id, k, v);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
             Ok(Some(record))
         } else {
             Ok(None)
@@ -9009,7 +9091,10 @@ impl PhysicalOperator for SetPropertyOperator {
     }
 
     fn describe(&self) -> OperatorDescription {
-        let sets: Vec<String> = self.items.iter().map(|(v, p, e)| format!("{}.{} = {}", v, p, format_expression(e))).collect();
+        let mut sets: Vec<String> = self.items.iter().map(|(v, p, e)| format!("{}.{} = {}", v, p, format_expression(e))).collect();
+        sets.extend(self.entity_items.iter().map(|(v, merge, e)| {
+            format!("{} {} {}", v, if *merge { "+=" } else { "=" }, format_expression(e))
+        }));
         OperatorDescription {
             name: "SetProperty".to_string(),
             details: sets.join(", "),

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1814,6 +1814,7 @@ impl QueryPlanner {
         let is_write = if !query.set_clauses.is_empty() {
             let mut items = Vec::new();
             let mut label_adds = Vec::new();
+            let mut entity_items = Vec::new();
             for set_clause in &query.set_clauses {
                 for item in &set_clause.items {
                     items.push((item.variable.clone(), item.property.clone(), item.value.clone()));
@@ -1823,9 +1824,14 @@ impl QueryPlanner {
                         label_adds.push((item.variable.clone(), label.clone()));
                     }
                 }
+                for item in &set_clause.entity_items {
+                    entity_items.push((item.variable.clone(), item.merge, item.value.clone()));
+                }
             }
-            if !items.is_empty() {
-                operator = Box::new(SetPropertyOperator::new(operator, items));
+            if !items.is_empty() || !entity_items.is_empty() {
+                operator = Box::new(SetPropertyOperator::with_entity_items(
+                    operator, items, entity_items,
+                ));
             }
             if !label_adds.is_empty() {
                 operator = Box::new(LabelMutationOperator::new(operator, label_adds, Vec::new()));

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -963,10 +963,32 @@ fn parse_set_label_item(pair: pest::iterators::Pair<Rule>) -> ParseResult<SetLab
 fn parse_set_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<SetClause> {
     let mut items = Vec::new();
     let mut label_items: Vec<SetLabelItem> = Vec::new();
+    let mut entity_items: Vec<crate::query::ast::SetEntityItem> = Vec::new();
 
     for inner in pair.into_inner() {
         if inner.as_rule() == Rule::set_label_item {
             label_items.push(parse_set_label_item(inner)?);
+            continue;
+        }
+        if inner.as_rule() == Rule::set_entity_item {
+            let mut variable = String::new();
+            let mut merge = false;
+            let mut value = None;
+            for part in inner.into_inner() {
+                match part.as_rule() {
+                    Rule::variable if variable.is_empty() => variable = part.as_str().to_string(),
+                    Rule::set_entity_op => merge = part.as_str().trim() == "+=",
+                    Rule::expression => value = Some(parse_expression(part)?),
+                    _ => {}
+                }
+            }
+            entity_items.push(crate::query::ast::SetEntityItem {
+                variable,
+                merge,
+                value: value.ok_or_else(|| {
+                    ParseError::SemanticError("SET <entity> = missing a value".to_string())
+                })?,
+            });
             continue;
         }
         if inner.as_rule() == Rule::set_item {
@@ -1000,7 +1022,7 @@ fn parse_set_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<SetClause>
         }
     }
 
-    Ok(SetClause { items, label_items })
+    Ok(SetClause { items, label_items, entity_items })
 }
 
 fn parse_remove_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<RemoveClause> {

--- a/tests/set_entity.rs
+++ b/tests/set_entity.rs
@@ -1,0 +1,139 @@
+//! `SET n = {…}` and `SET n += {…}` — whole-entity assignment (openCypher TCK).
+//!
+//! `SET n += $props` is the standard upsert idiom, and neither spelling
+//! parsed. The two differ only in what happens to properties the right-hand
+//! side does *not* mention — `+=` leaves them, `=` removes them — so every
+//! test here checks a property that is absent from the assignment as well as
+//! the ones that are present. Checking only the assigned keys would pass
+//! against an implementation that did nothing but merge.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn write(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).expect("query should parse");
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .expect("query should run");
+}
+
+/// One row's named properties, as `Option<i64>` so absence is distinguishable
+/// from zero — which is the entire subject of this file.
+fn props(store: &GraphStore, cypher: &str, keys: &[&str]) -> Vec<Option<i64>> {
+    let q = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&q).expect("query should run");
+    let r = &batch.records[0];
+    keys.iter()
+        .map(|k| match r.get(k) {
+            Some(Value::Property(PropertyValue::Integer(n))) => Some(*n),
+            Some(Value::Property(PropertyValue::Null)) | None => None,
+            other => panic!("expected an integer or null in {k}, got {other:?}"),
+        })
+        .collect()
+}
+
+#[test]
+fn plus_equals_merges_and_leaves_the_rest_alone() {
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (:P {a: 1, b: 2})");
+    write(&mut store, "MATCH (n:P) SET n += {b: 20, c: 3}");
+    assert_eq!(
+        props(&store, "MATCH (n:P) RETURN n.a AS a, n.b AS b, n.c AS c", &["a", "b", "c"]),
+        vec![Some(1), Some(20), Some(3)],
+        "a untouched, b overwritten, c added"
+    );
+}
+
+#[test]
+fn equals_replaces_and_removes_what_is_not_mentioned() {
+    // The half that distinguishes the two operators. An implementation that
+    // merged for both would pass every "the new value is there" assertion.
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (:P {a: 1, b: 2})");
+    write(&mut store, "MATCH (n:P) SET n = {z: 9}");
+    assert_eq!(
+        props(&store, "MATCH (n:P) RETURN n.a AS a, n.b AS b, n.z AS z", &["a", "b", "z"]),
+        vec![None, None, Some(9)],
+        "a and b are gone; only z survives"
+    );
+}
+
+#[test]
+fn assigning_one_entity_to_another_copies_its_properties() {
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (:A {x: 1, y: 2}), (:B {q: 7})");
+    write(&mut store, "MATCH (a:B), (b:A) SET a = b");
+    assert_eq!(
+        props(&store, "MATCH (n:B) RETURN n.x AS x, n.y AS y, n.q AS q", &["x", "y", "q"]),
+        vec![Some(1), Some(2), None],
+        "B takes A's properties and loses its own"
+    );
+}
+
+#[test]
+fn plus_equals_from_an_entity_keeps_both_sides() {
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (:A {x: 1}), (:B {q: 7})");
+    write(&mut store, "MATCH (a:B), (b:A) SET a += b");
+    assert_eq!(
+        props(&store, "MATCH (n:B) RETURN n.x AS x, n.q AS q", &["x", "q"]),
+        vec![Some(1), Some(7)],
+    );
+}
+
+#[test]
+fn a_relationship_can_be_assigned_too() {
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (:A)-[:R {a: 1, b: 2}]->(:B)");
+    write(&mut store, "MATCH ()-[r:R]->() SET r += {b: 20, c: 3}");
+    assert_eq!(
+        props(&store, "MATCH ()-[r:R]->() RETURN r.a AS a, r.b AS b, r.c AS c", &["a", "b", "c"]),
+        vec![Some(1), Some(20), Some(3)],
+    );
+
+    write(&mut store, "MATCH ()-[r:R]->() SET r = {only: 5}");
+    assert_eq!(
+        props(&store, "MATCH ()-[r:R]->() RETURN r.a AS a, r.only AS only", &["a", "only"]),
+        vec![None, Some(5)],
+    );
+}
+
+#[test]
+fn an_empty_map_clears_every_property() {
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (:P {a: 1, b: 2})");
+    write(&mut store, "MATCH (n:P) SET n = {}");
+    assert_eq!(
+        props(&store, "MATCH (n:P) RETURN n.a AS a, n.b AS b", &["a", "b"]),
+        vec![None, None],
+    );
+}
+
+#[test]
+fn per_property_set_still_works_beside_it() {
+    // `set_item` is tried before the entity form because it needs a `.`;
+    // this pins that the ordering did not break the commoner spelling.
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (:P {a: 1})");
+    write(&mut store, "MATCH (n:P) SET n.a = 5, n.b = 6");
+    assert_eq!(
+        props(&store, "MATCH (n:P) RETURN n.a AS a, n.b AS b", &["a", "b"]),
+        vec![Some(5), Some(6)],
+    );
+}
+
+#[test]
+fn setting_a_label_still_parses_as_a_label() {
+    // `SET n:Admin` and `SET n = …` both start with a bare variable, so the
+    // grammar's alternative order decides which wins.
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE (:P {a: 1})");
+    write(&mut store, "MATCH (n:P) SET n:Admin");
+    let q = parse_query("MATCH (n:Admin) RETURN count(n) AS c").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&q).unwrap();
+    assert!(matches!(
+        batch.records[0].get("c"),
+        Some(Value::Property(PropertyValue::Integer(1)))
+    ));
+}


### PR DESCRIPTION
Follow-on from #615, rebuilt on top of it. (#619 was the same diff on a branch whose history diverged after the squash merge.)

## Whole-entity assignment

`SET n += $props` is the standard upsert idiom and neither spelling parsed. The right-hand side may be a map or another entity, so `SET a = b` copies b's properties onto a.

```cypher
MATCH (n:P) SET n += {b: 20, c: 3}   -- merge: keeps a, overwrites b, adds c
MATCH (n:P) SET n  = {z: 9}          -- replace: a and b are removed
MATCH (a:B), (b:A) SET a = b         -- copy b's properties, drop a's own
```

The two operators differ **only** in what happens to properties the right-hand side does not mention, so every test asserts an absent key as well as the present ones. Asserting only that the new values arrived would pass against an implementation that merged in both cases — the obvious way to get this half-right.

Two more tests pin the grammar's neighbours rather than the feature: `set_item` needs a `.` so `n = {…}` falls through to the entity form, and `set_entity_item` must precede `set_label_item` because both start with a bare variable. So `SET n.a = 5` and `SET n:Admin` each get a test.

## The diagnostics

`tck_runner --failures-detail` is the tool this whole sweep was run from. Grouping 560 failures by *cause* rather than by feature is what showed that 228 were the parser rejecting the query outright, and which constructs those were.

Parse failures now report **the query** instead of pest's list of grammar rules that could have matched — the rule list says which alternatives were tried, never which syntax the engine is missing.

It is deliberately separate from `--failures-manifest`: the detail text embeds row dumps, which differ between runs for unordered results, and `CH-DETERM` compares manifests as sets. Mixing them would make the determinism suite flag its own diagnostics as nondeterminism.

The skip histogram groups on the category before the colon, so "setup did not parse" can carry the offending statement without making every row unique. **That count is now 7, down from 197.**

## Numbers

- openCypher TCK **663 → 671** of 1,239 evaluated (54.2%), from 46.6% at the start of the sweep.
- `cargo test --workspace` green across **93** blocks; 8 new tests.
- Both CI conformance gates (`import_invariants`, `doc_check`) pass locally — GitHub did not schedule a run for this branch, so that check is by hand.