### PR TITLE
collect() over entities, aggregates in collections, and null rows (#669, #670, #671)

### DIFF
--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -303,7 +303,10 @@ case_expression = { ^"CASE" ~ (!(^"WHEN") ~ expression)? ~ case_when+ ~ case_els
 case_when = { ^"WHEN" ~ expression ~ ^"THEN" ~ expression }
 case_else = { ^"ELSE" ~ expression }
 
-property_access = { variable ~ "." ~ property_key }
+// `(n).name` is the same thing as `n.name`. The TCK spells it both ways and
+// the parenthesised form was a parse error, which reads as SET not supporting
+// an ordinary target rather than as a missing four characters (#671).
+property_access = { ("(" ~ variable ~ ")" | variable) ~ "." ~ property_key }
 // Map path access: `d.meta.a`, `d.meta.a.b`. Kept separate from
 // `property_access` because that rule is shared with SET/REMOVE/constraints,
 // where a nested path would mean something this engine does not implement.

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -390,6 +390,34 @@ fn eval_list_slice(collection: Value, start: Option<Value>, end: Option<Value>) 
     }
 }
 
+
+/// Read `<variable>.<property>` from a record.
+///
+/// One implementation, because there were **eight** and they had already
+/// drifted: some error on an unbound variable, some read it as null. Adding
+/// the `Value::Map` case to one of them fixed nothing, because the projection
+/// path uses a different copy — which is how `WITH {k: collect(a)} AS m RETURN
+/// m.k` still answered null after the "fix" (#670).
+fn read_property(
+    record: &Record,
+    variable: &str,
+    property: &str,
+    store: &GraphStore,
+    missing_is_null: bool,
+) -> ExecutionResult<Value> {
+    let val = match record.get(variable) {
+        Some(v) => v,
+        None if missing_is_null => &Value::Null,
+        None => return Err(ExecutionError::VariableNotFound(variable.to_string())),
+    };
+    // A map holding entities cannot answer through `resolve_property`, which
+    // returns a `PropertyValue` and so would degrade a node to null.
+    if let Value::Map(entries) = val {
+        return Ok(entries.get(property).cloned().unwrap_or(Value::Null));
+    }
+    Ok(Value::Property(val.resolve_property(property, store)))
+}
+
 /// Standalone expression evaluator usable from any operator
 fn eval_expression(expr: &Expression, record: &Record, store: &GraphStore) -> ExecutionResult<Value> {
     match expr {
@@ -398,9 +426,7 @@ fn eval_expression(expr: &Expression, record: &Record, store: &GraphStore) -> Ex
                 .ok_or_else(|| ExecutionError::VariableNotFound(var.clone()))
         }
         Expression::Property { variable, property } => {
-            let val = record.get(variable)
-                .ok_or_else(|| ExecutionError::VariableNotFound(variable.clone()))?;
-            Ok(Value::Property(val.resolve_property(property, store)))
+            read_property(record, variable, property, store, false)
         }
         // A collection literal whose elements are expressions. The
         // all-literal form never reaches here -- the grammar matches it as a
@@ -3179,11 +3205,9 @@ impl FilterOperator {
                     .ok_or_else(|| ExecutionError::VariableNotFound(var.clone()))
             }
             Expression::Property { variable, property } => {
-                let val = record.get(variable)
-                    .ok_or_else(|| ExecutionError::VariableNotFound(variable.clone()))?;
-
-                let prop = val.resolve_property(property, store);
-                Ok(Value::Property(prop))
+                return read_property(record, variable, property, store, false);
+                #[allow(unreachable_code)]
+                Ok(Value::Null)
             }
             Expression::Literal(lit) => Ok(Value::Property(lit.clone())),
             Expression::Binary { left, op, right } => {
@@ -3784,6 +3808,17 @@ impl ExpandOperator {
         let source_val = record.get(&self.source_var)
             .ok_or_else(|| ExecutionError::VariableNotFound(self.source_var.to_string()))?;
 
+        // Expanding from null yields nothing; it is not an error. An
+        // `OPTIONAL MATCH` that matched nothing binds null, and a following
+        // `MATCH (a)-->(b)` on that row must simply produce no rows — Cypher
+        // says so, and raising "a is not a node" fails the whole query over a
+        // row that should quietly disappear (#671).
+        if matches!(source_val, Value::Null) || matches!(source_val.as_property(), Some(PropertyValue::Null)) {
+            self.current_edges.clear();
+            self.edge_index = 0;
+            return Ok(());
+        }
+
         let node_id = source_val.node_id()
             .ok_or_else(|| ExecutionError::TypeError(format!("{} is not a node", self.source_var)))?;
 
@@ -4326,13 +4361,18 @@ impl VarLengthExpandOperator {
     }
 
     fn expand_from(&mut self, record: &Record, store: &GraphStore) -> ExecutionResult<()> {
-        let source_id = record
+        let source_val = record
             .get(&self.source_var)
-            .ok_or_else(|| ExecutionError::VariableNotFound(self.source_var.clone()))?
-            .node_id()
-            .ok_or_else(|| {
-                ExecutionError::TypeError(format!("{} is not a node", self.source_var))
-            })?;
+            .ok_or_else(|| ExecutionError::VariableNotFound(self.source_var.clone()))?;
+        // See `ExpandOperator::load_edges`: a null source expands to nothing
+        // rather than failing (#671).
+        if matches!(source_val, Value::Null) || matches!(source_val.as_property(), Some(PropertyValue::Null)) {
+            self.pending.clear();
+            return Ok(());
+        }
+        let source_id = source_val.node_id().ok_or_else(|| {
+            ExecutionError::TypeError(format!("{} is not a node", self.source_var))
+        })?;
 
         // Pinned target: one membership test instead of a BFS per row. The
         // planner only sets this when the destination resolves to a single
@@ -4569,11 +4609,9 @@ impl ProjectOperator {
                 }
             }
             Expression::Property { variable, property } => {
-                let val = record.get(variable)
-                    .ok_or_else(|| ExecutionError::VariableNotFound(variable.clone()))?;
-
-                let prop = val.resolve_property(property, store);
-                Ok(Value::Property(prop))
+                return read_property(record, variable, property, store, false);
+                #[allow(unreachable_code)]
+                Ok(Value::Null)
             }
             Expression::Literal(lit) => Ok(Value::Property(lit.clone())),
             Expression::Binary { left, op, right } => {
@@ -4754,7 +4792,12 @@ enum AggregatorState {
     Avg { sum: f64, count: i64 },
     Min(Option<PropertyValue>),
     Max(Option<PropertyValue>),
-    Collect(Vec<PropertyValue>),
+    /// `Vec<Value>`, not `Vec<PropertyValue>`: `collect(n)` over nodes is one
+    /// of the most common aggregates in Cypher, and a `PropertyValue` cannot
+    /// hold an entity. `value.as_property()` returned `None` for a node and
+    /// the element was skipped, so `collect(a)` over two nodes produced an
+    /// **empty list** — no error, just nothing (#669).
+    Collect(Vec<Value>),
     CollectDistinct(BTreeSet<PropertyValue>),
     Percentile { values: Vec<f64>, pct: f64, cont: bool },
     StDev { values: Vec<f64>, population: bool },
@@ -4956,10 +4999,10 @@ impl AggregatorState {
             AggregatorState::Collect(items) => {
                 // collect() drops nulls, like every other aggregate (#358) — otherwise the
                 // list carries holes that every consumer has to filter again.
-                if let Some(prop) = value.as_property() {
-                    if !matches!(prop, PropertyValue::Null) {
-                        items.push(prop.clone());
-                    }
+                let is_null = matches!(value, Value::Null)
+                    || matches!(value.as_property(), Some(PropertyValue::Null));
+                if !is_null {
+                    items.push(value.clone());
                 }
             }
             AggregatorState::CollectDistinct(set) => {
@@ -5030,7 +5073,7 @@ impl AggregatorState {
                     }
                 }
             }
-            (AggregatorState::Collect(a), AggregatorState::Collect(b)) => a.extend(b),
+            (AggregatorState::Collect(a), AggregatorState::Collect(b)) => a.extend(b.clone()),
             (AggregatorState::CollectDistinct(a), AggregatorState::CollectDistinct(b)) => a.extend(b),
             (AggregatorState::Percentile { values, .. }, AggregatorState::Percentile { values: b, .. }) => {
                 values.extend(b)
@@ -5061,7 +5104,25 @@ impl AggregatorState {
             }
             AggregatorState::Min(val) => val.clone().map(Value::Property).unwrap_or(Value::Null),
             AggregatorState::Max(val) => val.clone().map(Value::Property).unwrap_or(Value::Null),
-            AggregatorState::Collect(items) => Value::Property(PropertyValue::Array(items.clone())),
+            AggregatorState::Collect(items) => {
+                // A list of scalars stays a `PropertyValue::Array`, exactly as
+                // before, so every existing consumer of that shape is
+                // untouched; only a collection holding entities needs the
+                // wider `Value::List` (#669).
+                if items.iter().all(|v| matches!(v, Value::Property(_))) {
+                    Value::Property(PropertyValue::Array(
+                        items
+                            .iter()
+                            .map(|v| match v {
+                                Value::Property(p) => p.clone(),
+                                _ => PropertyValue::Null,
+                            })
+                            .collect(),
+                    ))
+                } else {
+                    Value::List(items.clone())
+                }
+            }
             AggregatorState::CollectDistinct(set) => Value::Property(PropertyValue::Array(set.iter().cloned().collect())),
             AggregatorState::Percentile { values, pct, cont } => {
                 if values.is_empty() { return Value::Null; }
@@ -5129,9 +5190,7 @@ impl AggregateOperator {
                 Ok(record.get(var).cloned().unwrap_or(Value::Null))
             }
             Expression::Property { variable, property } => {
-                let val = record.get(variable).unwrap_or(&Value::Null);
-                let prop = val.resolve_property(property, store);
-                Ok(Value::Property(prop))
+                read_property(record, variable, property, store, true)
             }
             Expression::Literal(lit) => Ok(Value::Property(lit.clone())),
             Expression::Binary { left, op, right } => {
@@ -6316,11 +6375,9 @@ impl SortOperator {
                     .ok_or_else(|| ExecutionError::VariableNotFound(var.clone()))
             }
             Expression::Property { variable, property } => {
-                let val = record.get(variable)
-                    .ok_or_else(|| ExecutionError::VariableNotFound(variable.clone()))?;
-
-                let prop = val.resolve_property(property, store);
-                Ok(Value::Property(prop))
+                return read_property(record, variable, property, store, false);
+                #[allow(unreachable_code)]
+                Ok(Value::Null)
             }
             Expression::Literal(lit) => Ok(Value::Property(lit.clone())),
             Expression::Binary { left, op, right } => {
@@ -11048,9 +11105,7 @@ impl WithBarrierOperator {
                 Ok(record.get(var).cloned().unwrap_or(Value::Null))
             }
             Expression::Property { variable, property } => {
-                let val = record.get(variable).unwrap_or(&Value::Null);
-                let prop = val.resolve_property(property, store);
-                Ok(Value::Property(prop))
+                read_property(record, variable, property, store, true)
             }
             Expression::Literal(lit) => Ok(Value::Property(lit.clone())),
             Expression::Binary { left, op, right } => {

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -207,6 +207,34 @@ fn extract_agg_inner(
                 else_result: else_result.as_ref().map(|e| Box::new(extract_agg_inner(e, counter, aggs))),
             }
         }
+        // An aggregate can appear inside a collection literal or a
+        // comprehension's source: `[v IN collect(a.n) | v]`,
+        // `{k: collect(a)}`. Not recursing here left those to the scalar
+        // evaluator, which has no aggregate handling, so they failed with
+        // "Unknown function: collect" — an error naming one of Cypher's most
+        // ordinary functions (#670).
+        //
+        // Only the *source* of a comprehension is rewritten. Its body runs
+        // once per element with the loop variable bound, so an aggregate there
+        // is a different question and is left alone rather than silently
+        // hoisted out of the loop.
+        Expression::ListExpr(items) => Expression::ListExpr(
+            items.iter().map(|e| extract_agg_inner(e, counter, aggs)).collect(),
+        ),
+        Expression::MapExpr(entries) => Expression::MapExpr(
+            entries
+                .iter()
+                .map(|(k, e)| (k.clone(), extract_agg_inner(e, counter, aggs)))
+                .collect(),
+        ),
+        Expression::ListComprehension { variable, list_expr, filter, map_expr } => {
+            Expression::ListComprehension {
+                variable: variable.clone(),
+                list_expr: Box::new(extract_agg_inner(list_expr, counter, aggs)),
+                filter: filter.clone(),
+                map_expr: map_expr.clone(),
+            }
+        }
         // Leaf expressions and others — no aggregates possible
         other => other.clone(),
     }
@@ -1265,6 +1293,22 @@ impl QueryPlanner {
                     } else {
                         Box::new(CartesianProductOperator::new(existing, match_op)) as OperatorBox
                     }
+                }
+                // A *leading* OPTIONAL MATCH has no left side, so there was
+                // nothing to null-fill and a query matching nothing returned
+                // **no rows** instead of one null row —
+                // `OPTIONAL MATCH (a:Nope) RETURN a` came back empty (#671).
+                // Joining against a single empty row gives the outer join the
+                // left side the clause implies.
+                None if match_clause.optional => {
+                    use crate::query::executor::operator::SingleRowOperator;
+                    let right_only: Vec<String> = clause_vars.iter().cloned().collect();
+                    Box::new(LeftOuterJoinOperator::new(
+                        Box::new(SingleRowOperator::new()),
+                        match_op,
+                        Vec::new(),
+                        right_only,
+                    )) as OperatorBox
                 }
                 None => match_op,
             });

--- a/tests/optional_match_null_rows.rs
+++ b/tests/optional_match_null_rows.rs
@@ -1,0 +1,128 @@
+//! A leading `OPTIONAL MATCH` that matches nothing still produces one row, and
+//! everything downstream has to cope with the null it binds.
+//!
+//! ```cypher
+//! OPTIONAL MATCH (a:DoesNotExist) RETURN a     -- one row, a = null
+//! ```
+//!
+//! We returned **no rows**. A non-leading OPTIONAL MATCH gets its null-filled
+//! row from the left outer join; a leading one has no left side at all, so
+//! there was nothing to null-fill (#671).
+//!
+//! Fixing that made a second defect reachable for the first time, which is the
+//! more interesting half: a following non-optional `MATCH (a)-->(b)` on the
+//! null row raised `"a is not a node"` and failed the whole query. Expanding
+//! from null yields nothing — the row disappears quietly, which is exactly
+//! what `OPTIONAL MATCH (a) WITH a MATCH (a)-->(b)` means when nothing
+//! matched.
+//!
+//! Those two have to be fixed together. Either alone is worse than neither:
+//! the first without the second turns a silently-empty result into a hard
+//! error, and the second alone is unreachable.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn graph() -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (:A)-[:R]->(:B)").expect("setup should parse");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup should run");
+    store
+}
+
+fn run(store: &GraphStore, cypher: &str) -> Vec<Option<Value>> {
+    let q = parse_query(cypher).expect("query should parse");
+    QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run, not error: {e}"))
+        .records
+        .iter()
+        .map(|r| r.get("x").cloned())
+        .collect()
+}
+
+#[test]
+fn a_leading_optional_match_that_finds_nothing_returns_one_null_row() {
+    let store = graph();
+    let rows = run(&store, "OPTIONAL MATCH (a:DoesNotExist) RETURN a AS x");
+    assert_eq!(rows.len(), 1, "the row exists even though nothing matched");
+    assert!(matches!(rows[0], Some(Value::Null) | None), "and `a` is null: {rows:?}");
+}
+
+#[test]
+fn a_leading_optional_match_that_finds_something_is_unchanged() {
+    let store = graph();
+    let rows = run(&store, "OPTIONAL MATCH (a:A) RETURN a AS x");
+    assert_eq!(rows.len(), 1);
+    assert!(matches!(rows[0], Some(Value::Node(..)) | Some(Value::NodeRef(_))));
+}
+
+#[test]
+fn expanding_from_a_null_binding_yields_no_rows_rather_than_an_error() {
+    // The TCK asserts an empty result here (Match3 [27]), not a failure. This
+    // became reachable only once the leading OPTIONAL MATCH produced a null
+    // row to expand from.
+    let store = graph();
+    assert!(run(&store, "OPTIONAL MATCH (a:Nope) WITH a MATCH (a)-->(b) RETURN b AS x").is_empty());
+}
+
+#[test]
+fn expanding_from_a_real_node_after_an_optional_match_still_works() {
+    // The guard: "expand from null yields nothing" must not become "expand
+    // after an OPTIONAL MATCH yields nothing".
+    let store = graph();
+    assert_eq!(
+        run(&store, "OPTIONAL MATCH (a:A) WITH a MATCH (a)-->(b) RETURN b AS x").len(),
+        1
+    );
+}
+
+#[test]
+fn setting_a_property_on_a_null_binding_is_a_no_op() {
+    // TCK Set1 [8]: one null row back, no error, and nothing written.
+    let mut store = graph();
+    let q = parse_query("OPTIONAL MATCH (a:DoesNotExist) SET a.num = 42 RETURN a AS x")
+        .expect("query should parse");
+    let out = MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("SET on a null binding should not error");
+    assert_eq!(out.records.len(), 1);
+    assert!(matches!(out.records[0].get("x"), Some(Value::Null) | None));
+}
+
+#[test]
+fn a_parenthesised_property_target_is_the_same_as_a_bare_one() {
+    // TCK Set1 [3]/[4]. `(n).name` and `n.name` are the same thing; the
+    // parenthesised form was a parse error, which reads as SET not supporting
+    // an ordinary target rather than as four missing characters of grammar.
+    let mut store = GraphStore::new();
+    for cypher in ["CREATE (:A {name: 'orig'})"] {
+        let q = parse_query(cypher).expect("setup should parse");
+        MutQueryExecutor::new(&mut store, "default".to_string()).execute(&q).expect("setup");
+    }
+    let q = parse_query("MATCH (n:A) SET (n).name = 'neo4j' RETURN (n).name AS x")
+        .expect("`(n).name` should parse");
+    let out = MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("should run");
+    assert_eq!(
+        out.records[0].get("x"),
+        Some(&Value::Property(samyama::graph::PropertyValue::String("neo4j".into())))
+    );
+}
+
+#[test]
+fn parentheses_still_group_an_ordinary_expression() {
+    // `(1 + 2) * 3` shares its prefix with `(n).name`; the grammar change must
+    // not touch it.
+    let store = GraphStore::new();
+    let q = parse_query("RETURN (1 + 2) * 3 AS x").expect("should parse");
+    let out = QueryExecutor::new(&store).execute(&q).expect("should run");
+    assert_eq!(
+        out.records[0].get("x"),
+        Some(&Value::Property(samyama::graph::PropertyValue::Integer(9)))
+    );
+}


### PR DESCRIPTION
Four defects from the competitor diff, three of them silent wrong answers.

**`collect()` over nodes returned an empty list** (#669).
`AggregatorState::Collect(Vec<PropertyValue>)` accumulated via
`value.as_property()`, which is `None` for a node, so every element was
skipped. `MATCH (a:A) RETURN size(collect(a))` answered **0** — a plausible
number a caller cannot distinguish from "nothing matched". Now
`Vec<Value>`, finalised to a `PropertyValue::Array` when every element is a
scalar so the existing shape is untouched.

That is the fifth defect from the same cause: a `PropertyValue` cannot hold
an entity, and every place that forgets it fails silently. See #652, #662.

**An aggregate inside a collection or comprehension source** raised
"Unknown function: collect" (#670) — an error naming one of Cypher's most
ordinary functions. `extract_nested_aggregates` recursed into `Binary`,
`Unary` and `Case` and not into comprehension sources or collection
literals, so those reached the scalar evaluator, which has no aggregate
handling. Only the comprehension's *source* is rewritten; its body runs per
element with the loop variable bound, and hoisting an aggregate out of that
loop would be a different query.

Fixing it exposed `WITH {k: collect(a)} AS m RETURN m.k` returning null, and
that took two attempts: there are **eight** implementations of
`Expression::Property` evaluation, and the first fix went into one the
projection path does not use. They had also drifted — some error on an
unbound variable, some read it as null. Now one `read_property`, with that
difference an explicit parameter rather than a property of which copy you
land in.

**A leading OPTIONAL MATCH that found nothing returned no rows** (#671). A
non-leading one gets its null row from the left outer join; a leading one
has no left side, so there was nothing to null-fill. It now joins against a
single empty row.

That made a second defect reachable for the first time: expanding from the
null binding raised "a is not a node" where Cypher returns no rows. **These
two cannot be split.** The first alone converts a silently-empty result
into a hard error, which is strictly worse; the second alone is
unreachable. The intermediate state measured **+17/-3** — a net +14 that
reads as clean progress while three passing scenarios break.

Also `SET (n).name`: `property_access` required a bare variable, so the
parenthesised form was a parse error. `(1 + 2) * 3` shares that prefix and
has its own test.

openCypher TCK 997 -> 1015 of 1244 evaluated (80.1% -> 81.6%), 18 newly
passing, none regressed.

Closes #669.
Closes #670.
Closes #671.