### PR TITLE
`1 < n.num < 3` means what Cypher says it means (#645)

### DIFF
--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1900,6 +1900,54 @@ fn parse_order_item(pair: pest::iterators::Pair<Rule>) -> ParseResult<OrderByIte
 }
 
 fn parse_expression(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
+    let inner: Vec<_> = pair.into_inner().collect();
+
+    // `1 < n.num < 3` means `1 < n.num AND n.num < 3`. Left-associative
+    // parsing makes it `(1 < n.num) < 3` instead, which compares a boolean to
+    // 3 -- "Cannot compare these types" on a query that is ordinary Cypher.
+    //
+    // The rewrite keys on the **token sequence**, not the parsed tree, and
+    // that distinction is the whole safety argument. Parentheses are inline in
+    // `primary`, so `(a < b) = true` and `a < b < c` are indistinguishable
+    // once parsed -- but at this level the first is one top-level comparison
+    // operator and the second is two. Applying the expansion only when *every*
+    // top-level operator is a comparison therefore cannot touch a
+    // parenthesised comparison being compared to something, and cannot touch
+    // anything joined by AND/OR/arithmetic, which the Pratt parser goes on
+    // handling exactly as before.
+    //
+    // The middle operand appears in both conjuncts. Cypher evaluates it once,
+    // and duplicating it is observationally the same here because expressions
+    // in this position are pure.
+    let ops: Vec<&pest::iterators::Pair<Rule>> = inner.iter().skip(1).step_by(2).collect();
+    if ops.len() >= 2 && ops.iter().all(|p| p.as_rule() == Rule::comparison_op) {
+        let mut terms = Vec::with_capacity(ops.len() + 1);
+        for term in inner.iter().step_by(2) {
+            terms.push(parse_term(term.clone())?);
+        }
+        if terms.len() == ops.len() + 1 {
+            let mut conjunction: Option<Expression> = None;
+            for (i, op) in ops.iter().enumerate() {
+                let comparison = Expression::Binary {
+                    left: Box::new(terms[i].clone()),
+                    op: parse_op_str(op.as_str())?,
+                    right: Box::new(terms[i + 1].clone()),
+                };
+                conjunction = Some(match conjunction {
+                    None => comparison,
+                    Some(previous) => Expression::Binary {
+                        left: Box::new(previous),
+                        op: BinaryOp::And,
+                        right: Box::new(comparison),
+                    },
+                });
+            }
+            if let Some(expr) = conjunction {
+                return Ok(expr);
+            }
+        }
+    }
+
     PRATT_PARSER
         .map_primary(|primary| parse_term(primary))
         .map_prefix(|op, rhs| match op.as_rule() {
@@ -1933,7 +1981,7 @@ fn parse_expression(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression
                 right: Box::new(right),
             })
         })
