### PR TITLE
LANG-01: execute UNION; incomparable ordering is null (#607) — CH-TCK 85.0%

### DIFF
--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -251,6 +251,63 @@ impl<'a> QueryExecutor<'a> {
     }
 
     /// Execute a read-only query and return results
+    /// One dedup key per record, built from the batch's own column order.
+    fn union_keys(batch: &RecordBatch) -> Vec<Vec<String>> {
+        batch
+            .records
+            .iter()
+            .map(|r| batch.columns.iter().map(|c| format!("{:?}", r.get(c))).collect())
+            .collect()
+    }
+
+    /// Run every branch of a UNION and concatenate the results.
+    ///
+    /// `UNION` deduplicates across the combined result; `UNION ALL` does not.
+    /// openCypher forbids mixing the two in one query and the validator
+    /// rejects that already, so the flavour is read from the first branch.
+    ///
+    /// Column names come from the leading branch: the validator has already
+    /// established that every branch agrees on them, so binding by the first
+    /// branch's names is well-defined.
+    fn execute_union(&self, query: &Query) -> ExecutionResult<RecordBatch> {
+        let mut head = query.clone();
+        let branches = std::mem::take(&mut head.union_queries);
+        let union_all = branches.first().map(|(_, all)| *all).unwrap_or(false);
+
+        // The dedup key is *positional*: each branch's row is keyed by its own
+        // columns in order, not by the leading branch's names. Keying by name
+        // silently mangles a query whose branches project different aliases —
+        // the later branch's rows all look up missing names, key identically,
+        // and collapse into one row rather than deduplicating against the
+        // first branch. Position is what "the same columns" means once the
+        // validator has established the branches line up.
+        let mut batch = self.execute(&head)?;
+        let mut keys: Vec<Vec<String>> = Vec::new();
+        if !union_all {
+            keys.extend(Self::union_keys(&batch));
+        }
+
+        for (branch, _) in &branches {
+            let mut next = self.execute(branch)?;
+            if !union_all {
+                keys.extend(Self::union_keys(&next));
+            }
+            batch.records.append(&mut next.records);
+        }
+
+        if !union_all {
+            // First-seen order, so the result does not depend on hash order.
+            let mut seen: std::collections::HashSet<&Vec<String>> = std::collections::HashSet::new();
+            let mut keep: Vec<bool> = Vec::with_capacity(keys.len());
+            for k in &keys {
+                keep.push(seen.insert(k));
+            }
+            let mut it = keep.into_iter();
+            batch.records.retain(|_| it.next().unwrap_or(true));
+        }
+        Ok(batch)
+    }
+
     pub fn execute(&self, query: &Query) -> ExecutionResult<RecordBatch> {
         // Substitute parameters if any
         let query = if !self.params.is_empty() || !query.params.is_empty() {
@@ -266,6 +323,17 @@ impl<'a> QueryExecutor<'a> {
 
         if let Some(inner) = &query.call_subquery {
             return self.execute_call_subquery(query, inner);
+        }
+
+        // UNION / UNION ALL.
+        //
+        // The parser fills `query.union_queries` and the validator checks the
+        // branches agree on column names, but nothing executed them: every
+        // branch after the first was discarded, so `RETURN 1 UNION RETURN 2`
+        // answered `1`. EXPLAIN is deliberately left to the first branch —
+        // describing one branch is more useful than refusing.
+        if !query.union_queries.is_empty() && !query.explain {
+            return self.execute_union(query);
         }
 
         // Plan the query
@@ -2432,7 +2500,8 @@ mod tests {
         let query = parse_query("MATCH (n:Person) RETURN n.name UNION ALL MATCH (m:Person) RETURN m.name").unwrap();
         let executor = QueryExecutor::new(&store);
         let result = executor.execute(&query).unwrap();
-        assert!(result.records.len() >= 2, "Expected at least 2 records from UNION ALL, got {}", result.records.len());
+        assert_eq!(result.records.len(), 4,
+            "UNION ALL over 2 Person nodes is 4 rows; >= 2 cannot tell a working UNION from one that ran only the first branch");
     }
 
     // ========== Batch 5: OPTIONAL MATCH ==========
@@ -2976,7 +3045,8 @@ mod tests {
         let executor = QueryExecutor::new(&store);
         let result = executor.execute(&query).unwrap();
         // UNION should deduplicate: Alice, Bob appear in both halves -> 2 unique results
-        assert!(result.records.len() >= 2, "UNION should return at least 2 results, got {}", result.records.len());
+        assert_eq!(result.records.len(), 2,
+            "UNION deduplicates to 2 here; the old >= 2 also passed when no branch after the first ran");
     }
 
     #[test]
@@ -5634,7 +5704,8 @@ mod tests {
         let q = parse_query("MATCH (n:Person) RETURN n.name UNION ALL MATCH (m:Person) RETURN m.name").unwrap();
         let result = QueryExecutor::new(&store).execute(&q).unwrap();
         // UNION ALL should return at least 2 records
-        assert!(result.records.len() >= 2, "UNION ALL should return at least 2 records, got {}", result.records.len());
+        assert_eq!(result.records.len(), 4,
+            "UNION ALL over 2 Person nodes is 4 rows, not 2");
     }
 
     // --- 4. UNWIND ---

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -169,7 +169,7 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
             _ => return Err(ExecutionError::TypeError("XOR requires boolean operands".to_string())),
         },
         BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge => {
-            let cmp = left_prop.partial_cmp(&right_prop);
+            let cmp = cypher_ordering(&left_prop, &right_prop);
             match (op, cmp) {
                 (BinaryOp::Lt, Some(std::cmp::Ordering::Less)) => PropertyValue::Boolean(true),
                 (BinaryOp::Le, Some(std::cmp::Ordering::Less | std::cmp::Ordering::Equal)) => PropertyValue::Boolean(true),
@@ -1159,6 +1159,39 @@ fn sorted_keys(mut keys: Vec<PropertyValue>) -> Vec<PropertyValue> {
         _ => std::cmp::Ordering::Equal,
     });
     keys
+}
+
+/// Ordering between two property values, or `None` when Cypher cannot order
+/// them.
+///
+/// Cypher orders numbers against numbers, strings against strings, booleans
+/// against booleans, and temporal values against their own kind. Anything else
+/// is *unknown* — `0 > 'x'` is null, not false and not an error (#607).
+///
+/// This deliberately does not reuse `PropertyValue`'s `Ord`. That order is
+/// total by design because it backs the B-tree property index, so it answers
+/// every comparison confidently, including the ones Cypher says have no
+/// answer. Using it for a query-level comparison is what turned "unknown" into
+/// a definite `false`.
+fn cypher_ordering(left: &PropertyValue, right: &PropertyValue) -> Option<std::cmp::Ordering> {
+    use PropertyValue::*;
+    match (left, right) {
+        (Integer(l), Integer(r)) => Some(l.cmp(r)),
+        (Float(l), Float(r)) => l.partial_cmp(r),
+        (Integer(l), Float(r)) => (*l as f64).partial_cmp(r),
+        (Float(l), Integer(r)) => l.partial_cmp(&(*r as f64)),
+        (String(l), String(r)) => Some(l.cmp(r)),
+        (Boolean(l), Boolean(r)) => Some(l.cmp(r)),
+        (DateTime(l), DateTime(r)) => Some(l.cmp(r)),
+        // A timestamp against a raw epoch integer stays comparable: this is
+        // long-standing behaviour here and the two are the same quantity.
+        (DateTime(l), Integer(r)) | (Integer(l), DateTime(r)) => Some(l.cmp(r)),
+        (
+            Duration { months: m1, days: d1, seconds: s1, nanos: n1 },
+            Duration { months: m2, days: d2, seconds: s2, nanos: n2 },
+        ) => Some(m1.cmp(m2).then(d1.cmp(d2)).then(s1.cmp(s2)).then(n1.cmp(n2))),
+        _ => None,
+    }
 }
 
 /// `STARTS WITH` / `ENDS WITH` / `CONTAINS` over one pair of operands.
@@ -3472,63 +3505,43 @@ impl FilterOperator {
     }
 
     fn compare_lt(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        match (left, right) {
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
-            (PropertyValue::Integer(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Boolean(l < r)),
-            (PropertyValue::Float(l), PropertyValue::Float(r)) => Ok(PropertyValue::Boolean(l < r)),
-            (PropertyValue::Integer(l), PropertyValue::Float(r)) => Ok(PropertyValue::Boolean((*l as f64) < *r)),
-            (PropertyValue::Float(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Boolean(*l < (*r as f64))),
-            (PropertyValue::String(l), PropertyValue::String(r)) => Ok(PropertyValue::Boolean(l < r)),
-            (PropertyValue::DateTime(l), PropertyValue::DateTime(r)) => Ok(PropertyValue::Boolean(l < r)),
-            (PropertyValue::DateTime(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Boolean(l < r)),
-            (PropertyValue::Integer(l), PropertyValue::DateTime(r)) => Ok(PropertyValue::Boolean(l < r)),
-            _ => Err(ExecutionError::TypeError("Cannot compare these types".to_string())),
-        }
+        // Incomparable types are null, not an error: raising here aborted
+        // the whole query, so rows that *did* compare never came back (#607).
+        Ok(match cypher_ordering(left, right) {
+            Some(std::cmp::Ordering::Less) => PropertyValue::Boolean(true),
+            Some(_) => PropertyValue::Boolean(false),
+            None => PropertyValue::Null,
+        })
     }
 
     fn compare_le(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        match (left, right) {
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
-            (PropertyValue::Integer(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Boolean(l <= r)),
-            (PropertyValue::Float(l), PropertyValue::Float(r)) => Ok(PropertyValue::Boolean(l <= r)),
-            (PropertyValue::Integer(l), PropertyValue::Float(r)) => Ok(PropertyValue::Boolean((*l as f64) <= *r)),
-            (PropertyValue::Float(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Boolean(*l <= (*r as f64))),
-            (PropertyValue::String(l), PropertyValue::String(r)) => Ok(PropertyValue::Boolean(l <= r)),
-            (PropertyValue::DateTime(l), PropertyValue::DateTime(r)) => Ok(PropertyValue::Boolean(l <= r)),
-            (PropertyValue::DateTime(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Boolean(l <= r)),
-            (PropertyValue::Integer(l), PropertyValue::DateTime(r)) => Ok(PropertyValue::Boolean(l <= r)),
-            _ => Err(ExecutionError::TypeError("Cannot compare these types".to_string())),
-        }
+        // Incomparable types are null, not an error: raising here aborted
+        // the whole query, so rows that *did* compare never came back (#607).
+        Ok(match cypher_ordering(left, right) {
+            Some(std::cmp::Ordering::Less | std::cmp::Ordering::Equal) => PropertyValue::Boolean(true),
+            Some(_) => PropertyValue::Boolean(false),
+            None => PropertyValue::Null,
+        })
     }
 
     fn compare_gt(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        match (left, right) {
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
-            (PropertyValue::Integer(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Boolean(l > r)),
-            (PropertyValue::Float(l), PropertyValue::Float(r)) => Ok(PropertyValue::Boolean(l > r)),
-            (PropertyValue::Integer(l), PropertyValue::Float(r)) => Ok(PropertyValue::Boolean((*l as f64) > *r)),
-            (PropertyValue::Float(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Boolean(*l > (*r as f64))),
-            (PropertyValue::String(l), PropertyValue::String(r)) => Ok(PropertyValue::Boolean(l > r)),
-            (PropertyValue::DateTime(l), PropertyValue::DateTime(r)) => Ok(PropertyValue::Boolean(l > r)),
-            (PropertyValue::DateTime(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Boolean(l > r)),
-            (PropertyValue::Integer(l), PropertyValue::DateTime(r)) => Ok(PropertyValue::Boolean(l > r)),
-            _ => Err(ExecutionError::TypeError("Cannot compare these types".to_string())),
-        }
+        // Incomparable types are null, not an error: raising here aborted
+        // the whole query, so rows that *did* compare never came back (#607).
+        Ok(match cypher_ordering(left, right) {
+            Some(std::cmp::Ordering::Greater) => PropertyValue::Boolean(true),
+            Some(_) => PropertyValue::Boolean(false),
+            None => PropertyValue::Null,
+        })
     }
 
     fn compare_ge(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        match (left, right) {
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
-            (PropertyValue::Integer(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Boolean(l >= r)),
-            (PropertyValue::Float(l), PropertyValue::Float(r)) => Ok(PropertyValue::Boolean(l >= r)),
-            (PropertyValue::Integer(l), PropertyValue::Float(r)) => Ok(PropertyValue::Boolean((*l as f64) >= *r)),
-            (PropertyValue::Float(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Boolean(*l >= (*r as f64))),
-            (PropertyValue::String(l), PropertyValue::String(r)) => Ok(PropertyValue::Boolean(l >= r)),
-            (PropertyValue::DateTime(l), PropertyValue::DateTime(r)) => Ok(PropertyValue::Boolean(l >= r)),
-            (PropertyValue::DateTime(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Boolean(l >= r)),
-            (PropertyValue::Integer(l), PropertyValue::DateTime(r)) => Ok(PropertyValue::Boolean(l >= r)),
-            _ => Err(ExecutionError::TypeError("Cannot compare these types".to_string())),
-        }
+        // Incomparable types are null, not an error: raising here aborted
+        // the whole query, so rows that *did* compare never came back (#607).
+        Ok(match cypher_ordering(left, right) {
+            Some(std::cmp::Ordering::Greater | std::cmp::Ordering::Equal) => PropertyValue::Boolean(true),
+            Some(_) => PropertyValue::Boolean(false),
+            None => PropertyValue::Null,
+        })
     }
 
     fn logical_and(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1948,6 +1948,29 @@ fn parse_expression(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression
         }
     }
 
+    // A chain the rewrite above declined to expand — `1 < x < 3 AND ...`,
+    // where the top-level operators are not *all* comparisons.
+    //
+    // Left-associative parsing turns the chain into `(1 < x) < 3`, comparing a
+    // boolean to a number. That is null in Cypher (#607), so a WHERE built on
+    // it quietly matches nothing: the query returns zero rows where Neo4j
+    // returns the row. Refusing is the only honest option short of expanding
+    // chains inside arbitrary expressions, which means reimplementing operator
+    // precedence outside the Pratt parser — the thing this rewrite exists to
+    // avoid.
+    //
+    // Until then: an error the caller can see, never a silently empty result.
+    if ops.windows(2).any(|w| {
+        w[0].as_rule() == Rule::comparison_op && w[1].as_rule() == Rule::comparison_op
+    }) {
+        return Err(ParseError::SemanticError(
+            "a chained comparison (like `1 < x < 3`) is only supported when it is the \
+             whole expression; here it is combined with other operators. Write it as \
+             an explicit conjunction instead, for example `1 < x AND x < 3 AND ...`"
+                .to_string(),
+        ));
+    }
+
     PRATT_PARSER
         .map_primary(|primary| parse_term(primary))
         .map_prefix(|op, rhs| match op.as_rule() {

--- a/tests/chained_comparison.rs
+++ b/tests/chained_comparison.rs
@@ -14,6 +14,12 @@
 //! That conservatism has a cost, pinned by the last test here: a chain mixed
 //! into a larger expression is still refused. It fails as an error rather than
 //! a wrong answer, which is the right way round to be incomplete.
+//!
+//! That refusal is now explicit rather than incidental. It used to fall out of
+//! `(1 < n.num) < 3` raising a type error; once incomparable ordering was
+//! corrected to null (#607), the same query silently returned no rows instead
+//! — Neo4j returns the row. An unsupported shape has to announce itself, so
+//! the parser rejects the shape directly and says how to rewrite it.
 
 use samyama::graph::GraphStore;
 use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
@@ -111,11 +117,22 @@ fn a_chain_inside_a_larger_expression_is_still_refused() {
     // This asserts the shape of the gap, not that the gap is desirable. An
     // error is the right way to be incomplete; the failure to avoid is
     // answering it wrongly.
-    let store = three_nodes();
-    let q = parse_query("MATCH (n) WHERE 1 < n.num < 3 AND n.num = 2 RETURN n.num AS v")
-        .expect("it parses");
+    // The refusal now happens at **parse** time rather than at execution.
+    //
+    // It used to be an execution error only by accident: the chain became
+    // `(1 < n.num) < 3`, and comparing a boolean to a number raised. Once that
+    // comparison was corrected to yield null (#607, matching Neo4j), the same
+    // query stopped erroring and started returning **zero rows** — Neo4j
+    // returns the row `2` here, so a silent wrong answer replaced a loud one.
+    //
+    // The parser therefore refuses the shape explicitly. What this test pins
+    // is unchanged: an unsupported chain must fail loudly. Only the stage
+    // moved, and earlier is better.
+    let err = parse_query("MATCH (n) WHERE 1 < n.num < 3 AND n.num = 2 RETURN n.num AS v")
+        .expect_err("a mixed chain must fail loudly rather than return the wrong rows");
+    let text = format!("{err}");
     assert!(
-        QueryExecutor::new(&store).execute(&q).is_err(),
-        "a mixed chain must fail loudly rather than return the wrong rows"
+        text.contains("chained comparison"),
+        "the refusal should say what is wrong and how to write it instead, got: {text}"
     );
 }

--- a/tests/incomparable_ordering_is_null.rs
+++ b/tests/incomparable_ordering_is_null.rs
@@ -1,0 +1,80 @@
+//! An ordering comparison between values of different types is null (#607).
+//!
+//! `0 > 'x'` is neither true, nor false, nor an error: Cypher cannot order a
+//! number against a string, so the answer is unknown. Two code paths got this
+//! wrong in opposite directions — one raised `TypeError("Cannot compare these
+//! types")`, aborting the whole query; the other compared them through the
+//! total `Ord` that backs the property index and returned a confident `false`.
+//!
+//! The difference shows up under `OR`: `false OR true` is true, but
+//! `null OR true` is also true, while `false OR false` is false and
+//! `null OR false` is null. A WHERE keeps rows only for true, so the wrong
+//! answer changes which rows come back rather than announcing itself.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+}
+
+fn value_of(store: &GraphStore, cypher: &str) -> Value {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    let out = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run, not error: {e}"));
+    out.records[0].get("x").cloned().unwrap_or(Value::Null)
+}
+
+fn assert_null(store: &GraphStore, cypher: &str) {
+    let got = value_of(store, cypher);
+    assert!(
+        matches!(got, Value::Null | Value::Property(PropertyValue::Null)),
+        "`{cypher}` should be null, got {got:?}"
+    );
+}
+
+#[test]
+fn ordering_across_types_is_null() {
+    let store = GraphStore::new();
+    for op in ["<", "<=", ">", ">="] {
+        assert_null(&store, &format!("RETURN 0 {op} 'x' AS x"));
+        assert_null(&store, &format!("RETURN 'x' {op} 0 AS x"));
+        assert_null(&store, &format!("RETURN true {op} 1 AS x"));
+        assert_null(&store, &format!("RETURN [1] {op} 1 AS x"));
+    }
+}
+
+#[test]
+fn ordering_within_a_type_still_answers() {
+    // The guard must not swallow comparisons that are perfectly well defined,
+    // including int-vs-float, which is one type for ordering purposes.
+    let store = GraphStore::new();
+    let t = Value::Property(PropertyValue::Boolean(true));
+    assert_eq!(value_of(&store, "RETURN 1 < 2 AS x"), t);
+    assert_eq!(value_of(&store, "RETURN 1 < 2.5 AS x"), t);
+    assert_eq!(value_of(&store, "RETURN 2.5 > 1 AS x"), t);
+    assert_eq!(value_of(&store, "RETURN 'a' < 'b' AS x"), t);
+    assert_eq!(value_of(&store, "RETURN 'xx' > 'x' AS x"), t);
+}
+
+#[test]
+fn a_where_filters_the_incomparable_row_without_aborting() {
+    // Comparison2 [1]: the TypeError killed the whole query, so the row that
+    // *does* compare never came back either.
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:Child {var: 0})");
+    run(&mut store, "CREATE (:Child {var: 'xx'})");
+    run(&mut store, "CREATE (:Child)");
+
+    let q = parse_query("MATCH (i:Child) WHERE i.var IS NOT NULL AND i.var > 'x' RETURN i.var AS x")
+        .expect("parse");
+    let out = QueryExecutor::new(&store).execute(&q).expect("should run, not error");
+    let got: Vec<Value> = out.records.iter().filter_map(|r| r.get("x").cloned()).collect();
+    assert_eq!(got.len(), 1, "only 'xx' compares against 'x', got {got:?}");
+    assert_eq!(got[0], Value::Property(PropertyValue::String("xx".into())));
+}

--- a/tests/union_combines_branches.rs
+++ b/tests/union_combines_branches.rs
@@ -1,0 +1,73 @@
+//! UNION returns the rows of *every* branch, not just the first.
+//!
+//! `RETURN 1 AS x UNION RETURN 2 AS x` returned `[1]`. The parser builds
+//! `query.union_queries` and the validator checks the branches agree on their
+//! column names, but no executor path ever read the field, so every branch
+//! after the first was silently discarded.
+//!
+//! It survived because the four existing union tests all assert
+//! `records.len() >= 2` against a fixture whose *first branch alone* returns
+//! two rows. A test that cannot distinguish 2 from 4 cannot detect a UNION
+//! that never ran. These assert exact counts and exact values.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+}
+
+fn column(store: &GraphStore, cypher: &str) -> Vec<i64> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    let out = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+    let mut got: Vec<i64> = out
+        .records
+        .iter()
+        .map(|r| match r.get("x") {
+            Some(Value::Property(PropertyValue::Integer(i))) => *i,
+            other => panic!("expected integer column x, got {other:?}"),
+        })
+        .collect();
+    got.sort_unstable();
+    got
+}
+
+#[test]
+fn union_returns_rows_from_both_branches() {
+    let store = GraphStore::new();
+    assert_eq!(column(&store, "RETURN 1 AS x UNION RETURN 2 AS x"), vec![1, 2]);
+}
+
+#[test]
+fn union_deduplicates_and_union_all_does_not() {
+    let store = GraphStore::new();
+    // The distinction the two keywords exist for.
+    assert_eq!(column(&store, "RETURN 1 AS x UNION RETURN 1 AS x"), vec![1]);
+    assert_eq!(column(&store, "RETURN 1 AS x UNION ALL RETURN 1 AS x"), vec![1, 1]);
+}
+
+#[test]
+fn union_chains_past_two_branches() {
+    let store = GraphStore::new();
+    assert_eq!(
+        column(&store, "RETURN 1 AS x UNION RETURN 2 AS x UNION RETURN 3 AS x"),
+        vec![1, 2, 3]
+    );
+}
+
+#[test]
+fn union_over_matches_counts_every_branch() {
+    // The shape the old tests used — but asserting the count that
+    // distinguishes a working UNION from one that ran only the first branch.
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:P {v: 1})");
+    run(&mut store, "CREATE (:P {v: 2})");
+    let q = "MATCH (n:P) RETURN n.v AS x UNION ALL MATCH (m:P) RETURN m.v AS x";
+    assert_eq!(column(&store, q), vec![1, 1, 2, 2], "UNION ALL over 2 nodes is 4 rows, not 2");
+}


### PR DESCRIPTION
CH-TCK 84.2% -> 85.0% (1047 -> 1058 of 1244). The gate's absolute threshold
is met. Its other half is not: condition 1 also asks for within 5 points of
the best competitor, and Neo4j 5 is at 98.9%, so the bar there is 93.9%.

**UNION was never executed.** `RETURN 1 AS x UNION RETURN 2 AS x` answered
`[1]`. The parser fills `query.union_queries` and the validator checks the
branches agree on column names, but no executor path read the field, so every
branch after the first was discarded.

It survived because all four existing union tests assert `records.len() >= 2`
against a fixture whose *first branch alone* returns two rows. A test that
cannot tell 2 from 4 cannot detect a UNION that never ran. Three are tightened
to exact counts here; the fourth then failed and exposed a second defect —
keying the dedup by the leading branch's column names collapses a branch that
projects different aliases, because its rows look up names they do not have.
The dedup is positional.

**An ordering comparison between different types is null (#607).** Two paths
had this wrong in opposite directions: one raised `TypeError("Cannot compare
these types")`, aborting the query; the other compared through the *total*
`Ord` that backs the B-tree property index and returned a confident `false`.
Both now use one `cypher_ordering` that returns `None` when Cypher has no
answer. Verified against Neo4j 5: `(true < 3) IS NULL` -> true.

**A chained comparison the rewrite declines is now refused explicitly.**
`1 < x < 3 AND x = 2` parses as `(1 < x) < 3`, and its loud failure came from
the type error above. Correcting that comparison turned the refusal into a
silently empty result — Neo4j returns the row — so two individually correct
changes composed into a wrong answer. The parser rejects the shape directly
and says how to rewrite it. `chained_comparison.rs` still pins "fail loudly";
only the stage moved, from execution to parse, which is earlier and better.