### PR TITLE
A float in a list literal keeps all 64 of its bits (#628)

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -720,9 +720,15 @@ impl GraphStore {
             match event {
                 NodeCreated { tenant_id, id, labels, properties } => {
                     for (key, value) in &properties {
-                        if let PropertyValue::Vector(vec) = value {
+                        // A numeric array counts, not only the `Vector`
+                        // variant: a list literal stays a list now (#628), so
+                        // `{embedding: [0.1, 0.2, 0.3]}` arrives as an `Array`
+                        // and matching on `Vector` alone silently indexed
+                        // nothing. The rebuild path already used `to_vector`,
+                        // which is why this only showed up on write.
+                        if let Some(vec) = value.to_vector() {
                             for label in &labels {
-                                let _ = vector_index.add_vector(label.as_str(), key, id, vec);
+                                let _ = vector_index.add_vector(label.as_str(), key, id, &vec);
                             }
                         }
                         for label in &labels {
@@ -835,9 +841,9 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
                     for label in &labels {
                         property_index.index_insert(label, &key, new_value.clone(), id);
                     }
-                    if let PropertyValue::Vector(vec) = &new_value {
+                    if let Some(vec) = new_value.to_vector() {
                         for label in &labels {
-                            let _ = vector_index.add_vector(label.as_str(), &key, id, vec);
+                            let _ = vector_index.add_vector(label.as_str(), &key, id, &vec);
                         }
                     }
                     
@@ -919,8 +925,8 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
                 }
                 LabelAdded { tenant_id, id, label, properties } => {
                     for (key, value) in properties {
-                        if let PropertyValue::Vector(vec) = &value {
-                            let _ = vector_index.add_vector(label.as_str(), &key, id, vec);
+                        if let Some(vec) = value.to_vector() {
+                            let _ = vector_index.add_vector(label.as_str(), &key, id, &vec);
                         }
                         property_index.index_insert(&label, &key, value.clone(), id);
                         
@@ -2706,6 +2712,25 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         }
     }
 
+    /// A property that should be treated as an embedding when *registering* a
+    /// vector index: all-numeric, non-empty, and carrying at least one float.
+    ///
+    /// Deliberately narrower than `PropertyValue::to_vector`, which any write
+    /// path may use because it can only fill an index someone already asked
+    /// for. See the call site for why the two differ.
+    fn embedding_candidate(v: &PropertyValue) -> Option<Vec<f32>> {
+        match v {
+            PropertyValue::Vector(vec) if !vec.is_empty() => Some(vec.clone()),
+            PropertyValue::Array(items)
+                if !items.is_empty()
+                    && items.iter().any(|i| matches!(i, PropertyValue::Float(_))) =>
+            {
+                v.to_vector()
+            }
+            _ => None,
+        }
+    }
+
     /// Discover all (label, property_key, dims) tuples from node Vector properties,
     /// register any missing HNSW indices, then populate them.
     /// This is the correct post-import call when no indices were pre-registered.
@@ -2720,7 +2745,18 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
                 continue;
             }
             for (k, v) in node.properties.iter() {
-                if let PropertyValue::Vector(vec) = v {
+                // Discovery *registers* indices, so it must not treat every
+                // numeric list as an embedding -- `{scores: [1, 2, 3]}` would
+                // get an HNSW index built over it. The rule is the one that was
+                // in force before list literals stopped being coerced to
+                // vectors (#628): all-numeric, non-empty, and containing at
+                // least one float. That keeps exactly the set of properties
+                // that used to arrive here as `Vector`, while an embedding
+                // written as a list literal -- now an `Array` -- is still
+                // found. The *write* paths are deliberately more permissive:
+                // they only fill an index that already exists.
+                if let Some(vec) = Self::embedding_candidate(v) {
+                    let vec = &vec;
                     // Use the MAX length seen for this (label, property): a stray
                     // empty/short embedding must not set the index dimension and
                     // cause every real vector to be skipped on rebuild.
@@ -3244,9 +3280,9 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         for label in labels {
             self.property_index.index_insert(label, key, new_value.clone(), id);
         }
-        if let PropertyValue::Vector(vec) = new_value {
+        if let Some(vec) = new_value.to_vector() {
             for label in labels {
-                let _ = self.vector_index.add_vector(label.as_str(), key, id, vec);
+                let _ = self.vector_index.add_vector(label.as_str(), key, id, &vec);
             }
         }
     }
@@ -3256,9 +3292,9 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         match event {
             NodeCreated { tenant_id: _, id, labels, properties } => {
                 for (key, value) in properties {
-                    if let PropertyValue::Vector(vec) = &value {
+                    if let Some(vec) = value.to_vector() {
                         for label in &labels {
-                            let _ = self.vector_index.add_vector(label.as_str(), &key, id, vec);
+                            let _ = self.vector_index.add_vector(label.as_str(), &key, id, &vec);
                         }
                     }
                     for label in &labels {
@@ -3282,16 +3318,16 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
                 for label in &labels {
                     self.property_index.index_insert(label, &key, new_value.clone(), id);
                 }
-                if let PropertyValue::Vector(vec) = &new_value {
+                if let Some(vec) = new_value.to_vector() {
                     for label in &labels {
-                        let _ = self.vector_index.add_vector(label.as_str(), &key, id, vec);
+                        let _ = self.vector_index.add_vector(label.as_str(), &key, id, &vec);
                     }
                 }
             }
             LabelAdded { tenant_id: _, id, label, properties } => {
                 for (key, value) in properties {
-                    if let PropertyValue::Vector(vec) = &value {
-                        let _ = self.vector_index.add_vector(label.as_str(), &key, id, vec);
+                    if let Some(vec) = value.to_vector() {
+                        let _ = self.vector_index.add_vector(label.as_str(), &key, id, &vec);
                     }
                     self.property_index.index_insert(&label, &key, value.clone(), id);
                 }

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2322,8 +2322,16 @@ impl QueryPlanner {
                 _ => return Err(ExecutionError::PlanningError("Second argument (property) must be a string literal".to_string())),
             };
 
+            // Any numeric list literal, not only one that parsed as a
+            // `Vector`. List literals stay lists now (#628), so requiring the
+            // `Vector` variant here would reject every query vector written
+            // with a decimal point -- which is all of them.
             let query_vector = match &call_clause.arguments[2] {
-                Expression::Literal(PropertyValue::Vector(v)) => v.clone(),
+                Expression::Literal(pv) => pv.to_vector().ok_or_else(|| {
+                    ExecutionError::PlanningError(
+                        "Third argument (vector) must be a list of numbers".to_string(),
+                    )
+                })?,
                 _ => return Err(ExecutionError::PlanningError("Third argument (vector) must be a vector literal".to_string())),
             };
 

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1699,32 +1699,25 @@ fn parse_value(pair: pest::iterators::Pair<Rule>) -> ParseResult<PropertyValue> 
                 // `Float(1.0), Float(2.0), Float(3.0)`: `UNWIND [1,2,3] AS x RETURN x`
                 // returned decimals for data that had none (#409).
                 //
-                // A list is only taken to be a vector when it actually contains a float.
-                // An all-integer list stays a list of integers, and the vector paths
-                // accept a numeric array (see `PropertyValue::to_vector`) so an embedding
-                // written as `[1, 0, 0]` still indexes.
+                // A list literal is a list. It used to become a
+                // `Vector(Vec<f32>)` as soon as one element was a float, on the
+                // theory that a float list is an embedding -- and every element
+                // was narrowed to 32 bits on the way in. Cypher floats are
+                // 64-bit, so `UNWIND [1.3, 1.5] AS v RETURN v` returned
+                // 1.2999999523162842, and `ORDER BY` on those values sorted
+                // numbers that were no longer the ones written (#628).
+                //
+                // Nothing needs the coercion: `PropertyValue::to_vector`
+                // already accepts a numeric array, which is how an embedding
+                // written as `[1, 0, 0]` has indexed since #409 -- an
+                // all-integer list was never turned into a vector either.
+                // Deciding vector-ness belongs to the consumer, not to whether
+                // the literal happened to contain a decimal point.
                 let mut items = Vec::new();
-                let mut numeric_vals = Vec::new();
-                let mut all_numeric = true;
-                let mut saw_float = false;
-
                 for item in inner.into_inner() {
                     if item.as_rule() == Rule::value {
-                        let val = parse_value(item)?;
-                        match val {
-                            PropertyValue::Float(f) => {
-                                saw_float = true;
-                                numeric_vals.push(f as f32);
-                            }
-                            PropertyValue::Integer(i) => numeric_vals.push(i as f32),
-                            _ => all_numeric = false,
-                        }
-                        items.push(val);
+                        items.push(parse_value(item)?);
                     }
-                }
-
-                if all_numeric && saw_float && !numeric_vals.is_empty() {
-                    return Ok(PropertyValue::Vector(numeric_vals));
                 }
                 return Ok(PropertyValue::Array(items));
             }
@@ -4013,12 +4006,20 @@ mod tests {
         let ast = result.unwrap();
         let create = ast.create_clause.unwrap();
         let props = create.pattern.paths[0].start.properties.as_ref().unwrap();
-        // Float list should be parsed as Vector
-        if let Some(PropertyValue::Vector(v)) = props.get("embedding") {
-            assert_eq!(v.len(), 4);
-        } else {
-            panic!("Expected Vector property, got {:?}", props.get("embedding"));
-        }
+        // A float list stays a list, at full precision. It is still indexable
+        // as an embedding -- `to_vector` accepts a numeric array -- but the
+        // literal keeps the 64-bit values that were written (#628).
+        let embedding = props.get("embedding").expect("embedding property");
+        assert_eq!(
+            embedding,
+            &PropertyValue::Array(vec![
+                PropertyValue::Float(0.1),
+                PropertyValue::Float(0.2),
+                PropertyValue::Float(0.3),
+                PropertyValue::Float(0.4),
+            ])
+        );
+        assert_eq!(embedding.to_vector().map(|v| v.len()), Some(4), "still indexable");
     }
 
     #[test]

--- a/tests/float_list_precision.rs
+++ b/tests/float_list_precision.rs
@@ -1,0 +1,108 @@
+//! A float in a list literal keeps all 64 of its bits.
+//!
+//! A list literal became a `Vector(Vec<f32>)` as soon as one element was a
+//! float, on the theory that a float list is an embedding. Every element was
+//! narrowed to 32 bits on the way in, so `UNWIND [1.3, 1.5] AS v RETURN v`
+//! returned **1.2999999523162842** — and `ORDER BY` over those values sorted
+//! numbers that were no longer the ones written.
+//!
+//! Cypher floats are IEEE doubles. The coercion was also unnecessary:
+//! `PropertyValue::to_vector` accepts a numeric array, so an embedding written
+//! as a list literal still indexes without the literal pretending to be a
+//! vector. Vector-ness is the consumer's decision, not the literal's.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn rows(store: &GraphStore, cypher: &str) -> Vec<Value> {
+    let q = parse_query(cypher).expect("query should parse");
+    QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"))
+        .records
+        .iter()
+        .map(|r| r.get("x").cloned().expect("column x"))
+        .collect()
+}
+
+fn floats(store: &GraphStore, cypher: &str) -> Vec<f64> {
+    rows(store, cypher)
+        .into_iter()
+        .map(|v| match v {
+            Value::Property(PropertyValue::Float(f)) => f,
+            other => panic!("expected a float, got {other:?}"),
+        })
+        .collect()
+}
+
+#[test]
+fn a_float_in_a_list_literal_survives_unwind_unchanged() {
+    let store = GraphStore::new();
+    // Exact equality is the assertion. 1.3 as an f32 widened back to f64 is
+    // 1.2999999523162842, which is not 1.3 by any tolerance worth having.
+    assert_eq!(floats(&store, "UNWIND [1.3, 1.5] AS v RETURN v AS x"), vec![1.3, 1.5]);
+    assert_eq!(floats(&store, "UNWIND [999.99] AS v RETURN v AS x"), vec![999.99]);
+}
+
+#[test]
+fn ordering_floats_from_a_list_compares_the_values_that_were_written() {
+    let store = GraphStore::new();
+    assert_eq!(
+        floats(&store, "UNWIND [1.3, 999.99, 1.5] AS v WITH v ORDER BY v DESC RETURN v AS x"),
+        vec![999.99, 1.5, 1.3]
+    );
+}
+
+#[test]
+fn a_list_literal_stays_a_list_whatever_it_contains() {
+    let store = GraphStore::new();
+    for (cypher, expected) in [
+        (
+            "RETURN [1.3, 1.5] AS x",
+            PropertyValue::Array(vec![PropertyValue::Float(1.3), PropertyValue::Float(1.5)]),
+        ),
+        (
+            "RETURN [1, 2] AS x",
+            PropertyValue::Array(vec![PropertyValue::Integer(1), PropertyValue::Integer(2)]),
+        ),
+        (
+            "RETURN [1, 2.5] AS x",
+            PropertyValue::Array(vec![PropertyValue::Integer(1), PropertyValue::Float(2.5)]),
+        ),
+    ] {
+        match rows(&store, cypher).into_iter().next() {
+            Some(Value::Property(got)) => assert_eq!(got, expected, "for `{cypher}`"),
+            other => panic!("expected a property for `{cypher}`, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn an_embedding_written_as_a_list_literal_is_still_searchable() {
+    // The reason the coercion existed. It has to keep working without it —
+    // otherwise this fix trades a precision bug for a silently empty index.
+    let mut store = GraphStore::new();
+    for cypher in [
+        "CREATE VECTOR INDEX doc_idx FOR (n:Doc) ON (n.embedding) OPTIONS {dimensions: 3, similarity: 'cosine'}",
+        "CREATE (n:Doc {name: 'near', embedding: [1.0, 0.0, 0.0]})",
+        "CREATE (n:Doc {name: 'far', embedding: [0.0, 1.0, 0.0]})",
+    ] {
+        let q = parse_query(cypher).expect("query should parse");
+        MutQueryExecutor::new(&mut store, "default".to_string())
+            .execute(&q)
+            .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+    }
+
+    let q = parse_query(
+        "CALL db.index.vector.queryNodes('Doc', 'embedding', [1.0, 0.1, 0.0], 1) \
+         YIELD node RETURN node.name AS x",
+    )
+    .expect("query should parse");
+    let found = QueryExecutor::new(&store).execute(&q).expect("search should run");
+    assert_eq!(found.records.len(), 1, "the index must not be empty");
+    assert_eq!(
+        found.records[0].get("x").and_then(|v| v.as_property()).and_then(|p| p.as_string()),
+        Some("near")
+    );
+}


### PR DESCRIPTION
`parse_value` turned a list literal into `PropertyValue::Vector(Vec<f32>)`
as soon as one element was a float, on the theory that a float list is an
embedding — narrowing every element on the way in.

    UNWIND [1.3, 1.5] AS v RETURN v    ->  1.2999999523162842
    RETURN 1.3                         ->  1.3

Cypher floats are IEEE doubles. `RETURN 1.3` was right only because a bare
literal never took that path; written inside `[...]` it lost 29 bits.
Nothing about this is specific to the `ORDER BY` scenarios that caught it —
any list literal with a decimal in it was affected, including one stored as
a property and compared against later.

The coercion was also unnecessary. `PropertyValue::to_vector` accepts a
numeric array, which is how an embedding written as `[1, 0, 0]` has indexed
since #409 — an all-integer list was never turned into a `Vector` either.
Vector-ness belongs to the consumer, not to whether the literal happened to
contain a decimal point.

Removing it exposed the other half. The write-side index paths matched on
the `Vector` variant specifically, so once literals stayed lists they
indexed **nothing** — `CREATE (n:Doc {embedding: [1.0, 0.0, 0.0]})`
followed by a vector search returned no rows. Only the rebuild path used
`to_vector`, which is why the comment claiming integer arrays already
indexed had never been true on write. All six sites now go through
`to_vector`.

Index *discovery* is deliberately left narrower — all-numeric, non-empty
and containing at least one float. It registers indices rather than filling
them, and widening it would have built an HNSW index over
`{scores: [1, 2, 3]}`. That keeps exactly the set of properties that used
to arrive as `Vector`.

openCypher TCK: 784 -> 789 of 1244 evaluated (63.0% -> 63.4%), 5 newly
passing, none regressed.

Closes #628.