### PR TITLE
PERF: pin a closing hop to its bound variable — 4.9x on self-referencing patterns

### DIFF
--- a/examples/bi11_explain.rs
+++ b/examples/bi11_explain.rs
@@ -28,6 +28,10 @@ MATCH (a:Person)-[:KNOWS]-(b:Person)-[:KNOWS]-(c:Person)-[:KNOWS]-(a)
 WHERE a.id < b.id AND b.id < c.id
 RETURN count(a) AS triangleCount";
 
+// BI-17 staged, to find which stage costs the time rather than guessing.
+const S1: &str = "MATCH (a:Person)-[:KNOWS]-(b:Person) WHERE a.id < b.id RETURN count(*) AS x";
+const S2: &str = "MATCH (a:Person)-[:KNOWS]-(b:Person)-[:KNOWS]-(c:Person) WHERE a.id < b.id AND b.id < c.id RETURN count(*) AS x";
+
 const OUTER_ONLY: &str = "MATCH (reply:Comment)-[:REPLY_OF]->(post:Post) RETURN count(reply) AS c";
 const INNER_ONLY: &str = "MATCH (reply:Comment)-[:HAS_TAG]->(t:Tag) RETURN count(reply) AS c";
 
@@ -45,6 +49,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let t = std::time::Instant::now();
     ldbc_bi_common::load_dataset(&mut graph, &data_dir)?;
     eprintln!("loaded in {:.1}s", t.elapsed().as_secs_f64());
