### PR TITLE
Enforce relationship isomorphism in MATCH (#684) — CH-TCK 85.0% -> 85.8%

### DIFF
--- a/examples/bi11_explain.rs
+++ b/examples/bi11_explain.rs
@@ -23,6 +23,11 @@ WHERE NOT EXISTS {
 RETURN count(reply) AS unrelatedReplies";
 
 // Sub-shapes, to separate "the anti-join is slow" from "the outer match is slow".
+const BI17: &str = "\
+MATCH (a:Person)-[:KNOWS]-(b:Person)-[:KNOWS]-(c:Person)-[:KNOWS]-(a)
+WHERE a.id < b.id AND b.id < c.id
+RETURN count(a) AS triangleCount";
+
 const OUTER_ONLY: &str = "MATCH (reply:Comment)-[:REPLY_OF]->(post:Post) RETURN count(reply) AS c";
 const INNER_ONLY: &str = "MATCH (reply:Comment)-[:HAS_TAG]->(t:Tag) RETURN count(reply) AS c";
 
@@ -41,7 +46,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ldbc_bi_common::load_dataset(&mut graph, &data_dir)?;
     eprintln!("loaded in {:.1}s", t.elapsed().as_secs_f64());
 
-    for (label, cypher) in [("BI-11", BI11), ("outer only", OUTER_ONLY), ("inner only", INNER_ONLY)] {
+    for (label, cypher) in [("BI-11", BI11), ("BI-17", BI17), ("outer only", OUTER_ONLY), ("inner only", INNER_ONLY)] {
         println!("\n================ {label} ================");
         println!("{cypher}\n");
         let q = parse_query(&format!("EXPLAIN {cypher}"))?;

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3844,6 +3844,16 @@ pub struct ExpandOperator {
     /// `edge_types` resolved to interned ids, cached after the first use.
     /// `Some(vec)` once resolved; the wildcard case never populates it.
     type_ids: Option<Vec<u16>>,
+    /// Enforce relationship isomorphism: refuse an edge this pattern has
+    /// already traversed, and record the ones it takes (#684).
+    ///
+    /// Off for a single-hop pattern, which cannot violate the rule and should
+    /// not pay for the bookkeeping.
+    track_edges: bool,
+    /// This expand begins a MATCH clause, so it clears the inherited history
+    /// first. Isomorphism is per-clause — `MATCH (a)-[:R]-(b) MATCH (b)-[:R]-(c)`
+    /// may legitimately reuse the edge.
+    starts_clause: bool,
 }
 
 impl ExpandOperator {
@@ -3865,6 +3875,8 @@ impl ExpandOperator {
             target_labels: Vec::new(),
             target_props: Vec::new(),
             target_ids: None,
+            track_edges: false,
+            starts_clause: false,
             direction,
             current_record: None,
             current_edges: Vec::new(),
@@ -3897,6 +3909,16 @@ impl ExpandOperator {
     /// The resolved node set for the target, when the planner could compute it.
     /// Preferred over `target_props`: an id membership test costs a hash
     /// lookup where the property check costs a node fetch (#665).
+    /// Enforce relationship isomorphism for this expand.
+    ///
+    /// `starts_clause` marks the first expand of a MATCH clause, which drops
+    /// any history inherited from an earlier clause.
+    pub fn with_edge_isolation(mut self, starts_clause: bool) -> Self {
+        self.track_edges = true;
+        self.starts_clause = starts_clause;
+        self
+    }
+
     pub fn with_target_ids(mut self, ids: std::collections::HashSet<NodeId>) -> Self {
         self.target_ids = Some(ids);
         self
@@ -3988,9 +4010,24 @@ impl ExpandOperator {
             };
         let target_props = &self.target_props;
         let target_ids = self.target_ids.as_ref();
-        let keeps = |target: NodeId| -> bool {
-            // Cheapest discriminator first: if the planner resolved the target
-            // to a known set, membership settles it without touching the node.
+        // Relationship isomorphism (#684): an edge this pattern already walked
+        // is not a candidate. Checked here, during the adjacency walk, so a
+        // rejected edge never becomes a record.
+        let used_edges: &[crate::graph::EdgeId] = if self.track_edges && !self.starts_clause {
+            record.used_edge_slice()
+        } else {
+            &[]
+        };
+        let keeps = |target: NodeId, eid: crate::graph::EdgeId| -> bool {
+            // Relationship isomorphism first: it is a comparison of a few u64s
+            // against a slice that is empty for every single-hop pattern, so it
+            // is cheaper than anything below and rejects the most rows on the
+            // patterns that need it.
+            if used_edges.contains(&eid) {
+                return false;
+            }
+            // Then the cheapest discriminator: if the planner resolved the
+            // target to a known set, membership settles it without touching the node.
             if let Some(ids) = target_ids {
                 if !ids.contains(&target) {
                     return false;
@@ -4019,21 +4056,21 @@ impl ExpandOperator {
         match self.direction {
             Direction::Outgoing => {
                 store.for_each_outgoing_neighbor(node_id, type_filter, |target, eid| {
-                    if keeps(target) {
+                    if keeps(target, eid) {
                         collected.push((eid, node_id, target));
                     }
                 });
             }
             Direction::Incoming => {
                 store.for_each_incoming_neighbor(node_id, type_filter, |source, eid| {
-                    if keeps(source) {
+                    if keeps(source, eid) {
                         collected.push((eid, source, node_id));
                     }
                 });
             }
             Direction::Both => {
                 store.for_each_outgoing_neighbor(node_id, type_filter, |target, eid| {
-                    if keeps(target) {
+                    if keeps(target, eid) {
                         collected.push((eid, node_id, target));
                     }
                 });
@@ -4046,7 +4083,7 @@ impl ExpandOperator {
                     if source == node_id {
                         return;
                     }
-                    if keeps(source) {
+                    if keeps(source, eid) {
                         collected.push((eid, source, node_id));
                     }
                 });
@@ -4118,6 +4155,15 @@ impl PhysicalOperator for ExpandOperator {
                     new_record.bind(path_var.clone(), extended);
                 }
 
+                // Relationship isomorphism (#684): remember what this pattern
+                // has walked so a later segment cannot take the same edge back.
+                if self.track_edges {
+                    if self.starts_clause {
+                        new_record.clear_used_edges();
+                    }
+                    new_record.mark_edge_used(edge_id);
+                }
+
                 return Ok(Some(new_record));
             }
 
@@ -4177,6 +4223,15 @@ impl PhysicalOperator for ExpandOperator {
                         let extended =
                             extend_path(new_record.get(path_var), source_id, target_id, edge_id);
                         new_record.bind(path_var.clone(), extended);
+                    }
+                    // Same isomorphism bookkeeping as the single-row path
+                    // above. Missing it here would make the answer depend on
+                    // whether the plan happened to run batched (#684).
+                    if self.track_edges {
+                        if self.starts_clause {
+                            new_record.clear_used_edges();
+                        }
+                        new_record.mark_edge_used(edge_id);
                     }
                     expanded_records.push(new_record);
                 }

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2875,6 +2875,12 @@ impl QueryPlanner {
                 // after the whole path (#328).
                 let mut bound: HashSet<String> = HashSet::new();
                 bound.insert(start_var.clone());
+                // Relationship isomorphism (#684): a pattern with more than one
+                // segment must not walk the same edge twice. The first expand
+                // built is the first to execute, so it clears history from an
+                // earlier clause — the rule is per-clause.
+                let track_edges = path.segments.len() > 1;
+                let mut first_expand = true;
                 for (seg_idx, segment) in path.segments.iter().enumerate() {
                     let target_var = path_nodes[seg_idx + 1].var.clone();
 
@@ -2978,6 +2984,10 @@ impl QueryPlanner {
                         edge_types,
                         segment.edge.direction.clone(),
                     );
+                    if track_edges {
+                        expand = expand.with_edge_isolation(first_expand);
+                        first_expand = false;
+                    }
                     // A selective equality on the far side of the expansion —
                     // LDBC IC11's `org.name = "..."` — applied during the walk
                     // rather than to the rows it produces (#656).
@@ -3249,6 +3259,17 @@ impl QueryPlanner {
         let anchor = &nodes[anchor_idx];
         let anchor_var = anchor.var.clone();
 
+        // Relationship isomorphism (#684). A single-hop pattern cannot reuse an
+        // edge, so it does not pay for the bookkeeping; anything longer must.
+        //
+        // The first expand built here is also the first to execute — each one
+        // wraps the previous — so it is the one that drops history inherited
+        // from an earlier clause. That matters because the rule is scoped to a
+        // clause: `MATCH (a)-[:R]-(b) MATCH (b)-[:R]-(c)` may legitimately walk
+        // the same edge twice, and Neo4j agrees.
+        let track_edges = path.segments.len() > 1;
+        let mut first_expand = true;
+
         // Predicates referencing only the anchor variable can be evaluated at the
         // anchor scan; everything else is deferred until the whole path is built,
         // mirroring the conservative deferral used by the start-anchored builder.
@@ -3402,7 +3423,11 @@ impl QueryPlanner {
                 } else {
                     target.var.clone()
                 };
-                let expand = ExpandOperator::new(path_operator, current_var.clone(), expand_var.clone(), edge_var, edge_types, reversed_dir);
+                let mut expand = ExpandOperator::new(path_operator, current_var.clone(), expand_var.clone(), edge_var, edge_types, reversed_dir);
+                if track_edges {
+                    expand = expand.with_edge_isolation(first_expand);
+                    first_expand = false;
+                }
                 let expanded: OperatorBox = if !target.labels.is_empty() {
                     Box::new(expand.with_target_labels(target.labels.clone()))
                 } else {
@@ -3492,7 +3517,11 @@ impl QueryPlanner {
                 } else {
                     target.var.clone()
                 };
-                let expand = ExpandOperator::new(path_operator, current_var.clone(), expand_var.clone(), edge_var, edge_types, segment.edge.direction.clone());
+                let mut expand = ExpandOperator::new(path_operator, current_var.clone(), expand_var.clone(), edge_var, edge_types, segment.edge.direction.clone());
+                if track_edges {
+                    expand = expand.with_edge_isolation(first_expand);
+                    first_expand = false;
+                }
                 let expanded: OperatorBox = if !target.labels.is_empty() {
                     Box::new(expand.with_target_labels(target.labels.clone()))
                 } else {

--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -70,6 +70,22 @@ pub struct Record {
     /// copies a vector of pointer pairs and bumps refcounts, where before it
     /// allocated a fresh `String` for every variable name on every row.
     bindings: Vec<(Arc<str>, Value)>,
+    /// Relationships already traversed by the MATCH pattern being matched.
+    ///
+    /// openCypher uses **relationship isomorphism**: one edge may not appear
+    /// twice in a single pattern. Without this, `MATCH (a)-[:R]-(b)-[:R]-(c)`
+    /// over a three-node chain returned 6 rows where Cypher gives 2 — every
+    /// two-hop undirected pattern was inflated by walking an edge back on
+    /// itself (#684).
+    ///
+    /// A `Vec` rather than a set: patterns bind a handful of relationships, so
+    /// a linear scan over a few `u64`s beats hashing, and an **empty `Vec`
+    /// does not allocate** — single-hop patterns, which cannot violate the
+    /// rule, pay only the 24 bytes in the struct and a null clone.
+    ///
+    /// Scoped to one clause. `MATCH (a)-[:R]-(b) MATCH (b)-[:R]-(c)` *may*
+    /// reuse the edge (Neo4j agrees), so a clause boundary clears this.
+    used_edges: Vec<crate::graph::EdgeId>,
 }
 
 /// Value types that can be bound to variables in a query record.
@@ -183,6 +199,7 @@ impl Record {
     pub fn new() -> Self {
         Self {
             bindings: Vec::new(),
+            used_edges: Vec::new(),
         }
     }
 
@@ -200,7 +217,29 @@ impl Record {
     pub fn clone_with_capacity(&self, extra: usize) -> Record {
         let mut bindings = Vec::with_capacity(self.bindings.len() + extra);
         bindings.extend(self.bindings.iter().cloned());
-        Record { bindings }
+        Record { bindings, used_edges: self.used_edges.clone() }
+    }
+
+    /// Has this relationship already been traversed by the current pattern?
+    pub fn edge_used(&self, edge: crate::graph::EdgeId) -> bool {
+        self.used_edges.contains(&edge)
+    }
+
+    /// Record a relationship as traversed by the current pattern.
+    pub fn mark_edge_used(&mut self, edge: crate::graph::EdgeId) {
+        self.used_edges.push(edge);
+    }
+
+    /// The relationships already traversed, for a caller that filters
+    /// candidates in a hot loop and wants no allocation.
+    pub fn used_edge_slice(&self) -> &[crate::graph::EdgeId] {
+        &self.used_edges
+    }
+
+    /// Forget the traversed relationships — a new MATCH clause starts fresh,
+    /// because relationship isomorphism is scoped to one clause.
+    pub fn clear_used_edges(&mut self) {
+        self.used_edges.clear();
     }
 
     /// Bind a variable to a value, replacing any previous binding.

--- a/tests/relationship_isomorphism.rs
+++ b/tests/relationship_isomorphism.rs
@@ -1,0 +1,132 @@
+//! One relationship may not be traversed twice within a single MATCH (#684).
+//!
+//! openCypher uses **relationship isomorphism**: a pattern that needs two
+//! relationships is not satisfied by one edge walked out and back. Nodes are
+//! *not* restricted this way — a node may repeat — so this is specifically
+//! about edges.
+//!
+//! The scope was checked against Neo4j 5 rather than assumed, because both
+//! halves are easy to get wrong in opposite directions:
+//!
+//! ```text
+//! MATCH (a)-[:R]-(b)-[:R]-(c)          over one edge -> 0   enforced, even with
+//!                                                            no repeated variable
+//! MATCH (a)-[:R]-(b) MATCH (b)-[:R]-(c) over one edge -> 2   NOT enforced across
+//!                                                            separate MATCH clauses
+//! ```
+//!
+//! So the rule is per-clause, and it applies to every multi-segment pattern,
+//! not only those that fold back onto a bound variable.
+//!
+//! The `EXISTS` walker already enforced this (`visited_edges` in
+//! `exists_expand_hops`); `ExpandOperator` did not, so the same question got
+//! two different answers depending on which evaluator the planner picked.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+}
+
+fn count(store: &GraphStore, cypher: &str) -> i64 {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    let out = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+    match out.records.first().and_then(|r| r.get("c")) {
+        Some(Value::Property(PropertyValue::Integer(i))) => *i,
+        other => panic!("expected integer c, got {other:?}"),
+    }
+}
+
+/// Exactly one edge: 1 -[:R]-> 2.
+fn one_edge() -> GraphStore {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:S {id: 1})");
+    run(&mut store, "CREATE (:S {id: 2})");
+    run(&mut store, "MATCH (x:S {id:1}), (y:S {id:2}) CREATE (x)-[:R]->(y)");
+    store
+}
+
+#[test]
+fn an_edge_cannot_be_reused_to_return_to_the_start() {
+    // Neo4j 5: 0. We returned 2 — the edge walked out and back, once from each end.
+    let store = one_edge();
+    assert_eq!(
+        count(&store, "MATCH (a:S)-[:R]-(b:S)-[:R]-(a) RETURN count(a) AS c"),
+        0,
+        "the pattern needs two relationships and the graph has one"
+    );
+}
+
+#[test]
+fn an_edge_cannot_be_reused_even_without_a_repeated_variable() {
+    // Nodes may repeat (c can be a), so this is not about node isomorphism —
+    // it is the edge that may not be reused. Neo4j 5: 0.
+    let store = one_edge();
+    assert_eq!(
+        count(&store, "MATCH (a:S)-[:R]-(b:S)-[:R]-(c:S) RETURN count(*) AS c"),
+        0
+    );
+}
+
+#[test]
+fn separate_match_clauses_may_reuse_an_edge() {
+    // The other half of the rule, and the one a too-broad fix breaks. Neo4j 5: 2.
+    let store = one_edge();
+    assert_eq!(
+        count(&store, "MATCH (a:S)-[:R]-(b:S) MATCH (b)-[:R]-(c:S) RETURN count(*) AS c"),
+        2,
+        "isomorphism is per-clause; a second MATCH starts fresh"
+    );
+}
+
+#[test]
+fn a_genuine_two_edge_path_still_matches() {
+    // The fix must not prune legitimate traversals: distinct edges are fine.
+    let mut store = GraphStore::new();
+    for i in 1..=3 {
+        run(&mut store, &format!("CREATE (:T {{id: {i}}})"));
+    }
+    run(&mut store, "MATCH (x:T {id:1}), (y:T {id:2}) CREATE (x)-[:R]->(y)");
+    run(&mut store, "MATCH (x:T {id:2}), (y:T {id:3}) CREATE (x)-[:R]->(y)");
+    assert_eq!(
+        count(&store, "MATCH (a:T)-[:R]-(b:T)-[:R]-(c:T) RETURN count(*) AS c"),
+        2,
+        "1-2-3 and 3-2-1 use two distinct edges each"
+    );
+}
+
+#[test]
+fn a_triangle_is_still_found() {
+    // BI-17's shape over a real triangle: three distinct edges, so it matches.
+    let mut store = GraphStore::new();
+    for i in 1..=3 {
+        run(&mut store, &format!("CREATE (:P {{id: {i}}})"));
+    }
+    for (x, y) in [(1, 2), (2, 3), (3, 1)] {
+        run(&mut store, &format!(
+            "MATCH (x:P {{id: {x}}}), (y:P {{id: {y}}}) CREATE (x)-[:R]->(y)"
+        ));
+    }
+    assert_eq!(
+        count(&store,
+            "MATCH (a:P)-[:R]-(b:P)-[:R]-(c:P)-[:R]-(a) \
+             WHERE a.id < b.id AND b.id < c.id RETURN count(a) AS c"),
+        1
+    );
+}
+
+#[test]
+fn a_self_loop_is_unaffected() {
+    // Revisiting a *node* is legal; only the edge is restricted (#639).
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:L {id: 1})");
+    run(&mut store, "MATCH (x:L {id:1}) CREATE (x)-[:R]->(x)");
+    assert_eq!(count(&store, "MATCH (a:L)-[:R]->(a) RETURN count(a) AS c"), 1);
+}


### PR DESCRIPTION
One relationship may not be traversed twice within a single MATCH. We did not
enforce it in the main MATCH path, so ordinary patterns returned rows that do
not exist:

  MATCH (a)-[:R]-(b)-[:R]-(c)   over a three-node chain
    before  6 rows
    after   2 rows
    Neo4j 5 2 rows

Three times too many rows on a two-hop undirected pattern — one of the most
common shapes there is — silently, with no error. TCK goes 1058 -> 1067 of
1244 evaluated, which is the independent check that this matches openCypher and
not merely the three probes I ran against Neo4j.

The `EXISTS` walker already enforced this: `exists_expand_hops` threads a
`visited_edges` slice and skips an edge it has used. `ExpandOperator` had no
such tracking, so the same question got two different answers depending on
which evaluator the planner picked — the recurring shape in this executor
rather than a one-off.

**Scope was measured, not assumed**, and both halves constrain the fix:

  MATCH (a)-[:R]-(b)-[:R]-(c)            -> 0   enforced with no repeated
                                                variable, so tracking cannot be
                                                limited to self-references
  MATCH (a)-[:R]-(b) MATCH (b)-[:R]-(c)  -> 2   NOT enforced across clauses, so
                                                a broader fix breaks a legal query

Both are pinned by tests, along with the cases a careless version breaks: a
genuine two-edge path, a real triangle, and a self-loop (a *node* may repeat;
only the edge is restricted, #639).

Implementation:

  * `Record.used_edges` is a `Vec`, not a set. An empty `Vec` does not
    allocate, so single-hop patterns — which cannot violate the rule — pay
    nothing beyond the field itself.
  * The isomorphism test runs *first* in the candidate guard: comparing a few
    u64s against a slice that is empty for most patterns is cheaper than the
    label sets or property reads below it.
  * Both `ExpandOperator::next` and `next_batch` are wired. Covering one only
    would make the answer depend on whether the plan happened to run batched.

Known gap, not hidden: comma-separated paths in one clause
(`MATCH (a)-[:R]-(b), (c)-[:R]-(d)`) reset per path rather than per clause, so
isomorphism is not enforced *between* them. Narrower than the defect being
fixed here, and tracked on #684.