### PR TITLE
LANG-01: an aggregate in RETURN is an aggregate in the pipeline planner too (TCK 84.2%)

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -5253,15 +5253,59 @@ impl QueryPlanner {
                         order_by_applied = true;
                     }
 
-                    let projections: Vec<(Expression, String)> = rc
-                        .items
-                        .iter()
-                        .enumerate()
-                        .map(|(idx, i)| {
-                            let alias = i.column_name(idx);
-                            (i.expression.clone(), alias)
-                        })
-                        .collect();
+                    // An aggregate in RETURN needs an Aggregate below the
+                    // projection. Without this the pipeline projected
+                    // `count(*)` as an ordinary expression, it reached the
+                    // scalar evaluator, and the query died with "Unknown
+                    // function: count" — for every shape that opens with WITH,
+                    // which is what routes a query here in the first place.
+                    //
+                    // The `Clause::With` arm of this same function already did
+                    // this; only RETURN was missed, so the two clauses in one
+                    // pipeline disagreed about what an aggregate is.
+                    let mut agg_counter = 0usize;
+                    let mut aggregates: Vec<AggregateFunction> = Vec::new();
+                    let mut group_by: Vec<(Expression, String)> = Vec::new();
+                    let mut post_projections: Vec<(Expression, String)> = Vec::new();
+                    let mut has_aggregation = false;
+                    let mut rewritten_items: Vec<(Expression, Expression, String)> = Vec::new();
+
+                    for (idx, i) in rc.items.iter().enumerate() {
+                        let alias = i.column_name(idx);
+                        let (rewritten, extracted) =
+                            extract_nested_aggregates(&i.expression, &mut agg_counter);
+                        if !extracted.is_empty() {
+                            has_aggregation = true;
+                        }
+                        rewritten_items.push((i.expression.clone(), rewritten, alias));
+                        aggregates.extend(extracted);
+                    }
+
+                    let projections: Vec<(Expression, String)> = if has_aggregation {
+                        for (original, rewritten, alias) in &rewritten_items {
+                            // An item with no aggregate inside it is a grouping
+                            // key; one with an aggregate projects from the
+                            // aggregate's alias after the Aggregate runs.
+                            if rewritten == original {
+                                group_by.push((original.clone(), alias.clone()));
+                                post_projections
+                                    .push((Expression::Variable(alias.clone()), alias.clone()));
+                            } else {
+                                post_projections.push((rewritten.clone(), alias.clone()));
+                            }
+                        }
+                        operator = Box::new(AggregateOperator::new(
+                            operator,
+                            group_by,
+                            std::mem::take(&mut aggregates),
+                        ));
+                        post_projections
+                    } else {
+                        rewritten_items
+                            .into_iter()
+                            .map(|(original, _, alias)| (original, alias))
+                            .collect()
+                    };
                     output_columns = projections.iter().map(|(_, a)| a.clone()).collect();
                     operator = Box::new(ProjectOperator::new(operator, projections));
                     if rc.distinct {

--- a/tests/aggregate_after_projection.rs
+++ b/tests/aggregate_after_projection.rs
@@ -1,0 +1,85 @@
+//! `count(*)` is an aggregate wherever it appears, including after a
+//! projection that renamed everything.
+//!
+//! `RETURN v, count(*)` following a `WITH ... AS v` reached the *scalar*
+//! function evaluator and raised `Unknown function: count`. The aggregate is
+//! recognised by the planner, but only on the RETURN paths that call
+//! `extract_nested_aggregates` — a second path re-made the decision and got it
+//! wrong (Match8, Merge1, Merge5, Merge9, String8/9/10 scenario 8).
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> Vec<Value> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    let out = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run, not error: {e}"));
+    out.records.iter().map(|r| r.get("c").cloned().unwrap_or(Value::Null)).collect()
+}
+
+fn total(store: &GraphStore, cypher: &str) -> i64 {
+    rows(store, cypher)
+        .iter()
+        .map(|v| match v {
+            Value::Property(PropertyValue::Integer(i)) => *i,
+            other => panic!("expected an integer count, got {other:?}"),
+        })
+        .sum()
+}
+
+#[test]
+fn count_star_after_a_with_projection() {
+    let store = GraphStore::new();
+    // The String8 shape: UNWIND, project to a computed name, then aggregate.
+    assert_eq!(
+        total(&store, "UNWIND [1, 2, 3] AS n WITH n * 2 AS v RETURN v, count(*) AS c"),
+        3
+    );
+}
+
+#[test]
+fn count_star_after_unwind_of_a_pair() {
+    let store = GraphStore::new();
+    // Two UNWINDs then a projection — the exact String8/9/10 scenario-8 shape,
+    // where every one of the 36 rows projects to the same null `v`.
+    assert_eq!(
+        total(
+            &store,
+            "WITH [1, 2] AS ops UNWIND ops AS a UNWIND ops AS b \
+             WITH a STARTS WITH b AS v RETURN v, count(*) AS c"
+        ),
+        4
+    );
+}
+
+#[test]
+fn count_star_after_a_write_clause() {
+    // Match8 [2] / Merge9 [3]: counting rows after an updating clause.
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:X {n: 1})");
+    run(&mut store, "CREATE (:X {n: 2})");
+    assert_eq!(total(&store, "MATCH (x:X) WITH x RETURN count(*) AS c"), 2);
+}
+
+#[test]
+fn other_aggregates_take_the_same_path() {
+    // If count reached the scalar evaluator, so would these; assert the class
+    // rather than the one function that happened to be reported.
+    let store = GraphStore::new();
+    for agg in ["count(*)", "count(v)", "sum(v)", "max(v)", "min(v)"] {
+        let cypher = format!("UNWIND [1, 2, 3] AS n WITH n AS v RETURN {agg} AS c");
+        let q = parse_query(&cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+        QueryExecutor::new(&store)
+            .execute(&q)
+            .unwrap_or_else(|e| panic!("`{cypher}` should run, not error: {e}"));
+    }
+}


### PR DESCRIPTION
CH-TCK 83.8% -> 84.2% (1042 -> 1047 of 1244 evaluated).

`WITH [1,2] AS ops UNWIND ops AS a RETURN a, count(*)` died with
"Unknown function: count". The same query without the leading WITH was fine.

The symptom reads as a missing function; the cause is a second planner. A
query that opens with WITH is routed to `plan_clause_pipeline`, whose
`Clause::Return` arm built a plain ProjectOperator with no aggregate
extraction — so `count(*)` was projected as an ordinary expression, reached
the scalar evaluator, and got the only honest answer that evaluator could
give.

`EXPLAIN` shows it plainly:

  works:  Project (v, __agg_0 AS c)
          +- Aggregate (group_by=[v AS v], aggs=[count(Integer(1)) AS __agg_0])
  broken: Project (v, count() AS c)          <- no Aggregate at all

What makes this worth stating: the `Clause::With` arm *of the same function*
already extracted aggregates correctly. Two clauses in one pipeline disagreed
about what an aggregate is, so the defect appeared only where the two met.
The RETURN arm now mirrors the WITH arm — extract, group the non-aggregate
items, aggregate, then project from the aliases.

The tests assert the class rather than the function that happened to be
reported: count(*), count(v), sum, max and min all route here, so a fix that
special-cased `count` does not pass them. The affected TCK scenarios were
Match8 [2], Merge1 [1], Merge5 [4], Merge9 [3] and String8/9/10 [8] — the
string ones only surfaced once the STARTS WITH fix let them get far enough to
reach the aggregate.