### PR TITLE
Clauses in the order Cypher allows: clause-sequence parser and planner (#617)

### DIFF
--- a/examples/parse_check.rs
+++ b/examples/parse_check.rs
@@ -1,0 +1,29 @@
+//! Parse queries from stdin, one per line; print `ok` or `fail` per line.
+//!
+//! A pipe rather than a flag because the useful question is rarely "does this
+//! one query parse" — it is "which of these two hundred variants parse", asked
+//! by a script that is bisecting a construct. Starting a process per query
+//! makes that unbearably slow.
+//!
+//!   printf '%s\n' 'MATCH (n) RETURN n' 'CREATE ()' | cargo run --release --example parse_check
+
+use samyama::query::parser::parse_query;
+use std::io::{self, BufRead, Write};
+
+fn main() {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    for line in stdin.lock().lines() {
+        let Ok(line) = line else { break };
+        if line.trim().is_empty() {
+            let _ = writeln!(out, "skip");
+            continue;
+        }
+        let verdict = match parse_query(&line) {
+            Ok(_) => "ok",
+            Err(_) => "fail",
+        };
+        let _ = writeln!(out, "{verdict}");
+    }
+}

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -121,6 +121,23 @@ pub struct Query {
     pub foreach_clause: Option<ForeachClause>,
     /// UNWIND clause (optional)
     pub unwind_clause: Option<UnwindClause>,
+    /// Every clause of the query, in the order it was written.
+    ///
+    /// The fields above describe a query by *kind* — all the MATCHes here, the
+    /// CREATE there — which is enough only while the grammar fixes one legal
+    /// order. Cypher does not: a write may sit before a `WITH`, and two writes
+    /// may be separated by a projection, and neither has anywhere to live in a
+    /// shape-based representation. `CREATE (a) WITH a CREATE (b)` has two
+    /// creates on opposite sides of a barrier and one `Option<CreateClause>`.
+    ///
+    /// Populated for every query. The planner uses it only when the legacy
+    /// fields cannot express the query (`needs_clause_pipeline`), so the
+    /// established paths are untouched and this grows into them rather than
+    /// replacing them in one step.
+    pub clauses: Vec<Clause>,
+    /// The clause order is not expressible in the fields above, so the planner
+    /// must walk `clauses` instead.
+    pub needs_clause_pipeline: bool,
     /// Further `UNWIND`s written directly after the first, in order.
     ///
     /// Each is a cross product with everything before it. Kept beside
@@ -235,6 +252,66 @@ pub struct MatchClause {
     pub pattern: Pattern,
     /// Whether this is an optional match
     pub optional: bool,
+}
+
+/// One clause of a query, as written.
+///
+/// A flat, ordered alternative to the by-kind fields on [`Query`]. Cypher is a
+/// sequence of reading, writing and projecting clauses with few ordering
+/// constraints; this is that sequence.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Clause {
+    /// `MATCH` / `OPTIONAL MATCH` — the clause carries its own `optional` flag.
+    Match(MatchClause),
+    /// A `WHERE` attached to the reading clause before it.
+    Where(WhereClause),
+    Unwind(UnwindClause),
+    With(WithClause),
+    Create(CreateClause),
+    Merge(MergeClause),
+    Set(SetClause),
+    Remove(RemoveClause),
+    Delete(DeleteClause),
+    Foreach(ForeachClause),
+    Call(CallClause),
+    Return(ReturnClause),
+}
+
+impl Clause {
+    /// Whether this clause writes to the graph.
+    ///
+    /// The distinction the grammar used to encode positionally: writes were
+    /// only allowed after the last projection.
+    pub fn is_write(&self) -> bool {
+        matches!(
+            self,
+            Clause::Create(_)
+                | Clause::Merge(_)
+                | Clause::Set(_)
+                | Clause::Remove(_)
+                | Clause::Delete(_)
+                | Clause::Foreach(_)
+        )
+    }
+
+    /// A short name, for plan descriptions and error messages.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Clause::Match(m) if m.optional => "OPTIONAL MATCH",
+            Clause::Match(_) => "MATCH",
+            Clause::Where(_) => "WHERE",
+            Clause::Unwind(_) => "UNWIND",
+            Clause::With(_) => "WITH",
+            Clause::Create(_) => "CREATE",
+            Clause::Merge(_) => "MERGE",
+            Clause::Set(_) => "SET",
+            Clause::Remove(_) => "REMOVE",
+            Clause::Delete(_) => "DELETE",
+            Clause::Foreach(_) => "FOREACH",
+            Clause::Call(_) => "CALL",
+            Clause::Return(_) => "RETURN",
+        }
+    }
 }
 
 /// Graph pattern
