### PR TITLE
Property access on any expression, and the SET rule it uncovered (#673)

### DIFF
--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -227,13 +227,20 @@ order_direction = { ^"ASC" | ^"DESC" }
 // any comparison, which is the opposite of openCypher. Emitting it here lets the Pratt
 // parser give it a precedence between AND and the comparison operators.
 expression = { not_op* ~ term ~ (binary_op ~ not_op* ~ term)* }
-term = { unary_op* ~ primary ~ index_op* ~ postfix_op? }
+// `member_op*` alongside `index_op*`: `startNode(r).id` is property access on
+// the *result* of a call, and there was no rule for it. `n.id` is matched by
+// `property_access` inside `primary`, and `d.meta["a"]` by `index_op`, so the
+// gap was invisible until a TCK scenario wrote `f(x).prop` — which reads as
+// `startNode` being unsupported rather than as a missing suffix (#673).
+term = { unary_op* ~ primary ~ (index_op | member_op)* ~ postfix_op? }
 // `n:Label` used as a *value*, not as a pattern: `WHERE n:Person`,
 // `RETURN n:Person AS isPerson`. It is a postfix on a term, which gives it a
 // tighter binding than any comparison — the same shape as `IS NULL`.
 postfix_op = { label_check | (^"IS" ~ ^"NOT" ~ ^"NULL") | (^"IS" ~ ^"NULL") }
 label_check = { (":" ~ label)+ }
 index_op = { "[" ~ (slice_op | expression) ~ "]" }
+// `.name` applied to whatever the term has produced so far.
+member_op = { "." ~ property_key }
 slice_op = { slice_start ~ ".." ~ slice_end | slice_start ~ ".." | ".." ~ slice_end | ".." }
 slice_start = { expression }
 slice_end = { expression }

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -344,8 +344,11 @@ fn eval_unary_op(op: &UnaryOp, val: Value) -> ExecutionResult<Value> {
     }
 }
 
