### PR TITLE
Hexadecimal and octal integer literals, and stop panicking on the ones that do not fit (#633)

### DIFF
--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -330,7 +330,10 @@ value = {
 
 null = { ^"NULL" }
 boolean = { ^"TRUE" | ^"FALSE" }
-integer = @{ "-"? ~ ASCII_DIGIT+ }
+// Hexadecimal and octal come first: ordered choice commits on a prefix, so
+// `ASCII_DIGIT+` would match the leading `0` of `0x1A` and leave `x1A`
+// behind as a parse error.
+integer = @{ "-"? ~ ( ("0" ~ ^"x" ~ ASCII_HEX_DIGIT+) | ("0" ~ ^"o" ~ ASCII_OCT_DIGIT+) | ASCII_DIGIT+ ) }
 // Float: digits.digits, leading-dot (.5), or exponent-without-decimal (1e-07),
 // each with an optional exponent. f64::parse handles all of these forms.
 float = @{ "-"? ~ ( (ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ ~ (^"e" ~ ("-" | "+")? ~ ASCII_DIGIT+)?) | (ASCII_DIGIT+ ~ ^"e" ~ ("-" | "+")? ~ ASCII_DIGIT+) | ("." ~ ASCII_DIGIT+ ~ (^"e" ~ ("-" | "+")? ~ ASCII_DIGIT+)?) ) }

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -243,6 +243,47 @@ fn parse_clause_pipeline(input: &str) -> ParseResult<Query> {
     Ok(query)
 }
 
+/// An integer literal, in decimal, hexadecimal (`0x1A`) or octal (`0o17`).
+///
+/// Returns an error rather than panicking when the value does not fit. The
+/// previous `.parse().unwrap()` meant `RETURN 9223372036854775808` **crashed
+/// the process**: an out-of-range literal is a syntax error in Cypher, and the
+/// TCK has two scenarios asserting exactly that, but a panic is reachable from
+/// any query string and takes the server with it (#633).
+fn parse_integer_literal(text: &str) -> ParseResult<i64> {
+    let text = text.trim();
+    let (negative, digits) = match text.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, text),
+    };
+    let (radix, digits) = if let Some(rest) = digits.strip_prefix("0x").or_else(|| digits.strip_prefix("0X")) {
+        (16, rest)
+    } else if let Some(rest) = digits.strip_prefix("0o").or_else(|| digits.strip_prefix("0O")) {
+        (8, rest)
+    } else {
+        (10, digits)
+    };
+
+    // Parsed as i128 so the magnitude of i64::MIN -- which is one larger than
+    // i64::MAX -- can be represented before the sign is applied. Without this,
+    // `-9223372036854775808` has no valid intermediate form.
+    let magnitude = i128::from_str_radix(digits, radix).map_err(|_| {
+        ParseError::SemanticError(format!("integer literal out of range: `{text}`"))
+    })?;
+    let value = if negative { -magnitude } else { magnitude };
+    i64::try_from(value).map_err(|_| {
+        ParseError::SemanticError(format!("integer literal out of range: `{text}`"))
+    })
+}
+
+/// A `SKIP`/`LIMIT` count. Same crash as the literal parser had, same fix:
+/// `LIMIT 99999999999999999999` panicked rather than being refused.
+fn parse_count_literal(text: &str) -> ParseResult<usize> {
+    let value = parse_integer_literal(text)?;
+    usize::try_from(value)
+        .map_err(|_| ParseError::SemanticError(format!("SKIP/LIMIT must not be negative: `{text}`")))
+}
+
 pub fn parse_query(input: &str) -> ParseResult<Query> {
     let pairs = match CypherParser::parse(Rule::query, input) {
         Ok(pairs) => pairs,
@@ -970,14 +1011,14 @@ fn parse_match_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
             Rule::skip_clause => {
                 for skip_inner in inner.into_inner() {
                     if skip_inner.as_rule() == Rule::integer {
-                        query.skip = Some(skip_inner.as_str().parse().unwrap());
+                        query.skip = Some(parse_count_literal(skip_inner.as_str())?);
                     }
                 }
             }
             Rule::limit_clause => {
                 for limit_inner in inner.into_inner() {
                     if limit_inner.as_rule() == Rule::integer {
-                        query.limit = Some(limit_inner.as_str().parse().unwrap());
+                        query.limit = Some(parse_count_literal(limit_inner.as_str())?);
                     }
                 }
             }
@@ -1062,14 +1103,14 @@ fn parse_with_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<WithClaus
             Rule::skip_clause => {
                 for skip_inner in inner.into_inner() {
                     if skip_inner.as_rule() == Rule::integer {
-                        skip = Some(skip_inner.as_str().parse().unwrap());
+                        skip = Some(parse_count_literal(skip_inner.as_str())?);
                     }
                 }
             }
             Rule::limit_clause => {
                 for limit_inner in inner.into_inner() {
                     if limit_inner.as_rule() == Rule::integer {
-                        limit = Some(limit_inner.as_str().parse().unwrap());
+                        limit = Some(parse_count_literal(limit_inner.as_str())?);
                     }
                 }
             }
@@ -1683,11 +1724,15 @@ fn parse_value(pair: pest::iterators::Pair<Rule>) -> ParseResult<PropertyValue> 
                 return Ok(PropertyValue::Boolean(val));
             }
             Rule::integer => {
-                let val = inner.as_str().parse().unwrap();
-                return Ok(PropertyValue::Integer(val));
+                return Ok(PropertyValue::Integer(parse_integer_literal(inner.as_str())?));
             }
             Rule::float => {
-                let val = inner.as_str().parse().unwrap();
+                let val = inner.as_str().trim().parse().map_err(|_| {
+                    ParseError::SemanticError(format!(
+                        "float literal out of range: `{}`",
+                        inner.as_str()
+                    ))
+                })?;
                 return Ok(PropertyValue::Float(val));
             }
             Rule::string => {
@@ -1922,6 +1967,31 @@ fn parse_term(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
                     Rule::postfix_op => postfix_pair = Some(inner),
                     Rule::index_op => index_pairs.push(inner),
                     _ => {}
+                }
+            }
+
+            // `-9223372036854775808` is i64::MIN, and its magnitude is not a
+            // valid i64 on its own -- so the minus has to be folded into the
+            // literal rather than applied to it afterwards, or the only way to
+            // write the smallest integer is a parse error. Every other negated
+            // literal folds to exactly what the operator would have produced.
+            if prefix_ops.len() == 1
+                && prefix_ops[0].as_str().trim() == "-"
+                && index_pairs.is_empty()
+                && postfix_pair.is_none()
+            {
+                if let Some(primary) = primary_pair.as_ref() {
+                    let text = primary.as_str().trim();
+                    let numeric = !text.is_empty()
+                        && text.bytes().all(|b| b.is_ascii_digit())
+                        || text.len() > 2
+                            && text.starts_with('0')
+                            && matches!(text.as_bytes()[1], b'x' | b'X' | b'o' | b'O');
+                    if numeric {
+                        if let Ok(value) = parse_integer_literal(&format!("-{text}")) {
+                            return Ok(Expression::Literal(PropertyValue::Integer(value)));
+                        }
+                    }
                 }
             }
 

--- a/tests/integer_literals.rs
+++ b/tests/integer_literals.rs
@@ -1,0 +1,92 @@
+//! Integer literals: every radix Cypher defines, and no crash at the edges.
+//!
+//! `parse_value` did `inner.as_str().parse().unwrap()`, so an out-of-range
+//! literal **panicked**. That is reachable from any query string — a server
+//! taking queries from anywhere could be stopped with `RETURN
+//! 9223372036854775808`. Cypher calls an oversized literal a syntax error, and
+//! a syntax error is what it should have been all along.
+//!
+//! The smallest integer is the awkward one: `-9223372036854775808` is
+//! representable, but its magnitude alone is not, so the sign has to be folded
+//! into the literal before it is parsed rather than applied afterwards.
+//!
+//! Hexadecimal and octal were simply missing (19 TCK scenarios).
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn value_of(cypher: &str) -> Result<PropertyValue, String> {
+    let q = parse_query(cypher).map_err(|e| e.to_string())?;
+    let out = QueryExecutor::new(&GraphStore::new())
+        .execute(&q)
+        .map_err(|e| e.to_string())?;
+    match out.records.first().and_then(|r| r.get("x")) {
+        Some(Value::Property(p)) => Ok(p.clone()),
+        other => Err(format!("expected a property, got {other:?}")),
+    }
+}
+
+fn int_of(cypher: &str) -> i64 {
+    match value_of(cypher) {
+        Ok(PropertyValue::Integer(n)) => n,
+        other => panic!("`{cypher}` should be an integer, got {other:?}"),
+    }
+}
+
+#[test]
+fn hexadecimal_literals_are_read_in_every_case() {
+    assert_eq!(int_of("RETURN 0x1 AS x"), 1);
+    assert_eq!(int_of("RETURN 0x0 AS x"), 0);
+    assert_eq!(int_of("RETURN 0x162CD4F6 AS x"), 372_036_854);
+    assert_eq!(int_of("RETURN 0x1A2b3c4D5E6f7 AS x"), 460_367_961_908_983);
+    assert_eq!(int_of("RETURN 0x7FFFFFFFFFFFFFFF AS x"), i64::MAX);
+    assert_eq!(int_of("RETURN -0x1 AS x"), -1);
+}
+
+#[test]
+fn octal_literals_are_read() {
+    assert_eq!(int_of("RETURN 0o1 AS x"), 1);
+    assert_eq!(int_of("RETURN 0o0 AS x"), 0);
+    assert_eq!(int_of("RETURN -0o0 AS x"), 0);
+    assert_eq!(int_of("RETURN 0o2613152366 AS x"), 372_036_854);
+    assert_eq!(int_of("RETURN -0o2613152366 AS x"), -372_036_854);
+    assert_eq!(int_of("RETURN 0o777777777777777777777 AS x"), i64::MAX);
+}
+
+#[test]
+fn the_smallest_integer_is_writable() {
+    // The magnitude 9223372036854775808 is not a valid i64, so this only works
+    // if the sign is part of the literal rather than an operator applied to it.
+    assert_eq!(int_of("RETURN -9223372036854775808 AS x"), i64::MIN);
+    assert_eq!(int_of("RETURN 9223372036854775807 AS x"), i64::MAX);
+}
+
+#[test]
+fn an_out_of_range_literal_is_refused_rather_than_crashing() {
+    // The assertion that matters is that control returns at all. `expect_err`
+    // is only reached if the parser did not panic.
+    for cypher in [
+        "RETURN 9223372036854775808 AS x",
+        "RETURN -9223372036854775809 AS x",
+        "RETURN 99999999999999999999999999 AS x",
+        "RETURN 0xFFFFFFFFFFFFFFFFF AS x",
+        "MATCH (n) RETURN n LIMIT 99999999999999999999",
+    ] {
+        let err = value_of(cypher).expect_err(&format!("`{cypher}` must be refused"));
+        assert!(
+            err.contains("out of range"),
+            "`{cypher}` was refused for the wrong reason: {err}"
+        );
+    }
+}
+
+#[test]
+fn ordinary_numbers_are_unaffected() {
+    assert_eq!(int_of("RETURN 0 AS x"), 0);
+    assert_eq!(int_of("RETURN -5 AS x"), -5);
+    assert_eq!(int_of("RETURN 42 AS x"), 42);
+    assert_eq!(value_of("RETURN 1.5 AS x"), Ok(PropertyValue::Float(1.5)));
+    assert_eq!(value_of("RETURN 1e3 AS x"), Ok(PropertyValue::Float(1000.0)));
+    assert_eq!(value_of("RETURN -1.5 AS x"), Ok(PropertyValue::Float(-1.5)));
+}


### PR DESCRIPTION
`Rule::integer` did `inner.as_str().parse().unwrap()`, so an out-of-range
literal **panicked**:

    RETURN 9223372036854775808     -- panic
    RETURN -9223372036854775809    -- panic
    LIMIT 99999999999999999999     -- panic, same unwrap on the SKIP/LIMIT path

Cypher calls an oversized literal a syntax error and the TCK asserts that,
but a panic is reachable from any query string — on the HTTP or protocol
server that is a way to stop the process with a `RETURN`. All four sites
now return a `SemanticError` naming the literal.

`RETURN -9223372036854775808`, the *smallest* integer and perfectly valid,
panicked too: the magnitude `9223372036854775808` is not a representable
i64, so the sign has to be folded into the literal rather than applied to
it as an operator afterwards. A single leading `-` on a numeric primary now
folds at parse time; every other negated literal folds to exactly what the
operator produced.

Hexadecimal and octal were missing from the grammar entirely. They are
listed **before** `ASCII_DIGIT+` because ordered choice commits on a
prefix — the digit rule would otherwise match the leading `0` of `0x1A` and
leave `x1A` behind, which is the same trap that cost a day in #617.

    RETURN 0x1A2b3c4D5E6f7        -- 460367961908983
    RETURN 0o777777777777777777777 -- i64::MAX
    RETURN -0x1                    -- -1

openCypher TCK: 800 -> 831 of 1244 evaluated (64.3% -> 66.8%), 31 newly
passing, none regressed. The parse-error count drops 180 -> 149.

Closes #633.