### PR TITLE
`IN` has three answers, not two (#647)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -954,16 +954,97 @@ fn eval_in_list(left: &PropertyValue, right: &PropertyValue) -> Option<PropertyV
             _ => None,
         }
     };
-    let found = items.iter().any(|item| {
-        if item == left {
-            return true;
+    // Cypher's IN is three-valued, and the answers that are neither true nor
+    // false are where it gets interesting:
+    //
+    //   null IN [null]            null   -- nothing can be known about it
+    //   4 IN [1, null, 3]         null   -- the null might have been the 4
+    //   1 IN [1, null]            true   -- a definite match wins regardless
+    //   null IN []                false  -- nothing to compare with at all
+    //   [1] IN [[1, null]]        false  -- different lengths cannot be equal
+    //   [1, 2] IN [[null, 'foo']] false  -- position 1 settles it
+    //
+    // `PartialEq` on `PropertyValue` is derived, so `Null == Null` is `true`
+    // and the first of these answered `true` while the second answered
+    // `false`. Both are values a caller will branch on, which makes this worse
+    // than an error (#647).
+    //
+    // The last two are why "does either side contain a null" is not the rule:
+    // a null makes a comparison unknown only when the comparison would
+    // otherwise have to look at it. A length mismatch, or a definite
+    // difference at any other position, settles the answer without ever
+    // reaching the null.
+
+    /// Cypher equality, three-valued: `None` means unknown.
+    fn eq3(a: &PropertyValue, b: &PropertyValue) -> Option<bool> {
+        match (a, b) {
+            (PropertyValue::Null, _) | (_, PropertyValue::Null) => None,
+            (PropertyValue::Array(x), PropertyValue::Array(y)) => {
+                if x.len() != y.len() {
+                    return Some(false);
+                }
+                let mut unknown = false;
+                for (i, j) in x.iter().zip(y.iter()) {
+                    match eq3(i, j) {
+                        // One definite difference is enough, whatever else the
+                        // lists contain.
+                        Some(false) => return Some(false),
+                        None => unknown = true,
+                        Some(true) => {}
+                    }
+                }
+                if unknown { None } else { Some(true) }
+            }
+            (PropertyValue::Map(x), PropertyValue::Map(y)) => {
+                if x.len() != y.len() || !x.keys().all(|k| y.contains_key(k)) {
+                    return Some(false);
+                }
+                let mut unknown = false;
+                for (key, xv) in x.iter() {
+                    match y.get(key).map(|yv| eq3(xv, yv)) {
+                        Some(Some(false)) | None => return Some(false),
+                        Some(None) => unknown = true,
+                        Some(Some(true)) => {}
+                    }
+                }
+                if unknown { None } else { Some(true) }
+            }
+            _ => {
+                if a == b {
+                    return Some(true);
+                }
+                // 1 and 1.0 are the same number.
+                let as_f64 = |p: &PropertyValue| -> Option<f64> {
+                    match p {
+                        PropertyValue::Integer(i) => Some(*i as f64),
+                        PropertyValue::Float(f) => Some(*f),
+                        _ => None,
+                    }
+                };
+                Some(match (as_f64(a), as_f64(b)) {
+                    (Some(x), Some(y)) => x == y,
+                    _ => false,
+                })
+            }
         }
-        match (numeric(left), numeric(item)) {
-            (Some(a), Some(b)) => a == b,
-            _ => false,
+    }
+
+    let mut unknown = false;
+    for item in items.iter() {
+        match eq3(left, item) {
+            Some(true) => return Some(PropertyValue::Boolean(true)),
+            Some(false) => {}
+            None => unknown = true,
         }
-    });
-    Some(PropertyValue::Boolean(found))
+    }
+
+    // An empty list falls out of this as `false`, which is what Cypher says:
+    // with nothing to compare against there is nothing undecidable.
+    Some(if unknown {
+        PropertyValue::Null
+    } else {
+        PropertyValue::Boolean(false)
+    })
 }
 
 /// Property names in a stable order.

--- a/tests/in_three_valued_logic.rs
+++ b/tests/in_three_valued_logic.rs
@@ -1,0 +1,106 @@
+//! `IN` has three answers, not two.
+//!
+//! ```text
+//! null IN [null]      null    -- nothing can be known about it
+//! 4 IN [1, null, 3]   null    -- the null might have been the 4
+//! 1 IN [1, null]      true    -- a definite match wins regardless
+//! null IN []          false   -- nothing to compare with at all
+//! ```
+//!
+//! `PartialEq` on `PropertyValue` is derived, so `Null == Null` is `true`:
+//! the first answered `true` and the second answered `false`. Neither is an
+//! error a caller would notice — they are values it will branch on, which
+//! makes this worse than a refusal (#647).
+//!
+//! The two cases that catch people out pull in opposite directions, and both
+//! are asserted here: an **empty** list is `false` however null the left side
+//! is, because no comparison is required; and a list that merely *contains*
+//! something null is unknown, even when neither side is itself null
+//! (`[null] IN [null]`).
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn result_of(cypher: &str) -> Value {
+    let q = parse_query(cypher).expect("query should parse");
+    let out = QueryExecutor::new(&GraphStore::new())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+    out.records[0].get("res").cloned().expect("column res")
+}
+
+fn assert_null(cypher: &str) {
+    let got = result_of(cypher);
+    assert!(
+        matches!(got, Value::Null | Value::Property(PropertyValue::Null)),
+        "`{cypher}` should be null, got {got:?}"
+    );
+}
+
+fn assert_bool(cypher: &str, expected: bool) {
+    assert_eq!(
+        result_of(cypher),
+        Value::Property(PropertyValue::Boolean(expected)),
+        "for `{cypher}`"
+    );
+}
+
+#[test]
+fn an_undecidable_membership_is_null() {
+    assert_null("RETURN null IN [null] AS res");
+    assert_null("RETURN null IN [1] AS res");
+    assert_null("RETURN 4 IN [1, null, 3] AS res");
+}
+
+#[test]
+fn a_definite_match_wins_over_a_null_elsewhere_in_the_list() {
+    // The ordering that matters: the null must not turn a found match into
+    // "unknown". Cypher answers the question it can answer.
+    assert_bool("RETURN 1 IN [1, null] AS res", true);
+    assert_bool("RETURN 1 IN [null, 1] AS res", true);
+}
+
+#[test]
+fn an_empty_list_is_false_however_null_the_left_side_is() {
+    // Pulls the opposite way from the rule above: with nothing to compare
+    // against, there is nothing undecidable.
+    assert_bool("RETURN null IN [] AS res", false);
+    assert_bool("RETURN [] IN [] AS res", false);
+    assert_bool("RETURN 1 IN [] AS res", false);
+}
+
+#[test]
+fn a_value_that_merely_contains_null_is_undecidable_too() {
+    // Neither side *is* null here, so a shallow check answers `false`.
+    assert_null("RETURN [null] IN [null] AS res");
+    // Same length, one undecidable position, nothing else to settle it.
+    assert_null("RETURN [1, 2] IN [[1, null]] AS res");
+}
+
+#[test]
+fn a_null_only_matters_if_the_comparison_has_to_look_at_it() {
+    // The first version of this fix asked "does either side contain a null"
+    // and made all four of these unknown. They are `false`: a length mismatch,
+    // or a definite difference at any other position, settles the comparison
+    // without ever reaching the null.
+    assert_bool("RETURN [1] IN [[1, null]] AS res", false);
+    assert_bool("RETURN [1, 2] IN [[null, 'foo']] AS res", false);
+    assert_bool("RETURN [1, 2] IN [1, [1, 2, null]] AS res", false);
+    assert_bool(
+        "RETURN [[1, 2], [3, 4]] IN [5, [[1, 2], [3, 4], null]] AS res",
+        false,
+    );
+}
+
+#[test]
+fn a_null_free_list_still_answers_true_or_false() {
+    assert_bool("RETURN 4 IN [1, 3] AS res", false);
+    assert_bool("RETURN 1 IN [1, 2] AS res", true);
+    assert_bool("RETURN 'a' IN ['a', 'b'] AS res", true);
+    assert_bool("RETURN 'c' IN ['a', 'b'] AS res", false);
+    // Cross-type numeric comparison is unaffected by any of this.
+    assert_bool("RETURN 1.0 IN [1] AS res", true);
+    // A list element compared against a list value.
+    assert_bool("RETURN [1] IN [[1], 2] AS res", true);
+}


### PR DESCRIPTION
    RETURN null IN [null]      -- true;  should be null
    RETURN 4 IN [1, null, 3]   -- false; should be null

`PartialEq` on `PropertyValue` is derived, so `Null == Null` is `true` --
that is the first. The second is the absence of any notion of "unknown":
nothing matched, so the answer came back a definite `false` when the null
might have been the 4. Neither is an error a caller notices; they are
values it will branch on.

The rule: a definite match wins outright even if the list also contains
nulls; otherwise an undecidable comparison makes the answer null; otherwise
false.

**"Either side contains a null" is not the test**, and getting that wrong
is instructive. The intuitive version gains 8 List5 scenarios and loses 4,
which nets to +4 and reads as progress on the headline. The four it breaks
are all the same shape:

    RETURN [1] IN [[1, null]]        -- false: the lengths differ
    RETURN [1, 2] IN [[null, 'foo']] -- false: position 1 settles it
    RETURN [1, 2] IN [[1, null]]     -- null:  nothing else settles it

A null makes a comparison unknown only when the comparison would otherwise
have to look at it. So this is a real three-valued equality that recurses
into lists and maps, returns "definitely unequal" for a length or key-set
mismatch, and reports unknown only when it actually reaches a null.

The other trap is the opposite way round: an **empty** list is `false`
however null the left side is, because with nothing to compare against
there is nothing undecidable. That falls out of the loop rather than being
special-cased, and has its own test.

openCypher TCK 912 -> 920 of 1244 evaluated (73.3% -> 74.0%), 8 newly
passing, none regressed.

Closes #647.