### PR TITLE
LANG-14: assert determinism across thread counts, in CI (#611)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,21 @@ jobs:
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
           cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 1079
 
+      - name: CH-DETERM-THREADS — the answer does not depend on the thread count
+        # LANG-14 (#611). CH-DETERM varies the *process*, which catches a
+        # RandomState seed reaching results. It says nothing about a parallel
+        # operator emitting rows in a different order at 8 threads than at 1.
+        #
+        # This runs here rather than nightly because it is nearly free: a TCK
+        # run is ~0.8 s, so three of them add ~3 s to a step whose 55 s is
+        # almost entirely the clone above. #611 assumed minutes and proposed
+        # deferring to nightly on that basis; the measurement says otherwise.
+        #
+        # It must land before morsel-driven parallel expand (PERF-06), not
+        # after — a determinism gate added afterwards cannot tell a new bug
+        # from a pre-existing one.
+        run: ./scripts/check_thread_determinism.sh /tmp/openCypher/tck/features
+
       - name: CH-ALGO-PARITY — the algorithms still agree with NetworkX
         # ALGO-02. The reference values are regenerated from NetworkX on a
         # cadence by the harness in samyama-graph-competitor-benchmarks; this

--- a/scripts/check_thread_determinism.sh
+++ b/scripts/check_thread_determinism.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# LANG-14: the same query on the same data returns identical results at any
+# thread count (#611).
+#
+# CH-DETERM varies the *process*, which catches a `RandomState` seed leaking
+# into results. It says nothing about a parallel operator emitting rows in a
+# different order at 8 threads than at 1 — which is the failure this checks,
+# and the one that matters as morsel-driven parallel expand lands under PERF-06.
+#
+# Compares full failure manifests as sets. A scenario that passes at 1 thread
+# and fails at 32 changes the manifest, and any difference fails the build.
+#
+#   usage: check_thread_determinism.sh <path to tck/features> [out-dir]
+set -euo pipefail
+
+FEATURES="${1:?usage: $0 <tck/features> [out-dir]}"
+OUT="${2:-$(mktemp -d)}"
+THREAD_COUNTS=(1 8 32)
+
+mkdir -p "$OUT"
+for t in "${THREAD_COUNTS[@]}"; do
+  RAYON_NUM_THREADS="$t" cargo run --release --quiet --example tck_runner -- \
+    --features "$FEATURES" --failures-manifest "$OUT/manifest-$t.txt" >/dev/null
+  if [ ! -s "$OUT/manifest-$t.txt" ]; then
+    echo "FAIL: no manifest produced at $t threads — the run did not complete"
+    exit 1
+  fi
+done
+
+base="${THREAD_COUNTS[0]}"
+status=0
+for t in "${THREAD_COUNTS[@]:1}"; do
+  if ! diff -u "$OUT/manifest-$base.txt" "$OUT/manifest-$t.txt" > "$OUT/diff-$base-$t.txt"; then
+    echo "FAIL: results differ between $base and $t threads."
+    echo "  A query's answer must not depend on how many threads ran it."
+    head -40 "$OUT/diff-$base-$t.txt"
+    status=1
+  fi
+done
+
+if [ "$status" -eq 0 ]; then
+  echo "OK: identical failure manifests at ${THREAD_COUNTS[*]} threads ($(wc -l < "$OUT/manifest-$base.txt") entries)"
+fi
+exit "$status"


### PR DESCRIPTION
CH-DETERM varies the *process*, which catches a `RandomState` seed reaching
results. It says nothing about a parallel operator emitting rows in a different
order at 8 threads than at 1 — which is what LANG-14 asks for and what matters
as morsel-driven parallel expand lands under PERF-06.

`scripts/check_thread_determinism.sh` runs the TCK at 1, 8 and 32 threads and
compares full failure manifests. Any difference fails the build.

**CI rather than nightly, decided on a measurement.** #611 proposed deferring
because "five TCK runs is minutes in release" and said picking neither home was
not defensible. A TCK run is **0.82 s**; the CI step's 55 s is almost entirely
the openCypher clone, which is already done. Three runs add roughly three
seconds. The cost estimate the deferral rested on does not hold.

Current state: identical manifests at all three thread counts, 165 entries.
So this starts green and stays a guard rather than a to-do.

Verified in both directions before wiring, as with the TCK ratchet: it passes
on the real run, and injecting one line into a manifest makes the comparison
exit non-zero. A gate that cannot fail reads as assurance while providing none.

Timing matters here beyond convenience — a determinism gate added *after*
parallel expand cannot distinguish a new bug from a pre-existing one.