### PR TITLE
Named pattern comprehensions, CREATE re-binding, and target ids resolved once (#662, #663, #664)

### DIFF
--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -275,7 +275,14 @@ predicate_function_name = @{ (^"all" | ^"any" | ^"none" | ^"single") ~ !(ASCII_A
 reduce_expression = { ^"reduce" ~ "(" ~ variable ~ "=" ~ expression ~ "," ~ variable ~ in_op ~ expression ~ "|" ~ expression ~ ")" }
 
 // Pattern comprehension: [(a)-[:REL]->(b) WHERE cond | expr]
-pattern_comprehension = { "[" ~ path ~ where_clause? ~ "|" ~ expression ~ "]" }
+// The `p =` prefix names the path, and `| p` then projects it — which is what
+// every Pattern2 scenario in the TCK does. Without it the whole feature was a
+// parse error despite the comprehension itself being supported.
+//
+// The optional group cannot swallow a list comprehension: for `[x IN xs | e]`
+// it matches `x`, finds `IN` where `=` must be, and backtracks to nothing —
+// then `path` needs a `(` and fails, so `list_comprehension` is tried next.
+pattern_comprehension = { "[" ~ (variable ~ "=")? ~ path ~ where_clause? ~ "|" ~ expression ~ "]" }
 
 // EXISTS { MATCH pattern WHERE condition }
 exists_subquery = { ^"EXISTS" ~ "{" ~ ^"MATCH" ~ pattern ~ where_clause? ~ "}" }

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -831,7 +831,11 @@ fn eval_pattern_comprehension(
     record: &Record,
     store: &GraphStore,
 ) -> ExecutionResult<Value> {
-    let mut results = Vec::new();
+    // `Vec<Value>`, not `Vec<PropertyValue>`: `[p = (n)-->() | p]` projects
+    // *paths*, and a `PropertyValue` cannot hold one (#662). An all-scalar
+    // comprehension is still returned as a `PropertyValue::Array` at the end,
+    // so nothing that consumed the old shape changes.
+    let mut results: Vec<Value> = Vec::new();
 
     for path in &pattern.paths {
         let start_var = path.start.variable.as_deref();
@@ -872,11 +876,7 @@ fn eval_pattern_comprehension(
                     let cond = eval_expression(f, &temp_record, store)?;
                     if !matches!(cond, Value::Property(PropertyValue::Boolean(true))) { continue; }
                 }
-                let val = eval_expression(projection, &temp_record, store)?;
-                match val {
-                    Value::Property(pv) => results.push(pv),
-                    _ => results.push(PropertyValue::Null),
-                }
+                results.push(eval_expression(projection, &temp_record, store)?);
             } else {
                 // One-hop traversal for pattern comprehension
                 for segment in &path.segments {
@@ -911,22 +911,39 @@ fn eval_pattern_comprehension(
                         if let Some(ref var) = segment.edge.variable {
                             temp_record.bind(var.clone(), Value::EdgeRef(edge.id, edge.source, edge.target, edge.edge_type.clone()));
                         }
+                        // `[p = (a)-->(b) | p]` — the named path, bound for the
+                        // projection to read.
+                        if let Some(ref pv) = path.path_variable {
+                            temp_record.bind(
+                                pv.clone(),
+                                Value::Path { nodes: vec![*node_id, target_id], edges: vec![edge.id] },
+                            );
+                        }
                         if let Some(f) = filter {
                             let cond = eval_expression(f, &temp_record, store)?;
                             if !matches!(cond, Value::Property(PropertyValue::Boolean(true))) { continue; }
                         }
-                        let val = eval_expression(projection, &temp_record, store)?;
-                        match val {
-                            Value::Property(pv) => results.push(pv),
-                            _ => results.push(PropertyValue::Null),
-                        }
+                        results.push(eval_expression(projection, &temp_record, store)?);
                     }
                 }
             }
         }
     }
 
-    Ok(Value::Property(PropertyValue::Array(results)))
+    // Kept as a `PropertyValue::Array` when every element is a scalar, which
+    // is what it always was; only a comprehension projecting entities needs
+    // the wider shape.
+    if results.iter().all(|v| matches!(v, Value::Property(_))) {
+        let scalars = results
+            .into_iter()
+            .map(|v| match v {
+                Value::Property(p) => p,
+                _ => PropertyValue::Null,
+            })
+            .collect();
+        return Ok(Value::Property(PropertyValue::Array(scalars)));
+    }
+    Ok(Value::List(results))
 }
 
 /// Evaluate a boolean predicate expression standalone (for parallel batch filtering).
@@ -3659,6 +3676,15 @@ pub struct ExpandOperator {
     /// the PERF-01 target. Applied here, a non-matching employer never
     /// becomes a row (#656).
     target_props: Vec<(String, PropertyValue)>,
+    /// The exact set of nodes the target may be, resolved once at plan time.
+    ///
+    /// `target_props` above still costs a `get_node` and a property compare per
+    /// candidate edge. On LDBC IC11 that is ~29,000 lookups at ~10us each and
+    /// the expand became 74% of the query — the filter moved earlier and got
+    /// *more* expensive per candidate. Resolving `org.name = "..."` to the one
+    /// matching Organisation once, and testing membership here, replaces that
+    /// with a hash lookup (#664).
+    target_ids: Option<std::collections::HashSet<NodeId>>,
     /// Direction
     direction: Direction,
     /// Current input record
@@ -3698,6 +3724,7 @@ impl ExpandOperator {
             edge_types,
             target_labels: Vec::new(),
             target_props: Vec::new(),
+            target_ids: None,
             direction,
             current_record: None,
             current_edges: Vec::new(),
@@ -3724,6 +3751,14 @@ impl ExpandOperator {
     /// only reduce what is materialised, never change what is returned.
     pub fn with_target_props(mut self, props: Vec<(String, PropertyValue)>) -> Self {
         self.target_props = props;
+        self
+    }
+
+    /// The resolved node set for the target, when the planner could compute it.
+    /// Preferred over `target_props`: an id membership test costs a hash
+    /// lookup where the property check costs a node fetch (#664).
+    pub fn with_target_ids(mut self, ids: std::collections::HashSet<NodeId>) -> Self {
+        self.target_ids = Some(ids);
         self
     }
 
@@ -3801,7 +3836,15 @@ impl ExpandOperator {
                 )
             };
         let target_props = &self.target_props;
+        let target_ids = self.target_ids.as_ref();
         let keeps = |target: NodeId| -> bool {
+            // Cheapest discriminator first: if the planner resolved the target
+            // to a known set, membership settles it without touching the node.
+            if let Some(ids) = target_ids {
+                if !ids.contains(&target) {
+                    return false;
+                }
+            }
             let label_ok = match &label_sets {
                 None => true,
                 // `Some(empty)` means a required label exists on no node.

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2827,6 +2827,14 @@ impl QueryPlanner {
                     // rather than to the rows it produces (#656).
                     let pushed = Self::target_equality_props(&deferred_predicates, &target_var);
                     if !pushed.is_empty() {
+                        // Resolved to ids where possible: the property check
+                        // costs a node fetch per candidate edge and this costs
+                        // a hash lookup (#664).
+                        if let Some(ids) =
+                            self.resolve_target_ids(&segment.node.labels, &pushed, store)
+                        {
+                            expand = expand.with_target_ids(ids);
+                        }
                         expand = expand.with_target_props(pushed);
                     }
 
@@ -2955,6 +2963,63 @@ impl QueryPlanner {
     /// query returns — only how much is materialised on the way. Getting a
     /// pushdown subtly wrong is a wrong answer; getting this one wrong is a
     /// slow query.
+    /// The exact node set a target's equality predicates admit, when that can
+    /// be computed without scanning the whole store.
+    ///
+    /// The profile of LDBC IC11 at SF10 is what motivates this. Pushing
+    /// `org.name = "..."` into the expand (#656) correctly cut its output to
+    /// 190 rows, and the expand still took **74% of the query** — because the
+    /// check costs a `get_node` and a property compare per candidate edge, and
+    /// there are ~29,000 of them. Moving a filter earlier made it more
+    /// expensive per candidate.
+    ///
+    /// Resolving the predicate to node ids once turns that into a hash lookup.
+    /// The property index answers it directly when one exists; otherwise a
+    /// label scan is used, which is worth it only because it happens once at
+    /// plan time against a small label — 7,955 Organisations against 29,000
+    /// edge candidates. The scan is capped for that reason: above the cap the
+    /// per-candidate check is the cheaper of the two (#664).
+    fn resolve_target_ids(
+        &self,
+        labels: &[Label],
+        props: &[(String, PropertyValue)],
+        store: &GraphStore,
+    ) -> Option<HashSet<crate::graph::NodeId>> {
+        let (key, value) = props.first()?;
+
+        // Preferred: an index answers without touching any node.
+        let candidates: Vec<Label> = labels
+            .iter()
+            .cloned()
+            .chain(store.catalog().label_counts.keys().cloned())
+            .collect();
+        for label in &candidates {
+            if let Some(index) = store.property_index.get_index(label, key) {
+                let ids = index.read().unwrap().get(value);
+                if !ids.is_empty() {
+                    return Some(ids.into_iter().collect());
+                }
+            }
+        }
+
+        // Fallback: scan one label, once. Only worth doing when the label is
+        // small — otherwise this trades a per-candidate cost for a per-query
+        // one that is larger.
+        const MAX_SCAN: usize = 50_000;
+        let label = labels.first()?;
+        let nodes = store.get_nodes_by_label(label);
+        if nodes.len() > MAX_SCAN {
+            return None;
+        }
+        Some(
+            nodes
+                .iter()
+                .filter(|n| n.get_property(key).is_some_and(|p| p == value))
+                .map(|n| n.id)
+                .collect(),
+        )
+    }
+
     fn target_equality_props(
         deferred: &[Expression],
         var: &str,

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -2445,8 +2445,12 @@ fn parse_pattern_comprehension(pair: pest::iterators::Pair<Rule>) -> ParseResult
     let mut projection = None;
     let mut expressions = Vec::new();
 
+    let mut path_variable = None;
     for inner in pair.into_inner() {
         match inner.as_rule() {
+            // The only bare `variable` in this rule is the `p =` prefix; the
+            // pattern's own variables are inside `path`.
+            Rule::variable => path_variable = Some(inner.as_str().to_string()),
             Rule::path => pattern_path = Some(parse_path(inner)?),
             Rule::where_clause => {
                 let wc = parse_where_clause(inner)?;
@@ -2460,7 +2464,10 @@ fn parse_pattern_comprehension(pair: pest::iterators::Pair<Rule>) -> ParseResult
     // The last expression is the projection
     projection = expressions.pop();
 
-    let path = pattern_path.ok_or_else(|| ParseError::SemanticError("Pattern comprehension missing pattern".to_string()))?;
+    let mut path = pattern_path.ok_or_else(|| ParseError::SemanticError("Pattern comprehension missing pattern".to_string()))?;
+    if path_variable.is_some() {
+        path.path_variable = path_variable;
+    }
 
     Ok(Expression::PatternComprehension {
         pattern: Pattern { paths: vec![path] },

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -320,13 +320,19 @@ pub fn validate(query: &Query) -> Result<(), ValidationError> {
                 }
             }
         }
+        // Tracked *within* the clause as well as before it. `CREATE (n:Foo)-[:T1]->(),
+        // (n:Bar)-[:T2]->()` binds `n` in its first path and re-labels it in its
+        // second, and a bound set computed only before the clause cannot see that.
+        let mut bound = bound;
         for path in &pattern.paths {
-            let mut check = |np: &crate::query::ast::NodePattern| -> Result<(), ValidationError> {
-                if let Some(v) = &np.variable {
-                    let adds_something = !np.labels.is_empty()
-                        || np.properties.as_ref().is_some_and(|p| !p.is_empty())
-                        || np.property_exprs.as_ref().is_some_and(|p| !p.is_empty());
-                    if bound.contains(v) && adds_something {
+            // A bare re-mention is how an edge between existing nodes is
+            // written -- `CREATE (a)-[:R]->(b)`, and the `CREATE (a), (b),
+            // (a)-[:R]->(b)` idiom every TCK fixture uses. A *standalone* one
+            // is not: `MATCH (a) CREATE (a)` re-creates a node that already
+            // exists and wires nothing, which Cypher rejects (#663).
+            if path.segments.is_empty() {
+                if let Some(v) = &path.start.variable {
+                    if bound.contains(v) {
                         return Err(if merge {
                             ValidationError::MergeOnBoundVariable(v.clone())
                         } else {
@@ -334,11 +340,41 @@ pub fn validate(query: &Query) -> Result<(), ValidationError> {
                         });
                     }
                 }
-                Ok(())
-            };
-            check(&path.start)?;
+            }
+            {
+                let bound = &bound;
+                let mut check = |np: &crate::query::ast::NodePattern| -> Result<(), ValidationError> {
+                    if let Some(v) = &np.variable {
+                        let adds_something = !np.labels.is_empty()
+                            || np.properties.as_ref().is_some_and(|p| !p.is_empty())
+                            || np.property_exprs.as_ref().is_some_and(|p| !p.is_empty());
+                        if bound.contains(v) && adds_something {
+                            return Err(if merge {
+                                ValidationError::MergeOnBoundVariable(v.clone())
+                            } else {
+                                ValidationError::CreateOnBoundVariable(v.clone())
+                            });
+                        }
+                    }
+                    Ok(())
+                };
+                check(&path.start)?;
+                for seg in &path.segments {
+                    check(&seg.node)?;
+                }
+            }
+            // Only now do this path's own variables count as bound, so a later
+            // path in the same clause sees them.
+            if let Some(v) = &path.start.variable {
+                bound.insert(v.clone());
+            }
             for seg in &path.segments {
-                check(&seg.node)?;
+                if let Some(v) = &seg.node.variable {
+                    bound.insert(v.clone());
+                }
+                if let Some(v) = &seg.edge.variable {
+                    bound.insert(v.clone());
+                }
             }
         }
     }

--- a/tests/create_semantics.rs
+++ b/tests/create_semantics.rs
@@ -188,3 +188,37 @@ fn an_unlabelled_node_is_not_findable_by_an_invented_label() {
         );
     }
 }
+
+#[test]
+fn creating_a_node_that_is_already_bound_is_refused() {
+    // `MATCH (a) CREATE (a)` re-creates a node that exists and wires nothing.
+    // A *bare* re-mention is legal only where it is doing work — attaching a
+    // relationship — which is why this check is on standalone paths and the
+    // idiom below still passes (#663).
+    for cypher in [
+        "MATCH (a) CREATE (a)",
+        "MATCH (a) CREATE (a:Foo)",
+        // `n` is bound by the *first path of the same clause* and re-labelled
+        // in the second. A bound set computed before the clause cannot see it.
+        "CREATE (n:Foo)-[:T1]->(), (n:Bar)-[:T2]->()",
+    ] {
+        let err = parse_query(cypher).expect_err(&format!("`{cypher}` must be refused"));
+        assert!(
+            err.to_string().contains('a') || err.to_string().contains('n'),
+            "the message should name the variable: {err}"
+        );
+    }
+}
+
+#[test]
+fn a_bare_re_mention_that_attaches_a_relationship_stays_legal() {
+    // The distinction the rule above turns on. Getting this wrong breaks the
+    // idiom every TCK fixture is written in, so it is asserted separately.
+    for cypher in [
+        "MATCH (a), (b) CREATE (a)-[:R]->(b)",
+        "CREATE (a), (b), (a)-[:R]->(b)",
+        "CREATE (n:Foo)-[:T1]->(), (n)-[:T2]->()",
+    ] {
+        assert!(parse_query(cypher).is_ok(), "`{cypher}` should be accepted");
+    }
+}

--- a/tests/query_validation.rs
+++ b/tests/query_validation.rs
@@ -79,13 +79,23 @@ fn create_may_not_add_labels_to_a_variable_match_already_bound() {
 }
 
 #[test]
-fn a_bare_re_mention_of_a_matched_variable_stays_legal() {
+fn a_bare_re_mention_that_attaches_a_relationship_stays_legal() {
     // This is how you write an edge between two matched nodes, and it is the
     // single most common write query in this codebase. If the rule above ever
     // starts rejecting it, every loader breaks.
-    accepted("MATCH (a) CREATE (a)");
     accepted("MATCH (a), (b) CREATE (a)-[:R]->(b)");
     accepted("MATCH (a:Person) CREATE (a)-[:OWNS]->(:Thing)");
+}
+
+#[test]
+fn a_standalone_re_mention_of_a_matched_variable_is_refused() {
+    // `MATCH (a) CREATE (a)` used to be listed alongside the cases above as
+    // legal. It is not: Cypher raises `VariableAlreadyBound`, Neo4j rejects
+    // it, and the TCK asserts the error (Create1 [13]). The two were
+    // conflated because both are "bare", but a bare mention inside a
+    // relationship pattern is doing work — attaching an edge — and a
+    // standalone one re-creates a node that already exists (#663).
+    rejected("MATCH (a) CREATE (a)");
 }
 
 #[test]


### PR DESCRIPTION
Three changes off the competitor diff — scenarios Neo4j passes and we do not.

**Named pattern comprehensions** (#662). `[p = (n)-->() | p]` did not parse:
`pattern_comprehension` had no place for the `p =` prefix, which is what all
nine Pattern2 scenarios use. The comprehension machinery was already there.

The unnamed form was quietly wrong too: `[(n)-[:HAS]->(m) | m]` accumulated
`Vec<PropertyValue>` and mapped anything that was not a `Property` to
`Null`, so projecting a node gave the right *number* of nulls. It now
accumulates `Vec<Value>` and returns a `PropertyValue::Array` when every
element is a scalar, so the existing shape is preserved exactly.

**CREATE re-binding** (#663). Six Create1 scenarios expect
`VariableAlreadyBound` and we accepted the query. Two gaps: a bare
re-mention was allowed unconditionally, and the bound set was computed
before the whole clause. `MATCH (a) CREATE (a)` re-creates a node that
exists; `CREATE (n:Foo)-[:T1]->(), (n:Bar)-[:T2]->()` re-labels `n` from a
path in the same clause.

The distinction is whether the mention is *doing work*: bare inside a
relationship pattern attaches an edge and stays legal, standalone does not.
`CREATE (a), (b), (a)-[:R]->(b)` — the idiom every TCK fixture uses — has
its own test, because breaking it would be far worse than the six scenarios
being fixed.

A test in `query_validation.rs` asserted `MATCH (a) CREATE (a)` was legal,
listed beside the genuinely-legal forms. It is not: Cypher raises
`VariableAlreadyBound`, Neo4j rejects it, Create1 [13] asserts the error.
Split rather than deleted, since the legal cases do need protecting.

**Target ids resolved at plan time** (#664). The SF10 profile of IC11 says
the earlier pushdown (#656) was counterproductive at scale:

    Expand ((friend)-[:WORK_AT]->(org))  283.40ms self  74.0%  190 rows
    VarLengthExpand ((p)-[:KNOWS*1..2]-)  90.12ms self  23.5%  13306 rows

It cut the output to 190 rows as designed, and cost a `get_node` plus a
property compare on each of ~29,000 candidate edges. The filter moved
earlier and became more expensive per candidate. Resolving
`org.name = "..."` to node ids once — property index where one exists,
otherwise a capped single-label scan — makes the per-edge test a hash
lookup. 7,955 Organisations scanned once against 29,000 edge candidates.

SF1 is unchanged at ~8.5 ms and that is expected: the Organisation set
there is tiny and the per-candidate cost never dominated. **This change is
not yet verified at the scale it was written for**; IC11 at SF10 is
242 ms / 9.6x as of `23b4b58` and needs another spot host to re-measure.

openCypher TCK 967 -> 981 of 1244 evaluated (77.7% -> 78.9%), none
regressed. LDBC SF1 21/21 with identical row counts.

Closes #662.
Closes #663.
Refs #616.