### PR TITLE
#487: ratchet the clippy count so the lint debt stops growing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,22 @@ jobs:
           # Share the cache across jobs in this workflow; key on Cargo.lock.
           shared-key: ci-test
 
-      # `cargo fmt --check` and `cargo clippy -D warnings` are deliberately NOT
-      # here yet. The tree currently has ~5,000 rustfmt diffs and ~680 clippy
-      # warnings, so either gate would be red on arrival -- and a gate that is
-      # always red is one everybody learns to ignore, which is worse than not
-      # having it. Adopting both needs a mechanical reformat commit and a lint
-      # ratchet; tracked separately so this lane can start green and mean
-      # something from its first run.
+      # `cargo fmt --check` and `cargo clippy -D warnings` are still not hard
+      # gates. Re-measured 2026-08-22: **5,958 rustfmt diffs and 769 clippy
+      # warnings** (the ~5,000/~680 above were the 2026-08-16 figures — the
+      # debt grew while it was described as static, which is the argument for
+      # the ratchet below).
+      #
+      # Either gate would be red on arrival, and a permanently red gate is one
+      # everybody learns to ignore. Adopting them needs a mechanical reformat
+      # touching nearly every file — `git blame` stops being useful and every
+      # branch in flight conflicts — which is a real decision and has not been
+      # made.
+      #
+      # The ratchet is the half that does not need that decision: the count may
+      # not rise. New code arrives clean, the backlog shrinks whenever anyone
+      # touches a file, and the big-bang stays available as a deliberate choice
+      # rather than a prerequisite (#487).
 
       - name: Tests
         # --no-fail-fast so one failing crate does not hide the rest; a PR
@@ -141,6 +150,11 @@ jobs:
         # after — a determinism gate added afterwards cannot tell a new bug
         # from a pre-existing one.
         run: ./scripts/check_thread_determinism.sh /tmp/openCypher/tck/features
+
+      - name: LINT-RATCHET — the clippy warning count may not rise
+        # A ceiling, not a clean-tree gate: the debt stops growing while what
+        # to do about the existing 769 stays open (#487).
+        run: ./scripts/check_lint_ratchet.sh 769
 
       - name: CH-ALGO-PARITY — the algorithms still agree with NetworkX
         # ALGO-02. The reference values are regenerated from NetworkX on a

--- a/scripts/check_lint_ratchet.sh
+++ b/scripts/check_lint_ratchet.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# #487: stop the lint debt growing, without a big-bang reformat.
+#
+# The tree has ~5,958 rustfmt diffs and ~769 clippy warnings. Turning either
+# into a hard gate today means reformatting nearly every file in one commit:
+# `git blame` stops being useful, and every branch in flight conflicts. That is
+# a decision with real costs, and it is not this script's to make.
+#
+# What this does instead is a ratchet, the same shape as the TCK one: the
+# warning count may not rise. New code arrives clean, the debt shrinks whenever
+# someone touches a file, and the big-bang stays available as a separate,
+# deliberate choice rather than a prerequisite.
+#
+#   usage: check_lint_ratchet.sh [clippy-ceiling]
+set -uo pipefail
+
+CEILING="${1:-769}"
+
+count=$(cargo clippy --workspace --all-targets 2>&1 | grep -cE "^warning")
+echo "clippy warnings: $count (ceiling $CEILING)"
+
+if [ "$count" -gt "$CEILING" ]; then
+  echo "FAIL: $((count - CEILING)) more clippy warnings than the ceiling."
+  echo "  New code should not add to the backlog. Fix the new warnings, or"
+  echo "  raise the ceiling in the same commit and say why."
+  exit 1
+fi
+
+if [ "$count" -lt "$CEILING" ]; then
+  echo "OK: $((CEILING - count)) below the ceiling — lower it to $count and lock the gain in."
+else
+  echo "OK: at the ceiling."
+fi


### PR DESCRIPTION
Re-measured today: **5,958 rustfmt diffs and 769 clippy warnings**. The CI
comment said ~5,000 and ~680, measured 2026-08-16. The debt grew by roughly a
thousand while the file described it as static, which is the argument for a
ratchet rather than a note.

Adopting `cargo fmt --check` and `clippy -D warnings` outright still needs a
mechanical reformat touching nearly every file: `git blame` stops being useful
and every branch in flight conflicts. That is a real decision with costs on
both sides and **it is not made here** — deliberately, because it is the kind
of call that should be taken openly rather than smuggled in beside a lint gate.

What lands is the half that needs no such decision. `check_lint_ratchet.sh`
fails when the warning count exceeds a ceiling, currently 769. New code arrives
clean, the backlog shrinks whenever anyone touches a file, and the big-bang
stays available as a separate choice.

Verified both ways, as with the TCK and determinism gates: it passes at 769 and
fails at 768 reporting "1 more clippy warnings than the ceiling".

When the count drops the script says so and asks for the ceiling to be lowered,
so a gain gets locked in rather than quietly re-spent.