### PR TITLE
Fix CREATE with several paths to bind every variable in one row (#614)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -7647,25 +7647,33 @@ impl PhysicalOperator for CreateNodeOperator {
             self.executed = true;
         }
 
-        // Return created nodes one by one
-        if self.current >= self.created_nodes.len() {
+        // One row, binding *every* node this CREATE made — not one row per node.
+        //
+        // `CREATE (a), (b) RETURN a, b` is a single row in Cypher with both
+        // bound. Emitting a record per node gave two rows, neither of which had
+        // both, so the RETURN failed with "Variable not found: b" while the
+        // nodes themselves were created correctly (#614). The relationship form
+        // was unaffected because `CreateNodesAndEdgesOperator` merges the
+        // bindings above this operator — which is why the bug looked like it
+        // was about commas rather than about rows.
+        if self.current > 0 || self.created_nodes.is_empty() {
             return Ok(None);
         }
-
-        let (node_id, variable) = &self.created_nodes[self.current];
-        self.current += 1;
-
-        let node = store.get_node(*node_id)
-            .ok_or_else(|| ExecutionError::RuntimeError(format!("Created node {:?} not found", node_id)))?;
+        self.current = 1;
 
         let mut record = Record::new();
-        // Always bind created node — use variable name if provided, otherwise
-        // generate an internal name so persistence code can discover it.
-        let bind_name = match variable {
-            Some(var) => var.clone(),
-            None => format!("__created_node_{}", self.current - 1),
-        };
-        record.bind(bind_name, Value::Node(*node_id, Box::new(node.clone())));
+        for (idx, (node_id, variable)) in self.created_nodes.iter().enumerate() {
+            let node = store.get_node(*node_id).ok_or_else(|| {
+                ExecutionError::RuntimeError(format!("Created node {:?} not found", node_id))
+            })?;
+            // Anonymous nodes still get a name, so persistence and edge wiring
+            // can find them; it is kept out of `output_columns` by the planner.
+            let bind_name = match variable {
+                Some(var) => var.clone(),
+                None => format!("__created_node_{idx}"),
+            };
+            record.bind(bind_name, Value::Node(*node_id, Box::new(node.clone())));
+        }
 
         Ok(Some(record))
     }

