### PR TITLE
MERGE and MATCH in the clause pipeline, and the guards the new path skipped (#617)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -6415,6 +6415,9 @@ pub struct CartesianProductOperator {
     left_index: usize,
     current_right: Option<Record>,
     left_materialized: bool,
+    /// Set once the left input has been drained through `next_mut`.
+    /// Without it a second call would re-drain an already-consumed side.
+    left_drained_mut: bool,
 }
 
 impl CartesianProductOperator {
@@ -6426,6 +6429,7 @@ impl CartesianProductOperator {
             left_index: 0,
             current_right: None,
             left_materialized: false,
+            left_drained_mut: false,
         }
     }
 
@@ -6518,6 +6522,30 @@ impl PhysicalOperator for CartesianProductOperator {
         }
     }
 
+
+    // A clause pipeline can put writes on the left of a join: `CREATE (n:C)
+    // WITH n MATCH (a:A) RETURN a, n` plans the CREATE below this operator.
+    // Draining that side with the read-only `next` makes the write operators
+    // refuse — they cannot reach a mutable store — so the left input is drained
+    // once with `next_mut` and replaced by its own rows. Everything below has
+    // then already run, and the read-only path is correct for the rest.
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        if !self.left_drained_mut {
+            let mut rows = Vec::new();
+            let mut count = 0u64;
+            while let Some(record) = self.left.next_mut(store, tenant_id)? {
+                rows.push(record);
+                count += 1;
+                if count % 10000 == 0 {
+                    check_deadline()?;
+                }
+            }
+            self.left = Box::new(MaterializedOperator::new(rows));
+            self.left_drained_mut = true;
+        }
+        self.next(store)
+    }
+
     fn reset(&mut self) {
         self.left.reset();
         self.right.reset();
@@ -6553,6 +6581,9 @@ pub struct JoinOperator {
     current_right_index: usize,
     current_left_list_index: usize,
     materialized: bool,
+    /// Set once the left input has been drained through `next_mut`.
+    /// Without it a second call would re-drain an already-consumed side.
+    left_drained_mut: bool,
 }
 
 impl JoinOperator {
@@ -6572,6 +6603,7 @@ impl JoinOperator {
             current_right_index: 0,
             current_left_list_index: 0,
             materialized: false,
+            left_drained_mut: false,
         }
     }
 
@@ -6678,6 +6710,30 @@ impl PhysicalOperator for JoinOperator {
         }
     }
 
