### PR TITLE
LANG-01: gate the TCK pass count in CI so it may never decrease (#436)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,27 @@ jobs:
         # so the two cannot drift apart again.
         run: cargo run --release --example api_contract
 
+      - name: CH-TCK — the openCypher pass count may not decrease
+        # LANG-01 (#436). The rate went 57.2% -> 86.7% over a few days with
+        # nothing stopping it going back: every fix so far has rested on this
+        # number, and an unguarded number is one refactor from being wrong.
+        #
+        # The scenario set is pinned to tag 2024.3. Not for reproducibility in
+        # the abstract — a moving denominator changes the rate without the
+        # engine changing, and then nobody can tell a regression from a new
+        # scenario.
+        #
+        # The floor is a *count*, not a percentage, for the same reason: a
+        # scenario the harness learns to judge moves from "skipped" to
+        # "evaluated" and shifts the percentage on its own. The count moves only
+        # when the engine does.
+        #
+        # Raise the floor when it goes up; lowering it is allowed but must say
+        # why in the same commit.
+        run: |
+          git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 1079
+
       - name: CH-ALGO-PARITY — the algorithms still agree with NetworkX
         # ALGO-02. The reference values are regenerated from NetworkX on a
         # cadence by the harness in samyama-graph-competitor-benchmarks; this

--- a/examples/tck_runner.rs
+++ b/examples/tck_runner.rs
@@ -1335,6 +1335,36 @@ fn main() {
     println!("scenarios this harness can judge; the coverage says how many it can judge at");
     println!("all. Quoting either alone misleads.");
 
+    // Ratchet (#436). CI passes the count the engine is known to reach; a run
+    // below it fails the build.
+    //
+    // The *count* rather than the rate, because the rate has a denominator that
+    // can move: a scenario the harness learns to judge shifts a scenario from
+    // "skipped" into "evaluated", which changes the percentage without the
+    // engine changing at all. The count of passing scenarios only moves when
+    // the engine does — provided the scenario set is pinned, which is what
+    // `TCK_REF` in the harness is for.
+    if let Some(min) = arg("--min-pass").and_then(|v| v.parse::<usize>().ok()) {
+        println!();
+        if pass < min {
+            println!(
+                "RATCHET FAILED: {pass} scenarios pass, floor is {min}. \
+                 {} fewer than the recorded baseline.",
+                min - pass
+            );
+            println!(
+                "  A drop here means a change took working behaviour away. If it is \
+                 deliberate, lower the floor in the same commit and say why."
+            );
+            std::process::exit(1);
+        }
+        println!("RATCHET OK: {pass} pass, floor {min}{}.", if pass > min {
+            format!(" (+{} — raise the floor)", pass - min)
+        } else {
+            String::new()
+        });
+    }
+
     println!("\nTop skip reasons:");
     let mut reasons: Vec<_> = skip_reasons.into_iter().collect();
     reasons.sort_by_key(|(_, n)| std::cmp::Reverse(*n));


### PR DESCRIPTION
CH-TCK went 57.2% -> 86.7% over a few days and nothing stopped it going back.
Every language fix in that stretch rested on the number, and an unguarded
number is one refactor away from being quietly wrong.

`tck_runner --min-pass N` exits 1 when fewer than N scenarios pass. CI runs it
with the floor at the current 1079.

**A count, not a percentage.** The rate has a denominator that moves: when the
harness learns to judge a scenario it shifts from "skipped" to "evaluated" and
the percentage changes with the engine untouched. The count of passing
scenarios moves only when behaviour does.

**The scenario set is pinned to tag 2024.3**, and fixing that was a
prerequisite rather than a nicety. `ch_tck.py`'s docstring claimed "pinned to a
tag" while the code ran `git clone --depth 1` with no ref — so it tracked
master, and every rate published up to today came from whatever master was at
the moment of first clone. That turned out to be 2024.3, verified after the
fact, so the numbers are comparable — by luck, not design. A ratchet on an
unpinned set would fail or pass for reasons that have nothing to do with the
engine.

The ratchet was checked in both directions before being wired up: it passes at
the true floor of 1079 and exits 1 at an impossible floor of 1200, reporting
"121 fewer than the recorded baseline". A gate that cannot fail is not a gate,
and this session has already seen one that could not (four UNION tests asserting
`>= 2` against a fixture whose first branch returned two).

Raising the floor when the count rises is the intended workflow. Lowering it is
allowed and must carry a reason in the same commit.