### PR TITLE
A list or map literal can hold an expression (#654)

### DIFF
--- a/crates/samyama-sdk/src/embedded.rs
+++ b/crates/samyama-sdk/src/embedded.rs
@@ -162,6 +162,11 @@ fn record_batch_to_query_result(batch: &RecordBatch, store: &GraphStore) -> Quer
             };
 
             match val {
+                Value::Map(entries) => {
+                    row.push(serde_json::Value::Object(
+                        entries.iter().map(|(k, v)| (k.clone(), serde_json::json!(format!("{v:?}")))).collect(),
+                    ));
+                }
                 Value::List(items) => {
                     row.push(serde_json::Value::Array(
                         items.iter().map(|i| serde_json::json!(format!("{i:?}"))).collect(),

--- a/examples/cypher_probe2.rs
+++ b/examples/cypher_probe2.rs
@@ -15,6 +15,10 @@ use samyama::query::parser::parse_query;
 
 fn render(v: Option<&Value>) -> String {
     match v {
+        Some(Value::Map(entries)) => format!(
+            "{{{}}}",
+            entries.iter().map(|(k, v)| format!("{k}: {}", render(Some(v)))).collect::<Vec<_>>().join(", ")
+        ),
         Some(Value::List(items)) => format!(
             "[{}]",
             items.iter().map(|i| render(Some(i))).collect::<Vec<_>>().join(", ")

--- a/examples/cypher_probe3.rs
+++ b/examples/cypher_probe3.rs
@@ -15,6 +15,10 @@ use samyama::query::parser::parse_query;
 
 fn render(v: Option<&Value>) -> String {
     match v {
+        Some(Value::Map(entries)) => format!(
+            "{{{}}}",
+            entries.iter().map(|(k, v)| format!("{k}: {}", render(Some(v)))).collect::<Vec<_>>().join(", ")
+        ),
         Some(Value::List(items)) => format!(
             "[{}]",
             items.iter().map(|i| render(Some(i))).collect::<Vec<_>>().join(", ")

--- a/examples/tck_runner.rs
+++ b/examples/tck_runner.rs
@@ -542,6 +542,9 @@ fn value_to_tck(v: &Value, store: &GraphStore) -> Tck {
             Tck::Rel(e.edge_type.as_str().to_string(), props)
         }
         Value::List(items) => Tck::List(items.iter().map(|i| value_to_tck(i, store)).collect()),
+        Value::Map(entries) => Tck::Map(
+            entries.iter().map(|(k, v)| (k.clone(), value_to_tck(v, store))).collect(),
+        ),
         Value::Path { nodes, edges } => {
             // An edge is stored with its own source and target, which need not
             // run the same way as the walk: `MATCH (b)<-[r]-(a)` traverses `r`

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -73,6 +73,9 @@ fn value_to_json(v: &crate::query::executor::record::Value) -> Value {
         V::Null => Value::Null,
         V::Property(p) => prop_to_json(p),
         V::List(items) => Value::Array(items.iter().map(value_to_json).collect()),
+        V::Map(entries) => {
+            Value::Object(entries.iter().map(|(k, v)| (k.clone(), value_to_json(v))).collect())
+        }
         V::Node(id, _) | V::NodeRef(id) => json!({ "node_id": id.as_u64() }),
         V::Edge(id, _) | V::EdgeRef(id, _, _, _) => json!({ "edge_id": id.as_u64() }),
         V::Path { nodes, edges } => json!({

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -139,6 +139,12 @@ pub async fn query_handler(
                     
                     // Extract graph elements for visualization
                     match val {
+                        Value::Map(entries) => {
+                            row.push(json!(entries
+                                .iter()
+                                .map(|(k, v)| (k.clone(), format!("{v:?}")))
+                                .collect::<std::collections::BTreeMap<_, _>>()));
+                        }
                         Value::List(items) => {
                             row.push(serde_json::Value::Array(
                                 items.iter().map(|i| json!(format!("{i:?}"))).collect(),

--- a/src/protocol/command.rs
+++ b/src/protocol/command.rs
@@ -340,6 +340,17 @@ impl CommandHandler {
             Value::List(items) => {
                 RespValue::Array(items.iter().map(|i| self.format_value(i)).collect())
             }
+            Value::Map(entries) => RespValue::Array(
+                entries
+                    .iter()
+                    .flat_map(|(k, v)| {
+                        [
+                            RespValue::BulkString(Some(k.clone().into_bytes())),
+                            self.format_value(v),
+                        ]
+                    })
+                    .collect(),
+            ),
             Value::Node(id, _node) => {
                 // Format node as JSON-like string
                 let node_str = format!("Node({:?})", id);

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -539,6 +539,14 @@ pub enum Expression {
     PathVariable(String),
     /// Query parameter reference ($name)
     Parameter(String),
+    /// `[a, f(b), 1]` — a list literal whose elements are expressions.
+    ///
+    /// Distinct from `Literal(PropertyValue::Array(..))`, which can only hold
+    /// literals. The grammar tries the literal form first, so this variant
+    /// appears only for collections the literal form cannot express (#654).
+    ListExpr(Vec<Expression>),
+    /// `{k: a, j: f(b)}` — a map literal whose values are expressions.
+    MapExpr(Vec<(String, Expression)>),
 }
 
 /// Binary operators

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -250,6 +250,8 @@ primary = {
     property_access |
     parameter |
     value |
+    list_expr |
+    map_expr |
     variable |
     pattern_predicate |
     "(" ~ expression ~ ")"
@@ -345,6 +347,19 @@ string = @{ "\"" ~ (escape_seq | !("\"" | "\\") ~ ANY)* ~ "\"" | "'" ~ (escape_s
 list = { "[" ~ (value ~ ("," ~ value)*)? ~ "]" }
 map = { "{" ~ (map_entry ~ ("," ~ map_entry)*)? ~ "}" }
 map_entry = { (string | property_key) ~ ":" ~ value }
+
+// Collection literals whose elements are arbitrary expressions.
+//
+// `list` and `map` above are built from `value`, which is literals only, so
+// `[abs(1)]`, `[date({year: 1910})]` and `{key: u}` were all parse errors —
+// the last one blocking every Delete5 scenario, which reaches its nodes
+// through a map. These are tried *after* `value` in `primary`, so an
+// all-literal collection keeps producing a `PropertyValue` and every existing
+// consumer of that shape is untouched; only collections that `value` cannot
+// match reach here.
+list_expr = { "[" ~ (expression ~ ("," ~ expression)*)? ~ "]" }
+map_expr = { "{" ~ (map_expr_entry ~ ("," ~ map_expr_entry)*)? ~ "}" }
+map_expr_entry = { (string | property_key) ~ ":" ~ expression }
 
 // Variable names
 variable = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -570,6 +570,19 @@ fn substitute_params(query: &mut Query, params: &HashMap<String, crate::graph::P
 fn substitute_expr(expr: &mut crate::query::ast::Expression, params: &HashMap<String, crate::graph::PropertyValue>) -> ExecutionResult<()> {
     use crate::query::ast::Expression;
     match expr {
+        // Recursed into, not skipped: a parameter inside a collection literal
+        // is still a parameter, and leaving it unsubstituted makes `$x` a
+        // missing variable at evaluation time (#654).
+        Expression::ListExpr(items) => {
+            for e in items.iter_mut() {
+                substitute_expr(e, params);
+            }
+        }
+        Expression::MapExpr(entries) => {
+            for (_, e) in entries.iter_mut() {
+                substitute_expr(e, params);
+            }
+        }
         Expression::Parameter(name) => {
             if let Some(val) = params.get(name.as_str()) {
                 *expr = Expression::Literal(val.clone());

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -402,6 +402,20 @@ fn eval_expression(expr: &Expression, record: &Record, store: &GraphStore) -> Ex
                 .ok_or_else(|| ExecutionError::VariableNotFound(variable.clone()))?;
             Ok(Value::Property(val.resolve_property(property, store)))
         }
+        // A collection literal whose elements are expressions. The
+        // all-literal form never reaches here -- the grammar matches it as a
+        // `PropertyValue` first -- so this is only the case that could not be
+        // expressed before (#654).
+        Expression::ListExpr(items) => Ok(Value::List(
+            items.iter().map(|e| eval_expression(e, record, store)).collect::<ExecutionResult<Vec<_>>>()?,
+        )),
+        Expression::MapExpr(entries) => {
+            let mut out = std::collections::BTreeMap::new();
+            for (k, e) in entries {
+                out.insert(k.clone(), eval_expression(e, record, store)?);
+            }
+            Ok(Value::Map(out))
+        }
         Expression::Literal(lit) => Ok(Value::Property(lit.clone())),
         Expression::Binary { left, op, right } => {
             let l = eval_expression(left, record, store)?;
@@ -3031,6 +3045,11 @@ const PARALLEL_PREDICATE_COST: u32 = 20;
 /// the answer lands on does, so the weights are deliberately coarse.
 fn predicate_cost(expr: &Expression) -> u32 {
     match expr {
+        // Cost of the elements, plus a little for building the collection.
+        Expression::ListExpr(items) => 1 + items.iter().map(predicate_cost).sum::<u32>(),
+        Expression::MapExpr(entries) => {
+            1 + entries.iter().map(|(_, e)| predicate_cost(e)).sum::<u32>()
+        }
         // The unit. A scattered column read plus the match to unwrap it.
         Expression::Property { .. } => 1,
         // Free: already in the record, or in the expression.
@@ -3132,6 +3151,11 @@ impl FilterOperator {
 
     fn evaluate_expression(&self, expr: &Expression, record: &Record, store: &GraphStore) -> ExecutionResult<Value> {
         match expr {
+            // Delegates rather than adding a sixth copy of this logic; the
+            // standalone evaluator is the one implementation (#654).
+            Expression::ListExpr(_) | Expression::MapExpr(_) => {
+                eval_expression(expr, record, store)
+            }
             Expression::Variable(var) => {
                 record.get(var)
                     .cloned()
@@ -4445,6 +4469,11 @@ impl ProjectOperator {
 
     fn evaluate_expression(&self, expr: &Expression, record: &Record, store: &GraphStore) -> ExecutionResult<Value> {
         match expr {
+            // Delegates rather than adding a sixth copy of this logic; the
+            // standalone evaluator is the one implementation (#654).
+            Expression::ListExpr(_) | Expression::MapExpr(_) => {
+                eval_expression(expr, record, store)
+            }
             Expression::Variable(var) => {
                 let val = record.get(var)
                     .cloned()
@@ -4775,6 +4804,9 @@ impl AggregatorState {
                     // A list is distinguished by its rendering, which is the
                     // cheapest total order available over mixed element types.
                     Value::List(items) => set.insert_prop(PropertyValue::String(format!("{items:?}"))),
+                    Value::Map(entries) => {
+                        set.insert_prop(PropertyValue::String(format!("{entries:?}")))
+                    }
                     Value::Property(prop) => {
                         if !prop.is_null() {
                             set.insert_prop(prop.clone());
@@ -5013,6 +5045,11 @@ impl AggregateOperator {
 
     fn evaluate_expression(expr: &Expression, record: &Record, store: &GraphStore) -> ExecutionResult<Value> {
         match expr {
+            // Delegates rather than adding a sixth copy of this logic; the
+            // standalone evaluator is the one implementation (#654).
+            Expression::ListExpr(_) | Expression::MapExpr(_) => {
+                eval_expression(expr, record, store)
+            }
             Expression::Variable(var) => {
                 Ok(record.get(var).cloned().unwrap_or(Value::Null))
             }
@@ -6193,6 +6230,11 @@ impl SortOperator {
 
     fn evaluate_expression(expr: &Expression, record: &Record, store: &GraphStore) -> ExecutionResult<Value> {
         match expr {
+            // Delegates rather than adding a sixth copy of this logic; the
+            // standalone evaluator is the one implementation (#654).
+            Expression::ListExpr(_) | Expression::MapExpr(_) => {
+                eval_expression(expr, record, store)
+            }
             Expression::Variable(var) => {
                 record.get(var)
                     .cloned()
@@ -9528,6 +9570,26 @@ impl PhysicalOperator for SetPropertyOperator {
                         Value::Null => PropertyValue::Null,
                         // Degrades to ids, as the node and edge arms below do:
                         // a `PropertyValue` cannot hold an entity.
+                        Value::Map(entries) => PropertyValue::Map(
+                            entries
+                                .iter()
+                                .map(|(k, v)| {
+                                    (
+                                        k.clone(),
+                                        match v {
+                                            Value::Property(p) => p.clone(),
+                                            Value::NodeRef(id) | Value::Node(id, _) => {
+                                                PropertyValue::Integer(id.as_u64() as i64)
+                                            }
+                                            Value::EdgeRef(id, ..) | Value::Edge(id, _) => {
+                                                PropertyValue::Integer(id.as_u64() as i64)
+                                            }
+                                            _ => PropertyValue::Null,
+                                        },
+                                    )
+                                })
+                                .collect(),
+                        ),
                         Value::List(items) => PropertyValue::Array(
                             items
                                 .iter()
@@ -9834,6 +9896,20 @@ impl PhysicalOperator for UnwindOperator {
 
             let list_val = eval_expression(&self.expression, &record, store)?;
 
+            // A `Value::List` is what a collection literal containing
+            // expressions evaluates to (#654). Without this arm `UNWIND
+            // [date({...})] AS d` iterated nothing and returned no rows --
+            // success, with the loop body never running.
+            if let Value::List(values) = list_val {
+                self.buffer.clear();
+                self.buffer_idx = 0;
+                for value in values {
+                    let mut new_record = record.clone();
+                    new_record.bind(self.variable.clone(), value);
+                    self.buffer.push(new_record);
+                }
+                continue;
+            }
             let items = match list_val {
                 Value::Property(PropertyValue::Array(arr)) => arr,
                 Value::Property(PropertyValue::Vector(vec)) => {
@@ -10838,6 +10914,11 @@ impl WithBarrierOperator {
 
     fn evaluate_expression(expr: &Expression, record: &Record, store: &GraphStore) -> ExecutionResult<Value> {
         match expr {
+            // Delegates rather than adding a sixth copy of this logic; the
+            // standalone evaluator is the one implementation (#654).
+            Expression::ListExpr(_) | Expression::MapExpr(_) => {
+                eval_expression(expr, record, store)
+            }
             Expression::Variable(var) => {
                 Ok(record.get(var).cloned().unwrap_or(Value::Null))
             }

--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -127,6 +127,11 @@ pub enum Value {
     /// integer ids and a variable-length relationship variable was not bound
     /// at all.
     List(Vec<Value>),
+    /// A map whose values are themselves `Value`s.
+    ///
+    /// `PropertyValue::Map` cannot hold an entity, and `{key: u}` over a node
+    /// is how the TCK's Delete5 scenarios reach what they delete (#654).
+    Map(std::collections::BTreeMap<String, Value>),
     /// Null
     Null,
 }
@@ -164,6 +169,10 @@ impl Hash for Value {
             Value::Property(p) => { 2u8.hash(state); p.hash(state); }
             Value::Path { nodes, edges } => { 3u8.hash(state); nodes.hash(state); edges.hash(state); }
             Value::List(items) => { 5u8.hash(state); items.hash(state); }
+            Value::Map(entries) => {
+                6u8.hash(state);
+                for (k, v) in entries { k.hash(state); v.hash(state); }
+            }
             Value::Null => { 4u8.hash(state); }
         }
     }

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -2255,6 +2255,42 @@ fn parse_primary(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
                 let val = parse_value(inner)?;
                 return Ok(Expression::Literal(val));
             }
+            // Reached only when the literal forms above could not match, so an
+            // all-literal collection still becomes a `PropertyValue` and every
+            // consumer of that shape is untouched (#654).
+            Rule::list_expr => {
+                let mut items = Vec::new();
+                for item in inner.into_inner() {
+                    if item.as_rule() == Rule::expression {
+                        items.push(parse_expression(item)?);
+                    }
+                }
+                return Ok(Expression::ListExpr(items));
+            }
+            Rule::map_expr => {
+                let mut entries = Vec::new();
+                for entry in inner.into_inner() {
+                    if entry.as_rule() != Rule::map_expr_entry {
+                        continue;
+                    }
+                    let mut key = String::new();
+                    let mut value = None;
+                    for part in entry.into_inner() {
+                        match part.as_rule() {
+                            Rule::property_key => key = part.as_str().to_string(),
+                            Rule::string => {
+                                key = unescape_string_literal(part.as_str());
+                            }
+                            Rule::expression => value = Some(parse_expression(part)?),
+                            _ => {}
+                        }
+                    }
+                    if let Some(v) = value {
+                        entries.push((key, v));
+                    }
+                }
+                return Ok(Expression::MapExpr(entries));
+            }
             Rule::expression => {
                 return parse_expression(inner);
             }

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -34,11 +34,17 @@ pub enum ValidationError {
     MergeVariableLengthRelationship,
     MergeOnBoundVariable(String),
     MergeRelationshipWithNullProperty(String),
+    VariableTypeConflict(String),
 }
 
 impl std::fmt::Display for ValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::VariableTypeConflict(name) => write!(
+                f,
+                "`{name}` is bound to a collection and cannot be used as a node or \
+                 relationship in a pattern"
+            ),
             Self::MergeRelationshipWithoutType => write!(
                 f,
                 "MERGE requires exactly one relationship type: `MERGE (a)-->(b)` does not say \
@@ -334,6 +340,117 @@ pub fn validate(query: &Query) -> Result<(), ValidationError> {
             for seg in &path.segments {
                 check(&seg.node)?;
             }
+        }
+    }
+
+    // ---- A pattern variable that is already bound to a collection.
+    //
+    // `WITH [n] AS users MATCH (users)-->(m)` is a compile-time error in
+    // Cypher: `users` is a list, and a list is not a node. Until collection
+    // literals could hold expressions this was unreachable — `[n]` did not
+    // parse, so the query failed for an unrelated reason and the TCK scenario
+    // asserting the error passed by accident. Making the literal work removed
+    // the accident, which is the honest moment to implement the rule (#654).
+    {
+        use crate::query::ast::Clause;
+        let mut collections: HashSet<String> = HashSet::new();
+        for clause in &query.clauses {
+            match clause {
+                Clause::With(wc) => {
+                    for item in &wc.items {
+                        let Some(alias) = item.alias.as_ref() else { continue };
+                        let is_collection = matches!(
+                            &item.expression,
+                            Expression::ListExpr(_)
+                                | Expression::MapExpr(_)
+                                | Expression::Literal(crate::graph::PropertyValue::Array(_))
+                                | Expression::Literal(crate::graph::PropertyValue::Map(_))
+                        );
+                        // Re-aliasing something else to the same name clears it.
+                        if is_collection {
+                            collections.insert(alias.clone());
+                        } else {
+                            collections.remove(alias);
+                        }
+                    }
+                }
+                Clause::Match(mc) => {
+                    for path in &mc.pattern.paths {
+                        let mut check = |v: &Option<String>| -> Result<(), ValidationError> {
+                            if let Some(name) = v {
+                                if collections.contains(name) {
+                                    return Err(ValidationError::VariableTypeConflict(name.clone()));
+                                }
+                            }
+                            Ok(())
+                        };
+                        check(&path.start.variable)?;
+                        for seg in &path.segments {
+                            check(&seg.node.variable)?;
+                            check(&seg.edge.variable)?;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // The by-kind shape says the same thing differently: `with_clause`
+        // plus the matches after `with_split_index`, then each extra WITH
+        // stage with the matches that follow it. Checking only the pipeline
+        // shape missed this query entirely, because `MATCH … WITH … MATCH …
+        // RETURN` is a shape the established rules already accept.
+        let mut collections: HashSet<String> = HashSet::new();
+        let mut note = |wc: &crate::query::ast::WithClause,
+                        collections: &mut HashSet<String>| {
+            for item in &wc.items {
+                let Some(alias) = item.alias.as_ref() else { continue };
+                let is_collection = matches!(
+                    &item.expression,
+                    Expression::ListExpr(_)
+                        | Expression::MapExpr(_)
+                        | Expression::Literal(crate::graph::PropertyValue::Array(_))
+                        | Expression::Literal(crate::graph::PropertyValue::Map(_))
+                );
+                if is_collection {
+                    collections.insert(alias.clone());
+                } else {
+                    collections.remove(alias);
+                }
+            }
+        };
+        let check_patterns = |mcs: &[crate::query::ast::MatchClause],
+                              collections: &HashSet<String>|
+         -> Result<(), ValidationError> {
+            for mc in mcs {
+                for path in &mc.pattern.paths {
+                    let mut check = |v: &Option<String>| -> Result<(), ValidationError> {
+                        if let Some(name) = v {
+                            if collections.contains(name) {
+                                return Err(ValidationError::VariableTypeConflict(name.clone()));
+                            }
+                        }
+                        Ok(())
+                    };
+                    check(&path.start.variable)?;
+                    for seg in &path.segments {
+                        check(&seg.node.variable)?;
+                        check(&seg.edge.variable)?;
+                    }
+                }
+            }
+            Ok(())
+        };
+        if let Some(wc) = &query.with_clause {
+            note(wc, &mut collections);
+            let from = query.with_split_index.unwrap_or(query.match_clauses.len());
+            if from <= query.match_clauses.len() {
+                check_patterns(&query.match_clauses[from..], &collections)?;
+            }
+        }
+        for (wc, _, matches, _) in &query.extra_with_stages {
+            note(wc, &mut collections);
+            check_patterns(matches, &collections)?;
         }
     }
 

--- a/tests/collection_literal_expressions.rs
+++ b/tests/collection_literal_expressions.rs
@@ -1,0 +1,125 @@
+//! A list or map literal can hold an expression, not only a literal.
+//!
+//! `list` and `map` in the grammar were built from `value`, which is literals
+//! only. So all of these were parse errors:
+//!
+//! ```cypher
+//! RETURN [abs(1)]
+//! UNWIND [date({year: 1910, month: 5, day: 6})] AS d RETURN d
+//! MATCH (u:User) WITH {key: u} AS nodes DELETE nodes.key
+//! ```
+//!
+//! They looked like three unrelated gaps — a function gap, a temporal gap and
+//! a DELETE gap — and were one missing pair of AST variants. The map case
+//! blocked every Delete5 scenario in the TCK, all of which reach the thing
+//! they delete through a map (#654).
+//!
+//! The literal forms are tried **first**, so an all-literal collection still
+//! produces a `PropertyValue` and nothing downstream of that changed. Only
+//! collections the literal form cannot express take the new path — which is
+//! also why the tests below assert the old shape is preserved.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn value_of(store: &GraphStore, cypher: &str) -> Value {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    let out = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+    assert!(!out.records.is_empty(), "`{cypher}` returned no rows");
+    out.records[0].get("x").cloned().unwrap_or(Value::Null)
+}
+
+#[test]
+fn a_list_literal_can_hold_a_function_call() {
+    let store = GraphStore::new();
+    match value_of(&store, "RETURN [abs(1), 2 * 3] AS x") {
+        Value::List(items) => {
+            assert_eq!(items.len(), 2);
+            assert_eq!(items[0], Value::Property(PropertyValue::Integer(1)));
+            assert_eq!(items[1], Value::Property(PropertyValue::Integer(6)));
+        }
+        other => panic!("expected a list, got {other:?}"),
+    }
+}
+
+#[test]
+fn an_all_literal_collection_keeps_its_old_shape() {
+    // The reason this change is safe: the literal rules are tried first, so
+    // every existing consumer of `PropertyValue::Array` and
+    // `PropertyValue::Map` sees exactly what it saw before.
+    let store = GraphStore::new();
+    assert!(matches!(
+        value_of(&store, "RETURN [1, 2] AS x"),
+        Value::Property(PropertyValue::Array(_))
+    ));
+    assert!(matches!(
+        value_of(&store, "RETURN {a: 1} AS x"),
+        Value::Property(PropertyValue::Map(_))
+    ));
+}
+
+#[test]
+fn unwind_iterates_a_list_of_expressions() {
+    // Without an arm for the new value shape, UNWIND iterated nothing and
+    // returned no rows — success, with the loop body never running.
+    let store = GraphStore::new();
+    let q = parse_query("UNWIND [abs(1), abs(-2)] AS v RETURN v AS x").expect("should parse");
+    let out = QueryExecutor::new(&store).execute(&q).expect("should run");
+    let got: Vec<i64> = out
+        .records
+        .iter()
+        .filter_map(|r| match r.get("x") {
+            Some(Value::Property(PropertyValue::Integer(n))) => Some(*n),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(got, vec![1, 2]);
+}
+
+#[test]
+fn a_map_literal_can_hold_a_node() {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (:User)").expect("should parse");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("should run");
+    match value_of(&store, "MATCH (u:User) WITH {key: u} AS m RETURN m AS x") {
+        Value::Map(entries) => {
+            assert_eq!(entries.len(), 1);
+            assert!(matches!(entries.get("key"), Some(Value::NodeRef(_) | Value::Node(..))));
+        }
+        other => panic!("expected a map holding a node, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_collection_cannot_be_used_as_a_node_in_a_pattern() {
+    // Cypher calls this a VariableTypeConflict. It was unreachable while `[n]`
+    // did not parse — the TCK scenario asserting the error passed because the
+    // query failed for an unrelated reason. Making the literal work removed
+    // that accident, so the rule has to be real now.
+    for cypher in [
+        "MATCH (n) WITH [n] AS users MATCH (users)-->(m) RETURN m",
+        "MATCH (n) WITH {k: n} AS users MATCH (users)-->(m) RETURN m",
+    ] {
+        let err = parse_query(cypher).expect_err(&format!("`{cypher}` must be refused"));
+        assert!(
+            err.to_string().contains("users"),
+            "the message should name the variable: {err}"
+        );
+    }
+}
+
+#[test]
+fn a_variable_rebound_to_something_else_is_usable_again() {
+    // The conflict is about what the name currently holds, not about the name
+    // ever having held a list.
+    assert!(parse_query(
+        "MATCH (n) WITH [n] AS users WITH users[0] AS users MATCH (users)-->(m) RETURN m"
+    )
+    .is_ok());
+    assert!(parse_query("MATCH (n) WITH [n] AS users RETURN users").is_ok());
+}


### PR DESCRIPTION
`list` and `map` were built from `value`, which is literals only, so all of
these were parse errors:

    RETURN [abs(1)]
    UNWIND [date({year: 1910, month: 5, day: 6})] AS d RETURN d
    MATCH (u:User) WITH {key: u} AS nodes DELETE nodes.key

Three unrelated-looking gaps — a function gap, a temporal gap, a DELETE gap
— and one missing pair of AST variants. The map case blocks **every**
Delete5 scenario, all of which reach the thing they delete through a map;
the list case blocks the temporal cluster in WithOrderBy1.

`Expression::ListExpr` / `MapExpr`, plus `Value::Map` alongside the
`Value::List` from #652: a map holding a node can no more be a
`PropertyValue::Map` than a list of nodes can be an `Array`.

**The new rules are tried after the literal ones.** Ordered choice then
means an all-literal collection still matches the literal rule and still
produces a `PropertyValue`, so nothing downstream of that shape changed —
which is the whole safety argument, and has its own test.

Two things that were not obvious. `UNWIND` needed an arm for the new value
shape or it iterated nothing and returned no rows: success, with the loop
body never running. And there are **six** separate `evaluate_expression`
implementations — the new logic went into the standalone one and the other
five delegate, rather than becoming a sixth copy. That duplication has
already produced divergence twice this week.

**One scenario regressed, correctly, and is now fixed.** `Match3 [30]`
asserts that `WITH [n] AS users MATCH (users)-->(m)` is a compile-time
`VariableTypeConflict`. It was passing only because `[n]` did not parse, so
the query failed for an unrelated reason. Making the literal work removed
the accident, so the rule is implemented for real — in both AST shapes,
since `MATCH … WITH … MATCH` is a shape the established rules accept and
checking only the clause pipeline missed it entirely.

openCypher TCK 959 -> 967 of 1244 evaluated (77.1% -> 77.7%), none
regressed.

Closes #654.