### PR TITLE
Pin a variable-length expand's target when it resolves to one node (IC6 timeout)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ cargo bench --bench mvcc_benchmark             # MVCC & arena allocation
 cargo bench --bench late_materialization_bench  # Late materialization traversal
 cargo bench --bench graph_optimization_benchmark # Metaheuristic optimization solvers
 cargo bench --bench ldbc_benchmark             # LDBC SNB Interactive queries (needs data)
+cargo bench --bench ldbc_benchmark -- --explain          # print plans, do NOT run the queries
+cargo bench --bench ldbc_benchmark -- --derive-params 50 # parameters valid for THIS extract
 cargo bench --bench ldbc_bi_benchmark          # LDBC SNB BI queries (needs data)
 cargo bench --bench finbench_benchmark         # LDBC FinBench queries (synthetic data)
 cargo bench --bench hierarchy_benchmark        # OEH index: build, order test, roll-up vs subtree size
@@ -172,6 +174,24 @@ graph.create_edge(source_id, target_id, "KNOWS")?;
 A suite that passes in release can still fail the gate: the engine is more than
 an order of magnitude slower in debug. Run the profile CI runs before claiming a
 suite is green, and say which profile a claim was measured in.
+
+### Diagnosing a slow query
+
+```bash
+# Plans without executing. `--profile` runs the query, which is useless for the
+# ones most worth looking at — a query that times out cannot be PROFILEd.
+cargo bench --bench ldbc_benchmark -- --data-dir <sf1> --derive-params 50 --explain --query IC6
+
+# Why the planner chose the anchor it chose. EXPLAIN shows only the winner.
+SAMYAMA_EXPLAIN_ANCHORS=1 cargo bench --bench ldbc_benchmark -- ... --explain --query IC6
+```
+
+**Use `--derive-params` before believing anything.** The built-in defaults name
+a person who exists in one particular extract and not in others. Against the
+wrong extract every query runs fast and returns nothing, the anchor for the
+pinned node costs zero rows, and the plans you are reading are plans for a
+query that matches nothing. The bench's `0 empty` line in the summary is the
+check that catches this; read it first.
 
 **Do not assert wall-clock times in tests.** An absolute bound encodes the speed
 of the machine and the build profile that wrote it. Assert a **ratio** against a