-        .parse(pair.into_inner())
+        .parse(inner.into_iter())
 }
 
 fn parse_op_str(op_str: &str) -> ParseResult<BinaryOp> {

--- a/tests/chained_comparison.rs
+++ b/tests/chained_comparison.rs
@@ -1,0 +1,121 @@
+//! `1 < n.num < 3` means `1 < n.num AND n.num < 3`.
+//!
+//! Left-associative parsing makes it `(1 < n.num) < 3`, which compares a
+//! boolean to 3 — "Cannot compare these types" on ordinary Cypher.
+//!
+//! The rewrite keys on the **token sequence**, not on the parsed tree, and
+//! that is the whole safety argument. Parentheses are inline in `primary`, so
+//! `(a < b) = true` and `a < b < c` are indistinguishable once parsed — but at
+//! the token level the first has one top-level comparison operator and the
+//! second has two. Expanding only when *every* top-level operator is a
+//! comparison therefore cannot touch a parenthesised comparison being compared
+//! to something, and cannot touch anything joined by AND/OR or arithmetic.
+//!
+//! That conservatism has a cost, pinned by the last test here: a chain mixed
+//! into a larger expression is still refused. It fails as an error rather than
+//! a wrong answer, which is the right way round to be incomplete.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn three_nodes() -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query("UNWIND [1, 2, 3] AS i CREATE ({num: i, name: toString(i)})")
+        .expect("setup should parse");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup should run");
+    store
+}
+
+fn nums(store: &GraphStore, cypher: &str) -> Vec<i64> {
+    let q = parse_query(cypher).expect("query should parse");
+    let mut out: Vec<i64> = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"))
+        .records
+        .iter()
+        .filter_map(|r| match r.get("v") {
+            Some(Value::Property(p)) => p.as_integer(),
+            _ => None,
+        })
+        .collect();
+    out.sort_unstable();
+    out
+}
+
+#[test]
+fn a_numeric_range_selects_the_middle() {
+    let store = three_nodes();
+    assert_eq!(nums(&store, "MATCH (n) WHERE 1 < n.num < 3 RETURN n.num AS v"), vec![2]);
+    assert_eq!(nums(&store, "MATCH (n) WHERE 1 <= n.num < 3 RETURN n.num AS v"), vec![1, 2]);
+    assert_eq!(nums(&store, "MATCH (n) WHERE 1 < n.num <= 3 RETURN n.num AS v"), vec![2, 3]);
+    assert_eq!(nums(&store, "MATCH (n) WHERE 1 <= n.num <= 3 RETURN n.num AS v"), vec![1, 2, 3]);
+}
+
+#[test]
+fn an_empty_range_selects_nothing_rather_than_erroring() {
+    let store = three_nodes();
+    assert_eq!(nums(&store, "MATCH (n) WHERE 10 < n.num <= 3 RETURN n.num AS v"), Vec::<i64>::new());
+}
+
+#[test]
+fn a_chain_of_strings_works_the_same_way() {
+    let store = three_nodes();
+    let q = parse_query("MATCH (n) WHERE '1' < n.name < '3' RETURN n.num AS v")
+        .expect("query should parse");
+    let got = QueryExecutor::new(&store).execute(&q).expect("query should run");
+    assert_eq!(got.records.len(), 1);
+}
+
+#[test]
+fn a_parenthesised_comparison_is_not_a_chain() {
+    // The case the token-level rule exists to protect. Rewriting this as
+    // `1 < 2 AND 2 = true` would be a wrong answer, and the parsed tree cannot
+    // tell it apart from a chain.
+    let store = GraphStore::new();
+    let q = parse_query("RETURN (1 < 2) = true AS v").expect("query should parse");
+    let got = QueryExecutor::new(&store).execute(&q).expect("query should run");
+    assert_eq!(
+        got.records[0].get("v"),
+        Some(&Value::Property(samyama::graph::PropertyValue::Boolean(true)))
+    );
+}
+
+#[test]
+fn ordinary_expressions_are_untouched() {
+    let store = three_nodes();
+    assert_eq!(nums(&store, "MATCH (n) WHERE 1 < n.num RETURN n.num AS v"), vec![2, 3]);
+    assert_eq!(
+        nums(&store, "MATCH (n) WHERE n.num > 1 AND n.num < 3 RETURN n.num AS v"),
+        vec![2]
+    );
+    let q = parse_query("RETURN 1 + 2 * 3 AS v").expect("query should parse");
+    let got = QueryExecutor::new(&GraphStore::new()).execute(&q).expect("should run");
+    assert_eq!(
+        got.records[0].get("v"),
+        Some(&Value::Property(samyama::graph::PropertyValue::Integer(7))),
+        "precedence is still the Pratt parser's job"
+    );
+}
+
+#[test]
+fn a_chain_inside_a_larger_expression_is_still_refused() {
+    // Deliberately not handled: the top-level operators here are `<`, `<`,
+    // `AND`, `=`, so the rule declines and the expression takes the ordinary
+    // path, where the chain is a type error. Recognising a chain *inside* a
+    // wider expression means reimplementing operator precedence outside the
+    // Pratt parser, which is how two parsers start disagreeing.
+    //
+    // This asserts the shape of the gap, not that the gap is desirable. An
+    // error is the right way to be incomplete; the failure to avoid is
+    // answering it wrongly.
+    let store = three_nodes();
+    let q = parse_query("MATCH (n) WHERE 1 < n.num < 3 AND n.num = 2 RETURN n.num AS v")
+        .expect("it parses");
+    assert!(
+        QueryExecutor::new(&store).execute(&q).is_err(),
+        "a mixed chain must fail loudly rather than return the wrong rows"
+    );
+}


### PR DESCRIPTION
Left-associative parsing made it `(1 < n.num) < 3`, which compares a
boolean to 3: "Cannot compare these types" on ordinary Cypher. All nine
Comparison3 scenarios are this shape, over integers and strings, in the
four open/closed combinations.

The rewrite keys on the **token sequence**, not the parsed tree, and that
is the whole safety argument. Parentheses are inline in the `primary` rule,
so `(a < b) = true` and `a < b < c` produce indistinguishable ASTs —
rewriting on the tree would turn the first into `a < b AND b = true`, a
wrong answer in place of a working query. At the token level the first has
one top-level comparison operator and the second has two, so expanding only
where *every* top-level operator is a comparison cannot reach it. Anything
joined by AND/OR or arithmetic keeps going to the Pratt parser untouched,
which is also why precedence is not re-implemented here.

The conservatism leaves a gap, and there is a test pinning it rather than
leaving it to be discovered: a chain inside a wider expression
(`1 < n.num < 3 AND n.num = 2`) is not recognised and stays a type error.
Closing that means deciding precedence outside the Pratt parser, which is
how two parsers start disagreeing — it belongs in the Pratt configuration
or nowhere. An error is the right way to be incomplete; the failure to
avoid is answering it wrongly.

The middle operand appears in both conjuncts. Cypher evaluates it once, and
duplicating it is observationally identical because expressions in this
position are pure.

openCypher TCK 902 -> 912 of 1244 evaluated (72.5% -> 73.3%), none
regressed.

Closes #645.