### PR TITLE
Sort below the projection in the clause pipeline (CH-DETERM catch)

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -4611,6 +4611,8 @@ impl QueryPlanner {
             }
         }
         let mut anon_seq = 0usize;
+        // Set when a RETURN has already placed the sort below its projection.
+        let mut order_by_applied = false;
 
         for clause in &clauses[split..] {
             match clause {
@@ -4725,6 +4727,48 @@ impl QueryPlanner {
                     operator = Box::new(FilterOperator::new(operator, w.predicate.clone()));
                 }
                 Clause::Return(rc) => {
+                    // ORDER BY goes **below** the projection, not after it.
+                    //
+                    // `WITH p, count(q) AS rng RETURN p ORDER BY rng` sorts on
+                    // a column the RETURN does not carry. Sorting above the
+                    // projection leaves the key unbound, the sort silently
+                    // becomes a no-op, and the rows come back in whatever
+                    // order the barrier produced — which is hash order, so the
+                    // answer differs between processes. CH-DETERM caught
+                    // exactly this scenario after the pipeline landed.
+                    if let Some(order_by) = &query.order_by {
+                        let order_keys: Vec<(Expression, String)> = rc
+                            .items
+                            .iter()
+                            .map(|i| {
+                                let alias = i.alias.clone().unwrap_or_else(|| match &i.expression {
+                                    Expression::Variable(v) => v.clone(),
+                                    Expression::Property { variable, property } => {
+                                        format!("{variable}.{property}")
+                                    }
+                                    _ => String::new(),
+                                });
+                                (i.expression.clone(), alias)
+                            })
+                            .collect();
+                        let sort_items: Vec<(Expression, bool)> = order_by
+                            .items
+                            .iter()
+                            .map(|i| {
+                                (
+                                    resolve_sort_key(
+                                        &i.expression,
+                                        &order_keys,
+                                        SortPosition::BeforeProjection,
+                                    ),
+                                    i.ascending,
+                                )
+                            })
+                            .collect();
+                        operator = Box::new(SortOperator::new(operator, sort_items));
+                        order_by_applied = true;
+                    }
+
                     let projections: Vec<(Expression, String)> = rc
                         .items
                         .iter()
@@ -4764,12 +4808,14 @@ impl QueryPlanner {
         }
 
         if let Some(order_by) = &query.order_by {
-            let sort_items: Vec<(Expression, bool)> = order_by
-                .items
-                .iter()
-                .map(|i| (i.expression.clone(), i.ascending))
-                .collect();
-            operator = Box::new(SortOperator::new(operator, sort_items));
+            if !order_by_applied {
+                let sort_items: Vec<(Expression, bool)> = order_by
+                    .items
+                    .iter()
+                    .map(|i| (i.expression.clone(), i.ascending))
+                    .collect();
+                operator = Box::new(SortOperator::new(operator, sort_items));
+            }
         }
         if let Some(skip) = query.skip {
             operator = Box::new(SkipOperator::new(operator, skip));

--- a/tests/clause_pipeline.rs
+++ b/tests/clause_pipeline.rs
@@ -188,3 +188,61 @@ fn the_clause_list_records_written_order() {
     let kinds: Vec<&str> = q.clauses.iter().map(|c| c.kind()).collect();
     assert_eq!(kinds, vec!["MATCH", "SET", "WITH", "RETURN"]);
 }
+
+#[test]
+fn order_by_a_column_the_return_does_not_carry_still_sorts() {
+    // `WITH p, count(q) AS rng RETURN p ORDER BY rng` sorts on a column the
+    // projection drops. Placing the sort *above* the projection leaves the key
+    // unbound, the sort silently becomes a no-op, and the rows come back in
+    // whatever order the barrier produced — which is hash order, so the answer
+    // differs between processes.
+    //
+    // `CH-DETERM` caught exactly this after the pipeline first landed: one
+    // scenario flipping across five runs. The assertion is on the order, and
+    // the fixture is built so the sorted order differs from the natural one.
+    let store = GraphStore::new();
+    let cypher = "WITH [0, 1] AS prows, [[2], [3, 4]] AS qrows \
+                  UNWIND prows AS p UNWIND qrows[p] AS q \
+                  WITH p, count(q) AS rng RETURN p AS v ORDER BY rng DESC";
+    let q = parse_query(cypher).expect("query should parse");
+    let batch = QueryExecutor::new(&store).execute(&q).expect("query should run");
+    let got: Vec<i64> = batch
+        .records
+        .iter()
+        .map(|r| match r.get("v") {
+            Some(Value::Property(PropertyValue::Integer(n))) => *n,
+            other => panic!("{other:?}"),
+        })
+        .collect();
+    // rng is 1 for p=0 and 2 for p=1, so DESC puts p=1 first — the reverse of
+    // the order the rows are produced in. Ascending would pass by accident.
+    assert_eq!(got, vec![1, 0]);
+}
+
+#[test]
+fn repeated_runs_of_a_pipeline_query_agree() {
+    // A cheap guard on the class CH-DETERM found. It cannot vary the hash seed
+    // within one process, so it would not have caught the original defect —
+    // but it costs nothing and catches a per-call variation.
+    let store = GraphStore::new();
+    let cypher = "WITH [3, 1, 2] AS xs UNWIND xs AS x WITH x RETURN x AS v ORDER BY x";
+    let q = parse_query(cypher).expect("query should parse");
+    let first: Vec<String> = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap()
+        .records
+        .iter()
+        .map(|r| format!("{:?}", r.get("v")))
+        .collect();
+    for _ in 0..20 {
+        let again: Vec<String> = QueryExecutor::new(&store)
+            .execute(&q)
+            .unwrap()
+            .records
+            .iter()
+            .map(|r| format!("{:?}", r.get("v")))
+            .collect();
+        assert_eq!(again, first);
+    }
+    assert_eq!(first.len(), 3);
+}


### PR DESCRIPTION
`CH-DETERM` caught this on the first run after #622 merged: one scenario flipping across five processes, **532/533/532/532/532** non-passing.

`WITH p, count(q) AS rng RETURN p ORDER BY rng` sorts on a column the projection drops. The pipeline applied `ORDER BY` *after* the `RETURN`'s projection, so the key was unbound, the sort silently became a no-op, and the rows came back in whatever order the barrier produced — hash order, which differs between processes.

The sort now goes below the projection and resolves its keys through `resolve_sort_key`, exactly as the established non-aggregation path does.

## Why this is worth more than the one scenario

This is the **same defect class** fixed earlier in this sweep for the established planner — a dropped `ORDER BY` producing a plausible answer — reintroduced in a new code path that had to make the same decision again and made it differently. New paths do not inherit old fixes.

The test asserts `ORDER BY rng DESC`, whose sorted order is the *reverse* of the order rows are produced in. Ascending would have passed with the sort dropped entirely, which is exactly how the original went unnoticed.

And the thing I would want recorded: the suite built two cycles ago to catch nondeterminism caught it in a change I made, within a day, in code I had just written and believed correct. It was not found by reading the diff.

TCK 711 → 712 of 1,244 (57.2%). `cargo test --workspace` green; 2 new tests.