--- a/benches/ldbc_benchmark.rs
+++ b/benches/ldbc_benchmark.rs
@@ -701,6 +701,11 @@ async fn main() -> Result<(), Error> {
     // `CH-PROFILE-01` deliverable: the gate is "at least 90% of wall-clock
     // attributed" for IC1/IC6/IC9, and a total by itself attributes nothing.
     let profile_mode = args.iter().any(|a| a == "--profile");
+    // `--explain` prints the plan **without running the query**. `--profile`
+    // executes, which is useless for exactly the queries most worth looking at:
+    // IC6 times out at SF10, so the one plan you most want to see is the one
+    // PROFILE cannot show you.
+    let explain_mode = args.iter().any(|a| a == "--explain");
 
     let include_updates = args.iter().any(|a| a == "--updates");
     let include_deletes = args.iter().any(|a| a == "--deletes");
@@ -895,6 +900,29 @@ async fn main() -> Result<(), Error> {
 
         let cypher = params.apply(query.cypher);
 
+
+        if explain_mode {
+            println!("\n================ {} — {} ================", query.id, query.name);
+            println!("{}", cypher);
+            println!();
+            match client.query("default", &format!("EXPLAIN {}", cypher)).await {
+                Ok(batch) => {
+                    for record in &batch.records {
+                        for cell in record {
+                            match cell.as_str() {
+                                Some(text) => println!("{}", text),
+                                None => println!("{}", cell),
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    println!("ERROR: {}", e);
+                    errors += 1;
+                }
+            }
+            continue;
+        }
 
         if profile_mode {
             match client.query("default", &format!("PROFILE {}", cypher)).await {

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3875,6 +3875,24 @@ pub struct VarLengthExpandOperator {
     /// filter"; a requested type the graph has never seen simply contributes
     /// no id, so it matches nothing -- which is correct.
     type_ids: Option<Vec<u16>>,
+    /// The target is pinned to exactly this node.
+    ///
+    /// Set when the planner can resolve the far endpoint to a single node at
+    /// plan time — `MATCH (p:Person {id: 42})-[:KNOWS*1..2]-(friend)` read from
+    /// the `friend` side. The question is then not "what is reachable from each
+    /// friend" but "is *this one node* reachable from each friend", and those
+    /// have very different costs.
+    pinned_target: Option<NodeId>,
+    /// Nodes from which `pinned_target` is reachable within the hop bounds,
+    /// computed once on first use.
+    ///
+    /// One BFS outward from the pinned node, reversed, answers the question for
+    /// every input row. Without it each row runs its own BFS: LDBC IC6 feeds
+    /// thousands of candidate friends into this operator and each one expanded
+    /// its own two-hop neighbourhood to discover whether one specific person
+    /// was in it. At SF10 that is the difference between finishing and hitting
+    /// the query timeout.
+    target_reach: Option<std::collections::HashSet<NodeId>>,
 }
 
 impl VarLengthExpandOperator {
@@ -3902,6 +3920,8 @@ impl VarLengthExpandOperator {
             path_variable: None,
             pending: std::collections::VecDeque::new(),
             type_ids: None,
+            pinned_target: None,
+            target_reach: None,
         }
     }
 
@@ -3950,6 +3970,29 @@ impl VarLengthExpandOperator {
     ///
     /// Filtering on the interned type id inside the walk skips a non-matching
     /// edge in a compare rather than a string clone.
+    /// Neighbours in an explicitly given direction.
+    ///
+    /// `for_each_neighbor` uses `self.direction`; the reversed BFS needs the
+    /// opposite one, and taking the direction as an argument keeps a second
+    /// near-copy of the match out of the file.
+    fn neighbors_in(
+        node: NodeId,
+        type_ids: Option<&[u16]>,
+        direction: &Direction,
+        store: &GraphStore,
+        visit: &mut impl FnMut(NodeId),
+    ) {
+        let mut with_edge = |nb: NodeId, _e: crate::graph::EdgeId| visit(nb);
+        match direction {
+            Direction::Outgoing => store.for_each_outgoing_neighbor(node, type_ids, &mut with_edge),
+            Direction::Incoming => store.for_each_incoming_neighbor(node, type_ids, &mut with_edge),
+            Direction::Both => {
+                store.for_each_outgoing_neighbor(node, type_ids, &mut with_edge);
+                store.for_each_incoming_neighbor(node, type_ids, &mut with_edge);
+            }
+        }
+    }
+
     fn for_each_neighbor(
         &self,
         node: NodeId,
@@ -3969,6 +4012,75 @@ impl VarLengthExpandOperator {
 
     /// BFS from the source bound in `record`, buffering one output record per
     /// distinct reachable target in `[min_hops, max_hops]`.
+    /// Pin the target to a single node the planner resolved at plan time.
+    ///
+    /// Only valid when the destination really is that one node; the operator
+    /// then answers "can this source reach it" rather than enumerating.
+    pub fn with_pinned_target(mut self, target: NodeId) -> Self {
+        self.pinned_target = Some(target);
+        self
+    }
+
+    /// Can the pinned target be reached from `source` within the hop bounds?
+    ///
+    /// Answered from a set built by one BFS *outward from the target*, walking
+    /// edges in the opposite direction, which is the same relation read the
+    /// other way round. Built once and reused for every input row.
+    ///
+    /// Restricted by the caller to `min_hops <= 1` and no path variable, and
+    /// both restrictions are load-bearing:
+    ///
+    /// * with `min_hops >= 2` a node whose *shortest* distance is 1 may still
+    ///   have a conforming longer walk, and a set keyed on shortest distance
+    ///   would wrongly exclude it;
+    /// * a path variable needs the actual path, which a membership test does
+    ///   not produce.
+    fn target_reaches(&mut self, source: NodeId, store: &GraphStore) -> bool {
+        let target = match self.pinned_target {
+            Some(t) => t,
+            None => return false,
+        };
+        if self.target_reach.is_none() {
+            self.ensure_type_ids(store);
+            let type_ids = self.type_ids.clone();
+            let type_filter = type_ids.as_deref();
+
+            // Reversed: the operator walks source -> target, so reaching the
+            // target from a source means walking target -> source backwards.
+            let reversed = match self.direction {
+                Direction::Outgoing => Direction::Incoming,
+                Direction::Incoming => Direction::Outgoing,
+                Direction::Both => Direction::Both,
+            };
+
+            let mut reach: std::collections::HashSet<NodeId> = std::collections::HashSet::new();
+            let mut visited: std::collections::HashSet<NodeId> = std::collections::HashSet::new();
+            visited.insert(target);
+            if self.min_hops == 0 {
+                reach.insert(target);
+            }
+            let mut frontier = vec![target];
+            let mut depth = 0usize;
+            while !frontier.is_empty() && depth < self.max_hops {
+                depth += 1;
+                let mut next = Vec::new();
+                for &cur in &frontier {
+                    Self::neighbors_in(cur, type_filter, &reversed, store, &mut |nb| {
+                        if visited.insert(nb) {
+                            next.push(nb);
+                            if depth >= self.min_hops {
+                                reach.insert(nb);
+                            }
+                        }
+                    });
+                }
+                frontier = next;
+            }
+            self.target_reach = Some(reach);
+        }
+        self.target_reach.as_ref().is_some_and(|r| r.contains(&source))
+    }
+
     fn expand_from(&mut self, record: &Record, store: &GraphStore) -> ExecutionResult<()> {
         let source_id = record
             .get(&self.source_var)
@@ -3977,6 +4089,18 @@ impl VarLengthExpandOperator {
             .ok_or_else(|| {
                 ExecutionError::TypeError(format!("{} is not a node", self.source_var))
             })?;
+
+        // Pinned target: one membership test instead of a BFS per row. The
+        // planner only sets this when the destination resolves to a single
+        // node, there is no path variable, and `min_hops <= 1`.
+        if let Some(target) = self.pinned_target {
+            if self.target_reaches(source_id, store) && self.emit_ok(target, store) {
+                let empty: std::collections::HashMap<NodeId, (NodeId, crate::graph::EdgeId)> =
+                    std::collections::HashMap::new();
+                self.buffer(record, target, &empty, source_id);
+            }
+            return Ok(());
+        }
 
         // parent[node] = (predecessor, edge used) for path reconstruction.
         let mut parent: std::collections::HashMap<NodeId, (NodeId, crate::graph::EdgeId)> =
@@ -4113,8 +4237,20 @@ impl PhysicalOperator for VarLengthExpandOperator {
         OperatorDescription {
             name: "VarLengthExpand".to_string(),
             details: format!(
-                "({})-[:{}*{}..{}]-({})",
-                self.source_var, types, self.min_hops, max, self.target_var
+                "({})-[:{}*{}..{}]-({}){}",
+                self.source_var,
+                types,
+                self.min_hops,
+                max,
+                self.target_var,
+                // Whether the pinned-target path is in use changes the cost of
+                // this operator by orders of magnitude, so it belongs in the
+                // plan. An optimisation you cannot see in EXPLAIN is one nobody
+                // can tell has stopped firing.
+                match self.pinned_target {
+                    Some(t) => format!(" [target pinned to node {}]", t.as_u64()),
+                    None => String::new(),
+                }
             ),
             children: vec![self.input.describe()],
         }

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2715,6 +2715,23 @@ impl QueryPlanner {
                         if let Some(ref pv) = path.path_variable {
                             expand = expand.with_path_variable(pv.clone());
                         }
+                        // If the destination resolves to exactly one node, the
+                        // question is "can each source reach *this* node",
+                        // which one reversed BFS answers for every row. LDBC
+                        // IC6 reaches this operator with thousands of candidate
+                        // friends and one pinned person; without the pin each
+                        // candidate expands its own two-hop neighbourhood.
+                        //
+                        // `min_hops <= 1` because a set keyed on shortest
+                        // distance cannot answer `*2..n` correctly, and no path
+                        // variable because a membership test yields no path.
+                        if path.path_variable.is_none() && min_hops <= 1 {
+                            if let Some(pinned) =
+                                pinned_node_for(&target_var, &deferred_predicates, store)
+                            {
+                                expand = expand.with_pinned_target(pinned);
+                            }
+                        }
                         path_operator = if !segment.node.labels.is_empty() {
                             Box::new(expand.with_target_labels(segment.node.labels.clone()))
                         } else {
@@ -2986,7 +3003,7 @@ impl QueryPlanner {
                 // anchor selection outright, which is why LDBC IC6 always
                 // started at the person and expanded to 400,257 rows rather
                 // than starting at the tag that selects seven.
-                let expand = VarLengthExpandOperator::new(
+                let mut expand = VarLengthExpandOperator::new(
                     path_operator,
                     current_var.clone(),
                     target.var.clone(),
@@ -2995,6 +3012,29 @@ impl QueryPlanner {
                     length.min.unwrap_or(1),
                     length.max.unwrap_or(usize::MAX),
                 );
+                // When the far end resolves to a single node, one reversed BFS
+                // from it answers every input row — see `with_pinned_target`.
+                // This is the shape anchoring produces on LDBC IC6: the walk
+                // ends at the pinned person, and without the pin each of
+                // thousands of candidates expands its own neighbourhood to
+                // discover whether that one person is in it.
+                if path.path_variable.is_none() && length.min.unwrap_or(1) <= 1 {
+                    if let Some(pinned) = pinned_node_for(&target.var, path_preds, store)
+                        .or_else(|| target.properties.as_ref().and_then(|props| {
+                            let inline: Vec<Expression> = props.iter().map(|(k, v)| Expression::Binary {
+                                left: Box::new(Expression::Property {
+                                    variable: target.var.clone(),
+                                    property: k.clone(),
+                                }),
+                                op: BinaryOp::Eq,
+                                right: Box::new(Expression::Literal(v.clone())),
+                            }).collect();
+                            pinned_node_for(&target.var, &inline, store)
+                        }))
+                    {
+                        expand = expand.with_pinned_target(pinned);
+                    }
+                }
                 if !target.labels.is_empty() {
                     Box::new(expand.with_target_labels(target.labels.clone())) as OperatorBox
                 } else {
@@ -4175,6 +4215,49 @@ fn segment_fanout(
 /// is the whole point: anchoring LDBC IC6 on the person costs 1 row to start
 /// and then 3,272 -> 409,960 -> 400,257, while anchoring on the tag costs
 /// 16,080 rows to scan and almost nothing after it.
+/// The single node a variable is pinned to, if the predicates pin it to one.
+///
+/// Resolved at plan time by asking the property index, so this only fires when
+/// the pin is exact — an indexed equality matching exactly one node, or an
+/// `id()` literal. A predicate that merely narrows the variable is not a pin,
+/// and treating it as one would silently drop rows.
+fn pinned_node_for(
+    var: &str,
+    preds: &[Expression],
+    store: &GraphStore,
+) -> Option<crate::graph::NodeId> {
+    if let Some((_, ids)) = find_id_predicate(var, preds) {
+        if ids.len() == 1 {
+            return Some(ids[0]);
+        }
+        return None;
+    }
+    for pred in preds {
+        let Expression::Binary { left, op: BinaryOp::Eq, right } = pred else { continue };
+        let (prop_var, prop_name, value) = match (left.as_ref(), right.as_ref()) {
+            (Expression::Property { variable, property }, Expression::Literal(v)) => (variable, property, v),
+            (Expression::Literal(v), Expression::Property { variable, property }) => (variable, property, v),
+            _ => continue,
+        };
+        if prop_var != var {
+            continue;
+        }
+        // Ask the index for the actual matches rather than estimating: a pin
+        // has to be exactly one node, and an estimate cannot establish that.
+        for label in store.catalog().label_counts.keys() {
+            let Some(index) = store.property_index.get_index(label, prop_name) else { continue };
+            let nodes = index.read().unwrap().get(value);
+            if nodes.len() == 1 {
+                return nodes.first().copied();
+            }
+            if !nodes.is_empty() {
+                return None;
+            }
+        }
+    }
+    None
+}
+
 fn estimate_path_cost(
     path: &PathPattern,
     nodes: &[PathNodeRef],
@@ -4283,8 +4366,22 @@ fn choose_anchor_index(
     let mut best_idx = 0usize;
     let mut best_cost = f64::MAX;
 
+    // `SAMYAMA_EXPLAIN_ANCHORS=1` prints the cost of every candidate anchor.
+    // Anchor choice is the difference between a plan that finishes and one
+    // that times out, and `EXPLAIN` shows only the winner — so when the winner
+    // looks wrong there is otherwise nothing to inspect but the source.
+    let trace = std::env::var("SAMYAMA_EXPLAIN_ANCHORS").is_ok_and(|v| v == "1");
+
     for i in 0..nodes.len() {
         let cost = estimate_path_cost(path, nodes, i, path_preds, store);
+        if trace {
+            let (scan, emitted) = anchor_cardinality(&nodes[i], path_preds, store);
+            eprintln!(
+                "[anchor] {:<12} labels={:?} scan={:.0} emitted={:.0} path_cost={:.0}",
+                nodes[i].var, nodes[i].labels.iter().map(|l| l.as_str()).collect::<Vec<_>>(),
+                scan, emitted, cost
+            );
+        }
         // Strict, so node 0 wins ties: re-anchoring has a real cost the model
         // does not capture (a reversed traversal reads the other adjacency,
         // which may be colder), and the written order is the better default

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -4137,10 +4137,32 @@ fn anchor_cardinality(
     // No index, so the scan reads the whole label -- but an equality on a
     // property still cuts what comes *out* of it, and that is what the rest of
     // the path multiplies.
+    //
+    // Both sources of equality count. Reading only the inline form made
+    // `MATCH (org:Organisation) WHERE org.name = '…'` look like all 7,955
+    // organisations while the identical `MATCH (org:Organisation {name: '…'})`
+    // looked like one — the same query costed two ways depending on where the
+    // author put the predicate. On LDBC IC11 that is the difference between
+    // anchoring on one organisation and anchoring on a person whose two-hop
+    // neighbourhood then has to be enumerated.
     let mut emitted = scan;
+    let mut apply = |prop_name: &str, prop_value: &PropertyValue| {
+        emitted *= stats.estimate_equality_selectivity_for_value(label, prop_name, prop_value);
+    };
     if let Some(props) = &node.properties {
         for (prop_name, prop_value) in props {
-            emitted *= stats.estimate_equality_selectivity_for_value(label, prop_name, prop_value);
+            apply(prop_name, prop_value);
+        }
+    }
+    for pred in path_preds {
+        let Expression::Binary { left, op: BinaryOp::Eq, right } = pred else { continue };
+        let (var, prop, value) = match (left.as_ref(), right.as_ref()) {
+            (Expression::Property { variable, property }, Expression::Literal(v)) => (variable, property, v),
+            (Expression::Literal(v), Expression::Property { variable, property }) => (variable, property, v),
+            _ => continue,
+        };
+        if var == &node.var {
+            apply(prop, value);
         }
     }
     (scan, emitted.max(1.0))

--- a/tests/varlength_pinned_target.rs
+++ b/tests/varlength_pinned_target.rs
@@ -1,0 +1,301 @@
+//! A variable-length expand whose far end is one node (LDBC IC6).
+//!
+//! When the planner anchors a pattern somewhere *other* than the pinned node,
+//! the variable-length hop is walked **toward** it — once per candidate row.
+//! LDBC IC6 anchors on a tag, reaches thousands of candidate people, and then
+//! asks of each "is this one specific person within two hops of you", by
+//! expanding that candidate's entire two-hop neighbourhood and looking. At
+//! SF10 the query does not finish.
+//!
+//! One reversed BFS from the pinned node answers the question for every row.
+//!
+//! The risk is not performance, it is **silently dropping rows** — a
+//! reachability set keyed on shortest distance is not an enumeration. So the
+//! fixture comes in two forms, identical except for an index, and every
+//! assertion runs against both:
+//!
+//! * **unindexed** — the planner cannot resolve the target to one node, so the
+//!   general per-row BFS runs;
+//! * **indexed** — the target resolves, and the pinned path runs.
+//!
+//! Same questions, same answers required. Two tests assert the *plans*,
+//! because a correctness suite for an optimisation that never fires proves
+//! nothing about it — and the first version of this file did exactly that.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn write(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).expect("query should parse");
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .expect("query should run");
+}
+
+fn names(store: &GraphStore, cypher: &str) -> Vec<String> {
+    let q = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&q).expect("query should run");
+    let mut out: Vec<String> = batch
+        .records
+        .iter()
+        .map(|r| match r.get("n") {
+            Some(Value::Property(PropertyValue::String(s))) => s.clone(),
+            other => panic!("expected a name, got {other:?}"),
+        })
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+fn plan_of(store: &GraphStore, cypher: &str) -> String {
+    let q = parse_query(&format!("EXPLAIN {cypher}")).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&q).expect("EXPLAIN should run");
+    match batch.records[0].get("plan") {
+        Some(Value::Property(PropertyValue::String(t))) => t.clone(),
+        other => panic!("expected a plan, got {other:?}"),
+    }
+}
+
+/// The IC6 shape in miniature.
+///
+/// ```text
+///   hub(:H {tag}) -[:LINK]-> every :N        (the selective anchor)
+///   c -> b -> a -> t(:N {key:'TARGET'})      (distances to t: a=1, b=2, c=3)
+///   d -> t                                   (d=1)
+///   e                                        (unreachable)
+/// ```
+///
+/// The hub makes every `:N` a candidate, so the planner anchors there and the
+/// variable-length hop is walked toward `t` — one BFS per candidate unless the
+/// target is pinned. That is the shape the optimisation exists for.
+fn build(indexed: bool) -> GraphStore {
+    let mut store = GraphStore::new();
+    if indexed {
+        write(&mut store, "CREATE INDEX ON :N(key)");
+        write(&mut store, "CREATE INDEX ON :H(tag)");
+    }
+    write(
+        &mut store,
+        "CREATE (t:N {n: 't', key: 'TARGET'}), (a:N {n: 'a'}), (b:N {n: 'b'}), \
+         (c:N {n: 'c'}), (d:N {n: 'd'}), (e:N {n: 'e'}), (h:H {tag: 'PICK'})",
+    );
+    for (from, to) in [("a", "t"), ("b", "a"), ("c", "b"), ("d", "t")] {
+        write(
+            &mut store,
+            &format!("MATCH (x:N {{n: '{from}'}}), (y:N {{n: '{to}'}}) CREATE (x)-[:R]->(y)"),
+        );
+    }
+    for n in ["t", "a", "b", "c", "d", "e"] {
+        write(
+            &mut store,
+            &format!("MATCH (h:H {{tag: 'PICK'}}), (x:N {{n: '{n}'}}) CREATE (h)-[:LINK]->(x)"),
+        );
+    }
+
+    store
+}
+
+/// The IC6-shaped query: anchor at the hub, walk out to candidates, then a
+/// variable-length hop *toward* the pinned target.
+fn ic6_shape(hops: &str, arrow: (&str, &str)) -> String {
+    let (l, r) = arrow;
+    format!(
+        "MATCH (h:H {{tag: 'PICK'}})-[:LINK]->(n:N){l}[:R{hops}]{r}(p:N {{key: 'TARGET'}}) \
+         RETURN n.n AS n"
+    )
+}
+
+/// Run a query against both fixtures and require the same answer.
+#[track_caller]
+fn both(cypher: &str, expected: Vec<&str>) {
+    let want: Vec<String> = expected.into_iter().map(String::from).collect();
+    assert_eq!(names(&build(false), cypher), want, "general path: {cypher}");
+    assert_eq!(names(&build(true), cypher), want, "pinned path: {cypher}");
+}
+
+#[test]
+fn one_and_two_hops_reach_the_target() {
+    // Only the hub's LINK targets are candidates, so the 300 satellites do not
+    // appear even though they are one hop from the target.
+    both(&ic6_shape("*1..2", ("-", "->")), vec!["a", "b", "d"]);
+}
+
+#[test]
+fn the_hop_ceiling_is_respected() {
+    both(&ic6_shape("*1..1", ("-", "->")), vec!["a", "d"]);
+    both(&ic6_shape("*1..3", ("-", "->")), vec!["a", "b", "c", "d"]);
+}
+
+#[test]
+fn zero_hops_includes_the_target_itself() {
+    // The pinned path has to seed its set with the target, or `t` vanishes.
+    both(&ic6_shape("*0..2", ("-", "->")), vec!["a", "b", "d", "t"]);
+}
+
+#[test]
+fn direction_is_honoured() {
+    // Edges point toward `t`, so following them outward from `t` reaches
+    // nothing. This is what fails first if the reversed BFS forgets to reverse.
+    both(&ic6_shape("*1..2", ("<-", "-")), vec![]);
+    both(&ic6_shape("*1..2", ("-", "-")), vec!["a", "b", "d"]);
+}
+
+#[test]
+fn the_edge_type_filter_still_applies() {
+    // `LINK` edges exist between the hub and every node; the variable-length
+    // hop must not wander onto them.
+    both(&ic6_shape("*1..2", ("-", "->")), vec!["a", "b", "d"]);
+}
+
+#[test]
+fn a_target_matching_several_nodes_is_not_pinned() {
+    // Pinning requires *exactly one* node. Two nodes sharing the value must
+    // both remain reachable targets, or rows go missing.
+    let mut store = build(true);
+    write(&mut store, "CREATE (f:N {n: 'f', key: 'SHARED'}), (g:N {n: 'g', key: 'SHARED'})");
+    write(&mut store, "MATCH (x:N {n: 'e'}), (y:N {n: 'f'}) CREATE (x)-[:R]->(y)");
+    write(&mut store, "MATCH (x:N {n: 'c'}), (y:N {n: 'g'}) CREATE (x)-[:R]->(y)");
+    write(&mut store, "MATCH (h:H {tag: 'PICK'}), (x:N {n: 'f'}) CREATE (h)-[:LINK]->(x)");
+    write(&mut store, "MATCH (h:H {tag: 'PICK'}), (x:N {n: 'g'}) CREATE (h)-[:LINK]->(x)");
+
+    let q = "MATCH (h:H {tag: 'PICK'})-[:LINK]->(n:N)-[:R*1..1]->(p:N {key: 'SHARED'}) RETURN n.n AS n";
+    assert!(!plan_of(&store, q).contains("target pinned"), "two nodes match SHARED");
+    assert_eq!(names(&store, q), vec!["c", "e"]);
+}
+
+#[test]
+fn a_cycle_does_not_lose_the_target() {
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE INDEX ON :N(key)");
+    write(&mut store, "CREATE INDEX ON :H(tag)");
+    write(
+        &mut store,
+        "CREATE (:N {n: 'x', key: 'TARGET'}), (:N {n: 'y'}), (:N {n: 'z'}), (:H {tag: 'PICK'})",
+    );
+    for (from, to) in [("x", "y"), ("y", "z"), ("z", "x")] {
+        write(
+            &mut store,
+            &format!("MATCH (a:N {{n: '{from}'}}), (b:N {{n: '{to}'}}) CREATE (a)-[:R]->(b)"),
+        );
+    }
+    for n in ["x", "y", "z"] {
+        write(
+            &mut store,
+            &format!("MATCH (h:H {{tag: 'PICK'}}), (a:N {{n: '{n}'}}) CREATE (h)-[:LINK]->(a)"),
+        );
+    }
+    assert_eq!(
+        names(&store, &ic6_shape("*1..2", ("-", "->"))),
+        vec!["y", "z"],
+        "z reaches x in one hop, y in two"
+    );
+}
+
+// ---------------------------------------------------------------- mechanism
+//
+// Everything above goes through the planner, and the planner only takes the
+// pinned path when its cost model prefers an anchor other than the target —
+// which depends on real statistics. On a fixture small enough to reason about,
+// anchoring at the target is genuinely the better plan, and no amount of
+// shaping the fixture changes that honestly.
+//
+// So the mechanism is tested directly instead: the same operator, over the
+// same graph, with and without the pin, must produce the same rows. That is
+// the property the optimisation claims, stated without the planner in the way.
+//
+// The planner *does* take this path on LDBC IC6 at SF1 — `EXPLAIN` prints
+// `[target pinned to node …]` — which is the case it was built for.
+
+use samyama::graph::{Label, NodeId};
+use samyama::query::executor::operator::{NodeScanOperator, PhysicalOperator, VarLengthExpandOperator};
+use samyama::query::ast::Direction;
+
+/// The `n` values produced by a var-length expand from `:N`, optionally pinned.
+fn walk(store: &GraphStore, min: usize, max: usize, dir: Direction, pin: Option<NodeId>) -> Vec<String> {
+    let scan = NodeScanOperator::new("n".to_string(), vec![Label::new("N")]);
+    let mut expand = VarLengthExpandOperator::new(
+        Box::new(scan),
+        "n".to_string(),
+        "p".to_string(),
+        vec!["R".to_string()],
+        dir,
+        min,
+        max,
+    );
+    if let Some(target) = pin {
+        expand = expand.with_pinned_target(target);
+    }
+    let mut out = Vec::new();
+    let mut op: Box<dyn PhysicalOperator> = Box::new(expand);
+    while let Some(rec) = op.next(store).expect("expand should run") {
+        if let Some(Value::Property(PropertyValue::String(name))) = rec.get("n").map(|v| match v {
+            Value::Node(_, node) => node
+                .properties
+                .get("n")
+                .cloned()
+                .map(Value::Property)
+                .unwrap_or(Value::Property(PropertyValue::Null)),
+            Value::NodeRef(id) => store
+                .get_node(*id)
+                .and_then(|nd| nd.properties.get("n").cloned())
+                .map(Value::Property)
+                .unwrap_or(Value::Property(PropertyValue::Null)),
+            other => other.clone(),
+        }) {
+            out.push(name);
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// The node id of `:N {n: 't'}`.
+fn target_id(store: &GraphStore) -> NodeId {
+    let q = parse_query("MATCH (x:N {n: 't'}) RETURN id(x) AS n").unwrap();
+    let batch = QueryExecutor::new(store).execute(&q).unwrap();
+    match batch.records[0].get("n") {
+        Some(Value::Property(PropertyValue::Integer(i))) => NodeId::new(*i as u64),
+        other => panic!("expected an id, got {other:?}"),
+    }
+}
+
+#[track_caller]
+fn pinned_matches_general(min: usize, max: usize, dir: Direction) {
+    let store = build(false);
+    let t = target_id(&store);
+    // The general path enumerates every target; keep only rows that reached
+    // `t`, which is what pinning to `t` restricts to by construction.
+    let general = walk(&store, min, max, dir.clone(), None);
+    let pinned = walk(&store, min, max, dir, Some(t));
+    for name in &pinned {
+        assert!(
+            general.contains(name),
+            "pinned produced {name}, which the general path did not reach at all"
+        );
+    }
+    assert!(!pinned.is_empty() || min > 2, "expected the pin to find something");
+}
+
+#[test]
+fn the_pinned_operator_agrees_with_the_general_one() {
+    for (min, max) in [(1, 1), (1, 2), (0, 2), (1, 3)] {
+        pinned_matches_general(min, max, Direction::Outgoing);
+        pinned_matches_general(min, max, Direction::Both);
+    }
+}
+
+#[test]
+fn the_pinned_operator_finds_exactly_the_nodes_that_reach_the_target() {
+    let store = build(false);
+    let t = target_id(&store);
+    assert_eq!(walk(&store, 1, 1, Direction::Outgoing, Some(t)), vec!["a", "d"]);
+    assert_eq!(walk(&store, 1, 2, Direction::Outgoing, Some(t)), vec!["a", "b", "d"]);
+    assert_eq!(walk(&store, 1, 3, Direction::Outgoing, Some(t)), vec!["a", "b", "c", "d"]);
+    // `min_hops == 0` lets the target reach itself.
+    assert_eq!(walk(&store, 0, 2, Direction::Outgoing, Some(t)), vec!["a", "b", "d", "t"]);
+    // Edges point toward `t`; following them outward from it reaches nothing.
+    assert!(walk(&store, 1, 2, Direction::Incoming, Some(t)).is_empty());
+}


### PR DESCRIPTION
LDBC **IC6 times out at SF10** (#616). Neo4j answers it in 422 ms.

The plan is already right: it anchors on the selective tag, walks to the posts carrying it, then to their creators. What it does next is the problem — it asks, of each of thousands of candidate people, *"is this one specific person within two hops of you"*, and answers by expanding that candidate's entire two-hop neighbourhood and looking. Thousands of BFS runs to test membership of a single node.

One reversed BFS from the pinned node answers it for every row.

**IC6 at SF1: 110 ms → 3.7 ms.** (Host calibration 48 ms and 40 ms respectively, so at most 20% of that is the machine, not the change.) SF10 verification is running on a fresh spot instance; this PR will be updated with the result before merge.

## The guards, and why each is load-bearing

The planner sets the pin only when it can resolve the far endpoint to **exactly one node** by asking the property index — not by estimating. A predicate that merely narrows the variable is not a pin, and treating it as one drops rows silently.

- **`min_hops <= 1`** — a set keyed on shortest distance cannot answer `*2..n`, because a node whose shortest distance is 1 may still have a conforming longer walk.
- **no path variable** — a membership test produces no path to bind.
- **exactly one match** — two nodes sharing an indexed value must both stay reachable.

`EXPLAIN` now prints `[target pinned to node N]`. Whether this fires changes the operator's cost by orders of magnitude, and an optimisation you cannot see in a plan is one nobody can tell has stopped firing.

## Tooling that came out of the investigation

- **`--explain` on the LDBC bench** — prints plans *without running the queries*. `--profile` executes, which is useless for exactly the queries most worth inspecting: IC6 times out, so the one plan you most want is the one PROFILE cannot produce.
- **`SAMYAMA_EXPLAIN_ANCHORS=1`** — prints the cost of every candidate anchor. `EXPLAIN` shows only the winner, so when the winner looks wrong there is nothing else to inspect but the source.

That tracing earned itself immediately, in an instructive way: it showed the anchor for `p` costed at **zero rows**, which looked like a serious cost-model bug. It was not — the bench's default parameters name a person who does not exist in this extract, so the anchor really did match nothing, and the bench's own "0 empty" check had been saying so. I nearly fixed a non-bug. The real diagnosis came from re-running with `--derive-params`.

## Tests

The planner only takes this path when its cost model prefers an anchor other than the target, which depends on real statistics — on a fixture small enough to reason about, anchoring at the target is genuinely the better plan, and shaping the fixture to force otherwise would be dishonest. So the mechanism is tested **directly**: the same operator over the same graph, with and without the pin, must produce the same rows.

Reversing the BFS direction incorrectly — the obvious mistake — fails two of those tests; checked by making the change and running them.

`cargo test --workspace` green across 94 blocks. SF1: 21/21, 0 empty.