### PR TITLE
A named path covers the whole pattern, not just its last hop (#631)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3482,6 +3482,40 @@ impl PhysicalOperator for FilterOperator {
 }
 
 /// Expand operator: `-[:KNOWS]->`
+/// The path the walk has built so far, with this hop added.
+///
+/// Every expand in a chain binds the *same* path variable, and each one used
+/// to bind a fresh two-node path for its own hop — so the last hop won and
+/// `MATCH p = (a)-[:R]->(b)-[:R]->(c)` produced a path of two nodes with
+/// `length(p) = 1` (#631). The variable-length expand assembles its whole path
+/// in one place and never had the defect; the fixed multi-hop spelling is
+/// built hop by hop, so each hop has to add to what came before.
+///
+/// A path is only continued when it actually ends where this hop starts.
+/// Anything else — a comma-separated pattern, a path variable rebound across
+/// disconnected parts — starts afresh rather than inventing an edge between
+/// two unrelated nodes.
+fn extend_path(
+    base: Option<&Value>,
+    source_id: NodeId,
+    target_id: NodeId,
+    edge_id: crate::graph::EdgeId,
+) -> Value {
+    if let Some(Value::Path { nodes, edges }) = base {
+        if nodes.last() == Some(&source_id) {
+            let mut nodes = nodes.clone();
+            let mut edges = edges.clone();
+            nodes.push(target_id);
+            edges.push(edge_id);
+            return Value::Path { nodes, edges };
+        }
+    }
+    Value::Path {
+        nodes: vec![source_id, target_id],
+        edges: vec![edge_id],
+    }
+}
+
 pub struct ExpandOperator {
     /// Input operator
     input: OperatorBox,
@@ -3731,10 +3765,9 @@ impl PhysicalOperator for ExpandOperator {
                     let source_id = new_record.get(&self.source_var)
                         .and_then(|v| v.node_id())
                         .unwrap_or(src);
-                    new_record.bind(path_var.clone(), Value::Path {
-                        nodes: vec![source_id, target_id],
-                        edges: vec![edge_id],
-                    });
+                    let extended =
+                        extend_path(new_record.get(path_var), source_id, target_id, edge_id);
+                    new_record.bind(path_var.clone(), extended);
                 }
 
                 return Ok(Some(new_record));
@@ -3793,10 +3826,9 @@ impl PhysicalOperator for ExpandOperator {
                         let source_id = new_record.get(&self.source_var)
                             .and_then(|v| v.node_id())
                             .unwrap_or(src);
-                        new_record.bind(path_var.clone(), Value::Path {
-                            nodes: vec![source_id, target_id],
-                            edges: vec![edge_id],
-                        });
+                        let extended =
+                            extend_path(new_record.get(path_var), source_id, target_id, edge_id);
+                        new_record.bind(path_var.clone(), extended);
                     }
                     expanded_records.push(new_record);
                 }