--- a/tests/create_multi_path_variables.rs
+++ b/tests/create_multi_path_variables.rs
@@ -1,0 +1,91 @@
+//! `CREATE (a), (b) RETURN a, b` must bind every path's variables, not the
+//! first path's (#614).
+//!
+//! `CREATE (a:X {n:1}), (b:Y {n:2}) RETURN a.n, b.n` failed with
+//! "Variable not found: b" while the single-path form worked. Comma-separated
+//! paths in one CREATE are the ordinary way to make several disconnected
+//! nodes, so this is a common shape rather than a corner.
+//!
+//! The nodes were created correctly — only the binding was lost, which is why
+//! it surfaced as a RETURN error rather than missing data.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn write(store: &mut GraphStore, cypher: &str) -> Vec<Vec<(String, Value)>> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    let out = MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+    let cols = out.columns.clone();
+    out.records
+        .iter()
+        .map(|r| cols.iter().map(|c| (c.clone(), r.get(c).cloned().unwrap_or(Value::Null))).collect())
+        .collect()
+}
+
+fn count(store: &GraphStore, cypher: &str) -> i64 {
+    let q = parse_query(cypher).unwrap();
+    match QueryExecutor::new(store).execute(&q).unwrap().records[0].get("c") {
+        Some(Value::Property(PropertyValue::Integer(i))) => *i,
+        other => panic!("expected integer, got {other:?}"),
+    }
+}
+
+#[test]
+fn two_comma_separated_paths_bind_both_variables() {
+    let mut store = GraphStore::new();
+    let rows = write(&mut store, "CREATE (a:X {n:1}), (b:Y {n:2}) RETURN a.n, b.n");
+    assert_eq!(rows.len(), 1, "one row, got {rows:?}");
+    let vals: Vec<&Value> = rows[0].iter().map(|(_, v)| v).collect();
+    assert_eq!(vals[0], &Value::Property(PropertyValue::Integer(1)), "a.n");
+    assert_eq!(vals[1], &Value::Property(PropertyValue::Integer(2)), "b.n");
+}
+
+#[test]
+fn three_paths_bind_all_three() {
+    // Not just the second: a fix that special-cased two would pass the test
+    // above and still be wrong.
+    let mut store = GraphStore::new();
+    let rows = write(
+        &mut store,
+        "CREATE (a:X {n:1}), (b:Y {n:2}), (c:Z {n:3}) RETURN a.n, b.n, c.n",
+    );
+    let vals: Vec<&Value> = rows[0].iter().map(|(_, v)| v).collect();
+    assert_eq!(vals[0], &Value::Property(PropertyValue::Integer(1)));
+    assert_eq!(vals[1], &Value::Property(PropertyValue::Integer(2)));
+    assert_eq!(vals[2], &Value::Property(PropertyValue::Integer(3)));
+}
+
+#[test]
+fn a_relationship_path_beside_a_node_path_binds_both() {
+    let mut store = GraphStore::new();
+    let rows = write(
+        &mut store,
+        "CREATE (a:X {n:1})-[:R]->(b:X {n:2}), (c:Z {n:3}) RETURN a.n, b.n, c.n",
+    );
+    let vals: Vec<&Value> = rows[0].iter().map(|(_, v)| v).collect();
+    assert_eq!(vals[0], &Value::Property(PropertyValue::Integer(1)));
+    assert_eq!(vals[1], &Value::Property(PropertyValue::Integer(2)));
+    assert_eq!(vals[2], &Value::Property(PropertyValue::Integer(3)));
+}
+
+#[test]
+fn the_nodes_are_created_regardless() {
+    // The data was always right; only the binding was lost. Pinning this so a
+    // fix to the binding cannot quietly change what gets written.
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (a:X {n:1}), (b:Y {n:2})").unwrap();
+    MutQueryExecutor::new(&mut store, "default".to_string()).execute(&q).unwrap();
+    assert_eq!(count(&store, "MATCH (n:X) RETURN count(n) AS c"), 1);
+    assert_eq!(count(&store, "MATCH (n:Y) RETURN count(n) AS c"), 1);
+}
+
+#[test]
+fn a_single_path_still_binds_its_variables() {
+    // Control: the form that already worked.
+    let mut store = GraphStore::new();
+    let rows = write(&mut store, "CREATE (a:X {n:1}) RETURN a.n");
+    assert_eq!(rows[0][0].1, Value::Property(PropertyValue::Integer(1)));
+}


### PR DESCRIPTION
`CREATE (a:X {n:1}), (b:Y {n:2}) RETURN a.n, b.n` failed with "Variable not
found: b". The single-path form worked.

The cause is not commas. `CreateNodeOperator` emitted **one row per created
node**, each a fresh `Record` binding only that node — so the query produced
two rows, one holding `a` and one holding `b`, and neither could answer a
RETURN naming both. In Cypher `CREATE (a), (b) RETURN a, b` is a single row
with both bound.

It now emits one row binding every node the CREATE made.

What located it was a control case rather than the failing one:

    CREATE (a:X)-[:R]->(b:X), (c:Z) RETURN a.n, b.n, c.n     worked

Comma-separated paths were therefore fine, and the relationship form works only
because `CreateNodesAndEdgesOperator` merges bindings above this operator.
Without that control the search would have gone to path parsing, which was
never wrong.

The nodes were always created correctly — `the_nodes_are_created_regardless`
passes before and after. Only the binding was lost, which is why this surfaced
as a RETURN error rather than as missing data, and why it could sit open since
2026-08-18 without anyone losing a write.

`three_paths_bind_all_three` is there because a fix special-casing two paths
would pass the two-path test and still be wrong.

Full workspace suite green; CH-TCK unchanged at 86.7% with no regressions,
which is the check that matters for a change altering the row count of every
CREATE.