### PR TITLE
A list can hold a node or a relationship (#652)

### DIFF
--- a/crates/samyama-sdk/src/embedded.rs
+++ b/crates/samyama-sdk/src/embedded.rs
@@ -162,6 +162,11 @@ fn record_batch_to_query_result(batch: &RecordBatch, store: &GraphStore) -> Quer
             };
 
             match val {
+                Value::List(items) => {
+                    row.push(serde_json::Value::Array(
+                        items.iter().map(|i| serde_json::json!(format!("{i:?}"))).collect(),
+                    ));
+                }
                 Value::Node(id, node) => {
                     let mut properties = serde_json::Map::new();
                     for (k, v) in &node.properties {

--- a/examples/cypher_probe2.rs
+++ b/examples/cypher_probe2.rs
@@ -15,6 +15,10 @@ use samyama::query::parser::parse_query;
 
 fn render(v: Option<&Value>) -> String {
     match v {
+        Some(Value::List(items)) => format!(
+            "[{}]",
+            items.iter().map(|i| render(Some(i))).collect::<Vec<_>>().join(", ")
+        ),
         Some(Value::Property(p)) => match p {
             PropertyValue::Integer(n) => n.to_string(),
             PropertyValue::Float(f) => format!("{f}"),

--- a/examples/cypher_probe3.rs
+++ b/examples/cypher_probe3.rs
@@ -15,6 +15,10 @@ use samyama::query::parser::parse_query;
 
 fn render(v: Option<&Value>) -> String {
     match v {
+        Some(Value::List(items)) => format!(
+            "[{}]",
+            items.iter().map(|i| render(Some(i))).collect::<Vec<_>>().join(", ")
+        ),
         Some(Value::Property(p)) => match p {
             PropertyValue::Integer(n) => n.to_string(),
             PropertyValue::Float(f) => format!("{f}"),

--- a/examples/tck_runner.rs
+++ b/examples/tck_runner.rs
@@ -541,6 +541,7 @@ fn value_to_tck(v: &Value, store: &GraphStore) -> Tck {
             let _ = id;
             Tck::Rel(e.edge_type.as_str().to_string(), props)
         }
+        Value::List(items) => Tck::List(items.iter().map(|i| value_to_tck(i, store)).collect()),
         Value::Path { nodes, edges } => {
             // An edge is stored with its own source and target, which need not
             // run the same way as the walk: `MATCH (b)<-[r]-(a)` traverses `r`

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -72,6 +72,7 @@ fn value_to_json(v: &crate::query::executor::record::Value) -> Value {
     match v {
         V::Null => Value::Null,
         V::Property(p) => prop_to_json(p),
+        V::List(items) => Value::Array(items.iter().map(value_to_json).collect()),
         V::Node(id, _) | V::NodeRef(id) => json!({ "node_id": id.as_u64() }),
         V::Edge(id, _) | V::EdgeRef(id, _, _, _) => json!({ "edge_id": id.as_u64() }),
         V::Path { nodes, edges } => json!({

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -139,6 +139,11 @@ pub async fn query_handler(
                     
                     // Extract graph elements for visualization
                     match val {
+                        Value::List(items) => {
+                            row.push(serde_json::Value::Array(
+                                items.iter().map(|i| json!(format!("{i:?}"))).collect(),
+                            ));
+                        }
                         Value::Node(id, node) => {
                             let mut properties = serde_json::Map::new();
                             if let Some(merged) = full_props.get(&id.as_u64()) {

--- a/src/protocol/command.rs
+++ b/src/protocol/command.rs
@@ -337,6 +337,9 @@ impl CommandHandler {
         match value {
             // _node prefixed with underscore - node data available but not used in
             // simple string formatting (only showing id for RESP compatibility)
+            Value::List(items) => {
+                RespValue::Array(items.iter().map(|i| self.format_value(i)).collect())
+            }
             Value::Node(id, _node) => {
                 // Format node as JSON-like string
                 let node_str = format!("Node({:?})", id);

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1350,32 +1350,41 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
             match &args[0] {
                 Value::Property(PropertyValue::String(s)) => Ok(Value::Property(PropertyValue::Integer(s.len() as i64))),
                 Value::Path { edges, .. } => Ok(Value::Property(PropertyValue::Integer(edges.len() as i64))),
+                // A list of entities -- what a variable-length relationship
+                // variable binds -- is a list, and `size()` counts it (#652).
+                Value::List(items) => Ok(Value::Property(PropertyValue::Integer(items.len() as i64))),
                 Value::Property(p) if p.as_list_items().is_some() => Ok(Value::Property(
                     PropertyValue::Integer(p.as_list_items().unwrap().len() as i64),
                 )),
                 _ => Err(ExecutionError::TypeError("size() requires string, list, or path".to_string())),
             }
         }
-        // Path functions
+        // Path functions.
+        //
+        // These return the nodes and relationships themselves. They used to
+        // return their **integer ids**, because a `PropertyValue::Array`
+        // cannot hold an entity -- so `nodes(p)` answered `[1, 2]` where
+        // Cypher answers `[(:A), (:B)]`, and anything reading a property off
+        // an element got nothing (#652).
         "nodes" => {
             match &args[0] {
-                Value::Path { nodes, .. } => {
-                    let arr: Vec<PropertyValue> = nodes.iter()
-                        .map(|id| PropertyValue::Integer(id.as_u64() as i64))
-                        .collect();
-                    Ok(Value::Property(PropertyValue::Array(arr)))
-                }
+                Value::Path { nodes, .. } => Ok(Value::List(
+                    nodes.iter().map(|id| Value::NodeRef(*id)).collect(),
+                )),
                 _ => Err(ExecutionError::TypeError("nodes() requires a path".to_string())),
             }
         }
         "relationships" | "rels" => {
             match &args[0] {
-                Value::Path { edges, .. } => {
-                    let arr: Vec<PropertyValue> = edges.iter()
-                        .map(|id| PropertyValue::Integer(id.as_u64() as i64))
-                        .collect();
-                    Ok(Value::Property(PropertyValue::Array(arr)))
-                }
+                Value::Path { edges, .. } => Ok(Value::List(
+                    edges
+                        .iter()
+                        .map(|id| match store.and_then(|s| s.get_edge(*id)) {
+                            Some(e) => Value::EdgeRef(*id, e.source, e.target, e.edge_type.clone()),
+                            None => Value::Null,
+                        })
+                        .collect(),
+                )),
                 _ => Err(ExecutionError::TypeError("relationships() requires a path".to_string())),
             }
         }
@@ -3987,6 +3996,9 @@ pub struct VarLengthExpandOperator {
     min_hops: usize,
     max_hops: usize,
     path_variable: Option<String>,
+    /// The pattern's own name for the relationships traversed, bound to a
+    /// list of them (#652).
+    rel_variable: Option<String>,
     /// Output records buffered for the current input record.
     pending: std::collections::VecDeque<Record>,
     /// `edge_types` resolved to interned ids, cached after the first use.
@@ -4039,6 +4051,7 @@ impl VarLengthExpandOperator {
             min_hops,
             max_hops,
             path_variable: None,
+            rel_variable: None,
             pending: std::collections::VecDeque::new(),
             type_ids: None,
             pinned_target: None,
@@ -4055,6 +4068,17 @@ impl VarLengthExpandOperator {
     /// Set path variable for named-path materialization.
     pub fn with_path_variable(mut self, var: String) -> Self {
         self.path_variable = Some(var);
+        self
+    }
+
+    /// Bind the pattern's relationship variable to the relationships traversed.
+    ///
+    /// `MATCH (a)-[r:T*]->(b)` makes `r` a **list of relationships**, one per
+    /// hop. The variable was simply dropped, so the query failed with
+    /// "Variable not found: r" -- the traversal was right and its own name for
+    /// what it traversed did not exist (#652).
+    pub fn with_rel_variable(mut self, var: String) -> Self {
+        self.rel_variable = Some(var);
         self
     }
 
@@ -4218,7 +4242,7 @@ impl VarLengthExpandOperator {
             if self.target_reaches(source_id, store) && self.emit_ok(target, store) {
                 let empty: std::collections::HashMap<NodeId, (NodeId, crate::graph::EdgeId)> =
                     std::collections::HashMap::new();
-                self.buffer(record, target, &empty, source_id);
+                self.buffer(record, target, &empty, source_id, store);
             }
             return Ok(());
         }
@@ -4231,7 +4255,7 @@ impl VarLengthExpandOperator {
 
         // Depth 0 endpoint (only relevant when min_hops == 0).
         if self.min_hops == 0 && self.emit_ok(source_id, store) {
-            self.buffer(record, source_id, &parent, source_id);
+            self.buffer(record, source_id, &parent, source_id, store);
         }
 
         // Cloned rather than borrowed: the BFS below calls `&mut self` methods
@@ -4261,7 +4285,7 @@ impl VarLengthExpandOperator {
             if depth >= self.min_hops {
                 for &nb in &next {
                     if self.emit_ok(nb, store) {
-                        self.buffer(record, nb, &parent, source_id);
+                        self.buffer(record, nb, &parent, source_id, store);
                     }
                 }
             }
@@ -4288,12 +4312,39 @@ impl VarLengthExpandOperator {
         target: NodeId,
         parent: &std::collections::HashMap<NodeId, (NodeId, crate::graph::EdgeId)>,
         source: NodeId,
+        store: &GraphStore,
     ) {
         let mut rec = base.clone();
         rec.bind(self.target_var.clone(), Value::NodeRef(target));
-        if let Some(ref pv) = self.path_variable {
+        if self.path_variable.is_some() || self.rel_variable.is_some() {
             let (nodes, edges) = reconstruct_path(parent, source, target);
-            rec.bind(pv.clone(), Value::Path { nodes, edges });
+            if let Some(ref rv) = self.rel_variable {
+                // A list of relationships, not of ids: `r` is the same kind of
+                // thing a single-hop `[r]` binds, one per hop.
+                // Resolved from the store rather than left as placeholders:
+                // an `EdgeRef` carrying a blank type renders as `[:]`, which
+                // is not what any caller means by a relationship.
+                rec.bind(
+                    rv.clone(),
+                    Value::List(
+                        edges
+                            .iter()
+                            .map(|e| match store.get_edge(*e) {
+                                Some(edge) => Value::EdgeRef(
+                                    *e,
+                                    edge.source,
+                                    edge.target,
+                                    edge.edge_type.clone(),
+                                ),
+                                None => Value::Null,
+                            })
+                            .collect(),
+                    ),
+                );
+            }
+            if let Some(ref pv) = self.path_variable {
+                rec.bind(pv.clone(), Value::Path { nodes, edges });
+            }
         }
         self.pending.push_back(rec);
     }
@@ -4721,6 +4772,9 @@ impl AggregatorState {
             }
             AggregatorState::CountDistinct(set) => {
                 match value {
+                    // A list is distinguished by its rendering, which is the
+                    // cheapest total order available over mixed element types.
+                    Value::List(items) => set.insert_prop(PropertyValue::String(format!("{items:?}"))),
                     Value::Property(prop) => {
                         if !prop.is_null() {
                             set.insert_prop(prop.clone());
@@ -9472,6 +9526,23 @@ impl PhysicalOperator for SetPropertyOperator {
                     Ok(v) => match v {
                         Value::Property(pv) => pv,
                         Value::Null => PropertyValue::Null,
+                        // Degrades to ids, as the node and edge arms below do:
+                        // a `PropertyValue` cannot hold an entity.
+                        Value::List(items) => PropertyValue::Array(
+                            items
+                                .iter()
+                                .map(|i| match i {
+                                    Value::Property(p) => p.clone(),
+                                    Value::NodeRef(id) | Value::Node(id, _) => {
+                                        PropertyValue::Integer(id.as_u64() as i64)
+                                    }
+                                    Value::EdgeRef(id, ..) | Value::Edge(id, _) => {
+                                        PropertyValue::Integer(id.as_u64() as i64)
+                                    }
+                                    _ => PropertyValue::Null,
+                                })
+                                .collect(),
+                        ),
                         Value::NodeRef(id) => PropertyValue::Integer(id.as_u64() as i64),
                         Value::Node(id, _) => PropertyValue::Integer(id.as_u64() as i64),
                         Value::EdgeRef(id, ..) => PropertyValue::Integer(id.as_u64() as i64),
@@ -12225,14 +12296,19 @@ mod tests {
             nodes: vec![NodeId::new(1), NodeId::new(2)],
             edges: vec![EdgeId::new(10)],
         };
+        // The nodes themselves, not their ids. This asserted an
+        // `Array([1, 2])` -- which is what the function used to return,
+        // because a `PropertyValue` cannot hold a node. An id is a
+        // plausible-looking answer that no property access can be read from
+        // (#652).
         let result = eval_function("nodes", &[path], None).unwrap();
         match result {
-            Value::Property(PropertyValue::Array(arr)) => {
-                assert_eq!(arr.len(), 2);
-                assert_eq!(arr[0].as_integer(), Some(1));
-                assert_eq!(arr[1].as_integer(), Some(2));
+            Value::List(items) => {
+                assert_eq!(items.len(), 2);
+                assert!(matches!(items[0], Value::NodeRef(id) if id.as_u64() == 1));
+                assert!(matches!(items[1], Value::NodeRef(id) if id.as_u64() == 2));
             }
-            _ => panic!("Expected Array"),
+            other => panic!("expected a list of nodes, got {other:?}"),
         }
     }
 
@@ -12249,13 +12325,13 @@ mod tests {
             nodes: vec![NodeId::new(1), NodeId::new(2)],
             edges: vec![EdgeId::new(10)],
         };
+        // With no store to resolve against, the element is `Null` rather
+        // than an invented edge -- the shape is a list either way, which is
+        // what changed (#652).
         let result = eval_function("relationships", &[path], None).unwrap();
         match result {
-            Value::Property(PropertyValue::Array(arr)) => {
-                assert_eq!(arr.len(), 1);
-                assert_eq!(arr[0].as_integer(), Some(10));
-            }
-            _ => panic!("Expected Array"),
+            Value::List(items) => assert_eq!(items.len(), 1),
+            other => panic!("expected a list of relationships, got {other:?}"),
         }
     }
 

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2751,6 +2751,12 @@ impl QueryPlanner {
                         if let Some(ref pv) = path.path_variable {
                             expand = expand.with_path_variable(pv.clone());
                         }
+                        // `MATCH (a)-[r:T*]->(b)` binds `r` to the list of
+                        // relationships traversed. Dropping it made the query
+                        // fail with "Variable not found: r" (#652).
+                        if let Some(ref rv) = segment.edge.variable {
+                            expand = expand.with_rel_variable(rv.clone());
+                        }
                         // If the destination resolves to exactly one node, the
                         // question is "can each source reach *this* node",
                         // which one reversed BFS answers for every row. LDBC
@@ -3087,6 +3093,12 @@ impl QueryPlanner {
                     length.min.unwrap_or(1),
                     length.max.unwrap_or(usize::MAX),
                 );
+                // `MATCH (a)-[r:T*]->(b)` binds `r` to the list of
+                // relationships traversed. Dropping it made the query fail
+                // with "Variable not found: r" (#652).
+                if let Some(ref rv) = segment.edge.variable {
+                    expand = expand.with_rel_variable(rv.clone());
+                }
                 // When the far end resolves to a single node, one reversed BFS
                 // from it answers every input row — see `with_pinned_target`.
                 // This is the shape anchoring produces on LDBC IC6: the walk
@@ -3185,7 +3197,7 @@ impl QueryPlanner {
             };
             let edge_types: Vec<String> = segment.edge.types.iter().map(|t| t.as_str().to_string()).collect();
             path_operator = if let Some(length) = &segment.edge.length {
-                let expand = VarLengthExpandOperator::new(
+                let mut expand = VarLengthExpandOperator::new(
                     path_operator,
                     current_var.clone(),
                     target.var.clone(),
@@ -3194,6 +3206,12 @@ impl QueryPlanner {
                     length.min.unwrap_or(1),
                     length.max.unwrap_or(usize::MAX),
                 );
+                // `MATCH (a)-[r:T*]->(b)` binds `r` to the list of
+                // relationships traversed. Dropping it made the query fail
+                // with "Variable not found: r" (#652).
+                if let Some(ref rv) = segment.edge.variable {
+                    expand = expand.with_rel_variable(rv.clone());
+                }
                 if !target.labels.is_empty() {
                     Box::new(expand.with_target_labels(target.labels.clone())) as OperatorBox
                 } else {

--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -120,6 +120,13 @@ pub enum Value {
         nodes: Vec<NodeId>,
         edges: Vec<EdgeId>,
     },
+    /// A list whose elements are themselves `Value`s.
+    ///
+    /// `PropertyValue::Array` cannot hold a node or a relationship, so a list
+    /// of them had nowhere to live: `relationships(p)` degraded its edges to
+    /// integer ids and a variable-length relationship variable was not bound
+    /// at all.
+    List(Vec<Value>),
     /// Null
     Null,
 }
@@ -156,6 +163,7 @@ impl Hash for Value {
             Value::Edge(id, _) | Value::EdgeRef(id, ..) => { 1u8.hash(state); id.hash(state); }
             Value::Property(p) => { 2u8.hash(state); p.hash(state); }
             Value::Path { nodes, edges } => { 3u8.hash(state); nodes.hash(state); edges.hash(state); }
+            Value::List(items) => { 5u8.hash(state); items.hash(state); }
             Value::Null => { 4u8.hash(state); }
         }
     }

--- a/tests/v060_features_test.rs
+++ b/tests/v060_features_test.rs
@@ -6,6 +6,7 @@
 
 use samyama::graph::{GraphStore, Label, PropertyValue};
 use samyama::query::QueryEngine;
+use samyama::query::executor::Value;
 
 // ---------------------------------------------------------------------------
 // Helper: build a small social graph for reuse across tests
@@ -193,12 +194,19 @@ fn test_nodes_function() {
         &store,
     ).unwrap();
     assert_eq!(result.len(), 1);
-    // nodes(p) should return a list with 2 nodes (Alice, Bob)
-    let ns = result.records[0].get("ns").unwrap().as_property().unwrap();
-    if let PropertyValue::Array(items) = ns {
-        assert_eq!(items.len(), 2, "Path Alice->Bob has 2 nodes");
-    } else {
-        panic!("Expected array from nodes(), got {:?}", ns);
+    // A list of *nodes*. This asserted a `PropertyValue::Array`, which cannot
+    // hold a node — so what it was really asserting was that `nodes()`
+    // returned the node **ids** (#652).
+    let ns = result.records[0].get("ns").unwrap();
+    match ns {
+        Value::List(items) => {
+            assert_eq!(items.len(), 2, "Path Alice->Bob has 2 nodes");
+            assert!(
+                items.iter().all(|i| matches!(i, Value::NodeRef(_) | Value::Node(..))),
+                "elements are nodes, not ids: {items:?}"
+            );
+        }
+        other => panic!("Expected a list of nodes from nodes(), got {other:?}"),
     }
 }
 
@@ -211,11 +219,16 @@ fn test_relationships_function() {
         &store,
     ).unwrap();
     assert_eq!(result.len(), 1);
-    let rels = result.records[0].get("rels").unwrap().as_property().unwrap();
-    if let PropertyValue::Array(items) = rels {
-        assert_eq!(items.len(), 1, "Path Alice->Bob has 1 relationship");
-    } else {
-        panic!("Expected array from relationships(), got {:?}", rels);
+    let rels = result.records[0].get("rels").unwrap();
+    match rels {
+        Value::List(items) => {
+            assert_eq!(items.len(), 1, "Path Alice->Bob has 1 relationship");
+            assert!(
+                items.iter().all(|i| matches!(i, Value::EdgeRef(..) | Value::Edge(..))),
+                "elements are relationships, not ids: {items:?}"
+            );
+        }
+        other => panic!("Expected a list of relationships, got {other:?}"),
     }
 }
 

--- a/tests/value_list.rs
+++ b/tests/value_list.rs
@@ -1,0 +1,114 @@
+//! A list can hold nodes and relationships, not just property scalars.
+//!
+//! `PropertyValue::Array` cannot hold an entity, so a list of them had nowhere
+//! to live. Two things followed from that, and both looked like small gaps
+//! while being the same missing type:
+//!
+//! ```cypher
+//! MATCH (a)-[r:T*]->(b) RETURN r       -- "Variable not found: r"
+//! MATCH p = (a)-[:T*]->(b) RETURN nodes(p)  -- [1, 2] — the ids, not the nodes
+//! ```
+//!
+//! `Value::List` is the missing variant. The variable-length relationship
+//! variable is the headline case — Cypher defines `r` there as *a list of
+//! relationships*, one per hop — but `nodes()` and `relationships()` were
+//! quietly answering with integers all along, which is worse: an id is a
+//! plausible-looking answer that no property access can be read from (#652).
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn chain() -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (a:A)-[:T {i: 1}]->(b:B)-[:T {i: 2}]->(c:C)")
+        .expect("setup should parse");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup should run");
+    store
+}
+
+fn one(store: &GraphStore, cypher: &str, col: &str) -> Value {
+    let q = parse_query(cypher).expect("query should parse");
+    let out = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+    assert!(!out.records.is_empty(), "`{cypher}` returned no rows");
+    out.records[0].get(col).cloned().unwrap_or(Value::Null)
+}
+
+#[test]
+fn a_variable_length_relationship_variable_is_a_list_of_relationships() {
+    let store = chain();
+    match one(&store, "MATCH (a:A)-[r:T*2]->(x) RETURN r", "r") {
+        Value::List(items) => {
+            assert_eq!(items.len(), 2, "one element per hop");
+            assert!(
+                items.iter().all(|i| matches!(i, Value::EdgeRef(..) | Value::Edge(..))),
+                "elements are relationships, not ids: {items:?}"
+            );
+        }
+        other => panic!("expected a list, got {other:?}"),
+    }
+}
+
+#[test]
+fn each_relationship_in_the_list_carries_its_real_type() {
+    // Built with placeholder endpoints and a blank type at first, which
+    // renders as `[:]` — a relationship-shaped hole rather than a
+    // relationship.
+    let store = chain();
+    match one(&store, "MATCH (a:A)-[r:T*2]->(x) RETURN r", "r") {
+        Value::List(items) => {
+            for item in &items {
+                match item {
+                    Value::EdgeRef(_, src, tgt, ty) => {
+                        assert_eq!(ty.as_str(), "T");
+                        assert_ne!(src.as_u64(), tgt.as_u64(), "endpoints are real");
+                    }
+                    other => panic!("expected an edge ref, got {other:?}"),
+                }
+            }
+        }
+        other => panic!("expected a list, got {other:?}"),
+    }
+}
+
+#[test]
+fn size_counts_a_list_of_relationships() {
+    let store = chain();
+    assert_eq!(
+        one(&store, "MATCH (a:A)-[r:T*2]->(x) RETURN size(r) AS n", "n"),
+        Value::Property(PropertyValue::Integer(2))
+    );
+}
+
+#[test]
+fn nodes_and_relationships_return_entities_rather_than_ids() {
+    let store = chain();
+    match one(&store, "MATCH p = (a:A)-[:T*2]->(x) RETURN nodes(p) AS v", "v") {
+        Value::List(items) => {
+            assert_eq!(items.len(), 3, "three nodes across two hops");
+            assert!(items.iter().all(|i| matches!(i, Value::NodeRef(_) | Value::Node(..))));
+        }
+        other => panic!("nodes() should be a list of nodes, got {other:?}"),
+    }
+    match one(&store, "MATCH p = (a:A)-[:T*2]->(x) RETURN relationships(p) AS v", "v") {
+        Value::List(items) => {
+            assert_eq!(items.len(), 2);
+            assert!(items.iter().all(|i| matches!(i, Value::EdgeRef(..) | Value::Edge(..))));
+        }
+        other => panic!("relationships() should be a list of relationships, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_single_hop_relationship_variable_is_unchanged() {
+    // `[r]` without a length binds one relationship, not a list of one.
+    let store = chain();
+    assert!(matches!(
+        one(&store, "MATCH (a:A)-[r:T]->(x) RETURN r", "r"),
+        Value::Edge(..) | Value::EdgeRef(..)
+    ));
+}


### PR DESCRIPTION
`PropertyValue::Array` holds `PropertyValue`s, and a node is not one, so a
list of entities had nowhere to live. Two failures that look unrelated turn
out to be the same missing type:

    MATCH (a)-[r:T*]->(b) RETURN r            -- "Variable not found: r"
    MATCH p = (a)-[:T*]->(b) RETURN nodes(p)  -- [1, 2], the ids

Cypher defines `r` in `-[r*]->` as a **list of relationships**, one per hop.
`VarLengthExpandOperator` had a `path_variable` and no equivalent for the
relationship, so the traversal was right and its own name for what it had
traversed did not exist.

`nodes()` and `relationships()` returning integers is the worse of the two,
because nothing errors: an id is a plausible-looking answer that no property
access can be read from, and a caller cannot tell that from a missing
property.

`Value::List(Vec<Value>)` is the variant that was missing. It touches 7 match
sites. Alongside it: `size()` counts a list of entities, and the
relationships in the list are resolved against the store so they carry their
real type and endpoints — built from placeholders they render as `[:]`, a
relationship-shaped hole rather than a relationship.

Two tests asserted the old behaviour and now assert the new contract rather
than being deleted; `nodes()` returning `Array([1, 2])` is what the defect
looked like from the inside, and that is worth keeping visible.

openCypher TCK 950 -> 959 of 1244 evaluated (76.4% -> 77.1%), none regressed.

A note for the next enum variant, because this cost four full-suite rounds:
`cargo test` reports **zero failures** while exiting 101 when an example
fails to compile. Compile everything first —
`cargo build --examples && cargo test --workspace --no-run` — and gate on the
exit code, not the failure count.

Closes #652.