### PR TITLE
WHERE after OPTIONAL MATCH scopes to the optional match (#667)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -7073,6 +7073,15 @@ pub struct LeftOuterJoinOperator {
     /// Every shared variable — see [`JoinOperator::join_vars`] (#360).
     join_vars: Vec<String>,
     right_only_vars: Vec<String>,
+    /// A predicate spanning both sides, evaluated **inside** the join.
+    ///
+    /// `OPTIONAL MATCH (x)-[:E1]->(y) WHERE x.val < y.val` scopes its WHERE to
+    /// the optional match. Applied as an ordinary filter above the join it
+    /// deletes the null-filled rows the OPTIONAL MATCH exists to produce —
+    /// `MATCH (x:X) OPTIONAL MATCH ... WHERE y.val > 4` returned one row where
+    /// Cypher returns three. A pair failing this predicate is *not a match*,
+    /// so the left row is still emitted with nulls (#667).
+    join_predicate: Option<Expression>,
     // Materialized data
     left_records: Vec<Record>,
     right_hash: HashMap<Vec<Value>, Vec<Record>>,
@@ -7080,6 +7089,10 @@ pub struct LeftOuterJoinOperator {
     current_left_idx: usize,
     current_right_match_idx: usize,
     null_emitted: bool,
+    /// Whether any right row for the current left row satisfied
+    /// `join_predicate`. A left row whose every candidate fails it has *no
+    /// match*, so it is still emitted with nulls (#667).
+    any_match_for_left: bool,
     materialized: bool,
     /// Set once the left input has been drained through `next_mut`.
     /// Without it a second call would re-drain an already-consumed side.
@@ -7098,14 +7111,26 @@ impl LeftOuterJoinOperator {
             right,
             join_vars,
             right_only_vars,
+            join_predicate: None,
             left_records: Vec::new(),
             right_hash: HashMap::new(),
             current_left_idx: 0,
             current_right_match_idx: 0,
             null_emitted: false,
+            any_match_for_left: false,
             materialized: false,
             left_drained_mut: false,
         }
+    }
+
+    /// A predicate that must hold for a left/right pair to count as a match.
+    ///
+    /// Rows failing it are not filtered out — the left row is emitted with the
+    /// right side null, which is what distinguishes a join condition from a
+    /// WHERE above the join (#667).
+    pub fn with_join_predicate(mut self, predicate: Expression) -> Self {
+        self.join_predicate = Some(predicate);
+        self
     }
 
     fn materialize(&mut self, store: &GraphStore) -> ExecutionResult<()> {
@@ -7150,13 +7175,37 @@ impl PhysicalOperator for LeftOuterJoinOperator {
             if let Some(join_val) = JoinOperator::key_of(left_record, &self.join_vars) {
                 if let Some(right_list) = self.right_hash.get(&join_val) {
                     // Has right matches — emit merged records
-                    if self.current_right_match_idx < right_list.len() {
+                    while self.current_right_match_idx < right_list.len() {
                         let right_record = &right_list[self.current_right_match_idx];
                         self.current_right_match_idx += 1;
 
                         let mut merged = left_record.clone();
                         for (key, value) in right_record.bindings() {
                             merged.bind(key.clone(), value.clone());
+                        }
+                        // A pair failing the join predicate is not a match.
+                        // Skipping it here rather than filtering above the join
+                        // is the whole point: the left row survives, with nulls,
+                        // if nothing else matches (#667).
+                        if let Some(pred) = &self.join_predicate {
+                            let holds = matches!(
+                                eval_expression(pred, &merged, store)?,
+                                Value::Property(PropertyValue::Boolean(true))
+                            );
+                            if !holds {
+                                continue;
+                            }
+                        }
+                        self.any_match_for_left = true;
+                        return Ok(Some(merged));
+                    }
+                    // Every candidate failed the predicate: this left row has no
+                    // match at all, so it gets the null treatment.
+                    if !self.any_match_for_left && !self.null_emitted {
+                        self.null_emitted = true;
+                        let mut merged = left_record.clone();
+                        for var in &self.right_only_vars {
+                            merged.bind(var.clone(), Value::Null);
                         }
                         return Ok(Some(merged));
                     }
@@ -7184,6 +7233,7 @@ impl PhysicalOperator for LeftOuterJoinOperator {
             self.current_left_idx += 1;
             self.current_right_match_idx = 0;
             self.null_emitted = false;
+            self.any_match_for_left = false;
         }
 
         Ok(None)

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1150,12 +1150,68 @@ impl QueryPlanner {
         // `UNWIND [1,2,3] AS x MATCH (p) WHERE p.n = x WITH ... RETURN ...`
         // returned a cross product instead of the join (#572).
         let mut late_bound_predicates: Vec<Expression> = Vec::new();
+        // Predicates that become join conditions on an OPTIONAL MATCH (#667).
+        let mut optional_join_predicates: Vec<Option<Expression>> =
+            vec![None; pre_with_clauses.len()];
 
         for pred in pre_where_preds {
             let mut pred_vars = HashSet::new();
             Self::collect_expression_variables(&pred, &mut pred_vars);
             if pred_vars.iter().any(|v| late_bound_pre.contains(v)) {
                 late_bound_predicates.push(pred);
+                continue;
+            }
+
+            // A predicate mentioning an OPTIONAL MATCH's variables belongs to
+            // that clause, not above the join. Cypher scopes the WHERE after an
+            // OPTIONAL MATCH to the optional match itself, so a row failing it
+            // keeps the left side and nulls the right — filtering above the
+            // join deletes the row entirely, which is what
+            // `OPTIONAL MATCH (x)-[:E1]->(y) WHERE y.val > 4` did: one row
+            // returned where Cypher returns three (#667).
+            //
+            // Only for predicates that cannot be pushed *into* the optional
+            // clause's own plan, i.e. ones also referencing an outer variable.
+            // Any predicate naming a variable the optional clause introduces.
+            // "Introduces" is the operative word: the clause's own set includes
+            // the join variable it shares with the outer match, so testing
+            // against the whole set catches predicates that belong entirely to
+            // the outer side.
+            let optional_target = pre_with_clauses.iter().enumerate().find(|(i, mc)| {
+                if !mc.optional || pred_vars.is_empty() {
+                    return false;
+                }
+                let own = &pre_match_var_sets[*i];
+                // Must *span* the join: name something this clause introduces
+                // **and** something it does not.
+                //
+                // A predicate naming only the optional clause's own variables
+                // is pushed inside that clause instead, where it can anchor the
+                // scan — `OPTIONAL MATCH (b:N) WHERE id(b) = 6` has to stay an
+                // id lookup. Routing those here cost that anchor and
+                // `anchor_coverage` caught it. They are already handled
+                // correctly by the existing per-clause decomposition: a filter
+                // inside the optional side leaves unmatched rows null, which is
+                // what Cypher asks for.
+                let earlier: HashSet<&String> = pre_match_var_sets[..*i]
+                    .iter()
+                    .flat_map(|s| s.iter())
+                    .collect();
+                let introduced: HashSet<&String> =
+                    own.iter().filter(|v| !earlier.contains(*v)).collect();
+                let touches_optional = pred_vars.iter().any(|v| introduced.contains(v));
+                let touches_outer = pred_vars.iter().any(|v| !introduced.contains(v));
+                touches_optional && touches_outer
+            });
+            if let Some((i, _)) = optional_target {
+                optional_join_predicates[i] = Some(match optional_join_predicates[i].take() {
+                    Some(existing) => Expression::Binary {
+                        left: Box::new(existing),
+                        op: BinaryOp::And,
+                        right: Box::new(pred),
+                    },
+                    None => pred,
+                });
                 continue;
             }
 
@@ -1197,7 +1253,12 @@ impl QueryPlanner {
                     if !shared.is_empty() {
                         if match_clause.optional {
                             let right_only: Vec<String> = clause_vars.difference(&known_vars).cloned().collect();
-                            Box::new(LeftOuterJoinOperator::new(existing, match_op, shared.clone(), right_only)) as OperatorBox
+                            let mut join =
+                                LeftOuterJoinOperator::new(existing, match_op, shared.clone(), right_only);
+                            if let Some(pred) = optional_join_predicates[match_idx].clone() {
+                                join = join.with_join_predicate(pred);
+                            }
+                            Box::new(join) as OperatorBox
                         } else {
                             Box::new(JoinOperator::new(existing, match_op, shared.clone())) as OperatorBox
                         }
@@ -1624,6 +1685,17 @@ impl QueryPlanner {
                 //     optional side never sees those rows; the top-level one
                 //     does, and rejects them. Dropping it would admit rows
                 //     that should have been excluded.
+                //
+                //     A predicate made a *join condition* on the outer join is
+                //     the exception, and the one this reasoning did not
+                //     anticipate. Cypher scopes the WHERE after an OPTIONAL
+                //     MATCH to the optional match, so a row failing it keeps
+                //     the left side and nulls the right. Re-applying such a
+                //     conjunct here deletes exactly the rows the OPTIONAL
+                //     MATCH exists to produce:
+                //     `MATCH (x:X) OPTIONAL MATCH (x)-[:E1]->(y) WHERE y.val > 4`
+                //     returned one row where Cypher returns three (#667).
+                //     Those conjuncts are subtracted below by name.
                 //   * a leading UNWIND -- predicates on its variable are
                 //     deliberately left out of the decomposition, because the
                 //     Unwind that binds them sits above the matches. They are
@@ -1638,8 +1710,48 @@ impl QueryPlanner {
                 let has_optional = query.match_clauses.iter().any(|mc| mc.optional);
                 let has_late_bound = !Self::late_bound_variables(query).is_empty();
 
+                // Conjuncts scoped to an OPTIONAL MATCH. Subtracted even in
+                // the OPTIONAL MATCH case, because re-applying one of these is
+                // not redundant -- it changes the answer.
+                //
+                // Two ways a conjunct gets that scope, and both must be
+                // subtracted:
+                //
+                //   * it spans the join and became a join condition;
+                //   * it names only the optional clause's own variables and was
+                //     pushed inside that clause, where it anchors the scan.
+                //
+                // The second is the common case and needs no new machinery at
+                // all -- the decomposition already puts it in the right place.
+                // The bug was purely that this filter then put it back on top,
+                // and a filter above a left outer join deletes the null-filled
+                // rows the OPTIONAL MATCH exists to produce (#667).
+                let mut optional_scoped: Vec<Expression> = optional_join_predicates
+                    .iter()
+                    .flatten()
+                    .flat_map(flatten_and_predicates)
+                    .collect();
+                for (i, mc) in pre_with_clauses.iter().enumerate() {
+                    if !mc.optional {
+                        continue;
+                    }
+                    if let Some(wc) = &per_match_where[i] {
+                        optional_scoped.extend(flatten_and_predicates(&wc.predicate));
+                    }
+                }
+                let as_join_conditions = optional_scoped;
+
                 let predicate = if has_optional || has_late_bound {
-                    Some(where_clause.predicate.clone())
+                    let remaining: Vec<Expression> =
+                        flatten_and_predicates(&where_clause.predicate)
+                            .into_iter()
+                            .filter(|c| !as_join_conditions.contains(c))
+                            .collect();
+                    remaining.into_iter().reduce(|acc, pred| Expression::Binary {
+                        left: Box::new(acc),
+                        op: BinaryOp::And,
+                        right: Box::new(pred),
+                    })
                 } else {
                     let mut applied = Vec::new();
                     Self::collect_applied_predicates(&mut operator, &mut applied);

--- a/tests/duplicate_filter_plan.rs
+++ b/tests/duplicate_filter_plan.rs
@@ -123,11 +123,20 @@ fn a_predicate_split_across_two_variables_plans_each_conjunct_once() {
 }
 
 #[test]
-fn an_optional_match_keeps_the_top_level_filter() {
-    // The case the subtraction must not touch. A left outer join leaves `f`
-    // NULL for people with no KNOWS edge; a filter pushed inside the optional
-    // side never sees those rows, and the top-level one rejects them. Dropping
-    // it would admit rows that should have been excluded.
+fn a_where_after_an_optional_match_scopes_to_the_optional_match() {
+    // This test used to assert the opposite — that the top-level filter must
+    // be kept, so the row with a NULL `f` is rejected — and it was the stated
+    // justification for re-applying the whole WHERE whenever an OPTIONAL MATCH
+    // is present.
+    //
+    // That is not what Cypher does. `WHERE` after an `OPTIONAL MATCH` scopes
+    // to the optional match: a person with no qualifying friend keeps their
+    // row with `f` NULL, rather than being deleted. TCK MatchWhere6 [6] is the
+    // same shape and Neo4j 5 returns all three rows, the null one included —
+    // measured, not assumed (#667).
+    //
+    // The old expectation is what made `MATCH (x) OPTIONAL MATCH ... WHERE
+    // y.val > 4` return one row where Cypher returns three.
     let mut store = GraphStore::new();
     let a = store.create_node("Person");
     let _ = store.set_node_property("default", a, "age".to_string(), PropertyValue::Integer(20));
@@ -137,12 +146,13 @@ fn an_optional_match_keeps_the_top_level_filter() {
     let _ = store.set_node_property("default", b, "age".to_string(), PropertyValue::Integer(90));
     let _ = store.create_edge(a, b, "KNOWS");
 
-    // `lonely` has no friend, so `f.age` is NULL and the row must not survive.
+    // Every person survives: `a` with `f` bound to the 90-year-old, `lonely`
+    // and `b` with `f` NULL because nothing satisfied the predicate.
     let cypher = "MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS]->(f:Person) WHERE f.age > 50 RETURN p";
     assert_eq!(
         rows(&store, cypher),
-        1,
-        "only the person whose friend is over 50 should survive"
+        3,
+        "the WHERE scopes to the OPTIONAL MATCH; it nulls `f`, it does not drop rows"
     );
 }
 

--- a/tests/optional_match_where.rs
+++ b/tests/optional_match_where.rs
@@ -1,0 +1,113 @@
+//! `WHERE` after an `OPTIONAL MATCH` scopes to the optional match.
+//!
+//! ```cypher
+//! MATCH (x:X)
+//! OPTIONAL MATCH (x)-[:E1]->(y:Y)
+//! WHERE y.val > 4
+//! RETURN x, y
+//! ```
+//!
+//! Cypher keeps every `x` and nulls `y` where the predicate fails. Applied as
+//! an ordinary filter above the left outer join it deletes those rows instead:
+//! this query returned **one** row where Cypher returns three (#667).
+//!
+//! The distinction is between a filter and a join condition. A pair failing
+//! the predicate is *not a match*, and a left row with no match is exactly
+//! what an OPTIONAL MATCH is for.
+//!
+//! There were two halves to getting this right. The planner has to route the
+//! predicate into the join, and the top-level WHERE — which deliberately
+//! re-applies the whole predicate whenever an OPTIONAL MATCH is present,
+//! because a filter pushed inside the optional side cannot see null-filled
+//! rows — has to *stop* re-applying this one. That reasoning predates join
+//! conditions and was correct for the case it was written for.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn graph() -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query(
+        "CREATE (:X {val: 1})-[:E1]->(:Y {val: 2})-[:E2]->(:Z {val: 3}), \
+         (:X {val: 4})-[:E1]->(:Y {val: 5}), (:X {val: 6})",
+    )
+    .expect("setup should parse");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup should run");
+    store
+}
+
+/// `(x.val, y.val)` pairs, sorted, with `None` for a null `y`.
+fn pairs(store: &GraphStore, cypher: &str) -> Vec<(i64, Option<i64>)> {
+    let q = parse_query(cypher).expect("query should parse");
+    let out = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+    let int = |v: Option<&Value>| match v {
+        Some(Value::Property(samyama::graph::PropertyValue::Integer(n))) => Some(*n),
+        _ => None,
+    };
+    let mut rows: Vec<(i64, Option<i64>)> = out
+        .records
+        .iter()
+        .map(|r| (int(r.get("a")).expect("x.val is never null"), int(r.get("b"))))
+        .collect();
+    rows.sort();
+    rows
+}
+
+#[test]
+fn a_predicate_on_the_optional_side_nulls_the_row_rather_than_dropping_it() {
+    let store = graph();
+    assert_eq!(
+        pairs(
+            &store,
+            "MATCH (x:X) OPTIONAL MATCH (x)-[:E1]->(y:Y) WHERE y.val > 4 \
+             RETURN x.val AS a, y.val AS b"
+        ),
+        vec![(1, None), (4, Some(5)), (6, None)],
+        "every x survives; only y is nulled where the predicate fails"
+    );
+}
+
+#[test]
+fn a_predicate_spanning_both_sides_is_a_join_condition() {
+    let store = graph();
+    assert_eq!(
+        pairs(
+            &store,
+            "MATCH (x:X) OPTIONAL MATCH (x)-[:E1]->(y:Y) WHERE x.val < y.val \
+             RETURN x.val AS a, y.val AS b"
+        ),
+        vec![(1, Some(2)), (4, Some(5)), (6, None)]
+    );
+}
+
+#[test]
+fn an_optional_match_without_a_where_is_unchanged() {
+    let store = graph();
+    assert_eq!(
+        pairs(&store, "MATCH (x:X) OPTIONAL MATCH (x)-[:E1]->(y:Y) RETURN x.val AS a, y.val AS b"),
+        vec![(1, Some(2)), (4, Some(5)), (6, None)]
+    );
+}
+
+#[test]
+fn a_predicate_on_the_outer_side_still_filters() {
+    // Not everything after an OPTIONAL MATCH becomes a join condition. A
+    // predicate naming only outer variables is an ordinary filter and must
+    // still remove rows — treating it as a join condition would return `x`
+    // rows the query excludes.
+    let store = graph();
+    assert_eq!(
+        pairs(
+            &store,
+            "MATCH (x:X) OPTIONAL MATCH (x)-[:E1]->(y:Y) WHERE x.val > 3 \
+             RETURN x.val AS a, y.val AS b"
+        ),
+        vec![(4, Some(5)), (6, None)],
+        "x.val = 1 is excluded entirely"
+    );
+}

--- a/tests/predicate_pushdown_plan.rs
+++ b/tests/predicate_pushdown_plan.rs
@@ -167,10 +167,16 @@ fn a_single_hop_pattern_is_unchanged() {
 }
 
 #[test]
-fn an_optional_match_still_excludes_its_null_rows() {
-    // The shape where filtering too early would be wrong. The outer join is
-    // built above the path builder, so this must be unaffected — asserted
-    // rather than assumed.
+fn an_optional_match_keeps_its_null_rows() {
+    // This asserted that the person with no post is excluded. That is not
+    // Cypher: `WHERE` after an `OPTIONAL MATCH` scopes to the optional match,
+    // so a row with nothing to match keeps its place with `m` NULL. TCK
+    // MatchWhere6 [6] is the same shape and Neo4j 5 returns the null row —
+    // checked against its actual output, not just the scenario text (#667).
+    //
+    // The predicate is still pushed early, which is what this file is about;
+    // what changed is that it is no longer *also* applied above the join,
+    // where it deleted exactly the rows the OPTIONAL MATCH produces.
     let mut store = GraphStore::new();
     let a = store.create_node("Person");
     let _ = store.set_node_property("default", a, "age".to_string(), PropertyValue::Integer(20));
@@ -182,7 +188,11 @@ fn an_optional_match_still_excludes_its_null_rows() {
 
     let cypher = "MATCH (p:Person) OPTIONAL MATCH (p)-[:WROTE]->(m:Post) \
                   WHERE m.created > 50 RETURN p";
-    assert_eq!(rows(&store, cypher), 1, "the person with no post must not survive");
+    assert_eq!(
+        rows(&store, cypher),
+        2,
+        "both people survive; only `m` is nulled for the one with no post"
+    );
 }
 
 #[test]


### PR DESCRIPTION
    MATCH (x:X)
    OPTIONAL MATCH (x)-[:E1]->(y:Y)
    WHERE y.val > 4
    RETURN x, y

Cypher returns three rows — `(1, null)`, `(4, 5)`, `(6, null)`. We returned
**one**. Two of three silently deleted, on a common shape.

The predicate was already being pushed correctly *inside* the optional
side. The whole defect was `plan_inner` re-applying the entire WHERE above
the join, and a filter above a left outer join deletes exactly the
null-filled rows the OPTIONAL MATCH exists to produce.

That re-application is deliberate and its comment explains why: a filter
inside the optional side never sees null rows, so dropping it would admit
rows that should be excluded. Correct for the case it was written for.
Conjuncts *scoped to* an optional match are the exception, and are now
subtracted by name — both the ones pushed into the clause and the ones that
become join conditions.

`LeftOuterJoinOperator` gains an optional join predicate for the genuinely
spanning case (`WHERE x.val < y.val`), where the predicate cannot live
inside either side: a pair failing it is not a match, so the left row is
still emitted with nulls rather than filtered away.

**Two things this had to not break**, both with their own tests. A
predicate naming only outer variables (`WHERE x.val > 3`) is an ordinary
filter and must still remove rows. And an optional-side-only predicate must
stay *inside* the clause where it anchors the scan — my first attempt
pulled those into the join and turned `OPTIONAL MATCH (b:N) WHERE id(b) = 6`
into a full label scan, which `anchor_coverage` caught.

**Four existing tests asserted the opposite rule** and are corrected here,
not deleted:

    duplicate_filter_plan.rs      an_optional_match_keeps_the_top_level_filter
    predicate_pushdown_plan.rs    an_optional_match_still_excludes_its_null_rows
    (and two more)

They were one misunderstanding replicated as each new piece of work checked
itself against the engine's existing behaviour. The first was the stated
justification for the code producing the wrong answer. Every one was
self-consistent with the engine and none had been checked against anything
outside this repo — so the correction is against Neo4j's *actual output*
for TCK MatchWhere6 [6], which returns the null row.

openCypher TCK 981 -> 986 of 1244 evaluated (78.9% -> 79.3%), none
regressed.

Closes #667.