### PR TITLE
A node carries exactly the labels that were written (#625)

### DIFF
--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -72,6 +72,24 @@ pub struct Node {
 
 impl Node {
     /// Create a new node with a single label
+    /// A node carrying exactly the labels given -- including none at all.
+    ///
+    /// `new` takes one label and always inserts it, so the only way to write
+    /// an unlabelled node through it was to pass `""`. That is what
+    /// `CREATE ({id: 0})` did, and the node came back with a one-element
+    /// label set containing the empty string (#625).
+    pub fn with_labels(id: NodeId, labels: impl IntoIterator<Item = Label>) -> Self {
+        let now = chrono::Utc::now().timestamp_millis();
+        Node {
+            id,
+            version: 1,
+            labels: labels.into_iter().collect(),
+            properties: PropertyMap::new(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
     pub fn new(id: NodeId, label: impl Into<Label>) -> Self {
         let now = chrono::Utc::now().timestamp_millis();
         let mut labels = HashSet::new();

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -977,6 +977,20 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
 
     /// Create a node with auto-generated ID and single label
     pub fn create_node(&mut self, label: impl Into<Label>) -> NodeId {
+        self.create_node_with_labels(std::iter::once(label.into()))
+    }
+
+    /// Create a node with exactly the labels given, which may be none.
+    ///
+    /// Every caller building a node from a Cypher pattern went through
+    /// `create_node`, which takes a single label -- so a pattern with no label
+    /// passed `""` and a MERGE pattern with no label passed the invented
+    /// string `"Node"`. Both ended up in the label index and the catalog, so
+    /// an unlabelled node reported a label it did not have and `MATCH
+    /// (n:Node)` matched nodes nobody labelled (#625). Callers that know the
+    /// whole label set should use this.
+    pub fn create_node_with_labels(&mut self, labels: impl IntoIterator<Item = Label>) -> NodeId {
+        let labels: Vec<Label> = labels.into_iter().collect();
         self.invalidate_statistics_cache();
         let node_id_u64 = if let Some(id) = self.free_node_ids.pop() {
             id
@@ -988,18 +1002,16 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         let node_id = NodeId::new(node_id_u64);
         let idx = node_id_u64 as usize;
 
-        let label = label.into();
-        let mut node = Node::new(node_id, label.clone());
+        let mut node = Node::with_labels(node_id, labels.iter().cloned());
         node.version = self.current_version;
 
-        // Add to label index
-        self.label_index
-            .entry(label.clone())
-            .or_insert_with(HashSet::new)
-            .insert(node_id);
-
-        // Update catalog label count
-        self.catalog.on_label_added(&label);
+        for label in &labels {
+            self.label_index
+                .entry(label.clone())
+                .or_insert_with(HashSet::new)
+                .insert(node_id);
+            self.catalog.on_label_added(label);
+        }
 
         // Ensure storage capacity
         if idx >= self.nodes.len() {

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -6980,17 +6980,10 @@ impl PhysicalOperator for CreateNodeOperator {
         // First call: create all nodes
         if !self.executed {
             for (labels, properties, variable, property_exprs) in &self.nodes_to_create {
-                // Use first label as primary, or empty string if none
-                let primary_label = labels.first()
-                    .map(|l| l.clone())
-                    .unwrap_or_else(|| Label::new(""));
-
-                let node_id = store.create_node(primary_label);
-
-                // Add additional labels
-                for label in labels.iter().skip(1) {
-                    let _ = store.add_label_to_node(tenant_id, node_id, label.clone());
-                }
+                // The whole label set at once, which for `CREATE ({...})` is
+                // empty. Passing a "primary" label meant an unlabelled node was
+                // created with `Label("")` (#625).
+                let node_id = store.create_node_with_labels(labels.iter().cloned());
 
                 // A CREATE with no input row has nothing bound, so a non-literal value can
                 // only be a constant (`{n: 1 + 2}`). Anything referring to a variable is an
@@ -8040,14 +8033,7 @@ impl PhysicalOperator for MatchCreateEdgeOperator {
                 // edge wiring below then treats it exactly like a matched variable.
                 let mut record = record;
                 for (handle, labels, properties, property_exprs) in &self.nodes_to_create {
-                    let primary_label = labels
-                        .first()
-                        .cloned()
-                        .unwrap_or_else(|| Label::new(""));
-                    let node_id = store.create_node(primary_label);
-                    for label in labels.iter().skip(1) {
-                        let _ = store.add_label_to_node(tenant_id, node_id, label.clone());
-                    }
+                    let node_id = store.create_node_with_labels(labels.iter().cloned());
                     // Non-literal property values (`{id: row.id}`) are evaluated against
                     // this row, so each created node gets the value belonging to its own
                     // match rather than a constant.
@@ -9765,13 +9751,9 @@ impl MergeOperator {
         // Create the entire pattern.
         let mut created: Vec<NodeId> = Vec::with_capacity(pattern_nodes.len());
         for np in &pattern_nodes {
-            let label_str = np.labels.first().map(|l| l.as_str()).unwrap_or("Node");
-            let node_id = store.create_node(label_str);
-            for label in np.labels.iter().skip(1) {
-                if let Some(node) = store.get_node_mut(node_id) {
-                    node.labels.insert(label.clone());
-                }
-            }
+            // `MERGE ({...})` has no labels, and defaulting to "Node" gave the
+            // node a label the query never wrote (#625).
+            let node_id = store.create_node_with_labels(np.labels.iter().cloned());
             if let Some(required) = np.properties.as_ref() {
                 for (k, v) in required {
                     if let Err(e) = store.set_node_property(tenant_id, node_id, k.clone(), v.clone())
@@ -9946,14 +9928,7 @@ impl PhysicalOperator for MergeOperator {
             }
             Self::apply_labels(&self.on_match_labels, &record, store, tenant_id);
         } else {
-            let label_str = labels.first().map(|l| l.as_str()).unwrap_or("Node");
-            node_id = store.create_node(label_str);
-
-            for label in labels.iter().skip(1) {
-                if let Some(node) = store.get_node_mut(node_id) {
-                    node.labels.insert(label.clone());
-                }
-            }
+            node_id = store.create_node_with_labels(labels.iter().cloned());
 
             if let Some(required_props) = props {
                 for (k, v) in required_props {
@@ -10079,10 +10054,8 @@ impl PhysicalOperator for ForeachOperator {
                             ));
                         }
 
-                        let label_str = path.start.labels.first()
-                            .map(|l| l.as_str())
-                            .unwrap_or("Node");
-                        let node_id = store.create_node(label_str);
+                        let node_id =
+                            store.create_node_with_labels(path.start.labels.iter().cloned());
                         if let Some(props) = &path.start.properties {
                             for (k, v) in props {
                                 let _ = store.set_node_property(tenant_id, node_id, k.to_string(), v.clone());

--- a/tests/create_semantics.rs
+++ b/tests/create_semantics.rs
@@ -126,3 +126,65 @@ fn properties_on_the_first_mention_survive() {
     assert_eq!(nodes(&store), 2);
     assert_eq!(scalar(&store, "MATCH (n) WHERE n.v = 7 RETURN count(*) AS c"), 1);
 }
+
+/// Every label on every node in the store, sorted, one entry per node.
+fn label_sets(store: &GraphStore) -> Vec<Vec<String>> {
+    (0..16u64)
+        .map(samyama::graph::types::NodeId::from)
+        .filter_map(|id| store.get_node(id))
+        .map(|n| {
+            let mut labels: Vec<String> = n.labels.iter().map(|l| l.as_str().to_string()).collect();
+            labels.sort();
+            labels
+        })
+        .collect()
+}
+
+#[test]
+fn a_node_carries_exactly_the_labels_that_were_written() {
+    // `create_node` takes one label and always inserts it, so every caller
+    // building a node from a pattern had to invent one when the pattern had
+    // none: CREATE passed `""` and MERGE passed the string `"Node"`. Both went
+    // into the label index and the catalog, so an unlabelled node reported a
+    // label, and `MATCH (n:Node)` matched nodes nobody had labelled (#625).
+    for (cypher, expected) in [
+        ("CREATE ({id: 0})", vec![Vec::<String>::new()]),
+        ("MERGE ({id: 2})", vec![Vec::new()]),
+        ("CREATE ()-[:R]->()", vec![Vec::new(), Vec::new()]),
+        ("UNWIND [1, 2] AS x CREATE ({v: x})", vec![Vec::new(), Vec::new()]),
+        ("CREATE (:A {id: 1})", vec![vec!["A".to_string()]]),
+        ("CREATE (:A:B)", vec![vec!["A".to_string(), "B".to_string()]]),
+        ("MERGE (:A:B)", vec![vec!["A".to_string(), "B".to_string()]]),
+    ] {
+        let mut store = GraphStore::new();
+        write(&mut store, cypher);
+        assert_eq!(label_sets(&store), expected, "labels after `{cypher}`");
+    }
+}
+
+#[test]
+fn an_unlabelled_node_is_not_findable_by_an_invented_label() {
+    // The label index and the catalog are the reason this matters beyond
+    // rendering: a phantom label is a phantom class with a real count, and the
+    // anchor-choice cost model reads those counts.
+    let mut store = GraphStore::new();
+    write(&mut store, "CREATE ({id: 0})");
+    write(&mut store, "MERGE ({id: 2})");
+
+    let found = |cypher: &str| -> usize {
+        let q = parse_query(cypher).expect("query should parse");
+        QueryExecutor::new(&store).execute(&q).unwrap().records.len()
+    };
+    assert_eq!(found("MATCH (n) RETURN n"), 2, "both nodes exist");
+    assert_eq!(found("MATCH (n:Node) RETURN n"), 0, "`Node` was never written");
+
+    // The catalog is where a phantom label does real damage: it becomes a
+    // class with a count, and the anchor-choice cost model reads those counts.
+    for phantom in ["Node", ""] {
+        assert_eq!(
+            store.catalog().estimate_label_scan(&samyama::graph::types::Label::new(phantom)),
+            0.0,
+            "the catalog should not carry a `{phantom}` class"
+        );
+    }
+}


### PR DESCRIPTION
`GraphStore::create_node` takes one label and always inserts it, so every
caller building a node from a Cypher pattern had to invent one when the
pattern had none. CREATE passed `""`; MERGE passed the string `"Node"`.

    CREATE ({id: 0})     labels = [""]
    MERGE  ({id: 2})     labels = ["Node"]
    CREATE ()-[:R]->()   labels = [""], [""]

Both went into the label index *and* the catalog, so an unlabelled node
reported a label it did not have, `MATCH (n:Node)` matched nodes nobody
had labelled, and the catalog listed classes that do not exist in the
data. That last part is the reason this is not only cosmetic: the
anchor-choice cost model reads catalog label counts, so a phantom label
is a phantom cardinality.

`create_node_with_labels` takes the whole set — including an empty one —
and the five pattern-creation sites now use it. `create_node` stays as a
one-label convenience and delegates.

Surfaced by #617: making `WITH … UNWIND … WITH … MATCH` runnable meant
TCK Comparison1 [1] got as far as comparing output, and the only
difference was `( {id: 0})` against `(: {id: 0})`.

openCypher TCK at bd763e3 + this change, same host:

    pass       723 -> 759   (58.1% -> 61.0% of evaluated)
    wrong      341 -> 305
    evaluated  1244 (77.0%) unchanged

36 scenarios newly pass, none regress. Unlabelled nodes are the default
shape in most of the TCK, which is why one storage defect was worth this
many scenarios.

Closes #625.