### PR TITLE
LANG-01: null propagation, string operators, and lists holding entities (TCK 81.9% -> 83.8%)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -287,21 +287,9 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
             (PropertyValue::Null, _) | (_, PropertyValue::Null) => PropertyValue::Null,
             _ => return Err(ExecutionError::TypeError("Mod requires numeric operands".to_string())),
         },
-        BinaryOp::StartsWith => match (&left_prop, &right_prop) {
-            (PropertyValue::String(l), PropertyValue::String(r)) => PropertyValue::Boolean(l.starts_with(r.as_str())),
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => PropertyValue::Null,
-            _ => return Err(ExecutionError::TypeError("STARTS WITH requires string operands".to_string())),
-        },
-        BinaryOp::EndsWith => match (&left_prop, &right_prop) {
-            (PropertyValue::String(l), PropertyValue::String(r)) => PropertyValue::Boolean(l.ends_with(r.as_str())),
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => PropertyValue::Null,
-            _ => return Err(ExecutionError::TypeError("ENDS WITH requires string operands".to_string())),
-        },
-        BinaryOp::Contains => match (&left_prop, &right_prop) {
-            (PropertyValue::String(l), PropertyValue::String(r)) => PropertyValue::Boolean(l.contains(r.as_str())),
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => PropertyValue::Null,
-            _ => return Err(ExecutionError::TypeError("CONTAINS requires string operands".to_string())),
-        },
+        BinaryOp::StartsWith => string_position_op(StringPositionOp::StartsWith, &left_prop, &right_prop),
+        BinaryOp::EndsWith => string_position_op(StringPositionOp::EndsWith, &left_prop, &right_prop),
+        BinaryOp::Contains => string_position_op(StringPositionOp::Contains, &left_prop, &right_prop),
         BinaryOp::In => match eval_in_list(&left_prop, &right_prop) {
             Some(v) => v,
             None => return Err(ExecutionError::TypeError("IN requires a list on the right".to_string())),
@@ -365,6 +353,17 @@ fn eval_index(collection: Value, index: Value, store: &GraphStore) -> ExecutionR
         // A map holding entities — `{k: collect(a)}` (#670).
         (Value::Map(map), Value::Property(PropertyValue::String(key))) => {
             Ok(map.get(key).cloned().unwrap_or(Value::Null))
+        }
+        // A *list* holding entities — `[a, 1]` where `a` is a node. The
+        // PropertyValue arm above cannot serve this: a PropertyValue list
+        // cannot hold an entity, so such a list is a `Value::List` and
+        // indexing it fell through to the catch-all and answered null.
+        (Value::List(items), Value::Property(PropertyValue::Integer(i))) => {
+            let idx = if *i < 0 { items.len() as i64 + *i } else { *i };
+            if idx < 0 {
+                return Ok(Value::Null);
+            }
+            Ok(items.get(idx as usize).cloned().unwrap_or(Value::Null))
         }
         // Indexing a *node or relationship* by name reads its property.
         // `startNode(r).id` desugars to `startNode(r)["id"]`, and without this
@@ -810,15 +809,26 @@ fn eval_predicate_function(
     store: &GraphStore,
 ) -> ExecutionResult<Value> {
     let list_val = eval_expression(list_expr, record, store)?;
-    let items = match list_val {
-        Value::Property(ref p) if p.as_list_items().is_some() => p.as_list_items().unwrap(),
+    // A list that holds entities is a `Value::List`; only a list of plain
+    // property values is a `PropertyValue`. Matching on the latter alone meant
+    // `any(x IN nodes WHERE ...)` fell through to `false` for every quantifier,
+    // silently — the caller gets a boolean it will branch on rather than an
+    // error it would notice (Quantifier1-4, scenarios 8 and 9).
+    let items: Vec<Value> = match list_val {
+        Value::Property(ref p) if p.as_list_items().is_some() => p
+            .as_list_items()
+            .unwrap()
+            .into_iter()
+            .map(Value::Property)
+            .collect(),
+        Value::List(items) => items,
         _ => return Ok(Value::Property(PropertyValue::Boolean(false))),
     };
 
     let mut true_count = 0usize;
     for item in &items {
         let mut inner_record = record.clone_with_capacity(1);
-        inner_record.bind(variable.to_string(), Value::Property(item.clone()));
+        inner_record.bind(variable.to_string(), item.clone());
         let result = eval_expression(predicate, &inner_record, store)?;
         if matches!(result, Value::Property(PropertyValue::Boolean(true))) {
             true_count += 1;
@@ -1151,9 +1161,63 @@ fn sorted_keys(mut keys: Vec<PropertyValue>) -> Vec<PropertyValue> {
     keys
 }
 
+/// `STARTS WITH` / `ENDS WITH` / `CONTAINS` over one pair of operands.
+///
+/// Two strings answer the question; anything else is null. Cypher does not
+/// treat `1 STARTS WITH 'a'` as a caller error — the TCK asks for all 36
+/// pairings from `[1, 3.14, true, [], {}, null]` and expects null for every
+/// one (String8/9/10 scenario 8).
+///
+/// This exists because the comparison was implemented twice and both copies
+/// had independently settled on raising instead. Both now call here.
+fn string_position_op(
+    op: StringPositionOp,
+    left: &PropertyValue,
+    right: &PropertyValue,
+) -> PropertyValue {
+    match (left, right) {
+        (PropertyValue::String(l), PropertyValue::String(r)) => {
+            let r = r.as_str();
+            PropertyValue::Boolean(match op {
+                StringPositionOp::StartsWith => l.starts_with(r),
+                StringPositionOp::EndsWith => l.ends_with(r),
+                StringPositionOp::Contains => l.contains(r),
+            })
+        }
+        _ => PropertyValue::Null,
+    }
+}
+
+#[derive(Clone, Copy)]
+enum StringPositionOp {
+    StartsWith,
+    EndsWith,
+    Contains,
+}
+
+/// Functions that are asked *about* null and so must see it themselves.
+///
+/// Everything else propagates. Keeping the exceptions explicit — rather than
+/// letting each arm decide — is what stops the rule from drifting apart again:
+/// twenty-two TCK scenarios failed because twenty-two arms each answered the
+/// question separately, and most answered it with a type error.
+const NULL_TOLERANT_FUNCTIONS: &[&str] = &["coalesce", "exists"];
+
 /// Shared function evaluation for scalar functions (not aggregates)
 pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> ExecutionResult<Value> {
-    match name.to_lowercase().as_str() {
+    let lowered = name.to_lowercase();
+
+    // Null in, null out. In Cypher null means "unknown", so a question asked
+    // about it has an unknown answer rather than being a caller error —
+    // `labels(null)` is the row where an OPTIONAL MATCH did not match, and
+    // raising there aborts a query Cypher answers with a null column.
+    if !NULL_TOLERANT_FUNCTIONS.contains(&lowered.as_str())
+        && args.iter().any(|a| matches!(a, Value::Null | Value::Property(PropertyValue::Null)))
+    {
+        return Ok(Value::Null);
+    }
+
+    match lowered.as_str() {
         // Hierarchy functions (ADR-035) — the direct surface for what the planner
         // rewrites cannot reach: an order test inside an arbitrary predicate, or a
         // roll-up in the middle of a larger projection.
@@ -1551,6 +1615,9 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     .first()
                     .map(|v| Value::Property(v.clone()))
                     .unwrap_or(Value::Null)),
+                // A list that holds entities is a Value::List, not a
+                // PropertyValue list — see eval_index.
+                Value::List(items) => Ok(items.first().cloned().unwrap_or(Value::Null)),
                 _ => Err(ExecutionError::TypeError("head() requires list".to_string())),
             }
         }
@@ -1562,6 +1629,7 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     .last()
                     .map(|v| Value::Property(v.clone()))
                     .unwrap_or(Value::Null)),
+                Value::List(items) => Ok(items.last().cloned().unwrap_or(Value::Null)),
                 _ => Err(ExecutionError::TypeError("last() requires list".to_string())),
             }
         }
@@ -1570,6 +1638,9 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                 Value::Property(PropertyValue::Array(arr)) => {
                     let tail: Vec<PropertyValue> = arr.iter().skip(1).cloned().collect();
                     Ok(Value::Property(PropertyValue::Array(tail)))
+                }
+                Value::List(items) => {
+                    Ok(Value::List(items.iter().skip(1).cloned().collect()))
                 }
                 _ => Err(ExecutionError::TypeError("tail() requires list".to_string())),
             }
@@ -3539,27 +3610,15 @@ impl FilterOperator {
     }
 
     fn string_starts_with(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        match (left, right) {
-            (PropertyValue::String(l), PropertyValue::String(r)) => Ok(PropertyValue::Boolean(l.starts_with(r.as_str()))),
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
-            _ => Err(ExecutionError::TypeError("STARTS WITH requires string operands".to_string())),
-        }
+        Ok(string_position_op(StringPositionOp::StartsWith, left, right))
     }
 
     fn string_ends_with(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        match (left, right) {
-            (PropertyValue::String(l), PropertyValue::String(r)) => Ok(PropertyValue::Boolean(l.ends_with(r.as_str()))),
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
-            _ => Err(ExecutionError::TypeError("ENDS WITH requires string operands".to_string())),
-        }
+        Ok(string_position_op(StringPositionOp::EndsWith, left, right))
     }
 
     fn string_contains(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        match (left, right) {
-            (PropertyValue::String(l), PropertyValue::String(r)) => Ok(PropertyValue::Boolean(l.contains(r.as_str()))),
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
-            _ => Err(ExecutionError::TypeError("CONTAINS requires string operands".to_string())),
-        }
+        Ok(string_position_op(StringPositionOp::Contains, left, right))
     }
 
     fn eval_in(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
@@ -12358,8 +12417,13 @@ mod tests {
 
     #[test]
     fn test_eval_function_tostring_null() {
+        // null in, null out — *not* the four-character string "null", which
+        // would be indistinguishable from a genuine value and would make
+        // `toString(x) = 'null'` true for a missing property. The TCK has no
+        // scenario pinning this one, so it was checked against Neo4j 5
+        // directly: `toString(null) IS NULL` -> true.
         let result = eval_function("tostring", &[Value::Null], None).unwrap();
-        assert_eq!(result, Value::Property(PropertyValue::String("null".to_string())));
+        assert_eq!(result, Value::Null);
     }
 
     #[test]
@@ -12875,12 +12939,17 @@ mod tests {
     }
 
     #[test]
-    fn test_binary_op_starts_with_type_error() {
+    fn test_binary_op_starts_with_non_string_is_null() {
+        // Not an error: `1 STARTS WITH 'x'` is null. openCypher TCK String8/9/10
+        // scenario 8 asks for all 36 pairings drawn from
+        // `[1, 3.14, true, [], {}, null]` and expects null for every one, and
+        // Neo4j 5 agrees (`(1 STARTS WITH 'x') IS NULL` -> true). This test
+        // previously asserted the refusal the engine happened to implement.
         let result = eval_binary_op(&BinaryOp::StartsWith,
             Value::Property(PropertyValue::Integer(1)),
             Value::Property(PropertyValue::String("x".to_string())),
         );
-        assert!(result.is_err());
+        assert_eq!(result.unwrap(), Value::Property(PropertyValue::Null));
     }
 
     #[test]
@@ -12902,12 +12971,17 @@ mod tests {
     }
 
     #[test]
-    fn test_binary_op_ends_with_type_error() {
+    fn test_binary_op_ends_with_non_string_is_null() {
+        // Not an error: `1 ENDS WITH 'x'` is null. openCypher TCK String8/9/10
+        // scenario 8 asks for all 36 pairings drawn from
+        // `[1, 3.14, true, [], {}, null]` and expects null for every one, and
+        // Neo4j 5 agrees (`(1 ENDS WITH 'x') IS NULL` -> true). This test
+        // previously asserted the refusal the engine happened to implement.
         let result = eval_binary_op(&BinaryOp::EndsWith,
             Value::Property(PropertyValue::Integer(1)),
             Value::Property(PropertyValue::String("x".to_string())),
         );
-        assert!(result.is_err());
+        assert_eq!(result.unwrap(), Value::Property(PropertyValue::Null));
     }
 
     #[test]
@@ -12929,12 +13003,17 @@ mod tests {
     }
 
     #[test]
-    fn test_binary_op_contains_type_error() {
+    fn test_binary_op_contains_non_string_is_null() {
+        // Not an error: `1 CONTAINS 'x'` is null. openCypher TCK String8/9/10
+        // scenario 8 asks for all 36 pairings drawn from
+        // `[1, 3.14, true, [], {}, null]` and expects null for every one, and
+        // Neo4j 5 agrees (`(1 CONTAINS 'x') IS NULL` -> true). This test
+        // previously asserted the refusal the engine happened to implement.
         let result = eval_binary_op(&BinaryOp::Contains,
             Value::Property(PropertyValue::Integer(1)),
             Value::Property(PropertyValue::String("x".to_string())),
         );
-        assert!(result.is_err());
+        assert_eq!(result.unwrap(), Value::Property(PropertyValue::Null));
     }
 
     #[test]

--- a/tests/function_null_propagation.rs
+++ b/tests/function_null_propagation.rs
@@ -1,0 +1,93 @@
+//! A scalar function given null returns null — it does not raise a type error.
+//!
+//! Cypher's rule is that null means "unknown", so asking a question about it
+//! yields an unknown answer rather than a refusal. `labels(null)` is not a
+//! caller mistake to be reported; it is a row where the node was optional and
+//! did not match.
+//!
+//! The engine instead raised `TypeError("labels() requires a node")` and
+//! friends, which aborts the whole query. A single OPTIONAL MATCH that misses
+//! therefore killed a query that Cypher answers with a null column. Twenty-two
+//! openCypher TCK scenarios fail on this rule; these tests pin the shape of it
+//! rather than one function at a time, because the fix belongs at the single
+//! point where scalar functions are dispatched, not in each arm.
+//!
+//! `coalesce` and `exists` are the deliberate exceptions: both exist precisely
+//! to be asked about null, so propagating would defeat them.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn result_of(cypher: &str) -> Value {
+    let q = parse_query(cypher).expect("query should parse");
+    let out = QueryExecutor::new(&GraphStore::new())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run, not error: {e}"));
+    out.records[0].get("res").cloned().expect("column res")
+}
+
+fn assert_null(cypher: &str) {
+    let got = result_of(cypher);
+    assert!(
+        matches!(got, Value::Null | Value::Property(PropertyValue::Null)),
+        "`{cypher}` should be null, got {got:?}"
+    );
+}
+
+#[test]
+fn graph_functions_on_null_are_null() {
+    assert_null("RETURN labels(null) AS res");
+    assert_null("RETURN type(null) AS res");
+    assert_null("RETURN properties(null) AS res");
+    assert_null("RETURN keys(null) AS res");
+    assert_null("RETURN id(null) AS res");
+    assert_null("RETURN startNode(null) AS res");
+    assert_null("RETURN endNode(null) AS res");
+}
+
+#[test]
+fn list_and_string_functions_on_null_are_null() {
+    assert_null("RETURN size(null) AS res");
+    assert_null("RETURN head(null) AS res");
+    assert_null("RETURN last(null) AS res");
+    assert_null("RETURN tail(null) AS res");
+    assert_null("RETURN toString(null) AS res");
+    assert_null("RETURN toInteger(null) AS res");
+    assert_null("RETURN toUpper(null) AS res");
+    assert_null("RETURN trim(null) AS res");
+    assert_null("RETURN reverse(null) AS res");
+}
+
+#[test]
+fn numeric_functions_on_null_are_null() {
+    assert_null("RETURN abs(null) AS res");
+    assert_null("RETURN ceil(null) AS res");
+    assert_null("RETURN sqrt(null) AS res");
+    assert_null("RETURN sign(null) AS res");
+}
+
+#[test]
+fn a_null_anywhere_in_the_arguments_propagates() {
+    // Not just the first argument: the rule is about the call, not arg zero.
+    assert_null("RETURN substring('abc', null) AS res");
+    assert_null("RETURN replace('abc', null, 'x') AS res");
+    assert_null("RETURN split(null, ',') AS res");
+    assert_null("RETURN range(1, null) AS res");
+}
+
+#[test]
+fn coalesce_and_exists_do_not_propagate() {
+    // These two are the reason the guard needs an exception list at all:
+    // they are the functions whose entire job is to be asked about null.
+    assert_eq!(
+        result_of("RETURN coalesce(null, 7) AS res"),
+        Value::Property(PropertyValue::Integer(7)),
+        "coalesce must look past the null rather than become it"
+    );
+    let got = result_of("RETURN exists(null) AS res");
+    assert!(
+        matches!(got, Value::Property(PropertyValue::Boolean(false))),
+        "exists(null) should be false, got {got:?}"
+    );
+}

--- a/tests/list_holding_entities.rs
+++ b/tests/list_holding_entities.rs
@@ -1,0 +1,130 @@
+//! A list may hold nodes and relationships, and stays usable afterwards.
+//!
+//! `[a, 1]` where `a` is a node is not expressible as a `PropertyValue`, which
+//! cannot hold an entity. The list therefore has to be a `Value::List` — and
+//! everything that consumes a list has to accept one, or the entity is lost at
+//! the first thing that touches it.
+//!
+//! Fourteen openCypher TCK scenarios depend on this: the four quantifiers over
+//! lists of nodes and of relationships (Quantifier1-4 scenario 8 and 9),
+//! `head()`/`last()`/`tail()` over such a list (Return4, With4, Match9), and
+//! the `labels()`/`type()` "type Any" scenarios, which build a mixed list and
+//! index into it.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+}
+
+fn value_of(store: &GraphStore, cypher: &str) -> Value {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    let out = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+    assert!(!out.records.is_empty(), "`{cypher}` returned no rows");
+    out.records[0].get("x").cloned().unwrap_or(Value::Null)
+}
+
+fn seeded() -> GraphStore {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:Foo {name: 'one'})");
+    store
+}
+
+#[test]
+fn a_list_literal_can_hold_a_node() {
+    let store = seeded();
+    match value_of(&store, "MATCH (a) RETURN [a, 1] AS x") {
+        Value::List(items) => {
+            assert_eq!(items.len(), 2, "both elements survive");
+            assert!(
+                matches!(items[0], Value::Node(..) | Value::NodeRef(_)),
+                "the node must still be a node, got {:?}",
+                items[0]
+            );
+        }
+        other => panic!("expected a list holding the node, got {other:?}"),
+    }
+}
+
+#[test]
+fn indexing_into_a_list_of_entities_returns_the_element() {
+    let store = seeded();
+    // The integer element, reached past a node — this is Graph3 [9]'s shape.
+    assert_eq!(
+        value_of(&store, "MATCH (a) RETURN [a, 1][1] AS x"),
+        Value::Property(samyama::graph::PropertyValue::Integer(1))
+    );
+    let first = value_of(&store, "MATCH (a) RETURN [a, 1][0] AS x");
+    assert!(
+        matches!(first, Value::Node(..) | Value::NodeRef(_)),
+        "index 0 should be the node, got {first:?}"
+    );
+}
+
+#[test]
+fn list_functions_accept_a_list_of_entities() {
+    let store = seeded();
+    assert_eq!(
+        value_of(&store, "MATCH (a) RETURN size([a, 1]) AS x"),
+        Value::Property(samyama::graph::PropertyValue::Integer(2))
+    );
+    let head = value_of(&store, "MATCH (a) RETURN head([a]) AS x");
+    assert!(
+        matches!(head, Value::Node(..) | Value::NodeRef(_)),
+        "head of a list of nodes is a node, got {head:?}"
+    );
+    let last = value_of(&store, "MATCH (a) RETURN last([1, a]) AS x");
+    assert!(
+        matches!(last, Value::Node(..) | Value::NodeRef(_)),
+        "last of a mixed list is the node, got {last:?}"
+    );
+    match value_of(&store, "MATCH (a) RETURN tail([1, a]) AS x") {
+        Value::List(items) => assert_eq!(items.len(), 1),
+        other => panic!("tail should be a one-element list, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_list_of_entities_survives_a_with_projection() {
+    let store = seeded();
+    // WITH re-binds the value; if the projection flattens it to a
+    // PropertyValue the node is gone by the time anything reads it back.
+    let v = value_of(&store, "MATCH (a) WITH [a, 1] AS list RETURN list[0] AS x");
+    assert!(
+        matches!(v, Value::Node(..) | Value::NodeRef(_)),
+        "the node must survive WITH, got {v:?}"
+    );
+}
+
+#[test]
+fn quantifiers_range_over_a_list_of_entities() {
+    // all/any/none/single took the PropertyValue path only, and a list that
+    // holds entities fell through to `false` — silently, for every one of the
+    // four. A wrong boolean is worse than a refusal: the caller branches on it.
+    // Quantifier1-4 scenario 8 and 9 in the TCK.
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:A {name: 'a'})");
+    run(&mut store, "CREATE (:B {name: 'b'})");
+
+    let t = Value::Property(samyama::graph::PropertyValue::Boolean(true));
+    let f = Value::Property(samyama::graph::PropertyValue::Boolean(false));
+
+    // A list holding two nodes, one of which is named 'a'.
+    let q = |tail: &str| format!("MATCH (a:A), (b:B) WITH [a, b] AS ns RETURN {tail} AS x");
+
+    assert_eq!(value_of(&store, &q("any(n IN ns WHERE n.name = 'a')")), t);
+    assert_eq!(value_of(&store, &q("none(n IN ns WHERE n.name = 'a')")), f);
+    assert_eq!(value_of(&store, &q("all(n IN ns WHERE n.name = 'a')")), f);
+    assert_eq!(value_of(&store, &q("single(n IN ns WHERE n.name = 'a')")), t);
+
+    // And the all-true / all-false ends, so a fix cannot just invert.
+    assert_eq!(value_of(&store, &q("all(n IN ns WHERE n.name IS NOT NULL)")), t);
+    assert_eq!(value_of(&store, &q("none(n IN ns WHERE n.name = 'zz')")), t);
+}

--- a/tests/string_operator_non_string_operands.rs
+++ b/tests/string_operator_non_string_operands.rs
@@ -1,0 +1,61 @@
+//! `STARTS WITH`, `ENDS WITH` and `CONTAINS` on a non-string yield null.
+//!
+//! Not only on null — on *any* non-string operand. The TCK asks for all 36
+//! pairings drawn from `[1, 3.14, true, [], {}, null]` and expects null for
+//! every one of them (String8/9/10 scenario 8). The engine raised
+//! `TypeError("STARTS WITH requires string operands")`, which aborts the
+//! query rather than yielding the unknown answer.
+//!
+//! The comparison is implemented twice, at two call sites that had drifted
+//! into the same wrong answer independently; these tests exercise the
+//! behaviour through queries so they pin whichever copy the planner routes to.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn result_of(cypher: &str) -> Value {
+    let q = parse_query(cypher).expect("query should parse");
+    let out = QueryExecutor::new(&GraphStore::new())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run, not error: {e}"));
+    out.records[0].get("res").cloned().expect("column res")
+}
+
+fn assert_null(cypher: &str) {
+    let got = result_of(cypher);
+    assert!(
+        matches!(got, Value::Null | Value::Property(PropertyValue::Null)),
+        "`{cypher}` should be null, got {got:?}"
+    );
+}
+
+#[test]
+fn non_string_operands_yield_null_not_an_error() {
+    for op in ["STARTS WITH", "ENDS WITH", "CONTAINS"] {
+        assert_null(&format!("RETURN 1 {op} 'a' AS res"));
+        assert_null(&format!("RETURN 'a' {op} 1 AS res"));
+        assert_null(&format!("RETURN 3.14 {op} 'a' AS res"));
+        assert_null(&format!("RETURN true {op} 'a' AS res"));
+        assert_null(&format!("RETURN null {op} 'a' AS res"));
+        assert_null(&format!("RETURN 'a' {op} null AS res"));
+        assert_null(&format!("RETURN [] {op} 'a' AS res"));
+    }
+}
+
+#[test]
+fn string_operands_still_answer_normally() {
+    // The guard must not swallow the cases the operators exist for.
+    assert_eq!(
+        result_of("RETURN 'abc' STARTS WITH 'ab' AS res"),
+        Value::Property(PropertyValue::Boolean(true))
+    );
+    assert_eq!(
+        result_of("RETURN 'abc' ENDS WITH 'bc' AS res"),
+        Value::Property(PropertyValue::Boolean(true))
+    );
+    assert_eq!(
+        result_of("RETURN 'abc' CONTAINS 'zz' AS res"),
+        Value::Property(PropertyValue::Boolean(false))
+    );
+}


### PR DESCRIPTION
CH-TCK 81.9% -> 83.8% (1019 -> 1042 of 1244 evaluated). Four fixes, each at
the one site the behaviour is decided, rather than per failing scenario.

**Null in, null out.** A scalar function given null returned a TypeError, so a
single OPTIONAL MATCH that did not match aborted a query Cypher answers with a
null column. The guard goes at the single dispatch point in eval_function with
an explicit exception list — `coalesce` and `exists` are the two functions
whose job is to be asked about null. Twenty-two arms had each answered this
separately and most answered it wrongly.

**String position operators.** `1 STARTS WITH 'x'` raised; it is null. The TCK
asks for all 36 pairings from `[1, 3.14, true, [], {}, null]` and expects null
for every one. This was implemented twice, at two call sites that had drifted
into the same wrong answer independently; both now call one function.

**Lists holding entities.** `[a, 1]` where `a` is a node cannot be a
PropertyValue, so it is a `Value::List` — and every consumer of a list had to
learn that or the entity is lost at the first thing that touches it.
Construction was already right; indexing, `head`/`last`/`tail`, and reading
the value back after a WITH projection were not.

**Quantifiers over those lists.** all/any/none/single matched only the
PropertyValue shape and fell through to `false`. Not an error — a wrong
boolean, for every one of the four, which the caller branches on and never
learns was wrong. This is the failure mode worth flagging: it was invisible in
the pass rate as "wrong result" rather than "errored".

Four unit tests asserted the old behaviour and were corrected, not deleted.
Three claimed the string operators must raise; the TCK settles those. The
fourth claimed `toString(null)` is the *string* "null" — no TCK scenario
covers it, so it was checked against Neo4j 5 directly, which answers null
(`toString(null) IS NULL` -> true). Each corrected test now cites what settled
it, because a test that encodes the defect is worse than no test.

One scenario, Graph3 [9], had been passing for the wrong reason: `labels()`
raised on everything it did not recognise, including a null that should not
have been null. It fails on the null fix alone and passes again only with the
entity-list fix.