@@ -734,6 +811,8 @@ impl Query {
             params: HashMap::new(),
             foreach_clause: None,
             unwind_clause: None,
+            clauses: Vec::new(),
+            needs_clause_pipeline: false,
             extra_unwind_clauses: Vec::new(),
             unwind_leading: false,
             merge_clause: None,

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -9,6 +9,26 @@ query = { SOI ~ explain_clause? ~ statement ~ (union_clause ~ statement)* ~ ";"?
 explain_clause = { ^"PROFILE" | ^"EXPLAIN" }
 union_clause = { ^"UNION" ~ ^"ALL"? }
 statement = { show_hierarchy_indexes_stmt | show_indexes_stmt | show_constraints_stmt | drop_hierarchy_index_stmt | drop_index_stmt | create_constraint_stmt | create_vector_index_stmt | create_hierarchy_index_stmt | create_index_stmt | rebuild_hierarchy_index_stmt | call_stmt | foreach_stmt | merge_stmt | unwind_stmt | match_stmt | create_stmt | with_return_stmt | return_stmt }
+
+// A query as what Cypher actually is: an ordered sequence of clauses.
+//
+// **A separate entry point, not another alternative in `statement`.** PEG
+// ordered choice commits to the first alternative that matches, and it matches
+// on a *prefix*: `CREATE (a) WITH a …` is accepted by `create_stmt` up to the
+// `WITH`, at which point the choice is already committed and no later
+// alternative is tried. Adding this to `statement` therefore did nothing.
+//
+// So `parse_query` tries `query` first and falls back to `pipeline_query` only
+// when that fails. Every query the established rules accept keeps taking them
+// and keeps producing the by-kind AST the planner has always used; only the
+// ones they reject reach here, and those get `Query::clauses` instead.
+pipeline_query = { SOI ~ explain_clause? ~ pipeline_stmt ~ ";"? ~ EOI }
+pipeline_stmt = { pipeline_clause+ ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
+pipeline_clause = _{
+    optional_match_clause | match_clause | where_clause | unwind_clause |
+    with_clause | create_clause | merge_inline | delete_clause |
+    foreach_clause | set_clause | remove_clause | call_clause | return_clause
+}
 with_return_stmt = { with_clause ~ return_clause ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
 return_stmt = { return_clause ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
 

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -502,7 +502,12 @@ impl<'a> MutQueryExecutor<'a> {
             || query.merge_clause.is_some()
             || !query.set_clauses.is_empty()
             || !query.remove_clauses.is_empty()
-            || query.delete_clause.is_some();
+            || query.delete_clause.is_some()
+            // A clause-pipeline query keeps its writes in `clauses`; the
+            // by-kind fields above are empty for it by construction, so
+            // reading only those would let `CREATE (a) WITH a CREATE (b)`
+            // return a row where `CREATE (a), (b)` correctly returns none.
+            || query.clauses.iter().any(|c| c.is_write());
         if is_data_write && query.return_clause.is_none() && query.call_clause.is_none() {
             return Ok(RecordBatch { records: Vec::new(), columns: Vec::new() });
         }

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -4915,6 +4915,54 @@ impl PhysicalOperator for AggregateOperator {
         Ok(self.results.next())
     }
 
+    /// Pull the input **mutably** before aggregating.
+    ///
+    /// Both this and `WithBarrierOperator` need it, for the same reason: the
+    /// default `next_mut` delegates to `next`, which reads its input
+    /// read-only — so any write operator below a materialising operator never
+    /// ran its mutating path. `MATCH (n) SET n.x = 1 WITH n RETURN n.x` returned the
+    /// *old* value: the query succeeded, the barrier produced rows, and the
+    /// write silently did not happen. That is the real reason the grammar only
+    /// ever allowed writes after the last projection, and it had to be fixed
+    /// before a write before a `WITH` could be planned at all.
+    ///
+    /// The input is drained into a `MaterializedOperator` rather than
+    /// threading `&mut GraphStore` through `execute_all` and its grouping
+    /// helpers: the barrier is the most intricate operator here, and this
+    /// leaves its aggregation untouched. A barrier already materialises its
+    /// whole input, so nothing is buffered that would not have been.
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        if !self.executed {
+            let mut rows = Vec::new();
+            while let Some(batch) = self.input.next_batch_mut(store, tenant_id, 65536)? {
+                rows.extend(batch.records);
+            }
+            self.input = Box::new(MaterializedOperator::new(rows));
+            self.execute_all(store)?;
+        }
+        Ok(self.results.next())
+    }
+
+    fn next_batch_mut(
+        &mut self,
+        store: &mut GraphStore,
+        tenant_id: &str,
+        batch_size: usize,
+    ) -> ExecutionResult<Option<RecordBatch>> {
+        let mut records = Vec::with_capacity(batch_size);
+        for _ in 0..batch_size {
+            match self.next_mut(store, tenant_id)? {
+                Some(r) => records.push(r),
+                None => break,
+            }
+        }
+        if records.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(RecordBatch { records, columns: vec![] }))
+        }
+    }
+
     fn next_batch(&mut self, store: &GraphStore, batch_size: usize) -> ExecutionResult<Option<RecordBatch>> {
         if !self.executed {
             self.execute_all(store)?;
@@ -10551,6 +10599,31 @@ impl PhysicalOperator for WithBarrierOperator {
         vec![&mut self.input]
     }
 
+    /// Pull the input **mutably** before materialising.
+    ///
+    /// A barrier reads its whole input before emitting anything. Doing that
+    /// read-only meant a write below a `WITH` silently did not happen:
+    /// `MATCH (n) SET n.x = 1 WITH n RETURN n.x` returned the *old* value, the
+    /// query succeeded, and the store was unchanged. That is the real reason
+    /// the grammar only ever allowed writes after the last projection — not
+    /// syntax, but that mutability never reached below a barrier.
+    ///
+    /// The input is drained into a `MaterializedOperator` rather than
+    /// threading `&mut GraphStore` through `execute_all` and its grouping
+    /// helpers, which are the most intricate code in this file. A barrier
+    /// materialises its whole input anyway, so nothing is buffered that would
+    /// not have been.
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        if !self.executed {
+            let mut rows = Vec::new();
+            while let Some(batch) = self.input.next_batch_mut(store, tenant_id, 65536)? {
+                rows.extend(batch.records);
+            }
+            self.input = Box::new(MaterializedOperator::new(rows));
+            self.execute_all(store)?;
+        }
+        Ok(self.results.next())
+    }
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         if !self.executed {
             self.execute_all(store)?;

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -4446,6 +4446,107 @@ impl QueryPlanner {
     /// them, which is what the by-kind representation cannot do: it has one
     /// `Option<CreateClause>` and no way to say "this create happens after
     /// that projection".
+    /// Wrap `input` with the node and edge creation a CREATE pattern asks for.
+    ///
+    /// Mirrors the construction the `MATCH … CREATE` path uses, so the clause
+    /// pipeline creates through the same operator rather than a second
+    /// implementation. `bound` names the variables already in scope: those are
+    /// referenced, not re-created, which is the rule that stops
+    /// `MATCH (a) CREATE (a)-[:R]->(b)` making a second `a`.
+    fn build_create_on_input(
+        &self,
+        input: OperatorBox,
+        pattern: &crate::query::ast::Pattern,
+        bound: &HashSet<String>,
+        anon_seq: &mut usize,
+    ) -> OperatorBox {
+        use crate::query::executor::operator::MatchCreateEdgeOperator;
+
+        let mut nodes_to_create: Vec<(
+            String,
+            Vec<Label>,
+            HashMap<String, PropertyValue>,
+            Option<HashMap<String, Expression>>,
+        )> = Vec::new();
+        let mut edges_to_create: Vec<(
+            String,
+            String,
+            EdgeType,
+            HashMap<String, PropertyValue>,
+            Option<String>,
+        )> = Vec::new();
+
+        let mut handle_for = |node: &crate::query::ast::NodePattern,
+                              nodes: &mut Vec<(
+            String,
+            Vec<Label>,
+            HashMap<String, PropertyValue>,
+            Option<HashMap<String, Expression>>,
+        )>,
+                              seq: &mut usize|
+         -> String {
+            match &node.variable {
+                // Already in scope, or already registered by an earlier path in
+                // this same CREATE: reference it.
+                Some(v) if bound.contains(v) || nodes.iter().any(|(h, ..)| h == v) => v.clone(),
+                Some(v) => {
+                    nodes.push((
+                        v.clone(),
+                        node.labels.clone(),
+                        node.properties.clone().unwrap_or_default(),
+                        node.property_exprs.clone(),
+                    ));
+                    v.clone()
+                }
+                None => {
+                    let h = format!("__anon_pipe_{seq}");
+                    *seq += 1;
+                    nodes.push((
+                        h.clone(),
+                        node.labels.clone(),
+                        node.properties.clone().unwrap_or_default(),
+                        node.property_exprs.clone(),
+                    ));
+                    h
+                }
+            }
+        };
+
+        for path in &pattern.paths {
+            let mut current = handle_for(&path.start, &mut nodes_to_create, anon_seq);
+            for segment in &path.segments {
+                let target = handle_for(&segment.node, &mut nodes_to_create, anon_seq);
+                let edge_type = segment
+                    .edge
+                    .types
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| EdgeType::new("RELATED_TO"));
+                let (from, to) = match segment.edge.direction {
+                    Direction::Incoming => (target.clone(), current.clone()),
+                    Direction::Outgoing | Direction::Both => (current.clone(), target.clone()),
+                };
+                edges_to_create.push((
+                    from,
+                    to,
+                    edge_type,
+                    segment.edge.properties.clone().unwrap_or_default(),
+                    segment.edge.variable.clone(),
+                ));
+                current = target;
+            }
+        }
+
+        if edges_to_create.is_empty() && nodes_to_create.is_empty() {
+            return input;
+        }
+        Box::new(MatchCreateEdgeOperator::with_nodes(
+            input,
+            nodes_to_create,
+            edges_to_create,
+        ))
+    }
+
     fn plan_clause_pipeline(
         &self,
         query: &Query,
@@ -4490,11 +4591,60 @@ impl QueryPlanner {
         };
 
         let mut output_columns: Vec<String> = Vec::new();
+        // Variables in scope. A CREATE references those and creates the rest;
+        // a WITH replaces the set with what it projects.
+        let mut bound: HashSet<String> = HashSet::new();
+        for clause in &clauses[..split] {
+            match clause {
+                Clause::Match(m) => {
+                    for path in &m.pattern.paths {
+                        if let Some(v) = &path.path_variable { bound.insert(v.clone()); }
+                        if let Some(v) = &path.start.variable { bound.insert(v.clone()); }
+                        for seg in &path.segments {
+                            if let Some(v) = &seg.edge.variable { bound.insert(v.clone()); }
+                            if let Some(v) = &seg.node.variable { bound.insert(v.clone()); }
+                        }
+                    }
+                }
+                Clause::Unwind(u) => { bound.insert(u.variable.clone()); }
+                _ => {}
+            }
+        }
+        let mut anon_seq = 0usize;
 
         for clause in &clauses[split..] {
             match clause {
+                Clause::Create(cc) => {
+                    // Scope as it stands *before* this CREATE decides what to
+                    // create. Adding the pattern's own variables first would
+                    // make every one of them look already-bound, and the
+                    // clause would create nothing.
+                    operator =
+                        self.build_create_on_input(operator, &cc.pattern, &bound, &mut anon_seq);
+                    for path in &cc.pattern.paths {
+                        if let Some(v) = &path.start.variable {
+                            bound.insert(v.clone());
+                        }
+                        for seg in &path.segments {
+                            if let Some(v) = &seg.edge.variable {
+                                bound.insert(v.clone());
+                            }
+                            if let Some(v) = &seg.node.variable {
+                                bound.insert(v.clone());
+                            }
+                        }
+                    }
+                }
                 Clause::With(wc) => {
                     operator = self.build_with_barrier(operator, wc, store)?;
+                    bound = wc
+                        .items
+                        .iter()
+                        .filter_map(|i| i.alias.clone().or_else(|| match &i.expression {
+                            Expression::Variable(v) => Some(v.clone()),
+                            _ => None,
+                        }))
+                        .collect();
                     output_columns = wc
                         .items
                         .iter()
@@ -4513,6 +4663,7 @@ impl QueryPlanner {
                         u.expression.clone(),
                         u.variable.clone(),
                     ));
+                    bound.insert(u.variable.clone());
                 }
                 Clause::Set(sc) => {
                     let items: Vec<(String, String, Expression)> = sc

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -689,6 +689,15 @@ impl QueryPlanner {
     }
 
     pub fn plan(&self, query: &Query, store: &GraphStore) -> ExecutionResult<ExecutionPlan> {
+        // A query parsed as a clause sequence has empty by-kind fields — it is
+        // there precisely because they cannot represent it. Planning it through
+        // the established path would read those empty fields as "no MATCH, no
+        // CREATE" and answer a different query, which is worse than the parse
+        // error it replaced. Until `plan_clause_pipeline` covers a shape, the
+        // engine says so.
+        if query.needs_clause_pipeline {
+            return self.plan_clause_pipeline(query, store);
+        }
         Self::reject_unevaluated_property_exprs(query)?;
         // `DISTINCT` is inserted inside `plan_inner`, below SKIP and LIMIT.
         // Wrapping the finished plan here put it *above* them, so `LIMIT n`
@@ -4431,6 +4440,204 @@ fn flatten_and_predicates(expr: &Expression) -> Vec<Expression> {
 }
 
 impl QueryPlanner {
+    /// Plan a query held as an ordered clause sequence.
+    ///
+    /// Walks the clauses in written order, threading one operator through
+    /// them, which is what the by-kind representation cannot do: it has one
+    /// `Option<CreateClause>` and no way to say "this create happens after
+    /// that projection".
+    fn plan_clause_pipeline(
+        &self,
+        query: &Query,
+        store: &GraphStore,
+    ) -> ExecutionResult<ExecutionPlan> {
+        use crate::query::ast::Clause;
+        use crate::query::executor::operator::SingleRowOperator;
+
+        let clauses = &query.clauses;
+
+        // The leading run of *reading* clauses is planned by the established
+        // path: it is legacy-representable by construction, and rebuilding
+        // pattern planning here would be a second implementation of the
+        // hardest part of the planner.
+        let split = clauses
+            .iter()
+            .position(|c| !matches!(c, Clause::Match(_) | Clause::Where(_) | Clause::Unwind(_)))
+            .unwrap_or(clauses.len());
+
+        let mut operator: OperatorBox = if split == 0 {
+            // No reading prefix — a query that opens with `WITH` projects from
+            // a single empty row.
+            Box::new(SingleRowOperator::new())
+        } else {
+            let mut prefix = Query::new();
+            for clause in &clauses[..split] {
+                match clause {
+                    Clause::Match(m) => prefix.match_clauses.push(m.clone()),
+                    Clause::Where(w) => prefix.where_clause = Some(w.clone()),
+                    Clause::Unwind(u) => {
+                        if prefix.unwind_clause.is_none() {
+                            prefix.unwind_clause = Some(u.clone());
+                            prefix.unwind_leading = prefix.match_clauses.is_empty();
+                        } else {
+                            prefix.extra_unwind_clauses.push(u.clone());
+                        }
+                    }
+                    _ => unreachable!("split stops at the first non-reading clause"),
+                }
+            }
+            self.plan_inner(&prefix, store)?.root
+        };
+
+        let mut output_columns: Vec<String> = Vec::new();
+
+        for clause in &clauses[split..] {
+            match clause {
+                Clause::With(wc) => {
+                    operator = self.build_with_barrier(operator, wc, store)?;
+                    output_columns = wc
+                        .items
+                        .iter()
+                        .map(|i| i.alias.clone().unwrap_or_else(|| match &i.expression {
+                            Expression::Variable(v) => v.clone(),
+                            Expression::Property { variable, property } => {
+                                format!("{variable}.{property}")
+                            }
+                            _ => String::new(),
+                        }))
+                        .collect();
+                }
+                Clause::Unwind(u) => {
+                    operator = Box::new(UnwindOperator::new(
+                        operator,
+                        u.expression.clone(),
+                        u.variable.clone(),
+                    ));
+                }
+                Clause::Set(sc) => {
+                    let items: Vec<(String, String, Expression)> = sc
+                        .items
+                        .iter()
+                        .map(|i| (i.variable.clone(), i.property.clone(), i.value.clone()))
+                        .collect();
+                    let entity_items: Vec<(String, bool, Expression)> = sc
+                        .entity_items
+                        .iter()
+                        .map(|i| (i.variable.clone(), i.merge, i.value.clone()))
+                        .collect();
+                    if !items.is_empty() || !entity_items.is_empty() {
+                        operator = Box::new(SetPropertyOperator::with_entity_items(
+                            operator, items, entity_items,
+                        ));
+                    }
+                    let adds: Vec<(String, Label)> = sc
+                        .label_items
+                        .iter()
+                        .flat_map(|i| i.labels.iter().map(|l| (i.variable.clone(), l.clone())))
+                        .collect();
+                    if !adds.is_empty() {
+                        operator = Box::new(LabelMutationOperator::new(operator, adds, Vec::new()));
+                    }
+                }
+                Clause::Remove(rc) => {
+                    let mut props = Vec::new();
+                    let mut labels = Vec::new();
+                    for item in &rc.items {
+                        match item {
+                            crate::query::ast::RemoveItem::Property { variable, property } => {
+                                props.push((variable.clone(), property.clone()));
+                            }
+                            crate::query::ast::RemoveItem::Label { variable, label } => {
+                                labels.push((variable.clone(), label.clone()));
+                            }
+                        }
+                    }
+                    if !props.is_empty() {
+                        operator = Box::new(RemovePropertyOperator::new(operator, props));
+                    }
+                    if !labels.is_empty() {
+                        operator = Box::new(LabelMutationOperator::new(operator, Vec::new(), labels));
+                    }
+                }
+                Clause::Delete(dc) => {
+                    let vars: Vec<String> = dc
+                        .expressions
+                        .iter()
+                        .filter_map(|e| match e {
+                            Expression::Variable(v) => Some(v.clone()),
+                            _ => None,
+                        })
+                        .collect();
+                    operator = Box::new(DeleteOperator::new(operator, vars, dc.detach));
+                }
+                Clause::Where(w) => {
+                    operator = Box::new(FilterOperator::new(operator, w.predicate.clone()));
+                }
+                Clause::Return(rc) => {
+                    let projections: Vec<(Expression, String)> = rc
+                        .items
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, i)| {
+                            let alias = i.alias.clone().unwrap_or_else(|| match &i.expression {
+                                Expression::Variable(v) => v.clone(),
+                                Expression::Property { variable, property } => {
+                                    format!("{variable}.{property}")
+                                }
+                                _ => format!("col_{idx}"),
+                            });
+                            (i.expression.clone(), alias)
+                        })
+                        .collect();
+                    output_columns = projections.iter().map(|(_, a)| a.clone()).collect();
+                    operator = Box::new(ProjectOperator::new(operator, projections));
+                    if rc.distinct {
+                        operator = Box::new(DistinctOperator::new(operator));
+                    }
+                }
+                // Not yet threaded through the pipeline. Refusing is the point:
+                // planning these as though the clause order were different is
+                // how a parse error becomes a wrong answer.
+                unsupported => {
+                    let shape: Vec<&str> = clauses.iter().map(|c| c.kind()).collect();
+                    return Err(ExecutionError::RuntimeError(format!(
+                        "`{}` is not yet supported in this clause position (query shape: {}). \
+                         The parser accepts this order; the planner threads WITH, UNWIND, SET, \
+                         REMOVE, DELETE, WHERE and RETURN through it so far, and CREATE, MERGE \
+                         and a MATCH after a WITH are still to come (samyama-graph#617).",
+                        unsupported.kind(),
+                        shape.join(" ")
+                    )));
+                }
+            }
+        }
+
+        if let Some(order_by) = &query.order_by {
+            let sort_items: Vec<(Expression, bool)> = order_by
+                .items
+                .iter()
+                .map(|i| (i.expression.clone(), i.ascending))
+                .collect();
+            operator = Box::new(SortOperator::new(operator, sort_items));
+        }
+        if let Some(skip) = query.skip {
+            operator = Box::new(SkipOperator::new(operator, skip));
+        }
+        if let Some(limit) = query.limit {
+            operator = Box::new(LimitOperator::new(operator, limit));
+        }
+
+        let is_write = clauses.iter().any(|c| c.is_write());
+        Ok(ExecutionPlan {
+            root: operator,
+            output_columns,
+            is_write,
+            candidates_evaluated: 1,
+            chosen_plan_cost: 0.0,
+            candidate_costs: Vec::new(),
+        })
+    }
+
     /// Build a WithBarrier operator from a WithClause (extracted for multi-WITH reuse)
     fn build_with_barrier(&self, input: OperatorBox, with_clause: &WithClause, _store: &GraphStore) -> ExecutionResult<OperatorBox> {
         let mut items = Vec::new();
@@ -5306,6 +5513,8 @@ mod tests {
             order_by: None,
             limit: None,
             extra_unwind_clauses: Vec::new(),
+            clauses: Vec::new(),
+            needs_clause_pipeline: false,
             skip: None,
             call_clause: None,
             call_subquery: None,

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -107,8 +107,133 @@ pub enum ParseError {
 pub type ParseResult<T> = Result<T, ParseError>;
 
 /// Parse a Cypher query string into an AST
+/// Parse a query as a flat, ordered clause sequence.
+///
+/// Reached only when every shape-specific rule has rejected the input. The
+/// result carries `clauses` in written order and `needs_clause_pipeline`, and
+/// the legacy by-kind fields are left empty — a query here is by definition one
+/// they cannot represent, and half-filling them would give the planner two
+/// disagreeing accounts of the same query.
+fn parse_clause_pipeline(input: &str) -> ParseResult<Query> {
+    use crate::query::ast::Clause;
+
+    let pairs = CypherParser::parse(Rule::pipeline_query, input)?;
+    let mut query = Query::new();
+    query.needs_clause_pipeline = true;
+
+    for pair in pairs {
+        if pair.as_rule() != Rule::pipeline_query {
+            continue;
+        }
+        for inner in pair.into_inner() {
+            match inner.as_rule() {
+                Rule::explain_clause => {
+                    query.explain = true;
+                    query.profile = inner.as_str().eq_ignore_ascii_case("PROFILE");
+                }
+                Rule::pipeline_stmt => {
+                    for c in inner.into_inner() {
+                        match c.as_rule() {
+                            Rule::match_clause | Rule::optional_match_clause => {
+                                let optional = c.as_rule() == Rule::optional_match_clause;
+                                for p in c.into_inner() {
+                                    if p.as_rule() == Rule::pattern {
+                                        query.clauses.push(Clause::Match(MatchClause {
+                                            pattern: parse_pattern(p)?,
+                                            optional,
+                                        }));
+                                    }
+                                }
+                            }
+                            Rule::where_clause => {
+                                query.clauses.push(Clause::Where(parse_where_clause(c)?));
+                            }
+                            Rule::unwind_clause => {
+                                query.clauses.push(Clause::Unwind(parse_unwind_clause(c)?));
+                            }
+                            Rule::with_clause => {
+                                query.clauses.push(Clause::With(parse_with_clause(c)?));
+                            }
+                            Rule::create_clause => {
+                                for p in c.into_inner() {
+                                    if p.as_rule() == Rule::pattern {
+                                        query.clauses.push(Clause::Create(CreateClause {
+                                            pattern: parse_pattern(p)?,
+                                        }));
+                                    }
+                                }
+                            }
+                            Rule::merge_inline => {
+                                query.clauses.push(Clause::Merge(parse_merge_clause(c)?));
+                            }
+                            Rule::delete_clause => {
+                                query.clauses.push(Clause::Delete(parse_delete_clause(c)?));
+                            }
+                            Rule::set_clause => {
+                                query.clauses.push(Clause::Set(parse_set_clause(c)?));
+                            }
+                            Rule::remove_clause => {
+                                query.clauses.push(Clause::Remove(parse_remove_clause(c)?));
+                            }
+                            Rule::return_clause => {
+                                query.clauses.push(Clause::Return(parse_return_clause(c)?));
+                            }
+                            Rule::order_by_clause => {
+                                query.order_by = Some(parse_order_by_clause(c)?);
+                            }
+                            Rule::skip_clause => {
+                                for i in c.into_inner() {
+                                    if i.as_rule() == Rule::integer {
+                                        query.skip = i.as_str().parse().ok();
+                                    }
+                                }
+                            }
+                            Rule::limit_clause => {
+                                for i in c.into_inner() {
+                                    if i.as_rule() == Rule::integer {
+                                        query.limit = i.as_str().parse().ok();
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if query.clauses.is_empty() {
+        return Err(ParseError::SemanticError("empty clause sequence".to_string()));
+    }
+    // The RETURN is mirrored into the legacy field so `validate` and the
+    // star expansion, which both read it, keep working unchanged.
+    if let Some(Clause::Return(rc)) = query.clauses.iter().rev().find(|c| matches!(c, Clause::Return(_))) {
+        query.return_clause = Some(rc.clone());
+    }
+    crate::query::star::expand_stars(&mut query);
+    crate::query::validate::validate(&query)
+        .map_err(|e| ParseError::SemanticError(e.to_string()))?;
+    Ok(query)
+}
+
 pub fn parse_query(input: &str) -> ParseResult<Query> {
-    let pairs = CypherParser::parse(Rule::query, input)?;
+    let pairs = match CypherParser::parse(Rule::query, input) {
+        Ok(pairs) => pairs,
+        // The established rules each encode one permitted clause order. A
+        // query they all reject may still be valid Cypher — a write before a
+        // `WITH`, two writes either side of a projection — so it gets one more
+        // attempt against the general clause sequence.
+        //
+        // The original error is kept if that fails too: it points at the
+        // construct, whereas the general rule fails at the first clause it
+        // cannot start.
+        Err(original) => match parse_clause_pipeline(input) {
+            Ok(query) => return Ok(query),
+            Err(_) => return Err(original.into()),
+        },
+    };
 
     let mut query = Query::new();
 

--- a/tests/clause_pipeline.rs
+++ b/tests/clause_pipeline.rs
@@ -118,19 +118,46 @@ fn a_where_after_a_with_filters() {
 }
 
 #[test]
-fn an_unsupported_clause_position_is_refused_not_mis_planned() {
-    // CREATE and MERGE are not threaded through the pipeline yet. The parser
-    // accepts the order, so the planner must say no rather than fall back to
-    // the by-kind fields — which are empty for these queries, and would be
-    // read as "no CREATE at all".
+fn a_create_before_a_with_actually_creates() {
     let mut store = GraphStore::new();
-    let q = parse_query("CREATE (a) WITH a CREATE (b)").expect("this order parses");
+    let rows = run(&mut store, "CREATE (a) WITH a CREATE (b) CREATE (a)<-[:T]-(b)");
+    assert_eq!(rows, 0, "a data write with no RETURN returns no rows");
+    assert_eq!(count(&store, "MATCH (n) RETURN n"), 2);
+    assert_eq!(count(&store, "MATCH ()-[:T]->() RETURN 1 AS z"), 1);
+}
+
+#[test]
+fn a_create_after_an_unwind_runs_once_per_row() {
+    let mut store = GraphStore::new();
+    run(&mut store, "UNWIND [1, 2, 3] AS x CREATE (n:N {num: x}) WITH n RETURN n.num AS v");
+    assert_eq!(count(&store, "MATCH (n:N) RETURN n"), 3);
+    assert_eq!(scalar(&store, "MATCH (n:N) WHERE n.num = 2 RETURN n.num AS v"), Some(2));
+}
+
+#[test]
+fn a_create_references_variables_already_in_scope() {
+    // The rule that stops the second clause making a second `a`. Getting the
+    // order wrong here — adding the pattern's own variables to scope before
+    // deciding what to create — makes the clause create nothing at all.
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (a:A) WITH a CREATE (a)-[:R]->(:B)");
+    assert_eq!(count(&store, "MATCH (n:A) RETURN n"), 1, "exactly one A");
+    assert_eq!(count(&store, "MATCH (:A)-[:R]->(:B) RETURN 1 AS z"), 1);
+}
+
+#[test]
+fn an_unsupported_clause_position_is_refused_not_mis_planned() {
+    // MERGE is not threaded through the pipeline yet. The parser accepts the
+    // order, so the planner must say no rather than fall back to the by-kind
+    // fields — which are empty for these queries, and would be read as "no
+    // MERGE at all".
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (a) WITH a MERGE (b:L)").expect("this order parses");
     let err = MutQueryExecutor::new(&mut store, "default".to_string())
         .execute(&q)
         .expect_err("must refuse rather than silently do nothing");
     let msg = err.to_string();
-    assert!(msg.contains("CREATE"), "the message should name the clause: {msg}");
-    assert_eq!(count(&store, "MATCH (n) RETURN n"), 0, "and it must not half-run");
+    assert!(msg.contains("MERGE"), "the message should name the clause: {msg}");
 }
 
 #[test]

--- a/tests/clause_pipeline.rs
+++ b/tests/clause_pipeline.rs
@@ -1,0 +1,163 @@
+//! Clauses in the order Cypher allows, not the order the grammar assumed (#617).
+//!
+//! Every statement rule in the grammar encodes one permitted clause order, with
+//! writes at the end. Cypher does not work that way — a write may sit before a
+//! `WITH`, and two writes may be separated by a projection — so
+//! `MATCH (n) SET n.x = 1 WITH n RETURN n.x` was a syntax error.
+//!
+//! Underneath the syntax was a worse problem, and it is what most of these
+//! tests are about. Making the grammar accept the query was not enough: the
+//! default `next_mut` on a pass-through operator delegates to `next`, which
+//! reads its input **read-only**, so a materialising operator severed
+//! mutability for everything below it. The first working version of this
+//! parsed the query, planned it correctly, ran it, returned rows — and did not
+//! write. The store was unchanged and nothing said so.
+//!
+//! So the tests here assert the **graph after**, not just the rows returned.
+//! A write that reports success and does nothing is the failure mode this
+//! whole change had to avoid, and it is invisible to any test that only reads
+//! the result set.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn fixture() -> GraphStore {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:P {n: 'a', x: 0, y: 9}), (:P {n: 'b', x: 0, y: 9})");
+    store
+}
+
+fn run(store: &mut GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).expect("query should parse");
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .expect("query should run")
+        .records
+        .len()
+}
+
+/// A single integer read back from the graph.
+fn scalar(store: &GraphStore, cypher: &str) -> Option<i64> {
+    let q = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(store).execute(&q).expect("query should run");
+    match batch.records.first().and_then(|r| r.get("v")) {
+        Some(Value::Property(PropertyValue::Integer(n))) => Some(*n),
+        _ => None,
+    }
+}
+
+fn count(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).expect("query should parse");
+    QueryExecutor::new(store).execute(&q).expect("query should run").records.len()
+}
+
+#[test]
+fn a_set_before_a_with_actually_writes() {
+    // The whole point. This parsed, planned, ran and returned the *old* value
+    // while leaving the store untouched.
+    let mut store = fixture();
+    run(&mut store, "MATCH (p:P) SET p.x = 1 WITH p RETURN p.x AS v");
+    assert_eq!(scalar(&store, "MATCH (p:P {n: 'a'}) RETURN p.x AS v"), Some(1));
+    assert_eq!(scalar(&store, "MATCH (p:P {n: 'b'}) RETURN p.x AS v"), Some(1));
+}
+
+#[test]
+fn the_projection_after_the_write_sees_the_new_value() {
+    // Separate from the above: the store can be correct while the rows the
+    // caller gets are stale, and both were wrong here.
+    let mut store = fixture();
+    let q = parse_query("MATCH (p:P {n: 'a'}) SET p.x = 7 WITH p RETURN p.x AS v").unwrap();
+    let batch = MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("query should run");
+    assert_eq!(
+        batch.records[0].get("v"),
+        Some(&Value::Property(PropertyValue::Integer(7)))
+    );
+}
+
+#[test]
+fn a_remove_before_a_with_actually_removes() {
+    let mut store = fixture();
+    run(&mut store, "MATCH (p:P) REMOVE p.y WITH p RETURN p.y AS v");
+    assert_eq!(scalar(&store, "MATCH (p:P {n: 'a'}) RETURN p.y AS v"), None);
+}
+
+#[test]
+fn a_delete_between_two_withs_actually_deletes() {
+    let mut store = fixture();
+    run(&mut store, "MATCH (p:P) WITH p DELETE p WITH 1 AS d RETURN d AS v");
+    assert_eq!(count(&store, "MATCH (p:P) RETURN p"), 0);
+}
+
+#[test]
+fn a_query_may_open_with_a_with() {
+    // No reading clause at all — the pipeline starts from a single empty row.
+    let store = GraphStore::new();
+    let q = parse_query("WITH 1 AS a UNWIND [10, 20] AS b WITH a, b RETURN a + b AS v").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&q).expect("query should run");
+    let mut got: Vec<i64> = batch
+        .records
+        .iter()
+        .map(|r| match r.get("v") {
+            Some(Value::Property(PropertyValue::Integer(n))) => *n,
+            other => panic!("{other:?}"),
+        })
+        .collect();
+    got.sort();
+    assert_eq!(got, vec![11, 21]);
+}
+
+#[test]
+fn a_where_after_a_with_filters() {
+    let store = GraphStore::new();
+    let q = parse_query("WITH [1, 2, 3] AS xs UNWIND xs AS x WITH x WHERE x > 1 RETURN x AS v").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&q).expect("query should run");
+    assert_eq!(batch.records.len(), 2);
+}
+
+#[test]
+fn an_unsupported_clause_position_is_refused_not_mis_planned() {
+    // CREATE and MERGE are not threaded through the pipeline yet. The parser
+    // accepts the order, so the planner must say no rather than fall back to
+    // the by-kind fields — which are empty for these queries, and would be
+    // read as "no CREATE at all".
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (a) WITH a CREATE (b)").expect("this order parses");
+    let err = MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect_err("must refuse rather than silently do nothing");
+    let msg = err.to_string();
+    assert!(msg.contains("CREATE"), "the message should name the clause: {msg}");
+    assert_eq!(count(&store, "MATCH (n) RETURN n"), 0, "and it must not half-run");
+}
+
+#[test]
+fn ordinary_queries_do_not_go_near_the_pipeline() {
+    // The fallback only runs when every shape-specific rule has rejected the
+    // input. If a common query started taking it, the blast radius of this
+    // change would be the whole engine rather than a handful of clause orders.
+    for cypher in [
+        "MATCH (n) RETURN n",
+        "MATCH (a)-[r]->(b) WHERE a.x = 1 RETURN a, r, b",
+        "CREATE (n:P {x: 1}) RETURN n",
+        "MATCH (n:P) SET n.x = 2",
+        "UNWIND [1, 2] AS x RETURN x",
+        "MERGE (n:P {x: 1})",
+        "MATCH (n) DETACH DELETE n",
+    ] {
+        let q = parse_query(cypher).expect("should parse");
+        assert!(
+            !q.needs_clause_pipeline,
+            "{cypher} was routed through the clause pipeline"
+        );
+    }
+}
+
+#[test]
+fn the_clause_list_records_written_order() {
+    let q = parse_query("MATCH (p:P) SET p.x = 1 WITH p RETURN p.x AS v").unwrap();
+    let kinds: Vec<&str> = q.clauses.iter().map(|c| c.kind()).collect();
+    assert_eq!(kinds, vec!["MATCH", "SET", "WITH", "RETURN"]);
+}


### PR DESCRIPTION
Every statement rule in the grammar encodes one permitted clause order, with writes at the end. Cypher does not work that way, so `MATCH (n) SET n.x = 1 WITH n RETURN n.x` was a syntax error.

**TCK 671 → 706** of 1,239 evaluated (54.2% → 57.0%), errored 242 → 202.

## The scope in #617 was wrong, and I corrected it before starting

The issue claimed 107 scenarios. Bisecting each of the 162 unparseable queries to its first failing clause, then re-testing that clause **in a legal position**, separates two different problems:

| | count |
|---|---:|
| **Ordering** — the clause is fine elsewhere | **47** |
| **Content** — the clause fails wherever you put it | 115 |

The fallback rescues **69** in total, because some "content" failures were really "no statement rule can *start* with this clause". The remaining 115 are a separate backlog: pattern comprehensions, temporal constructors, map projections, aggregates in compound expressions.

## A second entry point, not another alternative

PEG ordered choice commits to the first alternative that matches a **prefix**. `create_stmt` accepts `CREATE (a) WITH a …` up to the `WITH`, at which point the choice is committed and no later alternative is tried — so adding a general rule to `statement` did literally nothing. `parse_query` now tries `query` first and falls back to `pipeline_query` only on failure. Every query the established rules accept keeps taking them and keeps producing the by-kind AST the planner has always used; a test asserts that seven common query shapes never reach the fallback.

## The syntax was not the real blocker

Making the grammar accept these queries got as far as parsing, planning correctly, running — **and not writing**.

The default `next_mut` on a pass-through operator delegates to `next`, which reads its input read-only. A materialising operator therefore severed mutability for everything below it. `MATCH (n) SET n.x = 1 WITH n RETURN n.x` returned the *old* value, the store was unchanged, and nothing reported a problem.

That is the actual reason the grammar only ever allowed writes after the last projection — not syntax, but that mutability never reached below a barrier.

`WithBarrierOperator` and `AggregateOperator` now drain their input mutably into a `MaterializedOperator` before aggregating. Both materialise their whole input anyway, so nothing is buffered that would not have been, and their grouping code — the most intricate in the file — is untouched.

## Unsupported orders are refused, not mis-planned

CREATE and MERGE inside the pipeline, and a MATCH after a WITH (7 of the 69), are not threaded yet. The by-kind fields are empty for these queries *by construction*, so falling through to the established path would read them as "no CREATE at all" and answer a different question. The error names the offending clause and the query's shape.

## Tests

They assert **the graph after**, not the rows returned. A write that reports success and does nothing is invisible to any test that only reads the result set, and that was the bug. Removing the barrier's mutable pull fails four of the nine; checked by making the change and running them.

`cargo test --workspace` green across 94 blocks; both CI conformance gates pass.

Also adds `examples/parse_check.rs` — reads queries from stdin, prints `ok`/`fail` per line. The scope analysis needed to parse a few thousand variants and a process per query makes that unbearable.