### PR TITLE
Two tests still asserted the MERGE refusal that #642 removed

### DIFF
--- a/tests/clause_pipeline.rs
+++ b/tests/clause_pipeline.rs
@@ -249,37 +249,37 @@ fn repeated_runs_of_a_pipeline_query_agree() {
 }
 
 #[test]
-fn both_planning_paths_refuse_an_expression_valued_merge_property() {
-    // The two queries below express the same thing: MERGE a node whose property
-    // comes from a bound variable rather than a literal. The left one goes
-    // through the established planner, the right one through the clause
-    // pipeline. Neither supports it yet, and the risk is that only *one* of
-    // them says so: the pipeline read none of the by-kind clause fields the
-    // guard inspected, so it planned a MERGE on the label alone and
-    // `UNWIND ['a','b','a'] AS x MERGE (n:N {v: x})` created a single node and
-    // reported success. A silent wrong answer is worse than the refusal.
+fn both_planning_paths_agree_on_an_expression_valued_merge_property() {
+    // The two queries express the same thing: MERGE a node whose key comes
+    // from the row rather than from a literal. The first goes through the
+    // established planner, the second through the clause pipeline.
     //
-    // Assert the agreement, not the message: whatever the two paths do here,
-    // they must do the same thing.
-    let legacy = "MATCH (a:Src) MERGE (n:N {v: a.k}) RETURN n";
-    let pipeline = "UNWIND ['a', 'b', 'a'] AS x MERGE (n:N {v: x}) WITH n RETURN n.v AS v";
+    // This test began life asserting they both *refused* it. They did, and the
+    // point was that only one of them refusing would be the dangerous
+    // outcome — the pipeline read none of the by-kind clause fields the guard
+    // inspected, so it planned a MERGE on the label alone and
+    // `UNWIND ['a','b','a'] AS x MERGE (n:N {v: x})` created a single node and
+    // reported success. #642 made the query answerable, so the assertion flips
+    // to what it was always really about: the two paths must do the same
+    // thing, and that thing must now be correct.
+    let mut legacy_store = GraphStore::new();
+    run(&mut legacy_store, "CREATE (:Src {k: 'a'}), (:Src {k: 'b'}), (:Src {k: 'a'})");
+    run(&mut legacy_store, "MATCH (a:Src) MERGE (n:N {v: a.k})");
 
-    for cypher in [legacy, pipeline] {
-        let mut store = GraphStore::new();
-        let q = parse_query(cypher).expect("query should parse");
-        let err = MutQueryExecutor::new(&mut store, "default".to_string())
-            .execute(&q)
-            .expect_err(&format!("`{cypher}` must be refused, not silently mis-planned"));
-        let msg = err.to_string();
-        assert!(
-            msg.contains("MERGE") && msg.contains("non-literal property value"),
-            "`{cypher}` was refused for the wrong reason: {msg}"
-        );
+    let mut pipeline_store = GraphStore::new();
+    run(
+        &mut pipeline_store,
+        "UNWIND ['a', 'b', 'a'] AS x MERGE (n:N {v: x}) WITH n RETURN n.v AS v",
+    );
+
+    for (label, store) in [("legacy", &legacy_store), ("pipeline", &pipeline_store)] {
         assert_eq!(
-            count(&store, "MATCH (n:N) RETURN n"),
-            0,
-            "`{cypher}` was refused but still wrote to the store"
+            count(store, "MATCH (n:N) RETURN n"),
+            2,
+            "{label}: one node per distinct key, not one per row and not one overall"
         );
+        assert_eq!(count(store, "MATCH (n:N {v: 'a'}) RETURN n"), 1, "{label}");
+        assert_eq!(count(store, "MATCH (n:N {v: 'b'}) RETURN n"), 1, "{label}");
     }
 }
 

--- a/tests/cypher_projection_semantics.rs
+++ b/tests/cypher_projection_semantics.rs
@@ -1647,9 +1647,17 @@ fn a_constant_expression_is_allowed_but_an_unbound_variable_is_refused() {
 }
 
 #[test]
-fn match_and_merge_refuse_non_literal_property_values_rather_than_ignoring_them() {
-    // These are not evaluated yet. Accepting and dropping the constraint would make
-    // `MATCH (p:P {n: x})` return *every* :P — a working-looking query returning too much.
+fn match_refuses_a_non_literal_property_value_and_merge_evaluates_it() {
+    // The danger both halves guard against is the same: accepting the pattern
+    // and dropping the constraint. `MATCH (p:P {n: x})` would then return
+    // *every* `:P` — a working-looking query returning too much.
+    //
+    // MATCH still refuses, because it still does not evaluate these. MERGE no
+    // longer needs to: #642 resolves the property against the row and uses the
+    // result for the match and the creation alike, which is what makes
+    // `UNWIND $rows AS row MERGE (n {id: row.id})` an upsert rather than a
+    // node factory. This test used to assert both refused; it now asserts each
+    // does the right thing, which is no longer the same thing.
     let mut s = GraphStore::new();
     let engine = QueryEngine::new();
     engine.execute_mut("CREATE (:P {n: 1})", &mut s, "default").unwrap();
@@ -1660,15 +1668,21 @@ fn match_and_merge_refuse_non_literal_property_values_rather_than_ignoring_them(
         .expect_err("must not silently match everything");
     assert!(format!("{err}").contains("WHERE"), "should name the workaround: {err}");
 
-    let err = engine
-        .execute_mut("MATCH (p:P) MERGE (:M {n: p.n})", &mut s, "default")
-        .expect_err("must not silently store null");
-    assert!(format!("{err}").contains("WHERE"), "{err}");
-
     // the WHERE form it points at does work
     assert_eq!(
         bag(&s, "UNWIND [1] AS x MATCH (p:P) WHERE p.n = x RETURN p.n AS v"),
         vec!["v=1"]
+    );
+
+    // MERGE keys on the row: one `:M` per distinct `p.n`, and running it again
+    // adds nothing.
+    engine.execute_mut("MATCH (p:P) MERGE (:M {n: p.n})", &mut s, "default").unwrap();
+    assert_eq!(scalar(&s, "MATCH (m:M) RETURN count(m) AS n"), "n=2");
+    engine.execute_mut("MATCH (p:P) MERGE (:M {n: p.n})", &mut s, "default").unwrap();
+    assert_eq!(
+        scalar(&s, "MATCH (m:M) RETURN count(m) AS n"),
+        "n=2",
+        "a second run must find the nodes the first one wrote"
     );
 }
 


### PR DESCRIPTION
`main` was red after #643. Both failures are tests that asserted MERGE
*refuses* an expression-valued property — correct before #642, obsolete the
moment the feature landed, and neither is a defect in the feature itself.

    tests/clause_pipeline.rs
      both_planning_paths_refuse_an_expression_valued_merge_property
    tests/cypher_projection_semantics.rs
      match_and_merge_refuse_non_literal_property_values_rather_than_ignoring_them

Each now asserts the behaviour rather than the prohibition. The first was
always really about the two planning paths *agreeing*, so it keeps that
shape and checks they agree on the right answer: one node per distinct key,
not one per row and not one overall. The second covered MATCH and MERGE
together and they no longer do the same thing — MATCH still refuses,
because it still does not evaluate these; MERGE now resolves the property
against the row — so it asserts each separately, including that a second
run of the MERGE adds nothing.

I merged #643 on a red suite: the run printed the failure and then
`EXIT=101`, and I read the top of the output rather than the bottom. The
per-file run I did before it passed, which is exactly the gap a
workspace-wide run exists to close. Auditing the other suite runs from this
session, every one of them was genuinely `EXIT=0`; this was the only red
merge.