### PR TITLE
feat(http): expose NLQ over HTTP — POST /api/nlq (#697) [WIP]

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -444,6 +444,49 @@ paths:
         '200':
           description: The snapshot was imported
 
+  /api/nlq:
+    post:
+      operationId: naturalLanguageQuery
+      summary: Translate a natural-language question into read-only Cypher
+      description: |
+        Translate a natural-language question into a read-only OpenCypher query using
+        a configured LLM provider. NLQ must be enabled via environment
+        (`NLQ_MODEL`, `OPENAI_API_KEY`, optional `NLQ_API_BASE_URL`). Returns the
+        generated Cypher only; execute it with `/api/query`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - question
+              properties:
+                question:
+                  type: string
+                  description: The natural-language question to translate.
+            examples:
+              ask:
+                summary: Ask for equipment by work-order count
+                value:
+                  question: "Which chillers have more than 100 work orders?"
+      responses:
+        '200':
+          description: Cypher generated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  cypher:
+                    type: string
+        '400':
+          description: NLQ disabled or generation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
 components:
   schemas:
     QueryRequest:

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -796,6 +796,75 @@ pub async fn restore_snapshot_handler(
     }
 }
 
+/// Request for a natural-language query (NLQ -> Cypher). Epic #696, step #697.
+#[derive(Deserialize)]
+pub struct NlqRequest {
+    pub question: String,
+}
+
+/// POST /api/nlq -- translate a natural-language question into read-only Cypher using the
+/// schema-grounded NLQ pipeline, and return it. Execution is left to the caller (`/api/query`)
+/// so this stays a thin, side-effect-free translation endpoint.
+///
+/// LLM config is read from the environment: `NLQ_PROVIDER` (default `openai`), `NLQ_MODEL`
+/// (default `gpt-4o`), `OPENAI_API_KEY`, optional `NLQ_API_BASE_URL`. `text_to_cypher`
+/// already rejects any generated query that contains write operations.
+pub async fn nlq_handler(
+    State(state): State<AppState>,
+    Json(payload): Json<NlqRequest>,
+) -> impl IntoResponse {
+    use crate::nlq::NLQPipeline;
+    use crate::persistence::tenant::{NLQConfig, LLMProvider};
+
+    let provider = match std::env::var("NLQ_PROVIDER")
+        .unwrap_or_default()
+        .to_lowercase()
+        .as_str()
+    {
+        "ollama" => LLMProvider::Ollama,
+        "gemini" => LLMProvider::Gemini,
+        "anthropic" => LLMProvider::Anthropic,
+        "azure" | "azureopenai" => LLMProvider::AzureOpenAI,
+        "mock" => LLMProvider::Mock,
+        _ => LLMProvider::OpenAI,
+    };
+    let config = NLQConfig {
+        enabled: true,
+        provider,
+        model: std::env::var("NLQ_MODEL").unwrap_or_else(|_| "gpt-4o".to_string()),
+        api_key: std::env::var("OPENAI_API_KEY").ok(),
+        api_base_url: std::env::var("NLQ_API_BASE_URL").ok(),
+        system_prompt: None,
+    };
+
+    let pipeline = match NLQPipeline::new(config) {
+        Ok(p) => p,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+
+    // Snapshot the schema summary and drop the read guard before the async LLM call.
+    let schema = {
+        let store_guard = state.store.read().await;
+        store_guard.schema_summary()
+    };
+
+    match pipeline.text_to_cypher(&payload.question, &schema).await {
+        Ok(cypher) => (StatusCode::OK, Json(json!({ "cypher": cypher }))).into_response(),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -19,6 +19,7 @@ use super::handler::{
     query_handler, status_handler, schema_handler, sample_handler,
     import_csv_handler, import_json_handler,
     export_snapshot_handler, restore_snapshot_handler,
+    nlq_handler,
 };
 use super::vector::{list_indexes_handler, create_index_handler, search_handler};
 
@@ -165,6 +166,7 @@ impl HttpServer {
         let main_router = Router::new()
             .route("/", get(static_handler))
             .route("/api/query", post(query_handler))
+            .route("/api/nlq", post(nlq_handler))
             .route("/api/status", get(status_handler))
             .route("/api/schema", get(schema_handler))
             .route("/api/sample", post(sample_handler))


### PR DESCRIPTION
**WIP — for review (do not merge yet).** First step of the OSS NLQ+GAK enablement epic #696.

## What
Adds `POST /api/nlq` — translates a natural-language question into **read-only Cypher** via the
existing schema-grounded `NLQPipeline` (fed by `store.schema_summary()`), and returns the Cypher.
Execution stays with `/api/query`, so this is a thin, side-effect-free translation endpoint.

- `src/http/handler.rs`: `NlqRequest { question }` + `nlq_handler` (~65 lines).
- `src/http/server.rs`: route + import (2 lines).
- LLM config from env: `NLQ_PROVIDER` (default `openai`), `NLQ_MODEL` (default `gpt-4o`),
  `OPENAI_API_KEY`, optional `NLQ_API_BASE_URL`. `text_to_cypher` already rejects write ops.

## Validated
Builds clean (`cargo build --release`). Smoke-tested live against the 12,647-node AssetOps graph:
```
{"question":"List the failure modes that the sensors of equipment CWC04006 monitor."}
-> {"cypher":"MATCH (e:Equipment {name:'CWC04006'})-[:HAS_SENSOR]->(s:Sensor)-[:MONITORS]->(f:FailureMode) RETURN f.name"}
```

## Review notes / open
- Returns Cypher only (no execute) by design — smallest reviewable surface. An `execute:true`
  convenience can follow if wanted.
- NLQ *quality* tuning (property vs edge grounding) is out of scope here; this only exposes the
  existing pipeline over HTTP.

Part of the reproducible-GAK track (samyama-research#182). Next: #698 single-graph EnrichConfig.