### PR TITLE
MERGE can key on a value from the row (#642)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -9698,6 +9698,50 @@ impl MergeOperator {
     }
 
     /// Does a node satisfy the pattern's labels and inline properties?
+
+    /// A pattern's properties with every expression resolved against this row.
+    ///
+    /// `property_exprs` holds the values that are not literals -- `{v: x}` from
+    /// an UNWIND, `{id: row.id}` from a batch upsert, `{name: a.name}` from a
+    /// bound node. MERGE did not evaluate them at all, so it matched on the
+    /// labels alone and `UNWIND ['a','b'] AS x MERGE (n:N {v: x})` found the
+    /// first `:N` for every row and created **one** node instead of two. The
+    /// planner refused the query outright rather than answer it wrongly; this
+    /// is what makes it answerable (#642).
+    ///
+    /// The resolved map is used for matching *and* for creation, which is the
+    /// property that matters: a MERGE that searched on one set of values and
+    /// wrote another would create a node its own pattern could not find, and
+    /// running the query twice would make two.
+    fn resolved_props(
+        literals: Option<&HashMap<String, PropertyValue>>,
+        exprs: Option<&HashMap<String, Expression>>,
+        record: &Record,
+        store: &GraphStore,
+    ) -> ExecutionResult<Option<HashMap<String, PropertyValue>>> {
+        let has_exprs = exprs.map_or(false, |e| !e.is_empty());
+        if !has_exprs {
+            return Ok(literals.cloned());
+        }
+        let mut out = literals.cloned().unwrap_or_default();
+        for (key, expr) in exprs.into_iter().flatten() {
+            match eval_expression(expr, record, store)? {
+                Value::Property(pv) => {
+                    out.insert(key.clone(), pv);
+                }
+                Value::Null => {
+                    out.insert(key.clone(), PropertyValue::Null);
+                }
+                other => {
+                    return Err(ExecutionError::TypeError(format!(
+                        "MERGE property `{key}` must be a scalar value, got {other:?}"
+                    )));
+                }
+            }
+        }
+        Ok(Some(out))
+    }
+
     fn node_matches(node: &crate::graph::Node, labels: &[Label], props: Option<&HashMap<String, PropertyValue>>) -> bool {
         if !labels.iter().all(|l| node.labels.contains(l)) {
             return false;
@@ -9738,7 +9782,13 @@ impl MergeOperator {
                 .first()
                 .cloned()
                 .unwrap_or_else(|| EdgeType::new("RELATED_TO"));
-            let props = segment.edge.properties.clone().unwrap_or_default();
+            let props = Self::resolved_props(
+                segment.edge.properties.as_ref(),
+                segment.edge.property_exprs.as_ref(),
+                &base,
+                store,
+            )?
+            .unwrap_or_default();
             let (a, b) = match segment.edge.direction {
                 Direction::Incoming => (to, from),
                 Direction::Outgoing | Direction::Both => (from, to),
@@ -9749,12 +9799,26 @@ impl MergeOperator {
         // Candidate node ids per pattern position. A pattern node with no label has no
         // cheap candidate set, so it cannot participate in a match and the pattern is
         // treated as absent (i.e. created).
-        let mut candidates: Vec<Vec<NodeId>> = Vec::with_capacity(pattern_nodes.len());
+        //
+        // Resolved once per pattern node, before the search, because the same
+        // values decide both what is matched and what would be created.
+        let mut node_props: Vec<Option<HashMap<String, PropertyValue>>> =
+            Vec::with_capacity(pattern_nodes.len());
         for np in &pattern_nodes {
+            node_props.push(Self::resolved_props(
+                np.properties.as_ref(),
+                np.property_exprs.as_ref(),
+                &base,
+                store,
+            )?);
+        }
+
+        let mut candidates: Vec<Vec<NodeId>> = Vec::with_capacity(pattern_nodes.len());
+        for (i, np) in pattern_nodes.iter().enumerate() {
             let mut ids = Vec::new();
             if let Some(first_label) = np.labels.first() {
                 for node in store.get_nodes_by_label(first_label) {
-                    if Self::node_matches(node, &np.labels, np.properties.as_ref()) {
+                    if Self::node_matches(node, &np.labels, node_props[i].as_ref()) {
                         ids.push(node.id);
                     }
                 }
@@ -9790,11 +9854,11 @@ impl MergeOperator {
 
         // Create the entire pattern.
         let mut created: Vec<NodeId> = Vec::with_capacity(pattern_nodes.len());
-        for np in &pattern_nodes {
+        for (i, np) in pattern_nodes.iter().enumerate() {
             // `MERGE ({...})` has no labels, and defaulting to "Node" gave the
             // node a label the query never wrote (#625).
             let node_id = store.create_node_with_labels(np.labels.iter().cloned());
-            if let Some(required) = np.properties.as_ref() {
+            if let Some(required) = node_props[i].as_ref() {
                 for (k, v) in required {
                     if let Err(e) = store.set_node_property(tenant_id, node_id, k.clone(), v.clone())
                     {
@@ -9929,7 +9993,16 @@ impl PhysicalOperator for MergeOperator {
         let start = &path.start;
         let start_var = start.variable.clone().unwrap_or_else(|| "n".to_string());
         let labels = &start.labels;
-        let props = start.properties.as_ref();
+        // The same map decides what is matched and what is created, so a value
+        // that came from the row cannot make MERGE search for one thing and
+        // write another.
+        let resolved = Self::resolved_props(
+            start.properties.as_ref(),
+            start.property_exprs.as_ref(),
+            &base,
+            store,
+        )?;
+        let props = resolved.as_ref();
 
         // Search for existing nodes matching labels + properties
         let mut matched_node_id = None;

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -630,19 +630,6 @@ impl QueryPlanner {
             }
         }
 
-        if let Some(merge) = &query.merge_clause {
-            for path in &merge.pattern.paths {
-                if let Some(key) = path.start.property_exprs.as_ref().and_then(|e| e.keys().next()) {
-                    return Err(complain("MERGE", key));
-                }
-                for seg in &path.segments {
-                    if let Some(key) = seg.node.property_exprs.as_ref().and_then(|e| e.keys().next()) {
-                        return Err(complain("MERGE", key));
-                    }
-                }
-            }
-        }
-
         // A clause-pipeline query keeps its clauses here and leaves the fields
         // above empty, so the checks above see nothing. Missing this let
         // `UNWIND ['a','b','a'] AS x MERGE (n:N {v: x})` create **one** node
@@ -651,9 +638,10 @@ impl QueryPlanner {
         // path had refused that query for exactly this reason since #311's
         // lesson — a new path does not inherit an old guard.
         for clause in &query.clauses {
+            // MERGE resolves its property expressions against the row now
+            // (#642), so only MATCH is still restricted here.
             let (label, pattern) = match clause {
                 crate::query::ast::Clause::Match(m) => ("MATCH", &m.pattern),
-                crate::query::ast::Clause::Merge(m) => ("MERGE", &m.pattern),
                 _ => continue,
             };
             for path in &pattern.paths {
@@ -924,8 +912,17 @@ impl QueryPlanner {
             return self.plan_aggregate_then_expand(query, pat);
         }
 
-        // Handle MERGE-only statement (no MATCH needed)
-        if query.match_clauses.is_empty() && query.call_clause.is_none() {
+        // Handle MERGE-only statement (no MATCH needed).
+        //
+        // A leading UNWIND is excluded for the same reason as the CREATE-only
+        // branch below: `UNWIND [...] AS x MERGE (n:N {v: x})` has no MATCH but
+        // is still row-driven, and planning it here runs the MERGE once with
+        // nothing bound. It falls through to the general path, where the
+        // Unwind feeds the merge.
+        if query.match_clauses.is_empty()
+            && query.call_clause.is_none()
+            && !Self::has_any_unwind(query)
+        {
             if let Some(merge_clause) = &query.merge_clause {
                 let on_create: Vec<(String, String, Expression)> = merge_clause.on_create_set.iter()
                     .map(|s| (s.variable.clone(), s.property.clone(), s.value.clone()))
@@ -1939,14 +1936,29 @@ impl QueryPlanner {
                 }
             }
 
-            if !edges_to_merge.is_empty() {
+            // `MatchMergeEdgeOperator` wires an edge between endpoints that
+            // are **already bound**, which is what this branch is for -- the
+            // `MATCH (a), (b) MERGE (a)-[:R]->(b)` shape. Without a MATCH the
+            // endpoints are not bound by anything, so it wired nothing and
+            // `UNWIND [...] AS i MERGE (:A {id: i})-[:R]->(:B {id: i})`
+            // silently created no nodes and no edges. That case is a
+            // whole-pattern merge, which `MergeOperator` already does (#642).
+            if !edges_to_merge.is_empty() && !query.match_clauses.is_empty() {
                 // Edge MERGE: use MatchMergeEdgeOperator
                 use crate::query::executor::operator::MatchMergeEdgeOperator;
                 operator = Box::new(MatchMergeEdgeOperator::new(
                     operator, edges_to_merge, on_create, on_match,
                 ));
             } else {
-                // Node-only MERGE: use existing MergeOperator with input
+                // Node-only MERGE, or a whole-pattern MERGE with nothing bound
+                // to hang it off, running once per upstream row.
+                //
+                // The comment here used to say "with input" while the code
+                // assigned over `operator` and threw the input away, so the
+                // MERGE ran exactly once no matter what fed it -- and, more to
+                // the point, could not see the row. That is why
+                // `UNWIND [...] AS x MERGE (n:N {v: x})` had nowhere to read
+                // `x` from (#642).
                 let on_create_labels: Vec<(String, Vec<Label>)> = merge_clause
                     .on_create_labels
                     .iter()
@@ -1957,13 +1969,16 @@ impl QueryPlanner {
                     .iter()
                     .map(|l| (l.variable.clone(), l.labels.clone()))
                     .collect();
-                operator = Box::new(MergeOperator::new(
-                    merge_clause.pattern.clone(),
-                    on_create,
-                    on_match,
-                    on_create_labels,
-                    on_match_labels,
-                ));
+                operator = Box::new(
+                    MergeOperator::new(
+                        merge_clause.pattern.clone(),
+                        on_create,
+                        on_match,
+                        on_create_labels,
+                        on_match_labels,
+                    )
+                    .with_input(operator),
+                );
             }
             true
         } else {

--- a/tests/merge_row_properties.rs
+++ b/tests/merge_row_properties.rs
@@ -1,0 +1,103 @@
+//! MERGE can key on a value that came from the row.
+//!
+//! ```cypher
+//! UNWIND $rows AS row MERGE (n:N {id: row.id})
+//! ```
+//!
+//! is the bulk-upsert idiom, and the planner used to refuse it outright:
+//! "MERGE does not yet support a non-literal property value". Refusing was the
+//! right call at the time — `property_exprs` was not evaluated at all, so MERGE
+//! matched on the labels alone and every row found the first `:N`, creating one
+//! node where the query asks for one per distinct key (#642).
+//!
+//! Two things had to be true for this to work, and each was separately broken:
+//! the properties must be resolved against the row, and the MERGE must be able
+//! to *see* the row. The node-only branch of the planner assigned over its
+//! input operator while its comment claimed to use it, so the clause ran once
+//! with nothing bound.
+//!
+//! The property that matters throughout is that the resolved values decide
+//! **both** the match and the creation. A MERGE that searched on one set of
+//! values and wrote another would create a node its own pattern could not
+//! find, and running the query twice would make two — which is why every test
+//! here runs its query a second time.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).expect("query should parse");
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+}
+
+fn count(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).expect("query should parse");
+    QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"))
+        .records
+        .len()
+}
+
+#[test]
+fn merge_keyed_on_an_unwound_value_creates_one_node_per_distinct_key() {
+    let mut store = GraphStore::new();
+    run(&mut store, "UNWIND ['a', 'b', 'a'] AS x MERGE (n:N {v: x})");
+    assert_eq!(count(&store, "MATCH (n:N) RETURN n"), 2, "'a' twice is still one node");
+    assert_eq!(count(&store, "MATCH (n:N {v: 'a'}) RETURN n"), 1);
+    assert_eq!(count(&store, "MATCH (n:N {v: 'b'}) RETURN n"), 1);
+}
+
+#[test]
+fn running_the_upsert_again_changes_nothing() {
+    // The real test of match-and-create agreeing. If MERGE searched on one set
+    // of values and wrote another, the second run would double the graph.
+    let mut store = GraphStore::new();
+    for _ in 0..3 {
+        run(&mut store, "UNWIND ['a', 'b', 'a'] AS x MERGE (n:N {v: x})");
+        assert_eq!(count(&store, "MATCH (n:N) RETURN n"), 2);
+    }
+}
+
+#[test]
+fn merge_can_key_on_a_property_of_a_bound_node() {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:Src {k: 'x'}), (:Src {k: 'y'})");
+    run(&mut store, "MATCH (a:Src) MERGE (n:N {v: a.k})");
+    assert_eq!(count(&store, "MATCH (n:N) RETURN n"), 2);
+    assert_eq!(count(&store, "MATCH (n:N {v: 'x'}) RETURN n"), 1);
+
+    run(&mut store, "MATCH (a:Src) MERGE (n:N {v: a.k})");
+    assert_eq!(count(&store, "MATCH (n:N) RETURN n"), 2, "still idempotent");
+}
+
+#[test]
+fn a_whole_pattern_merge_can_key_on_the_row() {
+    // No MATCH binds these endpoints, so this is a whole-pattern merge rather
+    // than the "wire an edge between two bound nodes" shape. Routing it to the
+    // latter created nothing at all and reported success.
+    let mut store = GraphStore::new();
+    run(&mut store, "UNWIND [1, 2, 1] AS i MERGE (a:A {id: i})-[:R {w: i}]->(b:B {id: i})");
+    assert_eq!(count(&store, "MATCH (n:A) RETURN n"), 2);
+    assert_eq!(count(&store, "MATCH (n:B) RETURN n"), 2);
+    assert_eq!(count(&store, "MATCH ()-[r:R]->() RETURN r"), 2);
+
+    run(&mut store, "UNWIND [1, 2, 1] AS i MERGE (a:A {id: i})-[:R {w: i}]->(b:B {id: i})");
+    assert_eq!(count(&store, "MATCH ()-[r:R]->() RETURN r"), 2, "still idempotent");
+}
+
+#[test]
+fn merge_between_two_bound_nodes_still_reuses_them() {
+    // The shape the MATCH-context operator exists for. It must keep working:
+    // openCypher creates *fresh* nodes for an absent whole pattern, so binding
+    // first is how you attach an edge to existing ones.
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:A {id: 1}), (:B {id: 1})");
+    run(&mut store, "MATCH (a:A), (b:B) MERGE (a)-[:R]->(b)");
+    assert_eq!(count(&store, "MATCH (n:A) RETURN n"), 1, "no second A was created");
+    assert_eq!(count(&store, "MATCH (n:B) RETURN n"), 1);
+    assert_eq!(count(&store, "MATCH ()-[r:R]->() RETURN r"), 1);
+}


### PR DESCRIPTION
    UNWIND $rows AS row MERGE (n:N {id: row.id})

is the bulk-upsert idiom, and the planner refused it outright. Refusing was
right at the time: `property_exprs` was never evaluated, so MERGE matched on
the **labels alone** and every row found the first `:N`, creating one node
where the query asks for one per distinct key.

Three separate things had to be fixed, and the refusal was hiding all of
them.

**The properties were not resolved against the row.** `merge_path` and the
single-node branch read `properties` and ignored `property_exprs`. Both now
resolve them once per pattern node, before the search, and use the result
for the match *and* the creation. That last part is the property worth
holding onto: a MERGE that searched on one set of values and wrote another
would create a node its own pattern cannot find, so running the query twice
would make two. Every test here runs its query a second time.

**The MERGE could not see the row.** The node-only branch read:

    // Node-only MERGE: use existing MergeOperator with input
    operator = Box::new(MergeOperator::new(...));   // assigns *over* `operator`

The comment said "with input"; the code threw the input away, so the clause
ran once with nothing bound. Separately the MERGE-only fast path fires
whenever there are no MATCH clauses — including with a leading UNWIND — and
planned the UNWIND out of existence. The CREATE-only path beside it already
excluded that case and said why.

**A relationship MERGE with nothing bound wired nothing.**
`MatchMergeEdgeOperator` connects endpoints that are already bound, which
is the `MATCH (a), (b) MERGE (a)-[:R]->(b)` shape. With no MATCH there is
nothing to connect, so `UNWIND [1,2] AS i MERGE (:A {id: i})-[:R]->(:B {id:
i})` created no nodes and no edges and reported success. That shape is a
whole-pattern merge, which `MergeOperator` already does.

openCypher TCK 892 -> 902 of 1244 evaluated (71.7% -> 72.5%), none
regressed. The planner still refuses an expression-valued property in
MATCH, which is a separate question and left alone.

Closes #642.