### PR TITLE
PERF: apply an EXISTS pin before expanding, not after — BI-11 stops timing out (#681)

### DIFF
--- a/examples/bi11_explain.rs
+++ b/examples/bi11_explain.rs
@@ -1,0 +1,60 @@
+//! EXPLAIN / PROFILE for LDBC BI-11 against a real SF1 extract (#681).
+//!
+//! BI-11 went from 5.1 s to not finishing at commit 4cbf36e, which changed
+//! anchor selection. A plan is the shortest route to seeing what that did, but
+//! the plan is cost-based, so it has to be taken against the real graph rather
+//! than an empty store.
+//!
+//!   cargo run --release --example bi11_explain -- --data-dir <ldbc-sf1-dir>
+
+#[path = "../benches/ldbc_bi_common/mod.rs"]
+mod ldbc_bi_common;
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+use std::path::PathBuf;
+
+const BI11: &str = "\
+MATCH (reply:Comment)-[:REPLY_OF]->(post:Post)
+WHERE NOT EXISTS {
+  MATCH (reply)-[:HAS_TAG]->(t:Tag)<-[:HAS_TAG]-(post)
+}
+RETURN count(reply) AS unrelatedReplies";
+
+// Sub-shapes, to separate "the anti-join is slow" from "the outer match is slow".
+const OUTER_ONLY: &str = "MATCH (reply:Comment)-[:REPLY_OF]->(post:Post) RETURN count(reply) AS c";
+const INNER_ONLY: &str = "MATCH (reply:Comment)-[:HAS_TAG]->(t:Tag) RETURN count(reply) AS c";
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().collect();
+    let data_dir = args
+        .iter()
+        .position(|a| a == "--data-dir")
+        .and_then(|i| args.get(i + 1))
+        .map(PathBuf::from)
+        .expect("--data-dir <path> is required");
+
+    let mut graph = GraphStore::new();
+    eprintln!("loading {} ...", data_dir.display());
+    let t = std::time::Instant::now();
+    ldbc_bi_common::load_dataset(&mut graph, &data_dir)?;
+    eprintln!("loaded in {:.1}s", t.elapsed().as_secs_f64());
+
+    for (label, cypher) in [("BI-11", BI11), ("outer only", OUTER_ONLY), ("inner only", INNER_ONLY)] {
+        println!("\n================ {label} ================");
+        println!("{cypher}\n");
+        let q = parse_query(&format!("EXPLAIN {cypher}"))?;
+        match QueryExecutor::new(&graph).execute(&q) {
+            Ok(out) => {
+                for r in &out.records {
+                    if let Some(v) = r.get("plan") {
+                        println!("{}", format!("{v:?}").replace("\\n", "\n"));
+                    }
+                }
+            }
+            Err(e) => println!("EXPLAIN failed: {e}"),
+        }
+    }
+    Ok(())
+}

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -721,7 +721,36 @@ fn exists_expand_hops(
         return Ok(false);
     }
 
