### PR TITLE
Point the target-id comments at #665, not the PR number

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3683,7 +3683,7 @@ pub struct ExpandOperator {
     /// the expand became 74% of the query — the filter moved earlier and got
     /// *more* expensive per candidate. Resolving `org.name = "..."` to the one
     /// matching Organisation once, and testing membership here, replaces that
-    /// with a hash lookup (#664).
+    /// with a hash lookup (#665).
     target_ids: Option<std::collections::HashSet<NodeId>>,
     /// Direction
     direction: Direction,
@@ -3756,7 +3756,7 @@ impl ExpandOperator {
 
     /// The resolved node set for the target, when the planner could compute it.
     /// Preferred over `target_props`: an id membership test costs a hash
-    /// lookup where the property check costs a node fetch (#664).
+    /// lookup where the property check costs a node fetch (#665).
     pub fn with_target_ids(mut self, ids: std::collections::HashSet<NodeId>) -> Self {
         self.target_ids = Some(ids);
         self

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2829,7 +2829,7 @@ impl QueryPlanner {
                     if !pushed.is_empty() {
                         // Resolved to ids where possible: the property check
                         // costs a node fetch per candidate edge and this costs
-                        // a hash lookup (#664).
+                        // a hash lookup (#665).
                         if let Some(ids) =
                             self.resolve_target_ids(&segment.node.labels, &pushed, store)
                         {
@@ -2978,7 +2978,7 @@ impl QueryPlanner {
     /// label scan is used, which is worth it only because it happens once at
     /// plan time against a small label — 7,955 Organisations against 29,000
     /// edge candidates. The scan is capped for that reason: above the cap the
-    /// per-candidate check is the cheaper of the two (#664).
+    /// per-candidate check is the cheaper of the two (#665).
     fn resolve_target_ids(
         &self,
         labels: &[Label],


### PR DESCRIPTION
The comments referenced #664, which turned out to be the PR number rather than an issue. The issue tracking the IC11 target-id work is #665.

Comment-only.