+
+    // A clause pipeline can put writes on the left of a join: `CREATE (n:C)
+    // WITH n MATCH (a:A) RETURN a, n` plans the CREATE below this operator.
+    // Draining that side with the read-only `next` makes the write operators
+    // refuse — they cannot reach a mutable store — so the left input is drained
+    // once with `next_mut` and replaced by its own rows. Everything below has
+    // then already run, and the read-only path is correct for the rest.
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        if !self.left_drained_mut {
+            let mut rows = Vec::new();
+            let mut count = 0u64;
+            while let Some(record) = self.left.next_mut(store, tenant_id)? {
+                rows.push(record);
+                count += 1;
+                if count % 10000 == 0 {
+                    check_deadline()?;
+                }
+            }
+            self.left = Box::new(MaterializedOperator::new(rows));
+            self.left_drained_mut = true;
+        }
+        self.next(store)
+    }
+
     fn reset(&mut self) {
         self.left.reset();
         self.right.reset();
@@ -6714,6 +6770,9 @@ pub struct LeftOuterJoinOperator {
     current_right_match_idx: usize,
     null_emitted: bool,
     materialized: bool,
+    /// Set once the left input has been drained through `next_mut`.
+    /// Without it a second call would re-drain an already-consumed side.
+    left_drained_mut: bool,
 }
 
 impl LeftOuterJoinOperator {
@@ -6734,6 +6793,7 @@ impl LeftOuterJoinOperator {
             current_right_match_idx: 0,
             null_emitted: false,
             materialized: false,
+            left_drained_mut: false,
         }
     }
 
@@ -6831,6 +6891,30 @@ impl PhysicalOperator for LeftOuterJoinOperator {
         } else {
             Ok(Some(RecordBatch { records: results, columns: Vec::new() }))
         }
+    }
+
+
+    // A clause pipeline can put writes on the left of a join: `CREATE (n:C)
+    // WITH n MATCH (a:A) RETURN a, n` plans the CREATE below this operator.
+    // Draining that side with the read-only `next` makes the write operators
+    // refuse — they cannot reach a mutable store — so the left input is drained
+    // once with `next_mut` and replaced by its own rows. Everything below has
+    // then already run, and the read-only path is correct for the rest.
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        if !self.left_drained_mut {
+            let mut rows = Vec::new();
+            let mut count = 0u64;
+            while let Some(record) = self.left.next_mut(store, tenant_id)? {
+                rows.push(record);
+                count += 1;
+                if count % 10000 == 0 {
+                    check_deadline()?;
+                }
+            }
+            self.left = Box::new(MaterializedOperator::new(rows));
+            self.left_drained_mut = true;
+        }
+        self.next(store)
     }
 
     fn reset(&mut self) {
@@ -9522,6 +9606,13 @@ impl PhysicalOperator for UnwindOperator {
 
 /// MERGE operator - upsert: match or create pattern
 pub struct MergeOperator {
+    /// Upstream rows, when this MERGE runs inside a clause pipeline.
+    ///
+    /// `None` is the established shape — a leaf that runs once. With an input
+    /// the clause runs **per incoming row**, which is what
+    /// `UNWIND [...] AS x MERGE (:N {v: x})` means, and it must keep the row's
+    /// existing bindings so `... WITH a MERGE (a)-[:R]->(b)` can see `a`.
+    input: Option<OperatorBox>,
     pattern: Pattern,
     on_create_set: Vec<(String, String, Expression)>,
     on_match_set: Vec<(String, String, Expression)>,
@@ -9541,6 +9632,7 @@ impl MergeOperator {
         on_match_labels: Vec<(String, Vec<Label>)>,
     ) -> Self {
         Self {
+            input: None,
             pattern,
             on_create_set,
             on_match_set,
@@ -9548,6 +9640,12 @@ impl MergeOperator {
             on_match_labels,
             executed: false,
         }
+    }
+
+    /// Run this MERGE once per row of `input`, extending each row.
+    pub fn with_input(mut self, input: OperatorBox) -> Self {
+        self.input = Some(input);
+        self
     }
 
     /// Add the labels an `ON CREATE` / `ON MATCH` branch asks for.
@@ -9596,6 +9694,7 @@ impl MergeOperator {
     fn merge_path(
         &self,
         path: &crate::query::ast::PathPattern,
+        base: Record,
         store: &mut GraphStore,
         tenant_id: &str,
     ) -> ExecutionResult<Option<Record>> {
@@ -9646,7 +9745,9 @@ impl MergeOperator {
             Self::search(&candidates, &pattern_rels, store, &mut assignment)
         };
 
-        let mut record = Record::new();
+        // Seeded from the incoming row so a MERGE inside a clause
+        // pipeline keeps the bindings its predecessors produced.
+        let mut record = base;
 
         if let Some(assignment) = found {
             for (i, np) in pattern_nodes.iter().enumerate() {
@@ -9769,10 +9870,27 @@ impl PhysicalOperator for MergeOperator {
     }
 
     fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
-        if self.executed {
-            return Ok(None);
-        }
-        self.executed = true;
+        // With an upstream, the clause runs once per incoming row and each row
+        // seeds the merge; without one it is a leaf that runs exactly once.
+        // Taking the input out first keeps the borrow checker happy while the
+        // merge body holds `&mut store`.
+        let base = match self.input.take() {
+            Some(mut input) => {
+                let row = input.next_mut(store, tenant_id)?;
+                self.input = Some(input);
+                match row {
+                    Some(r) => r,
+                    None => return Ok(None),
+                }
+            }
+            None => {
+                if self.executed {
+                    return Ok(None);
+                }
+                self.executed = true;
+                Record::new()
+            }
+        };
 
         let path = self.pattern.paths.first()
             .ok_or_else(|| ExecutionError::PlanningError("MERGE pattern has no paths".to_string()))?;
@@ -9783,7 +9901,7 @@ impl PhysicalOperator for MergeOperator {
         // segments were ignored outright, so `MERGE (a:X {..})-[:R]->(b:X {..})` matched
         // the first node, created no relationship, and reported success.
         if !path.segments.is_empty() {
-            return self.merge_path(path, store, tenant_id);
+            return self.merge_path(path, base, store, tenant_id);
         }
 
         let start = &path.start;
@@ -9812,7 +9930,7 @@ impl PhysicalOperator for MergeOperator {
         }
 
         let node_id;
-        let mut record = Record::new();
+        let mut record = base;
 
         if let Some(existing_id) = matched_node_id {
             node_id = existing_id;

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -643,6 +643,34 @@ impl QueryPlanner {
             }
         }
 
+        // A clause-pipeline query keeps its clauses here and leaves the fields
+        // above empty, so the checks above see nothing. Missing this let
+        // `UNWIND ['a','b','a'] AS x MERGE (n:N {v: x})` create **one** node
+        // instead of two: the property is an expression, MERGE matched on the
+        // label alone, and every row found the first `:N`. The established
+        // path had refused that query for exactly this reason since #311's
+        // lesson — a new path does not inherit an old guard.
+        for clause in &query.clauses {
+            let (label, pattern) = match clause {
+                crate::query::ast::Clause::Match(m) => ("MATCH", &m.pattern),
+                crate::query::ast::Clause::Merge(m) => ("MERGE", &m.pattern),
+                _ => continue,
+            };
+            for path in &pattern.paths {
+                if let Some(key) = path.start.property_exprs.as_ref().and_then(|e| e.keys().next()) {
+                    return Err(complain(label, key));
+                }
+                for seg in &path.segments {
+                    if let Some(key) = seg.node.property_exprs.as_ref().and_then(|e| e.keys().next()) {
+                        return Err(complain(label, key));
+                    }
+                    if let Some(key) = seg.edge.property_exprs.as_ref().and_then(|e| e.keys().next()) {
+                        return Err(complain(label, key));
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -695,10 +723,13 @@ impl QueryPlanner {
         // CREATE" and answer a different query, which is worse than the parse
         // error it replaced. Until `plan_clause_pipeline` covers a shape, the
         // engine says so.
+        // Checked for *both* paths. It reads `query.clauses` as well as the
+        // by-kind fields, so a pipeline query cannot slip a pattern carrying an
+        // unevaluated property expression past it.
+        Self::reject_unevaluated_property_exprs(query)?;
         if query.needs_clause_pipeline {
             return self.plan_clause_pipeline(query, store);
         }
-        Self::reject_unevaluated_property_exprs(query)?;
         // `DISTINCT` is inserted inside `plan_inner`, below SKIP and LIMIT.
         // Wrapping the finished plan here put it *above* them, so `LIMIT n`
         // took n duplicate-bearing rows and DISTINCT then collapsed them --
@@ -4637,6 +4668,88 @@ impl QueryPlanner {
                         }
                     }
                 }
+                Clause::Match(mc) => {
+                    // Same join rule as the established multi-MATCH path: every
+                    // shared variable is a join key, and only a pattern sharing
+                    // nothing with what is already bound becomes a cartesian
+                    // product. Taking a subset of the keys would silently widen
+                    // the result instead of failing (#360), so the intersection
+                    // is taken whole and sorted — it comes from a HashSet, and
+                    // an unsorted key order varies between runs.
+                    let mut clause_vars: HashSet<String> = HashSet::new();
+                    for path in &mc.pattern.paths {
+                        if let Some(v) = &path.start.variable {
+                            clause_vars.insert(v.clone());
+                        }
+                        for seg in &path.segments {
+                            if let Some(v) = &seg.node.variable {
+                                clause_vars.insert(v.clone());
+                            }
+                            if let Some(v) = &seg.edge.variable {
+                                clause_vars.insert(v.clone());
+                            }
+                        }
+                    }
+                    let match_op = self.dispatch_plan_match(mc, None, store)?;
+                    let mut shared: Vec<String> = bound.intersection(&clause_vars).cloned().collect();
+                    shared.sort();
+                    operator = if shared.is_empty() {
+                        Box::new(CartesianProductOperator::new(operator, match_op)) as OperatorBox
+                    } else if mc.optional {
+                        let right_only: Vec<String> =
+                            clause_vars.difference(&bound).cloned().collect();
+                        Box::new(LeftOuterJoinOperator::new(operator, match_op, shared, right_only))
+                            as OperatorBox
+                    } else {
+                        Box::new(JoinOperator::new(operator, match_op, shared)) as OperatorBox
+                    };
+                    bound.extend(clause_vars);
+                }
+                Clause::Merge(mc) => {
+                    let on_create: Vec<(String, String, Expression)> = mc
+                        .on_create_set
+                        .iter()
+                        .map(|i| (i.variable.clone(), i.property.clone(), i.value.clone()))
+                        .collect();
+                    let on_match: Vec<(String, String, Expression)> = mc
+                        .on_match_set
+                        .iter()
+                        .map(|i| (i.variable.clone(), i.property.clone(), i.value.clone()))
+                        .collect();
+                    let on_create_labels: Vec<(String, Vec<Label>)> = mc
+                        .on_create_labels
+                        .iter()
+                        .map(|l| (l.variable.clone(), l.labels.clone()))
+                        .collect();
+                    let on_match_labels: Vec<(String, Vec<Label>)> = mc
+                        .on_match_labels
+                        .iter()
+                        .map(|l| (l.variable.clone(), l.labels.clone()))
+                        .collect();
+                    operator = Box::new(
+                        MergeOperator::new(
+                            mc.pattern.clone(),
+                            on_create,
+                            on_match,
+                            on_create_labels,
+                            on_match_labels,
+                        )
+                        .with_input(operator),
+                    );
+                    for path in &mc.pattern.paths {
+                        if let Some(v) = &path.start.variable {
+                            bound.insert(v.clone());
+                        }
+                        for seg in &path.segments {
+                            if let Some(v) = &seg.edge.variable {
+                                bound.insert(v.clone());
+                            }
+                            if let Some(v) = &seg.node.variable {
+                                bound.insert(v.clone());
+                            }
+                        }
+                    }
+                }
                 Clause::With(wc) => {
                     operator = self.build_with_barrier(operator, wc, store)?;
                     bound = wc
@@ -4797,9 +4910,9 @@ impl QueryPlanner {
                     let shape: Vec<&str> = clauses.iter().map(|c| c.kind()).collect();
                     return Err(ExecutionError::RuntimeError(format!(
                         "`{}` is not yet supported in this clause position (query shape: {}). \
-                         The parser accepts this order; the planner threads WITH, UNWIND, SET, \
-                         REMOVE, DELETE, WHERE and RETURN through it so far, and CREATE, MERGE \
-                         and a MATCH after a WITH are still to come (samyama-graph#617).",
+                         The parser accepts this order; the planner threads MATCH, WHERE, \
+                         UNWIND, WITH, CREATE, MERGE, SET, REMOVE, DELETE and RETURN through it \
+                         so far, and FOREACH and CALL are still to come (samyama-graph#617).",
                         unsupported.kind(),
                         shape.join(" ")
                     )));

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -195,7 +195,32 @@ fn parse_clause_pipeline(input: &str) -> ParseResult<Query> {
                                     }
                                 }
                             }
-                            _ => {}
+                            // Anything this builder cannot lower has to be an
+                            // error. Falling through silently was the worse
+                            // failure: FOREACH and CALL parsed cleanly, were
+                            // dropped on the floor, and the query then ran as
+                            // though the clause had never been written —
+                            // `CREATE (a:A) WITH a FOREACH (i IN [1,2] | SET
+                            // a.n = i)` reported success having set nothing. A
+                            // clause the engine cannot run must never be
+                            // mistaken for one it ran.
+                            other => {
+                                let keyword = c
+                                    .as_str()
+                                    .split_whitespace()
+                                    .next()
+                                    .unwrap_or("")
+                                    .to_uppercase();
+                                let name = if keyword.is_empty() {
+                                    format!("{other:?}")
+                                } else {
+                                    keyword
+                                };
+                                return Err(ParseError::SemanticError(format!(
+                                    "`{name}` is not yet supported in this clause position \
+                                     (samyama-graph#617)"
+                                )));
+                            }
                         }
                     }
                 }
@@ -231,6 +256,11 @@ pub fn parse_query(input: &str) -> ParseResult<Query> {
         // cannot start.
         Err(original) => match parse_clause_pipeline(input) {
             Ok(query) => return Ok(query),
+            // A semantic error means the general rule *did* recognise the
+            // clause order and then refused to lower one of the clauses. That
+            // names the actual obstacle, so it wins; a plain parse failure
+            // does not, and the original error is kept instead.
+            Err(e @ ParseError::SemanticError(_)) => return Err(e),
             Err(_) => return Err(original.into()),
         },
     };

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -30,11 +30,35 @@ pub enum ValidationError {
     CreateUndirectedRelationship,
     CreateVariableLengthRelationship,
     CreateOnBoundRelationship(String),
+    MergeRelationshipWithoutType,
+    MergeVariableLengthRelationship,
+    MergeOnBoundVariable(String),
+    MergeRelationshipWithNullProperty(String),
 }
 
 impl std::fmt::Display for ValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::MergeRelationshipWithoutType => write!(
+                f,
+                "MERGE requires exactly one relationship type: `MERGE (a)-->(b)` does not say \
+                 what kind of edge to create"
+            ),
+            Self::MergeVariableLengthRelationship => write!(
+                f,
+                "MERGE cannot use a variable-length relationship: it does not say what the \
+                 intermediate nodes are"
+            ),
+            Self::MergeOnBoundVariable(name) => write!(
+                f,
+                "MERGE cannot impose new labels or properties on `{name}`, which is already \
+                 bound; use SET instead"
+            ),
+            Self::MergeRelationshipWithNullProperty(key) => write!(
+                f,
+                "MERGE cannot create a relationship with a null property (`{key}`): the pattern \
+                 would never match what it creates"
+            ),
             Self::DuplicateColumn(name) => write!(
                 f,
                 "Multiple result columns with the same name are not supported: `{name}`"
@@ -95,22 +119,81 @@ fn columns(query: &Query) -> Vec<String> {
 }
 
 /// Variables a MATCH clause binds — the ones a later CREATE must not redeclare.
-fn matched_variables(query: &Query) -> HashSet<String> {
-    let mut out = HashSet::new();
-    for mc in &query.match_clauses {
-        for path in &mc.pattern.paths {
-            if let Some(v) = &path.start.variable {
+fn pattern_variables(pattern: &crate::query::ast::Pattern, out: &mut HashSet<String>) {
+    for path in &pattern.paths {
+        if let Some(v) = &path.start.variable {
+            out.insert(v.clone());
+        }
+        for seg in &path.segments {
+            if let Some(v) = &seg.edge.variable {
                 out.insert(v.clone());
             }
-            for seg in &path.segments {
-                if let Some(v) = &seg.edge.variable {
-                    out.insert(v.clone());
-                }
-                if let Some(v) = &seg.node.variable {
-                    out.insert(v.clone());
-                }
+            if let Some(v) = &seg.node.variable {
+                out.insert(v.clone());
             }
         }
+    }
+}
+
+/// Which write clause a pattern came from. The two differ: an undirected
+/// `MERGE (a)-[:R]-(b)` is legal Cypher and an undirected CREATE is not.
+#[derive(Clone, Copy, PartialEq)]
+enum WriteKind {
+    Create,
+    Merge,
+}
+
+/// Every write pattern in the order it was written, each paired with the
+/// variables in scope *before* it.
+///
+/// A query reaches the validator in one of two shapes: the by-kind fields
+/// (`match_clauses`, `create_clause`, `merge_clause`), or an ordered
+/// `clauses` list when the clause-sequence path parsed it. Reading only the
+/// first shape is how these checks came to be inert for half the queries in
+/// the language — `CREATE (a:Foo) MERGE (a)-[r:KNOWS]->(a:Bar)` has no
+/// `create_clause` and no `merge_clause`, so every rule below simply did not
+/// run and the query was accepted. The scope has to be tracked in written
+/// order anyway, so both shapes are flattened into one sequence here.
+fn write_patterns(query: &Query) -> Vec<(WriteKind, &crate::query::ast::Pattern, HashSet<String>)> {
+    use crate::query::ast::Clause;
+    let mut out = Vec::new();
+    let mut bound: HashSet<String> = HashSet::new();
+
+    if query.needs_clause_pipeline {
+        for clause in &query.clauses {
+            match clause {
+                Clause::Match(mc) => pattern_variables(&mc.pattern, &mut bound),
+                Clause::Unwind(uc) => {
+                    bound.insert(uc.variable.clone());
+                }
+                Clause::Create(cc) => {
+                    out.push((WriteKind::Create, &cc.pattern, bound.clone()));
+                    pattern_variables(&cc.pattern, &mut bound);
+                }
+                Clause::Merge(mc) => {
+                    out.push((WriteKind::Merge, &mc.pattern, bound.clone()));
+                    pattern_variables(&mc.pattern, &mut bound);
+                }
+                // A WITH re-projects rather than binds new pattern variables,
+                // and its aliases are what survive it. Anything this does not
+                // model can only *shrink* the bound set, which risks accepting
+                // an invalid query rather than rejecting a valid one -- the
+                // trade this module states up front.
+                _ => {}
+            }
+        }
+        return out;
+    }
+
+    for mc in &query.match_clauses {
+        pattern_variables(&mc.pattern, &mut bound);
+    }
+    if let Some(create) = &query.create_clause {
+        out.push((WriteKind::Create, &create.pattern, bound.clone()));
+        pattern_variables(&create.pattern, &mut bound);
+    }
+    if let Some(merge) = &query.merge_clause {
+        out.push((WriteKind::Merge, &merge.pattern, bound.clone()));
     }
     out
 }
@@ -159,51 +242,90 @@ pub fn validate(query: &Query) -> Result<(), ValidationError> {
         }
     }
 
-    // ---- CREATE over a variable a MATCH already bound.
+    // ---- Writes over a variable something already bound, and edges that do
+    // not say what they are.
     //
     // `MATCH (a) CREATE (a:Foo)` looks like "add a label" and is not: Cypher
     // requires SET for that, and the CREATE form is an error. A *bare*
-    // re-mention — `MATCH (a), (b) CREATE (a)-[:R]->(b)` — is how you write
-    // an edge between matched nodes and stays legal.
-    if let Some(create) = &query.create_clause {
-        let bound = matched_variables(query);
-
-        // A relationship being *created* has to say exactly what it is. These
-        // are ambiguous rather than merely unsupported: `CREATE (a)-->(b)`
-        // does not say what kind of edge to make, `CREATE (a)-[:R]-(b)` does
-        // not say which way it points, and `CREATE (a)-[:R*2]->(b)` does not
-        // say what the intermediate node is. Cypher rejects all three, and
-        // accepting them means inventing an answer.
-        //
-        // Note this is only in CREATE. The same patterns are perfectly good in
-        // MATCH, where they mean "any type", "either direction" and "two
-        // hops" — which is why the check lives here and not in the grammar.
-        for path in &create.pattern.paths {
+    // re-mention -- `MATCH (a), (b) CREATE (a)-[:R]->(b)` -- is how you write
+    // an edge between matched nodes and stays legal. MERGE says the same for
+    // its own patterns (TCK Merge5 [22]).
+    //
+    // A relationship being written has to say exactly what it is. These are
+    // ambiguous rather than merely unsupported: `CREATE (a)-->(b)` does not
+    // say what kind of edge to make, `CREATE (a)-[:R]-(b)` does not say which
+    // way it points, and `CREATE (a)-[:R*2]->(b)` does not say what the
+    // intermediate node is. Cypher rejects all three, and accepting them means
+    // inventing an answer.
+    //
+    // Note this is only in CREATE and MERGE. The same patterns are perfectly
+    // good in MATCH, where they mean "any type", "either direction" and "two
+    // hops" -- which is why the check lives here and not in the grammar. The
+    // one place the two kinds differ is direction: `MERGE (a)-[:R]-(b)` is
+    // legal and creates an outgoing edge, so undirected is refused for CREATE
+    // only.
+    for (kind, pattern, bound) in write_patterns(query) {
+        let merge = kind == WriteKind::Merge;
+        for path in &pattern.paths {
             for seg in &path.segments {
                 if seg.edge.length.is_some() {
-                    return Err(ValidationError::CreateVariableLengthRelationship);
+                    return Err(if merge {
+                        ValidationError::MergeVariableLengthRelationship
+                    } else {
+                        ValidationError::CreateVariableLengthRelationship
+                    });
                 }
                 if seg.edge.types.len() != 1 {
-                    return Err(ValidationError::CreateRelationshipWithoutType);
+                    return Err(if merge {
+                        ValidationError::MergeRelationshipWithoutType
+                    } else {
+                        ValidationError::CreateRelationshipWithoutType
+                    });
                 }
-                if matches!(seg.edge.direction, crate::query::ast::Direction::Both) {
+                if !merge && matches!(seg.edge.direction, crate::query::ast::Direction::Both) {
                     return Err(ValidationError::CreateUndirectedRelationship);
+                }
+                // A null property on a written edge cannot be matched back:
+                // `MERGE (a)-[r:X {num: null}]->(b)` would create an edge the
+                // same pattern does not find, so a second run creates another.
+                if merge {
+                    if let Some(props) = &seg.edge.properties {
+                        let mut nulls: Vec<&String> = props
+                            .iter()
+                            .filter(|(_, v)| matches!(v, crate::graph::PropertyValue::Null))
+                            .map(|(k, _)| k)
+                            .collect();
+                        nulls.sort();
+                        if let Some(key) = nulls.first() {
+                            return Err(ValidationError::MergeRelationshipWithNullProperty(
+                                (*key).clone(),
+                            ));
+                        }
+                    }
                 }
                 if let Some(v) = &seg.edge.variable {
                     if bound.contains(v) {
-                        return Err(ValidationError::CreateOnBoundRelationship(v.clone()));
+                        return Err(if merge {
+                            ValidationError::MergeOnBoundVariable(v.clone())
+                        } else {
+                            ValidationError::CreateOnBoundRelationship(v.clone())
+                        });
                     }
                 }
             }
         }
-        for path in &create.pattern.paths {
+        for path in &pattern.paths {
             let mut check = |np: &crate::query::ast::NodePattern| -> Result<(), ValidationError> {
                 if let Some(v) = &np.variable {
                     let adds_something = !np.labels.is_empty()
                         || np.properties.as_ref().is_some_and(|p| !p.is_empty())
                         || np.property_exprs.as_ref().is_some_and(|p| !p.is_empty());
                     if bound.contains(v) && adds_something {
-                        return Err(ValidationError::CreateOnBoundVariable(v.clone()));
+                        return Err(if merge {
+                            ValidationError::MergeOnBoundVariable(v.clone())
+                        } else {
+                            ValidationError::CreateOnBoundVariable(v.clone())
+                        });
                     }
                 }
                 Ok(())

--- a/tests/clause_pipeline.rs
+++ b/tests/clause_pipeline.rs
@@ -147,17 +147,18 @@ fn a_create_references_variables_already_in_scope() {
 
 #[test]
 fn an_unsupported_clause_position_is_refused_not_mis_planned() {
-    // MERGE is not threaded through the pipeline yet. The parser accepts the
+    // FOREACH is not threaded through the pipeline yet. The parser accepts the
     // order, so the planner must say no rather than fall back to the by-kind
     // fields — which are empty for these queries, and would be read as "no
-    // MERGE at all".
-    let mut store = GraphStore::new();
-    let q = parse_query("CREATE (a) WITH a MERGE (b:L)").expect("this order parses");
-    let err = MutQueryExecutor::new(&mut store, "default".to_string())
-        .execute(&q)
-        .expect_err("must refuse rather than silently do nothing");
+    // FOREACH at all", i.e. as a query that simply does less than it says.
+    //
+    // Keep this test pointed at whatever is still unsupported. It started on
+    // MERGE and moved here when MERGE landed; the assertion is about the
+    // refusal existing at the boundary, not about which clause is outside it.
+    let err = parse_query("CREATE (a:A) WITH a FOREACH (i IN [1, 2] | SET a.n = i)")
+        .expect_err("must refuse rather than silently drop the clause");
     let msg = err.to_string();
-    assert!(msg.contains("MERGE"), "the message should name the clause: {msg}");
+    assert!(msg.contains("FOREACH"), "the message should name the clause: {msg}");
 }
 
 #[test]
@@ -245,4 +246,144 @@ fn repeated_runs_of_a_pipeline_query_agree() {
         assert_eq!(again, first);
     }
     assert_eq!(first.len(), 3);
+}
+
+#[test]
+fn both_planning_paths_refuse_an_expression_valued_merge_property() {
+    // The two queries below express the same thing: MERGE a node whose property
+    // comes from a bound variable rather than a literal. The left one goes
+    // through the established planner, the right one through the clause
+    // pipeline. Neither supports it yet, and the risk is that only *one* of
+    // them says so: the pipeline read none of the by-kind clause fields the
+    // guard inspected, so it planned a MERGE on the label alone and
+    // `UNWIND ['a','b','a'] AS x MERGE (n:N {v: x})` created a single node and
+    // reported success. A silent wrong answer is worse than the refusal.
+    //
+    // Assert the agreement, not the message: whatever the two paths do here,
+    // they must do the same thing.
+    let legacy = "MATCH (a:Src) MERGE (n:N {v: a.k}) RETURN n";
+    let pipeline = "UNWIND ['a', 'b', 'a'] AS x MERGE (n:N {v: x}) WITH n RETURN n.v AS v";
+
+    for cypher in [legacy, pipeline] {
+        let mut store = GraphStore::new();
+        let q = parse_query(cypher).expect("query should parse");
+        let err = MutQueryExecutor::new(&mut store, "default".to_string())
+            .execute(&q)
+            .expect_err(&format!("`{cypher}` must be refused, not silently mis-planned"));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("MERGE") && msg.contains("non-literal property value"),
+            "`{cypher}` was refused for the wrong reason: {msg}"
+        );
+        assert_eq!(
+            count(&store, "MATCH (n:N) RETURN n"),
+            0,
+            "`{cypher}` was refused but still wrote to the store"
+        );
+    }
+}
+
+#[test]
+fn merge_below_a_barrier_runs_once_per_input_row() {
+    // MERGE in the pipeline takes an input operator, so it runs per row rather
+    // than once. Two rows, distinct literals, must leave two nodes; a third row
+    // repeating the first must not add a third.
+    let mut store = GraphStore::new();
+    let q = parse_query("UNWIND [1, 2, 1] AS x MERGE (n:N) WITH n RETURN 1 AS r")
+        .expect("query should parse");
+    let out = MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("merge below a barrier should execute");
+    assert_eq!(out.records.len(), 3, "one row in, one row out");
+    assert_eq!(
+        count(&store, "MATCH (n:N) RETURN n"),
+        1,
+        "MERGE is match-or-create: the second and third rows find the first node"
+    );
+}
+
+/// Rows of `(x, y)` from a two-column query, sorted so the assertion does not
+/// depend on scan order.
+fn pairs(store: &mut GraphStore, cypher: &str) -> Vec<(String, String)> {
+    let q = parse_query(cypher).expect("query should parse");
+    let out = MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should execute: {e}"));
+    let mut rows: Vec<(String, String)> = out
+        .records
+        .iter()
+        .map(|r| (format!("{:?}", r.get("x")), format!("{:?}", r.get("y"))))
+        .collect();
+    rows.sort();
+    rows
+}
+
+fn two_a_two_b() -> GraphStore {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:A {k: 1}), (:A {k: 2}), (:B {k: 1}), (:B {k: 9})");
+    run(&mut store, "MATCH (a:A {k: 1}), (b:B {k: 1}) CREATE (a)-[:R]->(b)");
+    store
+}
+
+#[test]
+fn a_match_after_a_with_sharing_no_variable_is_a_cartesian_product() {
+    let mut store = two_a_two_b();
+    let rows = pairs(&mut store, "MATCH (a:A) WITH a MATCH (b:B) RETURN a.k AS x, b.k AS y");
+    assert_eq!(rows.len(), 4, "two As against two Bs, uncorrelated: {rows:?}");
+}
+
+#[test]
+fn a_match_after_a_with_sharing_a_variable_stays_correlated() {
+    // The failure this guards against is the previous test's answer showing up
+    // here: joining on nothing turns a correlated MATCH into a cross product,
+    // which is a wrong answer rather than an error. Only one A has an :R edge.
+    let mut store = two_a_two_b();
+    let rows = pairs(
+        &mut store,
+        "MATCH (a:A) WITH a MATCH (a)-[:R]->(b:B) RETURN a.k AS x, b.k AS y",
+    );
+    assert_eq!(rows.len(), 1, "only a.k = 1 has an outgoing :R: {rows:?}");
+    assert!(rows[0].0.contains('1') && rows[0].1.contains('1'));
+}
+
+#[test]
+fn an_optional_match_after_a_with_keeps_the_unmatched_row() {
+    let mut store = two_a_two_b();
+    let rows = pairs(
+        &mut store,
+        "MATCH (a:A) WITH a OPTIONAL MATCH (a)-[:R]->(b:B) RETURN a.k AS x, b.k AS y",
+    );
+    assert_eq!(rows.len(), 2, "both As survive: {rows:?}");
+    assert_eq!(
+        rows.iter().filter(|(_, y)| y.contains("Null")).count(),
+        1,
+        "the A with no edge keeps a null b: {rows:?}"
+    );
+}
+
+#[test]
+fn a_match_can_read_what_an_earlier_clause_created() {
+    // The join operators materialise both sides, and materialising the left one
+    // read-only makes any write below it refuse outright — this query returned
+    // "requires mutable store access" rather than rows. The write has to run
+    // before the join reads.
+    let mut store = two_a_two_b();
+    let rows = pairs(
+        &mut store,
+        "CREATE (n:C {k: 7}) WITH n MATCH (a:A) RETURN a.k AS x, n.k AS y",
+    );
+    assert_eq!(rows.len(), 2, "one row per A: {rows:?}");
+    assert!(rows.iter().all(|(_, y)| y.contains('7')), "{rows:?}");
+    assert_eq!(count(&store, "MATCH (n:C) RETURN n"), 1, "exactly one C, created once");
+}
+
+#[test]
+fn a_match_after_an_unwind_filters_per_row() {
+    let mut store = two_a_two_b();
+    let rows = pairs(
+        &mut store,
+        "UNWIND [1, 2] AS k MATCH (a:A) WHERE a.k = k RETURN k AS x, a.k AS y",
+    );
+    assert_eq!(rows.len(), 2, "each k finds its own A, not both: {rows:?}");
+    assert!(rows.iter().all(|(x, y)| x == y), "{rows:?}");
 }


### PR DESCRIPTION
Completes #617. The clause-sequence path now threads MERGE and a MATCH
after a WITH, which is the rest of what the issue scoped.

The interesting part is not the two clauses; it is that the new path
started out not inheriting three things the established path already did.

**A guard that read the wrong field.** `reject_unevaluated_property_exprs`
inspected `query.match_clauses` and `query.merge_clause`. A pipeline query
leaves both empty and keeps its clauses in `query.clauses`, so the guard
saw nothing and `plan()` skipped it entirely for those queries.
`UNWIND ['a','b','a'] AS x MERGE (n:N {v: x})` therefore matched on the
label alone and created **one** node instead of two, and reported success.
The established path refuses that query. Now the guard reads both shapes
and runs for both paths.

**Clauses dropped on the floor.** The pipeline builder matched the clause
rules it could lower and had a `_ => {}` for the rest. FOREACH and CALL
parsed cleanly and then vanished: `CREATE (a:A) WITH a FOREACH (i IN [1,2]
| SET a.n = i)` returned success having set nothing. An unlowered clause
is now a hard error naming the clause.

**Validations that only covered CREATE.** Routing MERGE through the
pipeline regressed four TCK negative scenarios — Merge5 [22], [23], [28],
[29] — which had been passing because the grammar rejected the clause
*order*, so an error came out for an unrelated reason. Those are real
Cypher rules and none of them existed: MERGE requires exactly one
relationship type, cannot use a variable-length relationship, cannot
impose new labels on a bound variable, and cannot create a relationship
with a null property. `validate` now walks the write clauses in written
order, which also makes the existing CREATE rules apply to pipeline
queries, where they were equally inert.

Joins needed `next_mut` for the same reason the barrier did in #622: they
materialise both sides, and materialising a left side read-only makes any
write below it refuse outright, so `CREATE (n:C) WITH n MATCH (a:A)`
errored instead of returning rows.

openCypher TCK, same host, twice, identical both runs:

    pass       711 -> 723   (57.2% -> 58.1% of evaluated)
    errored    193 -> 180
    evaluated  1244 (77.0%) unchanged

No scenario regressed. Two Comparison1 scenarios newly pass and one moved
errored -> wrong_result, all three being `WITH ... UNWIND ... WITH ...
MATCH` — the shape this change enables. That last one exposed two
pre-existing defects, filed separately rather than fixed here: an
unlabelled `CREATE ({id: 0})` stores a node with one empty-string label,
and an unlabelled `MERGE ({id: 2})` invents a label called `Node`.

Closes #617.