+    // If the node this segment lands on is *already bound* and the segment is a
+    // single hop, only that node can close it. Recursing into every neighbour
+    // and rejecting them one level down is the same answer at O(degree) cost —
+    // and it clones the binding record per neighbour to get there.
+    //
+    // LDBC BI-11 is the case that makes this matter: `(t)<-[:HAS_TAG]-(post)`
+    // with `post` bound walks every node carrying that tag, ~250 of them on
+    // SF1, for each of ~1.19M outer rows (#681).
+    //
+    // Restricted to single-hop segments deliberately: in a variable-length
+    // segment the pin applies to the far end, not to the intermediate
+    // positions this loop is walking through, so filtering here would cut off
+    // legitimate paths.
+    let pinned_target: Option<NodeId> = if max_hops == 1 {
+        match segment.node.variable.as_deref().and_then(|v| bindings.get(v)) {
+            Some(Value::NodeRef(id)) | Some(Value::Node(id, _)) => Some(*id),
+            _ => None,
+        }
+    } else {
+        None
+    };
+
     for (edge, neighbor) in exists_neighbors(store, current, &segment.edge) {
+        // The pin cannot be satisfied by any other neighbour, so skip before
+        // the record clone below rather than after the recursion.
+        if let Some(target) = pinned_target {
+            if neighbor != target {
+                continue;
+            }
+        }
         // Relationship isomorphism: an edge may not repeat within one path.
         if visited_edges.contains(&edge.id) {
             continue;

--- a/tests/exists_pinned_endpoint.rs
+++ b/tests/exists_pinned_endpoint.rs
@@ -1,0 +1,120 @@
+//! `EXISTS { (a)-[:R]->(b) }` with `b` already bound must not enumerate every
+//! neighbour of `a` before noticing (#681).
+//!
+//! The walker expanded all neighbours, cloned the binding record for each, and
+//! only checked the pin one recursion level down. For LDBC BI-11 the pinned end
+//! is a Tag's other side — ~250 nodes per tag, over ~1.19M outer rows.
+//!
+//! These tests pin the *semantics*, which the optimisation must not change:
+//! filtering the expansion to the pinned node has to give the same answers as
+//! enumerating and rejecting. The cases that would break a careless version are
+//! a pinned node that is a neighbour, one that is not, one reachable only by
+//! the wrong direction, and one reachable only by the wrong edge type.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+}
+
+fn count(store: &GraphStore, cypher: &str) -> i64 {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    let out = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+    match out.records.first().and_then(|r| r.get("c")) {
+        Some(Value::Property(PropertyValue::Integer(i))) => *i,
+        other => panic!("expected integer c, got {other:?}"),
+    }
+}
+
+/// a -[:R]-> hub <-[:R]- b, plus decoys hanging off the hub so a naive walker
+/// has something to enumerate, and c which shares no hub with a.
+fn seeded() -> GraphStore {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:N {name: 'a'})");
+    run(&mut store, "CREATE (:N {name: 'b'})");
+    run(&mut store, "CREATE (:N {name: 'c'})");
+    run(&mut store, "CREATE (:H {name: 'hub'})");
+    run(&mut store, "CREATE (:N {name: 'd1'})");
+    run(&mut store, "CREATE (:N {name: 'd2'})");
+    run(&mut store, "MATCH (a:N {name:'a'}), (h:H) CREATE (a)-[:R]->(h)");
+    run(&mut store, "MATCH (b:N {name:'b'}), (h:H) CREATE (b)-[:R]->(h)");
+    run(&mut store, "MATCH (d:N {name:'d1'}), (h:H) CREATE (d)-[:R]->(h)");
+    run(&mut store, "MATCH (d:N {name:'d2'}), (h:H) CREATE (d)-[:R]->(h)");
+    // c attaches by a different edge type, so it must not count as sharing.
+    run(&mut store, "CREATE (:H {name: 'hub2'})");
+    run(&mut store, "MATCH (c:N {name:'c'}), (h:H {name:'hub2'}) CREATE (c)-[:OTHER]->(h)");
+    store
+}
+
+#[test]
+fn a_pinned_endpoint_that_is_reachable_matches() {
+    let store = seeded();
+    // BI-11's exact shape: both ends bound, meeting at a shared middle node.
+    assert_eq!(
+        count(&store,
+            "MATCH (a:N {name:'a'}), (b:N {name:'b'}) \
+             WHERE EXISTS { MATCH (a)-[:R]->(h:H)<-[:R]-(b) } RETURN count(*) AS c"),
+        1
+    );
+}
+
+#[test]
+fn a_pinned_endpoint_that_is_not_reachable_does_not_match() {
+    let store = seeded();
+    // c hangs off a different hub by a different edge type.
+    assert_eq!(
+        count(&store,
+            "MATCH (a:N {name:'a'}), (c:N {name:'c'}) \
+             WHERE EXISTS { MATCH (a)-[:R]->(h:H)<-[:R]-(c) } RETURN count(*) AS c"),
+        0
+    );
+}
+
+#[test]
+fn the_negation_is_the_complement() {
+    // BI-11 is NOT EXISTS, so the inverse has to hold on the same fixture.
+    let store = seeded();
+    assert_eq!(
+        count(&store,
+            "MATCH (a:N {name:'a'}), (b:N {name:'b'}) \
+             WHERE NOT EXISTS { MATCH (a)-[:R]->(h:H)<-[:R]-(b) } RETURN count(*) AS c"),
+        0
+    );
+    assert_eq!(
+        count(&store,
+            "MATCH (a:N {name:'a'}), (c:N {name:'c'}) \
+             WHERE NOT EXISTS { MATCH (a)-[:R]->(h:H)<-[:R]-(c) } RETURN count(*) AS c"),
+        1
+    );
+}
+
+#[test]
+fn direction_is_still_honoured_for_a_pinned_endpoint() {
+    // b reaches the hub by an outgoing edge; demanding an incoming one from the
+    // hub's perspective must fail. A filter that ignores direction would pass.
+    let store = seeded();
+    assert_eq!(
+        count(&store,
+            "MATCH (a:N {name:'a'}), (b:N {name:'b'}) \
+             WHERE EXISTS { MATCH (a)-[:R]->(h:H)-[:R]->(b) } RETURN count(*) AS c"),
+        0
+    );
+}
+
+#[test]
+fn edge_type_is_still_honoured_for_a_pinned_endpoint() {
+    let store = seeded();
+    assert_eq!(
+        count(&store,
+            "MATCH (a:N {name:'a'}), (b:N {name:'b'}) \
+             WHERE EXISTS { MATCH (a)-[:R]->(h:H)<-[:OTHER]-(b) } RETURN count(*) AS c"),
+        0
+    );
+}


### PR DESCRIPTION
LDBC BI-11 did not finish on main. It now completes in 26.4 s at SF1.

  4cbf36e         >1,735 s   the regression bisected in #681
  main (before)   timed out  at the bench's own per-query budget
  main (after)      26.4 s
  365b07d            5.1 s   historical best

`EXISTS { (reply)-[:HAS_TAG]->(t:Tag)<-[:HAS_TAG]-(post) }` binds both ends
from the outer row. The walker expanded *every* neighbour of the tag, cloned
the binding record for each, recursed, and only then compared the node against
the pinned `post` one level down. On SF1 a Tag carries ~250 nodes (4M HAS_TAG
edges over 16,080 tags) and the outer match is ~1.19M rows, so the pin was
being applied roughly 300M times too late.

The pin now filters the expansion before the clone. Same answers, same order of
evaluation, O(1) work per neighbour instead of a record clone plus a recursive
call.

Restricted to single-hop segments on purpose: in a variable-length segment the
pin constrains the *far end*, not the intermediate positions this loop walks
through, so filtering there would cut off legitimate paths. That restriction is
the difference between a performance fix and a wrong-answer bug.

The five tests were written and passing before the change, so they are a
baseline rather than a description of the new behaviour. They cover what a
careless filter breaks: a pinned endpoint that is reachable, one that is not,
the NOT EXISTS complement, a pin reachable only in the wrong direction, and one
reachable only by the wrong edge type.

This does **not** close #681:

  * 26.4 s is still 5x the 5.1 s baseline. `NOT EXISTS` is executed as a
    per-row Filter — `semi_join_detector.rs` matches a different shape — and
    1.19M subquery evaluations is the ceiling until it gets an anti-join plan.
  * the anchor flip in 4cbf36e is untouched. This makes its consequence
    survivable; it does not undo it.

What it does settle is H1 gate condition 2 for this query: "no BI timeouts".
BI-11 completes.

`examples/bi11_explain.rs` prints the plan for BI-11 and its sub-shapes against
a real extract. The plan is cost-based, so it has to be taken against the real
graph — an empty store yields a different plan entirely, which is how a probe
can look like it disproves the thing it never tested.