### PR TITLE
Snapshot import: put every property type in the column, not just scalars

### DIFF
--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -503,7 +503,16 @@ fn import_tenant_inner(
                             }
                         }
                         _ => {
-                            // Complex types: merge into HashMap if not present
+                            // Complex types: into the column as well as the row.
+                            // Same reason as the insert path above — the column
+                            // can hold them now, and leaving them row-only makes
+                            // them invisible to a column read (#545).
+                            if matches!(
+                                store.node_columns.get_property(eid.as_u64() as usize, key),
+                                PropertyValue::Null
+                            ) {
+                                store.set_column_property(eid, key, pv.clone());
+                            }
                             if let Some(node) = store.get_node_mut(eid) {
                                 if node.get_property(key).is_none() {
                                     node.set_property(key.clone(), pv);
@@ -538,18 +547,33 @@ fn import_tenant_inner(
                         node.add_label(label.as_str());
                     }
                 }
-                // Set properties: simple types go to ColumnStore, complex to HashMap
+                // Every property reaches the ColumnStore, whatever its type.
+                //
+                // This used to route `String`/`Integer`/`Float`/`Boolean` to the
+                // column and everything else to the row map alone, from when the
+                // column had no representation for the rest. `Column::Other`
+                // holds every variant now (#545), so the split left arrays, maps
+                // and temporals readable only through the row fallback — a
+                // snapshot round trip returned `Null` from the column for them
+                // while the row still had the value.
+                //
+                // Queries were unaffected, because `resolve_property` reads the
+                // column and falls back to the row. That fallback is exactly the
+                // copy #545 proposes to delete, so this had to be true before
+                // that becomes safe.
                 for (key, json_val) in &snap_node.props {
                     let pv = json_to_property(json_val);
-                    match &pv {
+                    store.set_column_property(new_id, &key, pv.clone());
+                    // The row copy is still written for the non-scalars, as
+                    // before: MVCC and the persistence encoder read it, and
+                    // narrowing that is #545's decision, not this fix's.
+                    if !matches!(
+                        pv,
                         PropertyValue::String(_) | PropertyValue::Integer(_)
-                        | PropertyValue::Float(_) | PropertyValue::Boolean(_) => {
-                            store.set_column_property(new_id, &key, pv);
-                        }
-                        _ => {
-                            if let Some(node) = store.get_node_mut(new_id) {
-                                node.set_property(key.clone(), pv);
-                            }
+                            | PropertyValue::Float(_) | PropertyValue::Boolean(_)
+                    ) {
+                        if let Some(node) = store.get_node_mut(new_id) {
+                            node.set_property(key.clone(), pv);
                         }
                     }
                 }

--- a/tests/snapshot_preserves_properties.rs
+++ b/tests/snapshot_preserves_properties.rs
@@ -1,0 +1,96 @@
+//! A snapshot round trip preserves property *values*, not just counts.
+//!
+//! `snapshot_persistence.rs` asserts `node_count == 2` and `edge_count == 1`
+//! after a restore. A round trip that dropped every property would satisfy
+//! both, so the existing coverage cannot detect the failure that would matter
+//! most — and #545 proposes removing the row copy of properties, which is
+//! exactly the change that would cause it.
+//!
+//! The double round trip is the case worth pinning. After an import,
+//! `node.properties` is **empty by design**: values live in the columnar
+//! store. Exporting *that* store is therefore a different situation from
+//! exporting a freshly-built one, and it is the one a real deployment hits —
+//! restore from a snapshot, then take a new snapshot.
+//!
+//! Note for anyone extending this: read values through the column or the
+//! merged view. Reading `node.properties` after an import shows `None` whether
+//! or not anything was lost, so an assertion on the row proves nothing.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::snapshot::{export_tenant, import_tenant};
+
+fn prop(store: &GraphStore, idx: usize, key: &str) -> PropertyValue {
+    store.node_columns.get_property(idx, key)
+}
+
+#[test]
+fn properties_survive_one_round_trip() {
+    let mut src = GraphStore::new();
+    let n = src.create_node("Person");
+    src.set_node_property("default", n, "name", "Alice").unwrap();
+    src.set_node_property("default", n, "age", 30i64).unwrap();
+
+    let mut buf = Vec::new();
+    export_tenant(&src, &mut buf).expect("export");
+    let mut dst = GraphStore::new();
+    import_tenant(&mut dst, &buf[..]).expect("import");
+
+    let idx = n.as_u64() as usize;
+    assert_eq!(dst.node_count(), 1);
+    assert_eq!(prop(&dst, idx, "name"), PropertyValue::String("Alice".into()));
+    assert_eq!(prop(&dst, idx, "age"), PropertyValue::Integer(30));
+}
+
+#[test]
+fn properties_survive_a_second_round_trip_from_an_imported_store() {
+    // Restore from a snapshot, then snapshot again — the shape a deployment
+    // actually performs, and the one where the row copy is already empty.
+    let mut src = GraphStore::new();
+    let n = src.create_node("Person");
+    src.set_node_property("default", n, "name", "Alice").unwrap();
+
+    let mut buf1 = Vec::new();
+    export_tenant(&src, &mut buf1).expect("export 1");
+    let mut mid = GraphStore::new();
+    import_tenant(&mut mid, &buf1[..]).expect("import 1");
+
+    let idx = n.as_u64() as usize;
+    assert!(
+        mid.get_node(n).map(|x| x.properties.is_empty()).unwrap_or(true),
+        "precondition: after an import the row copy is empty and the column holds the value"
+    );
+
+    let mut buf2 = Vec::new();
+    export_tenant(&mid, &mut buf2).expect("export 2");
+    let mut end = GraphStore::new();
+    import_tenant(&mut end, &buf2[..]).expect("import 2");
+
+    assert_eq!(
+        prop(&end, idx, "name"),
+        PropertyValue::String("Alice".into()),
+        "the value must survive an export taken from an imported store"
+    );
+}
+
+#[test]
+fn non_scalar_properties_survive_a_round_trip() {
+    // Arrays and maps live in `Column::Other`. They are the variants #545
+    // called out as row-only, and are no longer, so a round trip must carry
+    // them.
+    let mut src = GraphStore::new();
+    let n = src.create_node("Thing");
+    src.set_node_property(
+        "default", n, "tags",
+        PropertyValue::Array(vec![PropertyValue::String("a".into()), PropertyValue::Integer(2)]),
+    ).unwrap();
+
+    let mut buf = Vec::new();
+    export_tenant(&src, &mut buf).expect("export");
+    let mut dst = GraphStore::new();
+    import_tenant(&mut dst, &buf[..]).expect("import");
+
+    match prop(&dst, n.as_u64() as usize, "tags") {
+        PropertyValue::Array(items) => assert_eq!(items.len(), 2, "both elements survive"),
+        other => panic!("expected an array after the round trip, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Import routed String/Integer/Float/Boolean to the ColumnStore and everything
else to the row map alone. After a round trip an array read from the column
came back `Null` while the row still held it:

    before export   column Array([String("a"), Integer(2)])   row Array([...])
    after import    column Null                                row Array([...])
    scalar control  column String("Alice")

That split dates from when the column had no representation for the rest.
`Column::Other` holds every variant now, and `promote_to_other` covers a
property changing type, so the split only kept values out of the column.

**No user-visible loss today**, because `resolve_property` reads the column and
falls back to the row. That fallback is precisely the copy #545 proposes to
delete — so this was a landmine underneath it: remove the row copy first and
every array, map and temporal in an imported graph disappears. This had to be
true before that change can be safe.

Both import paths are fixed, the plain insert and the dedup merge — they made
the same decision separately.

The row write is unchanged. MVCC version chains and the persistence encoder
still read it, and narrowing that is #545's decision rather than this fix's.

**The existing round-trip test could not have caught this**:
`snapshot_persistence.rs` asserts `node_count == 2` and `edge_count == 1`, which
a round trip that dropped every property would satisfy. The new tests assert
values, including the double round trip — export, import, export again — which
is the shape a deployment performs when it restores from a snapshot and then
takes one.

They also carry a warning worth more than the tests: read through the column,
not `node.properties`. After an import the row is empty by design, so an
assertion on it shows `None` whether or not anything was lost. Checking the row
first is how this nearly got reported as a data-loss bug that did not exist.