### PR TITLE
The LDBC bench refuses an unknown flag instead of ignoring it (#660)

### DIFF
--- a/benches/ldbc_benchmark.rs
+++ b/benches/ldbc_benchmark.rs
@@ -676,6 +676,32 @@ async fn main() -> Result<(), Error> {
 
     let args: Vec<String> = std::env::args().collect();
 
+    // An unrecognised flag is a hard error, not something to skip past.
+    //
+    // Every option below is read with `args.iter().position(|a| a == "--x")`,
+    // so a misspelling simply does not match and the bench runs with a default
+    // instead. That is how an SF10 run was taken with `--params` (the flag is
+    // `--params-file`): the built-in parameters were used, four reads came back
+    // empty, IC11 answered in 122 ms and the summary said `OK`. A timing taken
+    // against parameters nobody chose is not a measurement, and nothing in the
+    // output said so (#660).
+    const KNOWN: &[&str] = &[
+        "--data-dir", "--deletes", "--derive-params", "--explain", "--params-file",
+        "--profile", "--query", "--runs", "--updates", "--write-params",
+        // cargo passes this to bench targets.
+        "--bench", "--nocapture", "--test-threads", "--color", "--format",
+    ];
+    let unknown: Vec<&String> = args[1..]
+        .iter()
+        .filter(|a| a.starts_with("--") && !KNOWN.contains(&a.as_str()))
+        .collect();
+    if !unknown.is_empty() {
+        eprintln!("unknown option(s): {}", unknown.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(" "));
+        eprintln!("known options: {}", KNOWN[..10].join(" "));
+        eprintln!("\nRefusing to run: an ignored flag produces a number measured under\nsettings nobody chose, and the output cannot tell you that happened.");
+        std::process::exit(64);
+    }
+
     let default_dir = "data/ldbc-sf1/social_network-sf1-CsvBasic-LongDateFormatter";
     let explicit_data_dir = args.iter().any(|a| a == "--data-dir");
     let data_dir = if let Some(pos) = args.iter().position(|a| a == "--data-dir") {


### PR DESCRIPTION
Every option is read with `args.iter().position(|a| a == "--x")`, so a
misspelling does not match and the run proceeds with a default. An SF10
comparison was taken that way yesterday with `--params` — the flag is
`--params-file`:

    Running IC11...IC11  Job Referral  10  122ms  123ms  133ms  OK
    Summary: 17/21 passed, 4 empty, 0 errors

IC11 answered ten rows and was marked `OK`. The number is not comparable to
anything, because the recorded Neo4j figure used `sf10.json` and this used
the built-in parameters.

The provenance line *was* printed — "built-in defaults — these resolve
against one particular extract only". It was missed because the run
otherwise looked entirely normal, which is the argument for refusing rather
than for printing more: an ignored flag produces a number measured under
settings nobody chose, and no amount of output makes that as visible as not
starting.

`--bench`, `--nocapture` and the other harness arguments cargo passes
through are in the known set, so `cargo bench` still works.

Costs a startup check; prevents a class of measurement that looks fine and
is worthless. The same class the `--derive-params` warning exists for
(#505), reached by a different route.

Closes #660.