### PR TITLE
A CREATEd relationship keeps its data, its name, and survives SKIP/LIMIT (#649)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -5958,6 +5958,25 @@ impl PhysicalOperator for LimitOperator {
         }
     }
 
+    // A pass-through operator's default `next_mut` delegates to `next`, which
+    // reads its input read-only -- so a LIMIT above a write made the write
+    // operators refuse outright: `UNWIND [...] AS x CREATE (n) RETURN n.num
+    // LIMIT 2` failed with "requires mutable store access". Same defect class
+    // as the barriers in #622 and the joins in #624, in the last two
+    // pass-through operators that still had it (#649).
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        if self.count >= self.limit {
+            return Ok(None);
+        }
+
+        if let Some(record) = self.input.next_mut(store, tenant_id)? {
+            self.count += 1;
+            Ok(Some(record))
+        } else {
+            Ok(None)
+        }
+    }
+
     fn try_push_limit(&mut self, n: usize) -> bool {
         // Forward the more restrictive of (incoming hint, our own limit).
         // This handles `RETURN ... LIMIT 5 LIMIT 3` and similar nested-limit
@@ -7967,8 +7986,14 @@ impl PhysicalOperator for CreateEdgeOperator {
 pub struct CreateNodesAndEdgesOperator {
     /// Node creation operator
     node_operator: OperatorBox,
-    /// Edges to create: (source_var, target_var, edge_type, properties, edge_var)
-    edges_to_create: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>)>,
+    /// Edges to create: (source_var, target_var, edge_type, literal properties,
+    /// edge_var, property expressions).
+    ///
+    /// The expressions are the row-dependent half -- `{num: x}` from an UNWIND.
+    /// Without them `CREATE ()-[r:R {num: x}]->()` made the relationship and
+    /// left `r.num` null, which is a wrong answer rather than a missing one
+    /// (#649). The node side of this operator has carried them since #467.
+    edges_to_create: Vec<EdgeToCreate>,
     /// Variable to NodeId mapping (built during node creation)
     var_to_node_id: HashMap<String, NodeId>,
     /// Created edges
@@ -7985,7 +8010,7 @@ impl CreateNodesAndEdgesOperator {
     /// Create a new CreateNodesAndEdgesOperator
     pub fn new(
         node_operator: OperatorBox,
-        edges_to_create: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>)>,
+        edges_to_create: Vec<EdgeToCreate>,
     ) -> Self {
         Self {
             node_operator,
@@ -8027,7 +8052,9 @@ impl PhysicalOperator for CreateNodesAndEdgesOperator {
 
         // Phase 1: Create all edges
         if self.phase == 1 {
-            for (source_var, target_var, edge_type, properties, edge_var) in &self.edges_to_create {
+            for (source_var, target_var, edge_type, properties, edge_var, _exprs) in
+                &self.edges_to_create
+            {
                 let source_id = self.var_to_node_id.get(source_var)
                     .ok_or_else(|| ExecutionError::VariableNotFound(source_var.clone()))?;
                 let target_id = self.var_to_node_id.get(target_var)
@@ -8088,6 +8115,17 @@ impl PhysicalOperator for CreateNodesAndEdgesOperator {
 /// Operator for MATCH...CREATE queries
 /// Example: `MATCH (a:Trial {id: 'NCT001'}), (b:Condition {mesh_id: 'D001'}) CREATE (a)-[:STUDIES]->(b)`
 /// This operator takes matched nodes and creates edges between them
+/// `(source_var, target_var, edge_type, literal properties, edge_var,
+/// property expressions)` for one relationship a CREATE has to build.
+pub type EdgeToCreate = (
+    String,
+    String,
+    EdgeType,
+    HashMap<String, PropertyValue>,
+    Option<String>,
+    Option<HashMap<String, Expression>>,
+);
+
 pub struct MatchCreateEdgeOperator {
     /// Input operator (MATCH results)
     input: OperatorBox,
@@ -8096,8 +8134,14 @@ pub struct MatchCreateEdgeOperator {
     /// were ignored entirely, so `MATCH (p) CREATE (p)-[:R]->(c:C {..})` created neither
     /// the node nor the edge and reported success.
     nodes_to_create: Vec<(String, Vec<Label>, HashMap<String, PropertyValue>, Option<HashMap<String, Expression>>)>,
-    /// Edges to create: (source_var, target_var, edge_type, properties, edge_var)
-    edges_to_create: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>)>,
+    /// Edges to create: (source_var, target_var, edge_type, literal properties,
+    /// edge_var, property expressions).
+    ///
+    /// The expressions are the row-dependent half -- `{num: x}` from an UNWIND.
+    /// Without them `CREATE ()-[r:R {num: x}]->()` made the relationship and
+    /// left `r.num` null, which is a wrong answer rather than a missing one
+    /// (#649). The node side of this operator has carried them since #467.
+    edges_to_create: Vec<EdgeToCreate>,
     /// Whether edges have been created for current batch
     done: bool,
     /// Results to return
@@ -8110,7 +8154,7 @@ impl MatchCreateEdgeOperator {
     /// Create a new MatchCreateEdgeOperator
     pub fn new(
         input: OperatorBox,
-        edges_to_create: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>)>,
+        edges_to_create: Vec<EdgeToCreate>,
     ) -> Self {
         Self::with_nodes(input, Vec::new(), edges_to_create)
     }
@@ -8121,7 +8165,7 @@ impl MatchCreateEdgeOperator {
     pub fn with_nodes(
         input: OperatorBox,
         nodes_to_create: Vec<(String, Vec<Label>, HashMap<String, PropertyValue>, Option<HashMap<String, Expression>>)>,
-        edges_to_create: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>)>,
+        edges_to_create: Vec<EdgeToCreate>,
     ) -> Self {
         Self {
             input,
@@ -8188,7 +8232,9 @@ impl PhysicalOperator for MatchCreateEdgeOperator {
                 }
 
                 // For each matched record, create the specified edges
-                for (source_var, target_var, edge_type, properties, _edge_var) in &self.edges_to_create {
+                for (source_var, target_var, edge_type, properties, edge_var, property_exprs) in
+                    &self.edges_to_create
+                {
                     // Get source node ID from record bindings
                     let source_id = match record.get(source_var).and_then(|v| v.node_id()) {
                         Some(id) => id,
@@ -8209,11 +8255,48 @@ impl PhysicalOperator for MatchCreateEdgeOperator {
                     for (key, value) in properties {
                         store.set_edge_property_sparse(edge_id, key.clone(), value.clone());
                     }
+                    // Property values that are expressions rather than
+                    // literals -- crucially including the loop variable. These
+                    // live in `property_exprs`, and not evaluating them made
+                    // `CREATE ()-[r:R {num: x}]->()` build the right number of
+                    // relationships with none of the data (#649), the same
+                    // defect the node side had in #467.
+                    if let Some(exprs) = property_exprs {
+                        for (key, expr) in exprs {
+                            if let Value::Property(pv) = eval_expression(expr, &record, store)? {
+                                store.set_edge_property_sparse(edge_id, key.clone(), pv);
+                            }
+                        }
+                    }
+
+                    // Property values that are expressions rather than
+                    // literals -- crucially including the loop variable. These
+                    // live in `property_exprs`, and not evaluating them made
+                    // `CREATE ()-[r:R {num: x}]->()` build the right number of
+                    // relationships with none of the data (#649), the same
+                    // defect the node side had in #467.
+                    if let Some(exprs) = property_exprs {
+                        for (key, expr) in exprs {
+                            if let Value::Property(pv) = eval_expression(expr, &record, store)? {
+                                store.set_edge_property_sparse(edge_id, key.clone(), pv);
+                            }
+                        }
+                    }
 
                     // Build result record with the created edge
                     let mut result_record = record.clone();
                     if let Some(edge) = store.get_edge(edge_id) {
-                        result_record.bind("_edge".to_string(), Value::Edge(edge_id, Box::new(edge)));
+                        let value = Value::Edge(edge_id, Box::new(edge));
+                        // Under the pattern's own name as well as the internal
+                        // one. Binding only `_edge` meant
+                        // `CREATE ()-[r:R {num: x}]->() RETURN r.num` could not
+                        // find `r`: the edge existed, with the right
+                        // properties, under a name the query never wrote
+                        // (#649).
+                        if let Some(var) = edge_var {
+                            result_record.bind(var.clone(), value.clone());
+                        }
+                        result_record.bind("_edge".to_string(), value);
                     }
                     self.results.push(result_record);
                 }
@@ -9190,6 +9273,19 @@ impl PhysicalOperator for SkipOperator {
             }
         }
         self.input.next(store)
+    }
+
+    // See `LimitOperator::next_mut`: skipping a row still has to *produce* it,
+    // and producing it may be a write (#649).
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        while self.skipped < self.skip {
+            if self.input.next_mut(store, tenant_id)?.is_some() {
+                self.skipped += 1;
+            } else {
+                return Ok(None);
+            }
+        }
+        self.input.next_mut(store, tenant_id)
     }
 
     fn next_batch(&mut self, store: &GraphStore, batch_size: usize) -> ExecutionResult<Option<RecordBatch>> {

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1695,7 +1695,7 @@ impl QueryPlanner {
             let create_pattern = &create_clause.pattern;
 
             // Collect edges to create from the CREATE pattern
-            let mut edges_to_create: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>)> = Vec::new();
+            let mut edges_to_create: Vec<crate::query::executor::operator::EdgeToCreate> = Vec::new();
 
             // Variables the MATCH already bound. Anything else in the CREATE pattern is a
             // *new* node: previously such nodes were dropped on the floor, so
@@ -1792,6 +1792,7 @@ impl QueryPlanner {
                         edge_type,
                         edge_properties,
                         edge_variable,
+                        edge.property_exprs.clone(),
                     ));
 
                     current_var = target_var;
@@ -2721,7 +2722,15 @@ impl QueryPlanner {
                 for (seg_idx, segment) in path.segments.iter().enumerate() {
                     let target_var = path_nodes[seg_idx + 1].var.clone();
 
-                    let edge_var = segment.edge.variable.clone();
+                    // An inline relationship property constraint has to be
+                    // applied; it used to be dropped, so
+                    // `MATCH ()-[r:R {num: 2}]->()` returned every `:R` (#649).
+                    // An anonymous relationship gets a name to filter on.
+                    let edge_filter = self.edge_property_filter(&segment.edge, seg_idx);
+                    let edge_var = match &edge_filter {
+                        Some((var, _)) => Some(var.clone()),
+                        None => segment.edge.variable.clone(),
+                    };
                     let edge_types: Vec<String> = segment.edge.types.iter()
                         .map(|t| t.as_str().to_string())
                         .collect();
@@ -2836,6 +2845,10 @@ impl QueryPlanner {
                             let filter_expr = self.build_property_filter(&target_var, props);
                             path_operator = Box::new(FilterOperator::new(path_operator, filter_expr));
                         }
+                    }
+
+                    if let Some((_, predicate)) = edge_filter {
+                        path_operator = Box::new(FilterOperator::new(path_operator, predicate));
                     }
 
                     bound.insert(target_var.clone());
@@ -3038,7 +3051,16 @@ impl QueryPlanner {
         for seg_idx in (0..anchor_idx).rev() {
             let segment = &path.segments[seg_idx];
             let target = &nodes[seg_idx];
-            let edge_var = segment.edge.variable.clone();
+            // Same rule as the main path builder: an inline relationship
+            // property constraint is applied rather than dropped (#649). Which
+            // of these builders runs depends on where the cheapest anchor is,
+            // so a fix in only one of them is a fix that depends on the
+            // optimiser's mood.
+            let edge_filter = self.edge_property_filter(&segment.edge, seg_idx);
+            let edge_var = match &edge_filter {
+                Some((var, _)) => Some(var.clone()),
+                None => segment.edge.variable.clone(),
+            };
             let edge_types: Vec<String> = segment.edge.types.iter().map(|t| t.as_str().to_string()).collect();
             let reversed_dir = match segment.edge.direction {
                 Direction::Outgoing => Direction::Incoming,
@@ -3134,6 +3156,9 @@ impl QueryPlanner {
                     path_operator = Box::new(FilterOperator::new(path_operator, filter_expr));
                 }
             }
+            if let Some((_, predicate)) = edge_filter {
+                path_operator = Box::new(FilterOperator::new(path_operator, predicate));
+            }
             bound.insert(target.var.clone());
             if let Some(ev) = &segment.edge.variable {
                 bound.insert(ev.clone());
@@ -3148,7 +3173,16 @@ impl QueryPlanner {
         for seg_idx in anchor_idx..path.segments.len() {
             let segment = &path.segments[seg_idx];
             let target = &nodes[seg_idx + 1];
-            let edge_var = segment.edge.variable.clone();
+            // Same rule as the main path builder: an inline relationship
+            // property constraint is applied rather than dropped (#649). Which
+            // of these builders runs depends on where the cheapest anchor is,
+            // so a fix in only one of them is a fix that depends on the
+            // optimiser's mood.
+            let edge_filter = self.edge_property_filter(&segment.edge, seg_idx);
+            let edge_var = match &edge_filter {
+                Some((var, _)) => Some(var.clone()),
+                None => segment.edge.variable.clone(),
+            };
             let edge_types: Vec<String> = segment.edge.types.iter().map(|t| t.as_str().to_string()).collect();
             path_operator = if let Some(length) = &segment.edge.length {
                 let expand = VarLengthExpandOperator::new(
@@ -3206,6 +3240,9 @@ impl QueryPlanner {
                     path_operator = Box::new(FilterOperator::new(path_operator, filter_expr));
                 }
             }
+            if let Some((_, predicate)) = edge_filter {
+                path_operator = Box::new(FilterOperator::new(path_operator, predicate));
+            }
             bound.insert(target.var.clone());
             if let Some(ev) = &segment.edge.variable {
                 bound.insert(ev.clone());
@@ -3220,6 +3257,30 @@ impl QueryPlanner {
 
     /// Build a filter expression from node properties.
     /// Converts {name: "Alice", age: 30} into (n.name = "Alice" AND n.age = 30)
+    /// A filter for an inline relationship property constraint, if it has one.
+    ///
+    /// `MATCH ()-[r:R {num: 2}]->()` was planned with the type filter only and
+    /// the properties dropped, so it returned **every** `:R` -- a silent
+    /// over-match, and the same query written `WHERE r.num = 2` answered
+    /// correctly. The node side of the pattern has always been filtered; this
+    /// is the relationship side of the same rule (#649).
+    ///
+    /// An anonymous relationship needs a name to filter on, so one is invented
+    /// when the pattern did not give it one. Nothing reads it: `RETURN *`
+    /// expands from the query's own variables, not from the record's keys.
+    fn edge_property_filter(
+        &self,
+        edge: &crate::query::ast::EdgePattern,
+        seg_idx: usize,
+    ) -> Option<(String, Expression)> {
+        let props = edge.properties.as_ref().filter(|p| !p.is_empty())?;
+        let var = edge
+            .variable
+            .clone()
+            .unwrap_or_else(|| format!("__edge_props_{seg_idx}"));
+        Some((var.clone(), self.build_property_filter(&var, props)))
+    }
+
     fn build_property_filter(&self, var: &str, props: &HashMap<String, PropertyValue>) -> Expression {
         let mut conditions: Vec<Expression> = Vec::new();
 
@@ -3769,7 +3830,7 @@ impl QueryPlanner {
         let mut output_columns: Vec<String> = Vec::new();
 
         // Collect edges to create: (source_var, target_var, edge_type, properties, edge_var)
-        let mut edges_to_create: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>)> = Vec::new();
+        let mut edges_to_create: Vec<crate::query::executor::operator::EdgeToCreate> = Vec::new();
 
         // Anonymous nodes still need a handle for edge wiring. Edges are wired by variable
         // name, so an endpoint written as `(:Label)` used to have nothing to wire to and
@@ -3913,6 +3974,7 @@ impl QueryPlanner {
                         edge_type,
                         edge_properties,
                         edge_variable,
+                        edge.property_exprs.clone(),
                     ));
                 }
 
@@ -4548,13 +4610,8 @@ impl QueryPlanner {
             HashMap<String, PropertyValue>,
             Option<HashMap<String, Expression>>,
         )> = Vec::new();
-        let mut edges_to_create: Vec<(
-            String,
-            String,
-            EdgeType,
-            HashMap<String, PropertyValue>,
-            Option<String>,
-        )> = Vec::new();
+        let mut edges_to_create: Vec<crate::query::executor::operator::EdgeToCreate> =
+            Vec::new();
 
         let mut handle_for = |node: &crate::query::ast::NodePattern,
                               nodes: &mut Vec<(
@@ -4612,6 +4669,7 @@ impl QueryPlanner {
                     edge_type,
                     segment.edge.properties.clone().unwrap_or_default(),
                     segment.edge.variable.clone(),
+                    segment.edge.property_exprs.clone(),
                 ));
                 current = target;
             }

--- a/tests/create_relationship_from_row.rs
+++ b/tests/create_relationship_from_row.rs
@@ -1,0 +1,100 @@
+//! `UNWIND [...] AS x CREATE ()-[r:R {num: x}]->() RETURN r.num`
+//!
+//! The bulk-load idiom for relationships, and three separate things stopped it
+//! working (#649). Each failed differently, and two of the three reported
+//! success.
+//!
+//! **The edge kept no data.** `edges_to_create` carried only the *literal*
+//! properties; `{num: x}` is an expression, and it was dropped. The right
+//! number of relationships were created with none of their data — the same
+//! defect the node side of this operator had in #467, in the half that was
+//! not fixed then.
+//!
+//! **The edge had no name.** The created relationship was bound under the
+//! internal key `_edge` and the pattern's own variable was discarded, so
+//! `RETURN r.num` could not find `r` at all.
+//!
+//! **SKIP and LIMIT could not sit above a write.** Both are pass-through
+//! operators whose default `next_mut` delegates to `next`, which reads its
+//! input read-only, so the write below refused outright — the same defect
+//! class as the barriers in #622 and the joins in #624.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) -> Vec<Option<i64>> {
+    let q = parse_query(cypher).expect("query should parse");
+    let out = MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+    let mut got: Vec<Option<i64>> = out
+        .records
+        .iter()
+        .map(|r| match r.get("num") {
+            Some(Value::Property(PropertyValue::Integer(n))) => Some(*n),
+            _ => None,
+        })
+        .collect();
+    got.sort();
+    got
+}
+
+fn count(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).expect("query should parse");
+    QueryExecutor::new(store).execute(&q).expect("should run").records.len()
+}
+
+#[test]
+fn a_created_relationship_keeps_the_property_that_came_from_the_row() {
+    let mut store = GraphStore::new();
+    let got = run(
+        &mut store,
+        "UNWIND [1, 2, 3] AS x CREATE ()-[r:R {num: x}]->() RETURN r.num AS num",
+    );
+    assert_eq!(got, vec![Some(1), Some(2), Some(3)], "each edge keeps its own value");
+    assert_eq!(count(&store, "MATCH ()-[r:R]->() RETURN r"), 3);
+    assert_eq!(count(&store, "MATCH ()-[r:R {num: 2}]->() RETURN r"), 1);
+}
+
+#[test]
+fn the_created_relationship_is_bound_under_its_own_name() {
+    // It was bound under an internal key, so the edge existed with the right
+    // properties under a name the query never wrote.
+    let mut store = GraphStore::new();
+    let got = run(
+        &mut store,
+        "UNWIND [7] AS x CREATE ()-[r:R {num: x}]->() WITH r RETURN r.num AS num",
+    );
+    assert_eq!(got, vec![Some(7)], "`r` survives a WITH");
+}
+
+#[test]
+fn a_filter_after_the_write_sees_the_new_relationship() {
+    let mut store = GraphStore::new();
+    let got = run(
+        &mut store,
+        "UNWIND [1, 2, 3, 4, 5] AS x CREATE ()-[r:R {num: x}]->() \
+         WITH r WHERE r.num % 2 = 0 RETURN r.num AS num",
+    );
+    assert_eq!(got, vec![Some(2), Some(4)]);
+    assert_eq!(
+        count(&store, "MATCH ()-[r:R]->() RETURN r"),
+        5,
+        "filtering the result must not filter the writes"
+    );
+}
+
+#[test]
+fn skip_and_limit_above_a_write_do_not_reduce_the_writes() {
+    // The rows are narrowed; the side effects are not. A LIMIT that stopped
+    // pulling would silently create fewer nodes than the query asks for, which
+    // is the failure worth pinning here rather than the row count.
+    let mut store = GraphStore::new();
+    let got = run(
+        &mut store,
+        "UNWIND [42, 42, 42, 42, 42] AS x CREATE (n:N {num: x}) RETURN n.num AS num SKIP 2 LIMIT 2",
+    );
+    assert_eq!(got.len(), 2, "two rows survive SKIP 2 LIMIT 2");
+    assert_eq!(count(&store, "MATCH (n:N) RETURN n"), 5, "all five were created");
+}


### PR DESCRIPTION
    UNWIND $rows AS row CREATE ()-[r:R {num: row.num}]->() RETURN r.num

Four defects, three of which reported success.

**The relationship kept no data.** `edges_to_create` carried only the
*literal* properties; `{num: x}` is an expression and was dropped. The
right number of relationships were created with none of their data — the
same defect the node side of this operator had in #467, in the half that
was not fixed then.

**The relationship had no name.** The created edge was bound under the
internal key `_edge` and the pattern's own variable discarded, so
`RETURN r.num` could not find `r`. The edge existed, correctly, under a
name the query never wrote.

**SKIP and LIMIT could not sit above a write.** Both are pass-through
operators whose default `next_mut` delegates to `next`, which reads its
input read-only, so the write below refused outright. Same defect class as
the barriers in #622 and the joins in #624 — these were the last two
pass-through operators that still had it. The test asserts the side
effects rather than the rows: `SKIP 2 LIMIT 2` over five rows narrows the
result to two and must still create all five.

**An inline relationship property constraint was ignored in MATCH**, found
while writing the test for the first defect:

    MATCH ()-[r:R {num: 2}]->() RETURN r          -- returned EVERY :R
    MATCH ()-[r:R]->() WHERE r.num = 2 RETURN r   -- correct

The worst of the four: a silent over-match, on a constraint the node side
of the same pattern has always applied. There are three separate path
builders in the planner and which one runs depends on where the cheapest
anchor is, so all three now apply it — a fix in one would have been a fix
that depends on the optimiser's mood. An anonymous relationship gets an
invented name to filter on; nothing reads it, because `RETURN *` expands
from the query's variables rather than the record's keys.

openCypher TCK 920 -> 932 of 1244 evaluated (74.0% -> 74.9%), 12 newly
passing, none regressed.

Closes #649.