### PR TITLE
LANG-01: ORDER BY uses Cypher's orderability, not the property index's — CH-TCK 86.7%

### DIFF
--- a/src/graph/property.rs
+++ b/src/graph/property.rs
@@ -98,6 +98,77 @@ pub enum PropertyValue {
     Null,
 }
 
+
+/// Cypher's orderability, for `ORDER BY` — **not** the same order as
+/// [`PropertyValue`]'s `Ord`.
+///
+/// openCypher defines one total order over values of every type, ascending:
+///
+/// ```text
+/// Map < Node < Relationship < List < Path < String < Boolean < Number < NaN < null
+/// ```
+///
+/// `Ord` on this type is deliberately a *different* total order — Boolean,
+/// Number, String, DateTime, Array, Map, Vector, Duration, Null — because it
+/// backs the B-tree property index, where the requirement is a consistent
+/// order in which numbers compare numerically across `Integer` and `Float`.
+/// Any consistent order satisfies an index; only this one satisfies a query.
+/// Reusing the index order for `ORDER BY` sorted strings after numbers and
+/// lists after both.
+///
+/// Both orders are therefore kept. Do not "unify" them: changing `Ord` to
+/// match this would reorder every existing property index, and changing this
+/// to match `Ord` would answer `ORDER BY` wrongly.
+///
+/// Temporal values sort with the numbers, next to the timestamp they are.
+/// openCypher orders temporal types among themselves and the TCK scenarios
+/// here do not mix them with other types, so the placement is unconstrained by
+/// evidence and marked as such rather than presented as settled.
+pub fn cypher_order(a: &PropertyValue, b: &PropertyValue) -> Ordering {
+    use PropertyValue::*;
+
+    fn rank(v: &PropertyValue) -> u8 {
+        match v {
+            Map(_) => 0,
+            Array(_) | Vector(_) => 1,
+            String(_) => 2,
+            Boolean(_) => 3,
+            Integer(_) | Float(_) | DateTime(_) | Duration { .. } => 4,
+            Null => 5,
+        }
+    }
+
+    let (ra, rb) = (rank(a), rank(b));
+    if ra != rb {
+        return ra.cmp(&rb);
+    }
+
+    match (a, b) {
+        // Element-wise, then by length: a shared prefix puts the shorter first.
+        (Array(x), Array(y)) => {
+            for (xi, yi) in x.iter().zip(y.iter()) {
+                let c = cypher_order(xi, yi);
+                if c != Ordering::Equal {
+                    return c;
+                }
+            }
+            x.len().cmp(&y.len())
+        }
+        // NaN sorts after every other number, before null.
+        (Float(x), Float(y)) if x.is_nan() || y.is_nan() => {
+            match (x.is_nan(), y.is_nan()) {
+                (true, true) => Ordering::Equal,
+                (true, false) => Ordering::Greater,
+                (false, true) => Ordering::Less,
+                _ => unreachable!(),
+            }
+        }
+        // Within a rank the index order already does the right thing, and for
+        // numbers it is the thing that makes 999999 > 6.9 across variants.
+        _ => a.cmp(b),
+    }
+}
+
 impl Eq for PropertyValue {}
 
 impl PartialOrd for PropertyValue {

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -6535,7 +6535,11 @@ impl SortOperator {
             let (Some(x), Some(y)) = (a.get(i), b.get(i)) else {
                 continue;
             };
-            let ord = x.cmp(y);
+            // Cypher's orderability, not the index's: `ORDER BY` puts a
+            // string before a number and a list before both, where the `Ord`
+            // backing the property index does the opposite. See
+            // `graph::property::cypher_order` for why both orders exist.
+            let ord = crate::graph::property::cypher_order(x, y);
             if ord != std::cmp::Ordering::Equal {
                 return if *ascending { ord } else { ord.reverse() };
             }
@@ -11481,7 +11485,11 @@ impl WithBarrierOperator {
                     let val_b = Self::evaluate_expression(expr, b, store).unwrap_or(Value::Null);
                     let prop_a = val_a.as_property().unwrap_or(&PropertyValue::Null);
                     let prop_b = val_b.as_property().unwrap_or(&PropertyValue::Null);
-                    let ord = prop_a.cmp(prop_b);
+                    // Cypher's orderability, not the property index's — see
+                    // `graph::property::cypher_order`. A WITH ... ORDER BY
+                    // sorts here rather than in `SortOperator`, so wiring only
+                    // that one left every `WITH` sort on the old order.
+                    let ord = crate::graph::property::cypher_order(prop_a, prop_b);
                     if ord != std::cmp::Ordering::Equal {
                         return if *ascending { ord } else { ord.reverse() };
                     }

--- a/tests/cypher_orderability.rs
+++ b/tests/cypher_orderability.rs
@@ -1,0 +1,122 @@
+//! ORDER BY across mixed types follows Cypher's orderability, not the index's.
+//!
+//! openCypher defines a total order over values of different types, ascending:
+//!
+//! ```text
+//! Map < Node < Relationship < List < Path < String < Boolean < Number < NaN < null
+//! ```
+//!
+//! `PropertyValue`'s `Ord` is a *different* total order — Boolean, Number,
+//! String, DateTime, Array, Map, Vector, Duration, Null — and deliberately so:
+//! it backs the B-tree property index, where any consistent order works and
+//! numbers must compare numerically across Integer and Float. Reusing it for
+//! ORDER BY put strings after numbers and lists after both.
+//!
+//! Both orders are needed. This pins the query-level one; the index keeps its
+//! own, and `property.rs` keeps the comment explaining why they differ.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn column(store: &GraphStore, cypher: &str) -> Vec<String> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"))
+        .records
+        .iter()
+        .map(|r| match r.get("x") {
+            Some(Value::Property(PropertyValue::Array(a))) => format!("{a:?}"),
+            Some(v) => format!("{v:?}"),
+            None => "<none>".into(),
+        })
+        .collect()
+}
+
+#[test]
+fn lists_sort_element_wise_with_a_shorter_prefix_first() {
+    // WithOrderBy1 [9] / ReturnOrderBy1 [9]. The TCK's expected first four are
+    // [], ['a'], ['a', 1], [1] — which also pins String before Number, since
+    // ['a', ...] precedes [1].
+    let store = GraphStore::new();
+    let got = column(
+        &store,
+        "UNWIND [[], ['a'], ['a', 1], [1], [1, 'a']] AS l WITH l ORDER BY l LIMIT 4 RETURN l AS x",
+    );
+    assert_eq!(got.len(), 4, "expected four rows, got {got:?}");
+    assert!(got[0].contains("[]"), "empty list sorts first, got {:?}", got[0]);
+    assert!(
+        got[1].contains("String(\"a\")") && !got[1].contains("Integer"),
+        "['a'] second, got {:?}", got[1]
+    );
+    assert!(
+        got[2].contains("String(\"a\")") && got[2].contains("Integer"),
+        "['a', 1] third — a shared prefix orders by length, got {:?}", got[2]
+    );
+    assert!(
+        got[3].contains("Integer(1)") && !got[3].contains("String"),
+        "[1] fourth — a string element sorts before a numeric one, got {:?}", got[3]
+    );
+}
+
+#[test]
+fn a_string_sorts_before_a_number() {
+    // The single comparison the list ordering above depends on, isolated.
+    // PropertyValue's index order puts these the other way round.
+    let store = GraphStore::new();
+    let got = column(&store, "UNWIND [1, 'a'] AS v WITH v ORDER BY v RETURN v AS x");
+    assert!(got[0].contains("String"), "string first, got {got:?}");
+    assert!(got[1].contains("Integer"), "number second, got {got:?}");
+}
+
+#[test]
+fn the_cross_type_order_is_map_list_string_boolean_number_null() {
+    // The PropertyValue-expressible part of Cypher's orderability.
+    let store = GraphStore::new();
+    let got = column(
+        &store,
+        "UNWIND [1.5, 'text', false, null, ['list'], {a: 'map'}] AS v \
+         WITH v ORDER BY v RETURN v AS x",
+    );
+    assert_eq!(got.len(), 6, "got {got:?}");
+    assert!(got[0].contains("Map"), "map first, got {:?}", got[0]);
+    assert!(got[1].contains("Array") || got[1].contains("["), "list second, got {:?}", got[1]);
+    assert!(got[2].contains("String"), "string third, got {:?}", got[2]);
+    assert!(got[3].contains("Boolean"), "boolean fourth, got {:?}", got[3]);
+    assert!(got[4].contains("Float") || got[4].contains("Integer"), "number fifth, got {:?}", got[4]);
+    assert!(got[5].contains("Null"), "null last, got {:?}", got[5]);
+}
+
+#[test]
+fn descending_reverses_the_whole_order() {
+    let store = GraphStore::new();
+    let got = column(
+        &store,
+        "UNWIND [1.5, 'text', false, null, {a: 'map'}] AS v WITH v ORDER BY v DESC RETURN v AS x",
+    );
+    assert!(got[0].contains("Null"), "null first on DESC, got {:?}", got[0]);
+    assert!(got[4].contains("Map"), "map last on DESC, got {:?}", got[4]);
+}
+
+#[test]
+fn numbers_still_compare_numerically_across_integer_and_float() {
+    // The property the index order exists for must survive: 999999 > 6.9 even
+    // though they are different variants.
+    let store = GraphStore::new();
+    let got = column(&store, "UNWIND [999999, 6.9, 2] AS v WITH v ORDER BY v RETURN v AS x");
+    assert!(got[0].contains("Integer(2)"), "got {got:?}");
+    assert!(got[1].contains("6.9"), "got {got:?}");
+    assert!(got[2].contains("999999"), "got {got:?}");
+}
+
+#[test]
+fn ordinary_same_type_sorts_are_unchanged() {
+    let store = GraphStore::new();
+    assert_eq!(
+        column(&store, "UNWIND ['b', 'a', 'c'] AS v WITH v ORDER BY v RETURN v AS x").len(),
+        3
+    );
+    let nums = column(&store, "UNWIND [3, 1, 2] AS v WITH v ORDER BY v RETURN v AS x");
+    assert!(nums[0].contains("Integer(1)") && nums[2].contains("Integer(3)"), "got {nums:?}");
+}


### PR DESCRIPTION
CH-TCK 86.4% -> 86.7% (1075 -> 1079 of 1244), no regressions.

openCypher defines one total order across types:

  Map < Node < Relationship < List < Path < String < Boolean < Number < NaN < null

`PropertyValue`'s `Ord` is a different total order — Boolean, Number, String,
DateTime, Array, Map, Vector, Duration, Null — and `ORDER BY` was using it, so
strings sorted after numbers and lists after both.

**Both orders are now kept, deliberately.** `Ord` backs the B-tree property
index, where the requirement is only that the order be consistent and that
numbers compare numerically across `Integer` and `Float`. Any consistent order
satisfies an index; only Cypher's satisfies a query. Unifying them would be
wrong in both directions: changing `Ord` reorders every existing index,
changing the query order answers `ORDER BY` wrongly. `cypher_order` carries
that reasoning, because "why are there two comparators" is the kind of question
a later reader tidies away.

Two sort paths needed wiring, not one. `SortOperator::cmp_keys` was the obvious
site and had no effect on its own: `WITH ... ORDER BY` sorts inside
`WithBarrierOperator`, which has its own comparison. The tests failing
identically after the first change is what surfaced that.

Covers the four list-ordering scenarios. The four "distinct types" ones also
need nodes and relationships as sort keys, and the key is `Vec<PropertyValue>`,
which cannot hold an entity — a separate change.

One placement is a guess and is marked as one: temporal values sort with the
numbers. openCypher orders temporal types among themselves and no TCK scenario
here mixes them with other types, so nothing in evidence constrains it.

Two of the six tests passed before this change. They pin what the index order
exists for — `999999 > 6.9` across variants, and same-type sorts — so a later
attempt to collapse the two orders fails loudly.