--- a/tests/named_path_extent.rs
+++ b/tests/named_path_extent.rs
@@ -1,0 +1,108 @@
+//! A named path covers the whole pattern, not just its last hop.
+//!
+//! Every expand in a chain binds the same path variable, and each one bound a
+//! fresh two-node path for its own hop — so the last hop overwrote the rest:
+//!
+//! ```cypher
+//! MATCH p = (a)-[:KNOWS]->(b)-[:KNOWS]->(c) RETURN length(p)   -- 1, not 2
+//! ```
+//!
+//! The wrong answer is a plausible one, which is what makes it dangerous:
+//! `length(p)` returns a number, just the wrong number, and anything walking
+//! `nodes(p)` sees a shorter journey than the one that matched. The
+//! variable-length spelling of the same traversal was always right, so the two
+//! agreed on which rows matched and disagreed only on what the path was
+//! (#631).
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn chain() -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query(
+        "CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})-[:KNOWS]->(c:C {name: 'C'})",
+    )
+    .expect("setup should parse");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup should run");
+    store
+}
+
+/// `(node count, edge count)` of the single path a query returns.
+fn path_extent(store: &GraphStore, cypher: &str) -> (usize, usize) {
+    let q = parse_query(cypher).expect("query should parse");
+    let out = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+    assert_eq!(out.records.len(), 1, "`{cypher}` should match exactly one path");
+    match out.records[0].get("p") {
+        Some(Value::Path { nodes, edges }) => (nodes.len(), edges.len()),
+        other => panic!("`{cypher}` should bind a path, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_two_hop_named_path_holds_both_hops() {
+    let store = chain();
+    assert_eq!(
+        path_extent(&store, "MATCH p = (a:A)-[:KNOWS]->(b)-[:KNOWS]->(c) RETURN p"),
+        (3, 2)
+    );
+}
+
+#[test]
+fn the_fixed_and_variable_length_spellings_agree_on_the_path() {
+    // They already agreed on which rows matched. The point of this test is
+    // that they now agree on what the path *is* — that agreement is what was
+    // missing, and it is the cheapest way to notice if one of them drifts.
+    let store = chain();
+    assert_eq!(
+        path_extent(&store, "MATCH p = (a:A)-[:KNOWS]->(b)-[:KNOWS]->(c) RETURN p"),
+        path_extent(&store, "MATCH p = (a:A)-[:KNOWS*2]->(c) RETURN p")
+    );
+}
+
+#[test]
+fn length_of_a_named_path_counts_every_relationship() {
+    let store = chain();
+    let q = parse_query("MATCH p = (a:A)-[:KNOWS]->(b)-[:KNOWS]->(c) RETURN length(p) AS n")
+        .expect("query should parse");
+    let out = QueryExecutor::new(&store).execute(&q).expect("query should run");
+    assert_eq!(
+        out.records[0].get("n"),
+        Some(&Value::Property(PropertyValue::Integer(2))),
+        "two relationships were traversed"
+    );
+}
+
+#[test]
+fn a_single_hop_named_path_is_unchanged() {
+    let store = chain();
+    assert_eq!(path_extent(&store, "MATCH p = (a:A)-[:KNOWS]->(b) RETURN p"), (2, 1));
+}
+
+#[test]
+fn a_path_is_not_continued_across_a_disconnected_pattern() {
+    // The extension only applies when the walk actually continues from where
+    // the path ended. Two comma-separated hops share the variable but not an
+    // endpoint, and stitching them would invent a journey that does not exist.
+    let mut store = chain();
+    let q = parse_query("CREATE (x:X {name: 'X'})-[:KNOWS]->(y:Y {name: 'Y'})")
+        .expect("setup should parse");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup should run");
+
+    let q = parse_query("MATCH (a:A)-[:KNOWS]->(b:B), p = (x:X)-[:KNOWS]->(y:Y) RETURN p")
+        .expect("query should parse");
+    let out = QueryExecutor::new(&store).execute(&q).expect("query should run");
+    assert_eq!(out.records.len(), 1);
+    match out.records[0].get("p") {
+        Some(Value::Path { nodes, edges }) => {
+            assert_eq!((nodes.len(), edges.len()), (2, 1), "just the X->Y hop");
+        }
+        other => panic!("expected a path, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Every expand in a chain binds the same path variable, and each one bound a
fresh two-node path for its own hop. The last hop therefore overwrote the
rest:

    MATCH p = (a)-[:KNOWS]->(b)-[:KNOWS]->(c) RETURN p
      -- 2 nodes, 1 edge; should be 3 and 2
    MATCH p = (a)-[:KNOWS]->(b)-[:KNOWS]->(c) RETURN length(p)
      -- 1, not 2

The wrong answer is a plausible one. `length(p)` returns a number, just the
wrong number, and anything walking `nodes(p)` sees a shorter journey than
the one that matched.

The variable-length spelling of the same traversal was always correct,
because it assembles its whole path in one place. The two constructions
agreed on which rows matched and disagreed only on what the path was, which
is the sort of disagreement nothing checks — so one of the tests here is
exactly that: the fixed and variable-length forms must produce the same
path, not merely the same rows.

`extend_path` continues the bound path only when it actually ends where the
hop starts. A comma-separated pattern that rebinds the variable across
disconnected parts starts afresh rather than inventing an edge between two
unrelated nodes; that case has a test too.

openCypher TCK 799 -> 800 of 1244 evaluated. Only one scenario moves — the
rest of the path scenarios are blocked on undirected pattern support — but
the defect is a wrong answer rather than a missing feature, which is the
class this repo treats as most damaging.

Closes #631.