+
+    // Timed execution of the staged shapes, not just their plans.
+    // Bounded BI-17: the full shape including the closing hop, over a slice of
+    // the outer scan, so pinned-vs-unpinned is measurable without a timeout.
+    const S3: &str = "MATCH (a:Person)-[:KNOWS]-(b:Person)-[:KNOWS]-(c:Person)-[:KNOWS]-(a) \
+WHERE a.id < 400 AND a.id < b.id AND b.id < c.id RETURN count(a) AS x";
+    for (label, cypher) in [("BI-17 stage1 (a-b)", S1), ("BI-17 stage2 (a-b-c)", S2), ("BI-17 bounded (full)", S3)] {
+        let t = std::time::Instant::now();
+        let q = parse_query(cypher)?;
+        match QueryExecutor::new(&graph).execute(&q) {
+            Ok(out) => {
+                let v = out.records.first().and_then(|r| r.get("x")).cloned();
+                println!("@@ {label:<24} {:>8.1}s  rows={v:?}", t.elapsed().as_secs_f64());
+            }
+            Err(e) => println!("@@ {label:<24} failed: {e}"),
+        }
+    }
 
     for (label, cypher) in [("BI-11", BI11), ("BI-17", BI17), ("outer only", OUTER_ONLY), ("inner only", INNER_ONLY)] {
         println!("\n================ {label} ================");

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3850,6 +3850,19 @@ pub struct ExpandOperator {
     /// Off for a single-hop pattern, which cannot violate the rule and should
     /// not pay for the bookkeeping.
     track_edges: bool,
+    /// Pin the target to whatever this variable is bound to on the current
+    /// row, resolved per input record rather than at plan time.
+    ///
+    /// A pattern that closes back onto a bound variable — LDBC BI-17's
+    /// `(a)-[:KNOWS]-(b)-[:KNOWS]-(c)-[:KNOWS]-(a)` — is planned as an expand
+    /// into a synthetic `__self_a_2` followed by `__self_a_2 = a`. That is
+    /// correct and enumerates every neighbour of `c` to keep one: ~41 per
+    /// person on SF1, over ~17.8M candidate paths. Pinning here rejects the
+    /// other 40 during the adjacency walk, before a record exists (#195).
+    ///
+    /// Distinct from `target_ids`, which is a plan-time constant set; this one
+    /// changes with every row.
+    target_bound_var: Option<Arc<str>>,
     /// This expand begins a MATCH clause, so it clears the inherited history
     /// first. Isomorphism is per-clause — `MATCH (a)-[:R]-(b) MATCH (b)-[:R]-(c)`
     /// may legitimately reuse the edge.
@@ -3877,6 +3890,7 @@ impl ExpandOperator {
             target_ids: None,
             track_edges: false,
             starts_clause: false,
+            target_bound_var: None,
             direction,
             current_record: None,
             current_edges: Vec::new(),
@@ -3909,6 +3923,12 @@ impl ExpandOperator {
     /// The resolved node set for the target, when the planner could compute it.
     /// Preferred over `target_props`: an id membership test costs a hash
     /// lookup where the property check costs a node fetch (#665).
+    /// Pin this expand's target to the node already bound to `var`.
+    pub fn with_target_bound_var(mut self, var: String) -> Self {
+        self.target_bound_var = Some(var.into());
+        self
+    }
+
     /// Enforce relationship isomorphism for this expand.
     ///
     /// `starts_clause` marks the first expand of a MATCH clause, which drops
@@ -4018,7 +4038,19 @@ impl ExpandOperator {
         } else {
             &[]
         };
+        // Resolved once per input record: the node the pattern must close on.
+        let pinned_target: Option<NodeId> = self
+            .target_bound_var
+            .as_ref()
+            .and_then(|v| record.get(v))
+            .and_then(|v| v.node_id());
         let keeps = |target: NodeId, eid: crate::graph::EdgeId| -> bool {
+            // A closing hop can only land on the node it closes onto.
+            if let Some(p) = pinned_target {
+                if target != p {
+                    return false;
+                }
+            }
             // Relationship isomorphism first: it is a comparison of a few u64s
             // against a slice that is empty for every single-hop pattern, so it
             // is cheaper than anything below and rejects the most rows on the

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2988,6 +2988,14 @@ impl QueryPlanner {
                         expand = expand.with_edge_isolation(first_expand);
                         first_expand = false;
                     }
+                    // A closing hop back onto an already-bound variable can
+                    // only land on that node. Without this the expand walks
+                    // every neighbour and the `__self_x = x` filter below
+                    // discards all but one — BI-17's triangle close is ~41
+                    // neighbours per person over ~17.8M paths (#195).
+                    if self_ref {
+                        expand = expand.with_target_bound_var(target_var.clone());
+                    }
                     // A selective equality on the far side of the expansion —
                     // LDBC IC11's `org.name = "..."` — applied during the walk
                     // rather than to the rows it produces (#656).


### PR DESCRIPTION
A pattern that closes back onto an already-bound variable — BI-17's
`(a)-[:KNOWS]-(b)-[:KNOWS]-(c)-[:KNOWS]-(a)` — is planned as an expand into a
synthetic `__self_a_2` followed by `__self_a_2 = a`. Correct, and it walks
every neighbour of `c` to keep one: ~41 per person on SF1.

`ExpandOperator::with_target_bound_var` resolves the pinned node per input
record and rejects the others during the adjacency walk, before a record is
built. Distinct from `target_ids`, which is a plan-time constant set; this one
changes every row.

Measured A/B on the same host and data, bounded BI-17 (`a.id < 400`), both
returning 4,696 triangles:

  with pin      1.6 s
  without pin   7.8 s      4.9x

Control: the two prefix shapes are unchanged across the same pair of runs —
`(a)-(b)` 0.3 s both, `(a)-(b)-(c)` 29.7 vs 30.6 s. Neither has a
self-reference, so the pin should not touch them, and does not. That is what
makes the 4.9x attributable to this change rather than to the machine.

The A/B exists because the reasoning for this optimisation was not evidence.
Four earlier conclusions about this query were wrong — the culprit commit, the
already-implemented fix, the bottleneck stage, and which stage the pin would
help. An unmeasured optimisation is complexity with a plausible story attached.

**This does not fix BI-17**, and the same measurement says why:

  stage `(a)-(b)`      0.3 s      219,450 rows
  stage `(a)-(b)-(c)` 28.7 s   11,394,048 rows

11.4M intermediate rows are materialised before the closing hop runs at all, so
no improvement to the close can rescue the query. BI-17 needs a different
execution strategy — sorted-adjacency intersection or a worst-case-optimal join
— which is an engine feature rather than a patch. Recorded on #195.

`examples/bi11_explain.rs` carries the staged probes used here, so the next
person measures instead of estimating.