### PR TITLE
An unmatched OPTIONAL MATCH binds its named path to null (#637)

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1126,17 +1126,10 @@ impl QueryPlanner {
         let post_with_clauses = &query.match_clauses[split..];
 
         // Pre-compute variable sets for each pre-WITH MATCH clause
-        let pre_match_var_sets: Vec<HashSet<String>> = pre_with_clauses.iter().map(|mc| {
-            let mut vars = HashSet::new();
-            for path in &mc.pattern.paths {
-                if let Some(v) = &path.start.variable { vars.insert(v.clone()); }
-                for seg in &path.segments {
-                    if let Some(v) = &seg.node.variable { vars.insert(v.clone()); }
-                    if let Some(v) = &seg.edge.variable { vars.insert(v.clone()); }
-                }
-            }
-            vars
-        }).collect();
+        let pre_match_var_sets: Vec<HashSet<String>> = pre_with_clauses
+            .iter()
+            .map(|mc| Self::clause_variables(&mc.pattern))
+            .collect();
 
         // Decompose WHERE clause: assign predicates to MATCH clauses or cross-MATCH
         let pre_where_preds = query.where_clause.as_ref()
@@ -4637,20 +4630,7 @@ impl QueryPlanner {
                     // the result instead of failing (#360), so the intersection
                     // is taken whole and sorted — it comes from a HashSet, and
                     // an unsorted key order varies between runs.
-                    let mut clause_vars: HashSet<String> = HashSet::new();
-                    for path in &mc.pattern.paths {
-                        if let Some(v) = &path.start.variable {
-                            clause_vars.insert(v.clone());
-                        }
-                        for seg in &path.segments {
-                            if let Some(v) = &seg.node.variable {
-                                clause_vars.insert(v.clone());
-                            }
-                            if let Some(v) = &seg.edge.variable {
-                                clause_vars.insert(v.clone());
-                            }
-                        }
-                    }
+                    let clause_vars = Self::clause_variables(&mc.pattern);
                     let match_op = self.dispatch_plan_match(mc, None, store)?;
                     let mut shared: Vec<String> = bound.intersection(&clause_vars).cloned().collect();
                     shared.sort();
@@ -4985,8 +4965,23 @@ impl QueryPlanner {
 
     /// Extract variable names from a MATCH clause
     fn extract_match_vars(&self, mc: &MatchClause) -> HashSet<String> {
+        Self::clause_variables(&mc.pattern)
+    }
+
+    /// Every variable a MATCH clause binds, **including the named path**.
+    ///
+    /// Leaving the path variable out is what made
+    /// `OPTIONAL MATCH p = (a)-[:X]->(b) RETURN p` fail with "Variable not
+    /// found: p" when nothing matched. The left outer join fills its
+    /// right-hand-only variables with null, and that list is this set minus
+    /// what was already bound -- so a variable missing here is a variable the
+    /// join never nulls, and an unmatched OPTIONAL MATCH then looks like a
+    /// query referring to something that does not exist. `b` was nulled
+    /// correctly the whole time; only `p` was invisible.
+    fn clause_variables(pattern: &crate::query::ast::Pattern) -> HashSet<String> {
         let mut vars = HashSet::new();
-        for path in &mc.pattern.paths {
+        for path in &pattern.paths {
+            if let Some(v) = &path.path_variable { vars.insert(v.clone()); }
             if let Some(v) = &path.start.variable { vars.insert(v.clone()); }
             for seg in &path.segments {
                 if let Some(v) = &seg.node.variable { vars.insert(v.clone()); }

--- a/tests/optional_named_path.rs
+++ b/tests/optional_named_path.rs
@@ -1,0 +1,71 @@
+//! An OPTIONAL MATCH that does not match binds its named path to null.
+//!
+//! ```cypher
+//! MATCH (a:A)
+//! OPTIONAL MATCH p = (a)-[:X]->(b)
+//! RETURN p            -- "Variable not found: p"
+//! ```
+//!
+//! The left outer join fills its right-hand-only variables with null, and that
+//! list came from a set of the pattern's node and edge variables — the named
+//! path was never in it. So `b` was nulled correctly the whole time and `p`
+//! was invisible, and a query that should return one null row failed as though
+//! it referred to something that did not exist (#637).
+//!
+//! Five separate places built that variable set and none of them included the
+//! path; the clause-level ones now share one function.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn graph() -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (a:A {num: 42}), (c:C) CREATE (a)-[:REL]->(c)")
+        .expect("setup should parse");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup should run");
+    store
+}
+
+fn one_value(store: &GraphStore, cypher: &str) -> Value {
+    let q = parse_query(cypher).expect("query should parse");
+    let out = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+    assert_eq!(out.records.len(), 1, "`{cypher}` should return one row");
+    out.records[0].get("p").cloned().unwrap_or(Value::Null)
+}
+
+#[test]
+fn an_unmatched_optional_named_path_is_null() {
+    let store = graph();
+    assert_eq!(
+        one_value(&store, "MATCH (a:A) OPTIONAL MATCH p = (a)-[:X]->(b) RETURN p"),
+        Value::Null,
+        "the row survives and p is null"
+    );
+}
+
+#[test]
+fn a_matched_optional_named_path_is_still_the_path() {
+    let store = graph();
+    match one_value(&store, "MATCH (a:A) OPTIONAL MATCH p = (a)-[:REL]->(b) RETURN p") {
+        Value::Path { nodes, edges } => assert_eq!((nodes.len(), edges.len()), (2, 1)),
+        other => panic!("expected a path, got {other:?}"),
+    }
+}
+
+#[test]
+fn the_other_optional_variables_are_unaffected() {
+    // `b` was always nulled correctly. Asserting it here so a future change to
+    // the variable set cannot fix the path by breaking the nodes.
+    let store = graph();
+    let q = parse_query("MATCH (a:A) OPTIONAL MATCH p = (a)-[:X]->(b) RETURN p, b")
+        .expect("query should parse");
+    let out = QueryExecutor::new(&store).execute(&q).expect("query should run");
+    assert_eq!(out.records.len(), 1);
+    assert_eq!(out.records[0].get("p"), Some(&Value::Null));
+    assert_eq!(out.records[0].get("b"), Some(&Value::Null));
+}


### PR DESCRIPTION
    MATCH (a:A)
    OPTIONAL MATCH p = (a)-[:X]->(b)
    RETURN p                            -- "Variable not found: p"

It should return one row with `p` null, and it does bind `p` correctly when
the pattern *does* match — so this was only the unmatched case.

`LeftOuterJoinOperator` fills its right-hand-only variables with null, and
that list is the clause's variable set minus what is already bound. The set
was built from the pattern's node and edge variables and never included
`path_variable`. `b` was therefore nulled correctly the whole time while
`p` was invisible to the join, so referring to it read as referring to
something that does not exist.

Five places in the planner built that set the same way and none included
the path. The clause-level ones now share `clause_variables`; the per-path
ones drive join-key and predicate placement, which is a different question,
and are left alone deliberately rather than swept along.

openCypher TCK 874 -> 879 of 1244 evaluated (70.3% -> 70.7%), none
regressed.

Closes #637.