-/// Shared list/map indexing evaluation
-fn eval_index(collection: Value, index: Value) -> ExecutionResult<Value> {
+/// Shared list/map indexing evaluation.
+///
+/// Takes the store because indexing a node or relationship by name reads a
+/// property, which may live in the column store rather than inline (#673).
+fn eval_index(collection: Value, index: Value, store: &GraphStore) -> ExecutionResult<Value> {
     match (&collection, &index) {
         // Any value that reads as a list, so an all-float literal -- which
         // parses as a `Vector` -- indexes rather than returning null (#605).
@@ -358,6 +361,18 @@ fn eval_index(collection: Value, index: Value) -> ExecutionResult<Value> {
         }
         (Value::Property(PropertyValue::Map(map)), Value::Property(PropertyValue::String(key))) => {
             Ok(map.get(key).map(|v| Value::Property(v.clone())).unwrap_or(Value::Null))
+        }
+        // A map holding entities — `{k: collect(a)}` (#670).
+        (Value::Map(map), Value::Property(PropertyValue::String(key))) => {
+            Ok(map.get(key).cloned().unwrap_or(Value::Null))
+        }
+        // Indexing a *node or relationship* by name reads its property.
+        // `startNode(r).id` desugars to `startNode(r)["id"]`, and without this
+        // it answered null — parsing was only half the work, and the half that
+        // fails silently (#673).
+        (Value::Node(..) | Value::NodeRef(_) | Value::Edge(..) | Value::EdgeRef(..),
+         Value::Property(PropertyValue::String(key))) => {
+            Ok(Value::Property(collection.resolve_property(key, store)))
         }
         _ => Ok(Value::Null),
     }
@@ -464,7 +479,7 @@ fn eval_expression(expr: &Expression, record: &Record, store: &GraphStore) -> Ex
         Expression::Index { expr: e, index } => {
             let collection = eval_expression(e, record, store)?;
             let idx = eval_expression(index, record, store)?;
-            eval_index(collection, idx)
+            eval_index(collection, idx, store)
         }
         Expression::ListSlice { expr: e, start, end } => {
             let collection = eval_expression(e, record, store)?;
@@ -3255,7 +3270,7 @@ impl FilterOperator {
             Expression::Index { expr, index } => {
                 let collection = self.evaluate_expression(expr, record, store)?;
                 let idx = self.evaluate_expression(index, record, store)?;
-                eval_index(collection, idx)
+                eval_index(collection, idx, store)
             }
             Expression::ListSlice { expr, start, end } => {
                 let collection = self.evaluate_expression(expr, record, store)?;
@@ -4635,7 +4650,7 @@ impl ProjectOperator {
             Expression::Index { expr, index } => {
                 let collection = self.evaluate_expression(expr, record, store)?;
                 let idx = self.evaluate_expression(index, record, store)?;
-                eval_index(collection, idx)
+                eval_index(collection, idx, store)
             }
             Expression::ListSlice { expr, start, end } => {
                 let collection = self.evaluate_expression(expr, record, store)?;
@@ -5214,7 +5229,7 @@ impl AggregateOperator {
             Expression::Index { expr, index } => {
                 let collection = Self::evaluate_expression(expr, record, store)?;
                 let idx = Self::evaluate_expression(index, record, store)?;
-                eval_index(collection, idx)
+                eval_index(collection, idx, store)
             }
             Expression::ListSlice { expr, start, end } => {
                 let collection = Self::evaluate_expression(expr, record, store)?;
@@ -6401,7 +6416,7 @@ impl SortOperator {
             Expression::Index { expr, index } => {
                 let collection = Self::evaluate_expression(expr, record, store)?;
                 let idx = Self::evaluate_expression(index, record, store)?;
-                eval_index(collection, idx)
+                eval_index(collection, idx, store)
             }
             Expression::ListSlice { expr, start, end } => {
                 let collection = Self::evaluate_expression(expr, record, store)?;
@@ -11129,7 +11144,7 @@ impl WithBarrierOperator {
             Expression::Index { expr, index } => {
                 let collection = Self::evaluate_expression(expr, record, store)?;
                 let idx = Self::evaluate_expression(index, record, store)?;
-                eval_index(collection, idx)
+                eval_index(collection, idx, store)
             }
             Expression::ListSlice { expr, start, end } => {
                 let collection = Self::evaluate_expression(expr, record, store)?;
@@ -13510,7 +13525,7 @@ mod tests {
             PropertyValue::Integer(20),
             PropertyValue::Integer(30),
         ]));
-        let result = eval_index(arr, Value::Property(PropertyValue::Integer(1))).unwrap();
+        let result = eval_index(arr, Value::Property(PropertyValue::Integer(1)), &GraphStore::new()).unwrap();
         assert_eq!(result, Value::Property(PropertyValue::Integer(20)));
     }
 
@@ -13521,14 +13536,14 @@ mod tests {
             PropertyValue::Integer(20),
             PropertyValue::Integer(30),
         ]));
-        let result = eval_index(arr, Value::Property(PropertyValue::Integer(-1))).unwrap();
+        let result = eval_index(arr, Value::Property(PropertyValue::Integer(-1)), &GraphStore::new()).unwrap();
         assert_eq!(result, Value::Property(PropertyValue::Integer(30)));
     }
 
     #[test]
     fn test_eval_index_array_out_of_bounds() {
         let arr = Value::Property(PropertyValue::Array(vec![PropertyValue::Integer(10)]));
-        let result = eval_index(arr, Value::Property(PropertyValue::Integer(5))).unwrap();
+        let result = eval_index(arr, Value::Property(PropertyValue::Integer(5)), &GraphStore::new()).unwrap();
         assert_eq!(result, Value::Null);
     }
 
@@ -13539,6 +13554,7 @@ mod tests {
         let result = eval_index(
             Value::Property(PropertyValue::Map(map)),
             Value::Property(PropertyValue::String("key".to_string())),
+            &GraphStore::new(),
         ).unwrap();
         assert_eq!(result, Value::Property(PropertyValue::Integer(42)));
     }
@@ -13550,6 +13566,7 @@ mod tests {
         let result = eval_index(
             Value::Property(PropertyValue::Map(map)),
             Value::Property(PropertyValue::String("missing".to_string())),
+            &GraphStore::new(),
         ).unwrap();
         assert_eq!(result, Value::Null);
     }
@@ -13559,6 +13576,7 @@ mod tests {
         let result = eval_index(
             Value::Property(PropertyValue::Integer(1)),
             Value::Property(PropertyValue::Integer(0)),
+            &GraphStore::new(),
         ).unwrap();
         assert_eq!(result, Value::Null);
     }

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -2019,7 +2019,10 @@ fn parse_term(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
                     Rule::unary_op => prefix_ops.push(inner),
                     Rule::primary => primary_pair = Some(inner),
                     Rule::postfix_op => postfix_pair = Some(inner),
-                    Rule::index_op => index_pairs.push(inner),
+                    // Both suffixes go into one list so `f(x).a[0].b` applies
+                    // them in source order; splitting them would apply every
+                    // subscript before every member (#673).
+                    Rule::index_op | Rule::member_op => index_pairs.push(inner),
                     _ => {}
                 }
             }
@@ -2054,6 +2057,23 @@ fn parse_term(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
             // Apply each index/slice suffix in source order, so chained
             // subscripts like m["a"]["b"] and xs[0][1] compose left to right.
             for index in index_pairs {
+                // `.name` desugars to `["name"]`, reusing the map indexing that
+                // `d.meta["a"]` already goes through — one evaluation path for
+                // both spellings rather than two that can drift (#452, #673).
+                if index.as_rule() == Rule::member_op {
+                    let key = index
+                        .into_inner()
+                        .find(|p| p.as_rule() == Rule::property_key)
+                        .map(|p| p.as_str().to_string())
+                        .ok_or_else(|| {
+                            ParseError::SemanticError("member access without a name".to_string())
+                        })?;
+                    expr = Expression::Index {
+                        expr: Box::new(expr),
+                        index: Box::new(Expression::Literal(PropertyValue::String(key))),
+                    };
+                    continue;
+                }
                 let mut handled = false;
                 for idx_inner in index.into_inner() {
                     if idx_inner.as_rule() == Rule::slice_op {

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -35,11 +35,17 @@ pub enum ValidationError {
     MergeOnBoundVariable(String),
     MergeRelationshipWithNullProperty(String),
     VariableTypeConflict(String),
+    PatternInSetValue,
 }
 
 impl std::fmt::Display for ValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::PatternInSetValue => write!(
+                f,
+                "a relationship pattern cannot be used as a value on the right of SET; \
+                 patterns belong in MATCH, WHERE or a pattern comprehension"
+            ),
             Self::VariableTypeConflict(name) => write!(
                 f,
                 "`{name}` is bound to a collection and cannot be used as a node or \
@@ -376,6 +382,50 @@ pub fn validate(query: &Query) -> Result<(), ValidationError> {
                     bound.insert(v.clone());
                 }
             }
+        }
+    }
+
+    // ---- A relationship pattern used as a *value* in SET.
+    //
+    // `SET n.prop = head(nodes(head((n)-[:REL]->()))).foo` is a compile-time
+    // error in Cypher: a pattern is a predicate or a comprehension source, not
+    // a thing you can store. This was unreachable until `f(x).prop` parsed
+    // (#673), so the TCK scenario asserting the error passed for an unrelated
+    // reason — making the parse work removed the accident, and the rule then
+    // has to be real.
+    //
+    // A pattern desugars to `ExistsSubquery`, so the check is structural
+    // rather than textual, and it looks *anywhere* in the value expression
+    // because the offending pattern is usually nested inside function calls.
+    {
+        fn holds_pattern(e: &Expression) -> bool {
+            match e {
+                Expression::ExistsSubquery { .. } | Expression::PatternComprehension { .. } => true,
+                Expression::Binary { left, right, .. } => holds_pattern(left) || holds_pattern(right),
+                Expression::Unary { expr, .. } => holds_pattern(expr),
+                Expression::Function { args, .. } => args.iter().any(holds_pattern),
+                Expression::Index { expr, index } => holds_pattern(expr) || holds_pattern(index),
+                Expression::ListExpr(items) => items.iter().any(holds_pattern),
+                Expression::MapExpr(entries) => entries.iter().any(|(_, v)| holds_pattern(v)),
+                _ => false,
+            }
+        }
+        fn set_values_of(sc: &crate::query::ast::SetClause) -> Vec<&Expression> {
+            let mut out: Vec<&Expression> = sc.items.iter().map(|i| &i.value).collect();
+            out.extend(sc.entity_items.iter().map(|i| &i.value));
+            out
+        }
+        let mut set_values: Vec<&Expression> = Vec::new();
+        for sc in &query.set_clauses {
+            set_values.extend(set_values_of(sc));
+        }
+        for clause in &query.clauses {
+            if let crate::query::ast::Clause::Set(sc) = clause {
+                set_values.extend(set_values_of(sc));
+            }
+        }
+        if set_values.into_iter().any(holds_pattern) {
+            return Err(ValidationError::PatternInSetValue);
         }
     }
 


### PR DESCRIPTION
    MATCH ()-[r]->() RETURN startNode(r).id     -- parse error
    MATCH (n) RETURN properties(n).id           -- parse error

`term` was `unary_op* ~ primary ~ index_op* ~ postfix_op?`. Subscripts
repeat, `n.id` is matched by `property_access` inside `primary`, and
`d.meta["a"]` works — so a `.name` suffix on an arbitrary term had no rule
at all, and nothing revealed it until a TCK scenario wrote
`startNode(r).id`. It reads as `startNode` being unsupported rather than as
a missing suffix.

`member_op` desugars to `["name"]`, reusing the map indexing `d.meta["a"]`
already goes through, so there is one evaluation path rather than two that
can drift (#452).

**Parsing was the half that failed loudly.** With the grammar fixed it
returned **null**: `eval_index` had no arm for indexing a node or
relationship by name. A parse fix alone would have converted an error into
a quiet wrong answer, which is worse than the error. `eval_index` now takes
the store, because the property may live in the column store rather than
inline.

**A scenario was passing by accident.** `Pattern1 [24]` expects a
`SyntaxError` for a pattern used as a SET value:

    MATCH (n) SET n.prop = head(nodes(head((n)-[:REL]->()))).foo

It passed only because that expression did not parse. Making `f(x).prop`
work removes the coincidence, so the actual rule is implemented: a
relationship pattern is a predicate or a comprehension source, not a value.
The check is structural — a pattern desugars to `ExistsSubquery` — and
looks anywhere in the value expression, because the pattern is normally
nested inside function calls. A pattern predicate in `WHERE` stays legal
and has its own test.

That is the fifth accidental refusal this week (Merge5 [22]/[23]/[28]/[29],
Match3 [30], now this). Each time, making something work removes a
coincidence and the genuine rule has to be written for real.

openCypher TCK 1015 -> 1019 of 1244 evaluated (81.6% -> 81.9%), none
regressed.

Closes #673.