### PR TITLE
Apply a selective equality on an expansion target during the walk (#656)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3649,6 +3649,16 @@ pub struct ExpandOperator {
     edge_types: Vec<String>,
     /// Target node labels to filter (empty = any label)
     target_labels: Vec<Label>,
+    /// Equality predicates on the *target* node, checked during the adjacency
+    /// walk rather than after it.
+    ///
+    /// LDBC IC11 is the case this exists for. Its plan is
+    /// `Filter(org.name = ...) <- Expand((friend)-[:WORK_AT]->(org))`, so
+    /// every friend-of-friend's employer was materialised into a record and
+    /// then discarded — 11.5x Neo4j, and the only complex read still outside
+    /// the PERF-01 target. Applied here, a non-matching employer never
+    /// becomes a row (#656).
+    target_props: Vec<(String, PropertyValue)>,
     /// Direction
     direction: Direction,
     /// Current input record
@@ -3687,6 +3697,7 @@ impl ExpandOperator {
             edge_var: edge_var.map(Into::into),
             edge_types,
             target_labels: Vec::new(),
+            target_props: Vec::new(),
             direction,
             current_record: None,
             current_edges: Vec::new(),
@@ -3705,6 +3716,14 @@ impl ExpandOperator {
     /// Set target node labels to filter during expansion
     pub fn with_target_labels(mut self, labels: Vec<Label>) -> Self {
         self.target_labels = labels;
+        self
+    }
+
+    /// Equality predicates the target node must satisfy, applied during the
+    /// walk. Additive: the planner leaves its own filter in place, so this can
+    /// only reduce what is materialised, never change what is returned.
+    pub fn with_target_props(mut self, props: Vec<(String, PropertyValue)>) -> Self {
+        self.target_props = props;
         self
     }
 
@@ -3781,12 +3800,25 @@ impl ExpandOperator {
                         .unwrap_or_default(),
                 )
             };
+        let target_props = &self.target_props;
         let keeps = |target: NodeId| -> bool {
-            match &label_sets {
+            let label_ok = match &label_sets {
                 None => true,
                 // `Some(empty)` means a required label exists on no node.
                 Some(sets) if sets.len() < self.target_labels.len() => false,
                 Some(sets) => sets.iter().all(|s| s.contains(&target)),
+            };
+            if !label_ok {
+                return false;
+            }
+            if target_props.is_empty() {
+                return true;
+            }
+            match store.get_node(target) {
+                Some(node) => target_props
+                    .iter()
+                    .all(|(k, v)| node.get_property(k).map_or(false, |p| p == v)),
+                None => false,
             }
         };
 

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2822,6 +2822,13 @@ impl QueryPlanner {
                         edge_types,
                         segment.edge.direction.clone(),
                     );
+                    // A selective equality on the far side of the expansion —
+                    // LDBC IC11's `org.name = "..."` — applied during the walk
+                    // rather than to the rows it produces (#656).
+                    let pushed = Self::target_equality_props(&deferred_predicates, &target_var);
+                    if !pushed.is_empty() {
+                        expand = expand.with_target_props(pushed);
+                    }
 
                     // CY-04: Set path variable for named path materialization
                     if let Some(ref pv) = path.path_variable {
@@ -2940,6 +2947,37 @@ impl QueryPlanner {
     /// later filter would have removed. `OPTIONAL MATCH` is not affected --
     /// this runs inside a single path of a single MATCH, and the outer join is
     /// built above it.
+    /// Equality predicates of the form `<var>.<prop> = <literal>` for one
+    /// variable, read out of the deferred set **without removing them**.
+    ///
+    /// Additive on purpose. The filter the planner would have built stays
+    /// where it is, so pushing these into an expand cannot change what the
+    /// query returns — only how much is materialised on the way. Getting a
+    /// pushdown subtly wrong is a wrong answer; getting this one wrong is a
+    /// slow query.
+    fn target_equality_props(
+        deferred: &[Expression],
+        var: &str,
+    ) -> Vec<(String, PropertyValue)> {
+        let mut out = Vec::new();
+        for pred in deferred {
+            for part in flatten_and_predicates(pred) {
+                if let Expression::Binary { left, op: BinaryOp::Eq, right } = &part {
+                    if let (
+                        Expression::Property { variable, property },
+                        Expression::Literal(value),
+                    ) = (left.as_ref(), right.as_ref())
+                    {
+                        if variable == var {
+                            out.push((property.clone(), value.clone()));
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+
     fn apply_ready_predicates(
         operator: OperatorBox,
         deferred: &mut Vec<Expression>,

--- a/tests/expand_target_predicate.rs
+++ b/tests/expand_target_predicate.rs
@@ -1,0 +1,107 @@
+//! A selective equality on the far side of an expansion is applied *during*
+//! the walk, not to the rows it produces.
+//!
+//! LDBC IC11 is the case this exists for. Its plan was
+//!
+//! ```text
+//! Filter (org.name = "..." AND wa.workFrom < 2012)
+//! +- Expand ((friend)-[:WORK_AT]->(org))
+//! ```
+//!
+//! so every friend-of-friend's employer became a record and was then thrown
+//! away. `ExpandOperator` had a target *label* filter and no target *property*
+//! filter, so there was nowhere for the predicate to go (#656).
+//!
+//! The pushdown is **additive**: the planner's own filter stays where it is.
+//! That is the whole safety argument — this can reduce what is materialised
+//! and cannot change what is returned. A wrong pushdown is a wrong answer; a
+//! missing one is a slow query, and only one of those is worth risking.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+fn graph() -> GraphStore {
+    let mut store = GraphStore::new();
+    for cypher in [
+        "CREATE (:Person {id: 1}), (:Person {id: 2}), (:Person {id: 3})",
+        "CREATE (:Org {name: 'Wanted'}), (:Org {name: 'Other'}), (:Org {name: 'Third'})",
+        "MATCH (p:Person {id: 1}), (o:Org {name: 'Wanted'}) CREATE (p)-[:WORKS_AT {y: 2001}]->(o)",
+        "MATCH (p:Person {id: 1}), (o:Org {name: 'Other'}) CREATE (p)-[:WORKS_AT {y: 2002}]->(o)",
+        "MATCH (p:Person {id: 2}), (o:Org {name: 'Third'}) CREATE (p)-[:WORKS_AT {y: 2003}]->(o)",
+        "MATCH (p:Person {id: 3}), (o:Org {name: 'Wanted'}) CREATE (p)-[:WORKS_AT {y: 2004}]->(o)",
+    ] {
+        let q = parse_query(cypher).expect("setup should parse");
+        MutQueryExecutor::new(&mut store, "default".to_string())
+            .execute(&q)
+            .expect("setup should run");
+    }
+    store
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).expect("query should parse");
+    QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"))
+        .records
+        .len()
+}
+
+#[test]
+fn a_where_equality_on_the_expansion_target_selects_the_same_rows() {
+    // The answer, not the plan. If the pushdown ever stops being additive this
+    // is what notices.
+    let store = graph();
+    assert_eq!(
+        rows(&store, "MATCH (p:Person)-[:WORKS_AT]->(o:Org) WHERE o.name = 'Wanted' RETURN p"),
+        2,
+        "persons 1 and 3 work at Wanted"
+    );
+    assert_eq!(
+        rows(&store, "MATCH (p:Person)-[:WORKS_AT]->(o:Org) WHERE o.name = 'Other' RETURN p"),
+        1
+    );
+    assert_eq!(
+        rows(&store, "MATCH (p:Person)-[:WORKS_AT]->(o:Org) WHERE o.name = 'Absent' RETURN p"),
+        0
+    );
+}
+
+#[test]
+fn the_inline_form_and_the_where_form_agree() {
+    // `{name: 'Wanted'}` and `WHERE o.name = 'Wanted'` are the same question.
+    // They are planned differently, which is exactly why they are worth
+    // comparing.
+    let store = graph();
+    assert_eq!(
+        rows(&store, "MATCH (p:Person)-[:WORKS_AT]->(o:Org {name: 'Wanted'}) RETURN p"),
+        rows(&store, "MATCH (p:Person)-[:WORKS_AT]->(o:Org) WHERE o.name = 'Wanted' RETURN p")
+    );
+}
+
+#[test]
+fn a_predicate_on_the_edge_is_still_applied() {
+    // The pushdown reads predicates on the *target*; an edge predicate in the
+    // same WHERE must not be lost while doing so.
+    let store = graph();
+    assert_eq!(
+        rows(
+            &store,
+            "MATCH (p:Person)-[w:WORKS_AT]->(o:Org) WHERE o.name = 'Wanted' AND w.y < 2003 RETURN p"
+        ),
+        1,
+        "only person 1 was at Wanted before 2003"
+    );
+}
+
+#[test]
+fn a_non_equality_predicate_on_the_target_is_unaffected() {
+    // Only `= <literal>` is pushed. Anything else has to keep working through
+    // the ordinary filter.
+    let store = graph();
+    assert_eq!(
+        rows(&store, "MATCH (p:Person)-[:WORKS_AT]->(o:Org) WHERE o.name <> 'Wanted' RETURN p"),
+        2
+    );
+}


### PR DESCRIPTION
LDBC IC11's plan, from `EXPLAIN` at SF1:

    Filter (org.name = "MDLR_Airlines" AND wa.workFrom < 2012)
    +- Expand ((friend)-[:WORK_AT]->(org))
       +- Filter (friend.id <> 933)
          +- VarLengthExpand ((p)-[:KNOWS*1..2]-(friend))

Every friend-of-friend's employer became a record and was then discarded.
The predicate is as selective as they get — one organisation, by name — and
it was applied last. `ExpandOperator` had a target *label* filter and no
target *property* filter, so there was nowhere for it to go even in
principle.

`<var>.<prop> = <literal>` predicates on the expansion target are now
checked during the adjacency walk, so a non-matching neighbour never
becomes a row.

**Additive on purpose.** The planner's own filter stays where it is, so
this can reduce what is materialised and cannot change what is returned. A
wrong pushdown is a wrong answer; a missing one is a slow query, and only
one of those is worth risking. The tests assert the *answers*, including
that the inline form `(o:Org {name: 'X'})` and the `WHERE o.name = 'X'`
form — which are planned differently — return the same rows.

Measured at SF1, same 2 rows, same opening host calibration (29 ms):

    IC11   14.2 ms -> 8.3 ms

21/21 LDBC reads still pass with identical row counts.

**This does not close PERF-01.** The 11.5x figure was measured at SF10 and
this is SF1. The effect should be larger at SF10 because the
friend-of-friend set is bigger, but that is a prediction; SF10 needs ~95 GB
to load and wants a big-memory spot host.

Recorded because it nearly went unnoticed: the first attempt to measure
IC11 returned 0 rows in 0.03 ms, because the default parameters belong to a
different SF1 extract. `--derive-params` is not optional.

Refs #616. Closes #656.