### PR TITLE
A repeated pattern variable is a constraint, and a self-relationship is one relationship (#639, #640)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3698,6 +3698,14 @@ impl ExpandOperator {
                     }
                 });
                 store.for_each_incoming_neighbor(node_id, type_filter, |source, eid| {
+                    // A self-relationship is incident to its node twice -- once
+                    // outgoing, once incoming -- and the walk above has already
+                    // taken it. Undirected matching traverses each
+                    // relationship once, so `MATCH ()--()` over a single
+                    // `(a)-[:LOOP]->(a)` is one match and not two (#640).
+                    if source == node_id {
+                        return;
+                    }
                     if keeps(source) {
                         collected.push((eid, source, node_id));
                     }

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2768,10 +2768,26 @@ impl QueryPlanner {
                         continue;
                     }
 
+                    // A variable already bound has to be *matched*, not
+                    // rebound. `ExpandOperator` binds its target
+                    // unconditionally, so `MATCH (b)-->(b)` bound the far end
+                    // of each edge over the near one and every edge matched --
+                    // a graph containing no self-relationships at all returned
+                    // one row per edge (#639). Expanding into a synthetic name
+                    // and requiring the two to be equal is what a repeated
+                    // variable means; the walk then continues from the
+                    // original, which the filter has just proved is the same
+                    // node.
+                    let self_ref = bound.contains(&target_var);
+                    let expand_var = if self_ref {
+                        format!("__self_{target_var}_{seg_idx}")
+                    } else {
+                        target_var.clone()
+                    };
                     let mut expand = ExpandOperator::new(
                         path_operator,
                         current_var.clone(),
-                        target_var.clone(),
+                        expand_var.clone(),
                         edge_var,
                         edge_types,
                         segment.edge.direction.clone(),
@@ -2788,6 +2804,16 @@ impl QueryPlanner {
                     } else {
                         Box::new(expand)
                     };
+                    if self_ref {
+                        path_operator = Box::new(FilterOperator::new(
+                            path_operator,
+                            Expression::Binary {
+                                left: Box::new(Expression::Variable(expand_var)),
+                                op: BinaryOp::Eq,
+                                right: Box::new(Expression::Variable(target_var.clone())),
+                            },
+                        ));
+                    }
 
                     // Add property filter for target node if properties specified
                     if let Some(ref props) = segment.node.properties {
@@ -3053,11 +3079,38 @@ impl QueryPlanner {
                     Box::new(expand) as OperatorBox
                 }
             } else {
-                let expand = ExpandOperator::new(path_operator, current_var.clone(), target.var.clone(), edge_var, edge_types, reversed_dir);
-                if !target.labels.is_empty() {
-                    Box::new(expand.with_target_labels(target.labels.clone())) as OperatorBox
+                // A variable already bound has to be *matched*, not rebound.
+                // `ExpandOperator` binds its target unconditionally, so
+                // `MATCH (b)-->(b)` bound the far end of each edge over the
+                // near one and every edge matched -- a graph containing no
+                // self-relationships at all returned one row per edge (#639).
+                // Expanding into a synthetic name and requiring the two to be
+                // equal is what a repeated variable means; the walk continues
+                // from the original, which the filter has just proved is the
+                // same node.
+                let self_ref = bound.contains(&target.var);
+                let expand_var = if self_ref {
+                    format!("__self_{}_{}", target.var, seg_idx)
                 } else {
-                    Box::new(expand) as OperatorBox
+                    target.var.clone()
+                };
+                let expand = ExpandOperator::new(path_operator, current_var.clone(), expand_var.clone(), edge_var, edge_types, reversed_dir);
+                let expanded: OperatorBox = if !target.labels.is_empty() {
+                    Box::new(expand.with_target_labels(target.labels.clone()))
+                } else {
+                    Box::new(expand)
+                };
+                if self_ref {
+                    Box::new(FilterOperator::new(
+                        expanded,
+                        Expression::Binary {
+                            left: Box::new(Expression::Variable(expand_var)),
+                            op: BinaryOp::Eq,
+                            right: Box::new(Expression::Variable(target.var.clone())),
+                        },
+                    )) as OperatorBox
+                } else {
+                    expanded
                 }
             };
             if let Some(ref props) = target.properties {
@@ -3098,11 +3151,38 @@ impl QueryPlanner {
                     Box::new(expand) as OperatorBox
                 }
             } else {
-                let expand = ExpandOperator::new(path_operator, current_var.clone(), target.var.clone(), edge_var, edge_types, segment.edge.direction.clone());
-                if !target.labels.is_empty() {
-                    Box::new(expand.with_target_labels(target.labels.clone())) as OperatorBox
+                // A variable already bound has to be *matched*, not rebound.
+                // `ExpandOperator` binds its target unconditionally, so
+                // `MATCH (b)-->(b)` bound the far end of each edge over the
+                // near one and every edge matched -- a graph containing no
+                // self-relationships at all returned one row per edge (#639).
+                // Expanding into a synthetic name and requiring the two to be
+                // equal is what a repeated variable means; the walk continues
+                // from the original, which the filter has just proved is the
+                // same node.
+                let self_ref = bound.contains(&target.var);
+                let expand_var = if self_ref {
+                    format!("__self_{}_{}", target.var, seg_idx)
                 } else {
-                    Box::new(expand) as OperatorBox
+                    target.var.clone()
+                };
+                let expand = ExpandOperator::new(path_operator, current_var.clone(), expand_var.clone(), edge_var, edge_types, segment.edge.direction.clone());
+                let expanded: OperatorBox = if !target.labels.is_empty() {
+                    Box::new(expand.with_target_labels(target.labels.clone()))
+                } else {
+                    Box::new(expand)
+                };
+                if self_ref {
+                    Box::new(FilterOperator::new(
+                        expanded,
+                        Expression::Binary {
+                            left: Box::new(Expression::Variable(expand_var)),
+                            op: BinaryOp::Eq,
+                            right: Box::new(Expression::Variable(target.var.clone())),
+                        },
+                    )) as OperatorBox
+                } else {
+                    expanded
                 }
             };
             if let Some(ref props) = target.properties {

--- a/tests/self_referencing_patterns.rs
+++ b/tests/self_referencing_patterns.rs
@@ -1,0 +1,82 @@
+//! A repeated variable is a constraint, and a self-relationship is one
+//! relationship.
+//!
+//! Two defects that both show up on patterns whose two ends are the same node,
+//! and that fail in opposite directions — one matched too much, the other
+//! counted too much.
+//!
+//! **`MATCH (b)-->(b)` matched every edge.** `ExpandOperator` binds its target
+//! unconditionally, so the far end of each edge was bound over the near one
+//! and the equality the pattern states was never checked. A graph containing
+//! no self-relationships at all returned one row per edge (#639).
+//!
+//! **`MATCH ()--()` counted a self-relationship twice.** A loop is incident to
+//! its node twice, once outgoing and once incoming, and the undirected walk
+//! took both (#640). Undirected matching traverses each relationship once —
+//! but for an edge between two *different* nodes it still yields both
+//! orientations, which is why the fix has to be about the loop and not about
+//! the direction.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+fn store_of(setup: &str) -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query(setup).expect("setup should parse");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup should run");
+    store
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).expect("query should parse");
+    QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"))
+        .records
+        .len()
+}
+
+#[test]
+fn a_repeated_variable_requires_both_ends_to_be_the_same_node() {
+    let store = store_of("CREATE (a), (b), (c) CREATE (a)-[:T]->(b), (b)-[:T]->(c)");
+    assert_eq!(rows(&store, "MATCH (b)-->(b) RETURN b"), 0, "no self-relationships exist");
+    assert_eq!(
+        rows(&store, "MATCH (a)-->(b), (b)-->(b) RETURN b"),
+        0,
+        "the second path cannot match either"
+    );
+    // The same graph, the same traversal, without the repetition: still two.
+    assert_eq!(rows(&store, "MATCH (a)-->(b) RETURN b"), 2);
+}
+
+#[test]
+fn a_repeated_variable_matches_a_real_self_relationship() {
+    // The constraint must not be so strict that the case it exists for stops
+    // working.
+    let store = store_of("CREATE (a:A) CREATE (a)-[:LOOP]->(a)");
+    assert_eq!(rows(&store, "MATCH (n)-->(n) RETURN n"), 1);
+}
+
+#[test]
+fn an_undirected_match_traverses_a_self_relationship_once() {
+    let store = store_of("CREATE (a:A) CREATE (a)-[:LOOP]->(a)");
+    assert_eq!(rows(&store, "MATCH ()--() RETURN 1 AS z"), 1);
+    assert_eq!(rows(&store, "MATCH (n)--(n) RETURN n"), 1);
+    assert_eq!(rows(&store, "MATCH ()-->() RETURN 1 AS z"), 1);
+}
+
+#[test]
+fn an_undirected_match_still_yields_both_orientations_between_distinct_nodes() {
+    // The dedup is about a loop being one relationship, not about undirected
+    // matching being one-way. Suppressing the second orientation here would
+    // halve the answer to every undirected query in the engine.
+    let store = store_of("CREATE (:A)-[:T]->(:B)");
+    assert_eq!(rows(&store, "MATCH ()--() RETURN 1 AS z"), 2, "A--B and B--A");
+    assert_eq!(rows(&store, "MATCH ()-->() RETURN 1 AS z"), 1);
+
+    let two_way = store_of("CREATE (a:A), (b:B) CREATE (a)-[:T]->(b), (b)-[:T]->(a)");
+    assert_eq!(rows(&two_way, "MATCH ()--() RETURN 1 AS z"), 4, "two edges, two ways each");
+}


### PR DESCRIPTION
Two defects on patterns whose ends are the same node, failing in opposite
directions — one matched too much, the other counted too much.

**`MATCH (b)-->(b)` matched every edge** (#639). `ExpandOperator` binds its
target unconditionally, so the far end of each edge was bound *over* the
near one and the equality the pattern states was never checked:

    CREATE (a), (b), (c) CREATE (a)-[:T]->(b), (b)-[:T]->(c)
    MATCH (b)-->(b) RETURN b               -- 2 rows, should be 0
    MATCH (a)-[r]->(b) WHERE a = b RETURN b -- 0 rows, correct

The pattern form and the hand-written form disagreed, and the pattern form
is the one people write. It stayed hidden because the case the pattern
exists for still looked right: on a graph that *is* one self-loop,
`MATCH (n)-->(n)` returns 1 — correct by coincidence, since every edge
there is a loop. A variable already bound now expands into a synthetic name
with an equality filter against the original; the walk continues from the
original, which the filter has just proved is the same node.

**`MATCH ()--()` counted a self-relationship twice** (#640). A loop is
incident to its node twice, once outgoing and once incoming, and
`Direction::Both` walks both adjacency lists.

The care here is that this must not become "undirected yields one row per
edge". Between two *distinct* nodes both orientations are real matches —
`CREATE (:A)-[:T]->(:B)` then `MATCH ()--()` is 2, and two-way edges
between two nodes are 4. Suppressing the second orientation in general
would halve the answer to every undirected query in the engine, which is
the more dangerous mistake, so the skip is on the loop and there is a test
asserting the distinct-node counts are unchanged.

openCypher TCK 879 -> 892 of 1244 evaluated (70.7% -> 71.7%), 13 newly
passing across both, none regressed.

Closes #639.
Closes #640.