### PR TITLE
Name an unaliased result column after the expression that was written (#635)

### DIFF
--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -625,6 +625,35 @@ pub struct ReturnItem {
     pub expression: Expression,
     /// Alias (optional)
     pub alias: Option<String>,
+    /// The expression exactly as it was written, when it came from source.
+    ///
+    /// Cypher names an unaliased result column after its own text, so
+    /// `RETURN count(*)` produces a column called `count(*)`. The planner used
+    /// to reconstruct a name from the AST and fall back to `col_0`, which is
+    /// not a name any client can ask for -- and it dropped the `*`, naming the
+    /// column `count()` (#635).
+    pub source_text: Option<String>,
+}
+
+impl ReturnItem {
+    /// The result column this item produces.
+    ///
+    /// One place, because the planner had this decision written out in ten
+    /// and they did not agree. `index` only matters for an expression with no
+    /// recorded text, which now means one the engine built itself.
+    pub fn column_name(&self, index: usize) -> String {
+        if let Some(alias) = &self.alias {
+            return alias.clone();
+        }
+        if let Some(text) = &self.source_text {
+            return text.clone();
+        }
+        match &self.expression {
+            Expression::Variable(v) => v.clone(),
+            Expression::Property { variable, property } => format!("{variable}.{property}"),
+            _ => format!("col_{index}"),
+        }
+    }
 }
 
 /// CREATE clause

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -966,11 +966,7 @@ impl QueryPlanner {
                 let mut output_columns = Vec::new();
                 if let Some(return_clause) = &query.return_clause {
                     let projections: Vec<(Expression, String)> = return_clause.items.iter().enumerate().map(|(i, item)| {
-                        let alias = item.alias.clone().unwrap_or_else(|| match &item.expression {
-                            Expression::Variable(v) => v.clone(),
-                            Expression::Property { variable, property } => format!("{}.{}", variable, property),
-                            _ => format!("col_{}", i),
-                        });
+                        let alias = item.column_name(i);
                         output_columns.push(alias.clone());
                         (item.expression.clone(), alias)
                     }).collect();
@@ -1001,11 +997,7 @@ impl QueryPlanner {
                 if let Some(return_clause) = &query.return_clause {
                     let mut output_columns = Vec::new();
                     let projections: Vec<(Expression, String)> = return_clause.items.iter().enumerate().map(|(i, item)| {
-                        let alias = item.alias.clone().unwrap_or_else(|| match &item.expression {
-                            Expression::Variable(v) => v.clone(),
-                            Expression::Property { variable, property } => format!("{}.{}", variable, property),
-                            _ => format!("col_{}", i),
-                        });
+                        let alias = item.column_name(i);
                         output_columns.push(alias.clone());
                         (item.expression.clone(), alias)
                     }).collect();
@@ -1020,7 +1012,7 @@ impl QueryPlanner {
 
                 // WITH projection: bind expressions to aliases
                 let with_projections: Vec<(Expression, String)> = with_clause.items.iter().enumerate().map(|(i, item)| {
-                    let alias = item.alias.clone().unwrap_or_else(|| format!("col_{}", i));
+                    let alias = item.column_name(i);
                     (item.expression.clone(), alias)
                 }).collect();
 
@@ -1032,11 +1024,7 @@ impl QueryPlanner {
                 // RETURN projection: project from WITH-bound variables
                 let mut output_columns = Vec::new();
                 let return_projections: Vec<(Expression, String)> = return_clause.items.iter().enumerate().map(|(i, item)| {
-                    let alias = item.alias.clone().unwrap_or_else(|| match &item.expression {
-                        Expression::Variable(v) => v.clone(),
-                        Expression::Property { variable, property } => format!("{}.{}", variable, property),
-                        _ => format!("col_{}", i),
-                    });
+                    let alias = item.column_name(i);
                     output_columns.push(alias.clone());
                     (item.expression.clone(), alias)
                 }).collect();
@@ -1060,11 +1048,7 @@ impl QueryPlanner {
                 use crate::query::executor::operator::SingleRowOperator;
                 let mut output_columns = Vec::new();
                 let projections: Vec<(Expression, String)> = return_clause.items.iter().enumerate().map(|(i, item)| {
-                    let alias = item.alias.clone().unwrap_or_else(|| match &item.expression {
-                        Expression::Variable(v) => v.clone(),
-                        Expression::Property { variable, property } => format!("{}.{}", variable, property),
-                        _ => format!("col_{}", i),
-                    });
+                    let alias = item.column_name(i);
                     output_columns.push(alias.clone());
                     (item.expression.clone(), alias)
                 }).collect();
@@ -2006,25 +1990,12 @@ impl QueryPlanner {
             let mut post_projections: Vec<(Expression, String)> = Vec::new();
 
             for (idx, item) in return_clause.items.iter().enumerate() {
-                let alias = item.alias.clone().unwrap_or_else(|| {
-                    match &item.expression {
-                        Expression::Variable(var) => var.clone(),
-                        Expression::Property { variable, property } => format!("{}.{}", variable, property),
-                        Expression::Function { name, args, distinct } => {
-                            let arg_strs: Vec<String> = args.iter().map(|a| match a {
-                                Expression::Variable(v) => v.clone(),
-                                Expression::Property { variable, property } => format!("{}.{}", variable, property),
-                                _ => "?".to_string(),
-                            }).collect();
-                            if *distinct {
-                                format!("{}(DISTINCT {})", name, arg_strs.join(", "))
-                            } else {
-                                format!("{}({})", name, arg_strs.join(", "))
-                            }
-                        },
-                        _ => format!("col_{}", idx),
-                    }
-                });
+                // `column_name` first: it uses the text the user wrote, which
+                // the reconstruction below cannot recover. `count(*)` came out
+                // as `count()` here because `*` is not an argument expression,
+                // and a column nobody can name by writing the query again is
+                // not a usable result (#635).
+                let alias = item.column_name(idx);
 
                 output_columns.push(alias.clone());
                 // Kept so ORDER BY can be translated between alias and expression form,
@@ -3320,13 +3291,7 @@ impl QueryPlanner {
                 let alias = item
                     .alias
                     .clone()
-                    .unwrap_or_else(|| match &item.expression {
-                        Expression::Variable(v) => v.clone(),
-                        Expression::Property { variable, property } => {
-                            format!("{}.{}", variable, property)
-                        }
-                        _ => format!("col_{}", i),
-                    });
+                    .unwrap_or_else(|| item.column_name(i));
                 output_columns.push(alias.clone());
                 // For the count() item, project the already-bound alias
                 // rather than re-evaluating the aggregate function.
@@ -3498,13 +3463,7 @@ impl QueryPlanner {
                 let alias = item
                     .alias
                     .clone()
-                    .unwrap_or_else(|| match &item.expression {
-                        Expression::Variable(v) => v.clone(),
-                        Expression::Property { variable, property } => {
-                            format!("{}.{}", variable, property)
-                        }
-                        _ => format!("col_{}", i),
-                    });
+                    .unwrap_or_else(|| item.column_name(i));
                 output_columns.push(alias.clone());
                 let expr = match &item.expression {
                     Expression::Function { name, .. }
@@ -3654,13 +3613,7 @@ impl QueryPlanner {
                 let alias = item
                     .alias
                     .clone()
-                    .unwrap_or_else(|| match &item.expression {
-                        Expression::Variable(v) => v.clone(),
-                        Expression::Property { variable, property } => {
-                            format!("{}.{}", variable, property)
-                        }
-                        _ => format!("col_{}", i),
-                    });
+                    .unwrap_or_else(|| item.column_name(i));
                 output_columns.push(alias.clone());
                 (item.expression.clone(), alias)
             })
@@ -4895,13 +4848,7 @@ impl QueryPlanner {
                         .iter()
                         .enumerate()
                         .map(|(idx, i)| {
-                            let alias = i.alias.clone().unwrap_or_else(|| match &i.expression {
-                                Expression::Variable(v) => v.clone(),
-                                Expression::Property { variable, property } => {
-                                    format!("{variable}.{property}")
-                                }
-                                _ => format!("col_{idx}"),
-                            });
+                            let alias = i.column_name(idx);
                             (i.expression.clone(), alias)
                         })
                         .collect();
@@ -4973,25 +4920,7 @@ impl QueryPlanner {
         let mut item_infos = Vec::new();
 
         for (idx, item) in with_clause.items.iter().enumerate() {
-            let alias = item.alias.clone().unwrap_or_else(|| {
-                match &item.expression {
-                    Expression::Variable(var) => var.clone(),
-                    Expression::Property { variable, property } => format!("{}.{}", variable, property),
-                    Expression::Function { name, args, distinct } => {
-                        let arg_strs: Vec<String> = args.iter().map(|a| match a {
-                            Expression::Variable(v) => v.clone(),
-                            Expression::Property { variable, property } => format!("{}.{}", variable, property),
-                            _ => "?".to_string(),
-                        }).collect();
-                        if *distinct {
-                            format!("{}(DISTINCT {})", name, arg_strs.join(", "))
-                        } else {
-                            format!("{}({})", name, arg_strs.join(", "))
-                        }
-                    },
-                    _ => format!("col_{}", idx),
-                }
-            });
+            let alias = item.column_name(idx);
 
             let (rewritten, extracted) = extract_nested_aggregates(&item.expression, &mut agg_counter);
             if !extracted.is_empty() {

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1832,6 +1832,10 @@ fn parse_return_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<ReturnC
 fn parse_return_item(pair: pest::iterators::Pair<Rule>) -> ParseResult<ReturnItem> {
     let mut expression = None;
     let mut alias = None;
+    // Captured before the pair is consumed. This is the column's name when no
+    // alias is given, so it has to be the text the user wrote rather than
+    // anything reconstructed from the AST.
+    let mut source_text = None;
 
     for inner in pair.into_inner() {
         match inner.as_rule() {
@@ -1839,6 +1843,7 @@ fn parse_return_item(pair: pest::iterators::Pair<Rule>) -> ParseResult<ReturnIte
                 expression = Some(Expression::Variable(crate::query::ast::STAR_ITEM.to_string()));
             }
             Rule::expression => {
+                source_text = Some(inner.as_str().trim().to_string());
                 expression = Some(parse_expression(inner)?);
             }
             Rule::variable => {
@@ -1851,6 +1856,7 @@ fn parse_return_item(pair: pest::iterators::Pair<Rule>) -> ParseResult<ReturnIte
     Ok(ReturnItem {
         expression: expression.ok_or_else(|| ParseError::SemanticError("Missing expression in RETURN".to_string()))?,
         alias,
+        source_text,
     })
 }
 

--- a/src/query/star.rs
+++ b/src/query/star.rs
@@ -117,6 +117,10 @@ fn expand_into(items: &mut Vec<ReturnItem>, scope: &[String]) {
                 out.push(ReturnItem {
                     expression: Expression::Variable(name.clone()),
                     alias: None,
+                    // `RETURN *` names each column after the variable it
+                    // expands to, which `column_name` derives from the
+                    // expression.
+                    source_text: None,
                 });
             }
         } else {

--- a/tests/result_column_names.rs
+++ b/tests/result_column_names.rs
@@ -1,0 +1,87 @@
+//! An unaliased result column is named after the expression as written.
+//!
+//! The planner reconstructed the name from the AST, in ten separate places
+//! that did not agree, and gave up on anything that was not a variable or a
+//! property:
+//!
+//! ```text
+//! RETURN 1 + 1        ->  col_0      RETURN count(*)  ->  count()
+//! ```
+//!
+//! `col_0` is not a name a client can ask for — the column exists but cannot
+//! be selected by key. `count()` is worse: a plausible name for a column that
+//! does not have it, on the most common aggregate anyone writes. The `*` was
+//! dropped because the reconstruction walks argument expressions and `*` is
+//! not one; no amount of care there recovers text that was discarded at parse
+//! time, which is why the name now comes from the source (#635).
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+fn columns(store: &GraphStore, cypher: &str) -> Vec<String> {
+    let q = parse_query(cypher).expect("query should parse");
+    QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"))
+        .columns
+}
+
+fn two_nodes() -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (:L {v: 1}), (:L {v: 2})").expect("setup should parse");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup should run");
+    store
+}
+
+#[test]
+fn an_unaliased_column_is_named_after_the_expression() {
+    let store = two_nodes();
+    for (cypher, expected) in [
+        ("RETURN 1 + 1", vec!["1 + 1"]),
+        ("RETURN 'x'", vec!["'x'"]),
+        ("UNWIND [1, 2] AS x RETURN x * 2", vec!["x * 2"]),
+        ("MATCH (n:L) RETURN n.v", vec!["n.v"]),
+        ("MATCH (n) RETURN n", vec!["n"]),
+    ] {
+        assert_eq!(columns(&store, cypher), expected, "for `{cypher}`");
+    }
+}
+
+#[test]
+fn count_star_keeps_its_star() {
+    // The reconstruction produced `count()` because `*` is not an argument
+    // expression. A caller asking for the `count(*)` key got nothing.
+    let store = two_nodes();
+    assert_eq!(columns(&store, "MATCH () RETURN count(*)"), vec!["count(*)"]);
+    assert_eq!(columns(&store, "MATCH (n) RETURN count(n)"), vec!["count(n)"]);
+    assert_eq!(
+        columns(&store, "MATCH (n) RETURN n.v, count(*)"),
+        vec!["n.v", "count(*)"]
+    );
+}
+
+#[test]
+fn an_alias_still_wins() {
+    let store = two_nodes();
+    assert_eq!(columns(&store, "MATCH (n) RETURN n.v AS val"), vec!["val"]);
+    assert_eq!(columns(&store, "MATCH () RETURN count(*) AS total"), vec!["total"]);
+}
+
+#[test]
+fn the_named_column_is_the_one_the_row_carries() {
+    // Naming the column in the header but binding the row under a different
+    // key would look identical in a column listing and return null to every
+    // caller, so the lookup is asserted rather than the header alone.
+    let store = two_nodes();
+    let q = parse_query("MATCH () RETURN count(*)").expect("query should parse");
+    let out = QueryExecutor::new(&store).execute(&q).expect("query should run");
+    assert_eq!(out.columns, vec!["count(*)"]);
+    assert!(
+        out.records[0].get("count(*)").is_some(),
+        "the row must bind the column it advertises, got {:?}",
+        out.records[0]
+    );
+}


### PR DESCRIPTION
Cypher names an unaliased column after its own text. The planner
reconstructed a name from the AST instead — in **ten separate places that
did not agree** — and gave up on anything that was not a variable or a
property:

    RETURN 1 + 1                    ->  col_0      should be  1 + 1
    UNWIND [1,2] AS x RETURN x * 2  ->  col_0      should be  x * 2
    RETURN count(*)                 ->  count()    should be  count(*)

`col_0` is not a name any client can ask for: the column exists and cannot
be selected by key, so a driver mapping results by name gets nothing.
`count()` is worse than unusable — a plausible name for a column that does
not have it, on the most common aggregate anyone writes.

No amount of care in the reconstruction fixes `count(*)`: `*` is not an
argument expression, and the text that would say so was discarded at parse
time. `ReturnItem` now carries the expression's source text, and
`ReturnItem::column_name` derives the name once — alias, then source text,
then the old AST fallback for items the engine builds itself.

The ten copies were the defect's shape rather than an accident of style:
the same decision, made ten times, and `count(*)` was wrong in all of them.

openCypher TCK: 831 -> 874 of 1244 evaluated (66.8% -> 70.3%), 43 newly
passing, none regressed. The size of that jump is a measure of how many
scenarios simply return an expression without aliasing it — which is to say
how ordinary the broken case was.

One deliberate consequence: the name now preserves the spacing as written,
so `RETURN count( n )` is named `count( n )` rather than normalised. That
matches what the text says, which is the rule being implemented.

Closes #635.