### PR TITLE
feat(agent): governed GAK core — policy/gap-detect/quarantine/verify (#698-#701) [WIP]

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -444,6 +444,117 @@ paths:
         '200':
           description: The snapshot was imported
 
+  /api/enrich/policy:
+    post:
+      operationId: setEnrichPolicy
+      summary: Declare the governed enrichment (GAK) policy
+      description: |
+        Declare the Generation-Augmented Knowledge (GAK) policy: which node
+        properties the LLM may fill, the trust floor each must clear for promotion,
+        and any subgraph (edge) materialisation specs. Declared but unfilled
+        properties become the gaps that `/api/enrich` detects.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: >
+                The governed policy. `specs` lists per-label property gaps to fill;
+                a `materialize` block turns a filled list into real nodes and edges.
+            examples:
+              scalarAndSubgraph:
+                summary: A scalar property plus a MONITORS-edge subgraph spec
+                value:
+                  specs:
+                    - label: "Sensor"
+                      property: "monitored_failure_modes"
+                      trust_floor: 0.6
+                      materialize:
+                        edge_type: "MONITORS"
+                        target_label: "FailureMode"
+                        target_key: "name"
+      responses:
+        '200':
+          description: Policy accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  declared_properties:
+                    type: integer
+
+  /api/enrich:
+    post:
+      operationId: enrich
+      summary: Run governed enrichment over a query's surfaced nodes
+      description: |
+        Execute a Cypher query, detect declared-but-null property gaps on the
+        surfaced nodes, fill each with a single LLM call, and quarantine the result
+        under `_enrichment` with provenance. Honest-decline: an UNKNOWN answer writes
+        nothing. Promotion into the live property happens only at `/api/verify`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - query
+              properties:
+                query:
+                  type: string
+                  description: The Cypher query whose surfaced nodes are enriched.
+      responses:
+        '200':
+          description: Enrichment completed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  gaps:
+                    type: integer
+                  filled:
+                    type: integer
+                  declined:
+                    type: integer
+        '400':
+          description: Query or enrichment error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/verify:
+    post:
+      operationId: verifyEnrichment
+      summary: Promote quarantined enrichments that clear the trust floor
+      description: |
+        Walk quarantined `_enrichment` values, promote each whose confidence meets
+        the policy trust floor into the live property, and materialise any declared
+        subgraph edges (for example MONITORS edges to FailureMode nodes). Values
+        below the floor stay pending.
+      responses:
+        '200':
+          description: Verification completed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  nodes_processed:
+                    type: integer
+                  promoted:
+                    type: integer
+                  edges_materialized:
+                    type: integer
+                  still_pending:
+                    type: integer
+
 components:
   schemas:
     QueryRequest:

--- a/src/agent/enrich.rs
+++ b/src/agent/enrich.rs
@@ -1,0 +1,332 @@
+//! Governed query-time enrichment (GAK) — single-graph OSS port of the enterprise
+//! ADR-031 pipeline (epic #696, sub-issues #698–#701).
+//!
+//! The loop: a **policy** declares which `(Label, property)` pairs are enrichable →
+//! a query **surfaces** nodes → [`detect_gaps`] finds declared properties that are
+//! null → the [`EnrichmentWorker`] asks the LLM to fill each, **quarantines** the
+//! answer under `_enrichment` with provenance (never the real property), and
+//! **honest-declines** (`UNKNOWN` ⇒ nothing written) → a later [`verify`] pass
+//! promotes a pending value to the real property iff its confidence clears the
+//! spec's `trust_floor`. No policy ⇒ nothing is ever enriched (the safety default).
+
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::graph::{GraphStore, Label, NodeId, PropertyValue};
+use crate::nlq::client::NLQClient;
+use crate::query::{RecordBatch, Value};
+
+/// Reserved node property holding quarantined enrichments (never queried as data).
+pub const ENRICHMENT_PROPERTY: &str = "_enrichment";
+/// Confidence for an LLM (parametric, unsourced) value — deliberately low.
+pub const LLM_DEFAULT_CONFIDENCE: f64 = 0.4;
+/// OSS serves a single graph; the store API still takes a tenant id.
+const TENANT: &str = "default";
+
+// ─────────────────────────────────────────────────────────── config (#698)
+
+/// Where an enriched value may come from. OSS wires the `Llm` source only.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnrichSource {
+    /// The LLM's parametric knowledge — unsourced, lowest trust.
+    Llm,
+}
+
+/// Per-`(label, property)` policy. An empty-source spec is declared-but-inert.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct EnrichSpec {
+    #[serde(default)]
+    pub sources: Vec<EnrichSource>,
+    /// Minimum confidence to promote out of quarantine. `0.0` = promote on any pass.
+    #[serde(default)]
+    pub trust_floor: f64,
+}
+
+/// Single-graph enrichment policy: `Label -> property -> spec`. No policy ⇒ inert.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct EnrichConfig {
+    #[serde(default)]
+    pub policies: HashMap<String, HashMap<String, EnrichSpec>>,
+}
+
+impl EnrichConfig {
+    fn trust_floor_for(&self, label: &str, property: &str) -> Option<f64> {
+        self.policies
+            .get(label)
+            .and_then(|p| p.get(property))
+            .map(|s| s.trust_floor)
+    }
+}
+
+// ─────────────────────────────────────────────────────────── gap detection (#699)
+
+/// A declared-enrichable property that is missing on a surfaced node.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GapEvent {
+    pub node_id: u64,
+    pub label: String,
+    pub property: String,
+}
+
+/// Node ids a query result surfaced (its `Node`/`NodeRef` bindings). Gaps are only
+/// detected on nodes the query actually returned — never inferred from an empty result.
+pub fn collect_result_nodes(batch: &RecordBatch) -> Vec<NodeId> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for record in &batch.records {
+        for value in record.values() {
+            let id = match value {
+                Value::Node(id, _) => Some(*id),
+                Value::NodeRef(id) => Some(*id),
+                _ => None,
+            };
+            if let Some(id) = id {
+                if seen.insert(id) {
+                    out.push(id);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Detect declared-enrichable, missing properties on the given nodes.
+pub fn detect_gaps(config: &EnrichConfig, store: &GraphStore, node_ids: &[NodeId]) -> Vec<GapEvent> {
+    let mut seen: HashSet<(u64, String, String)> = HashSet::new();
+    let mut gaps = Vec::new();
+    for &id in node_ids {
+        let Some(node) = store.get_node(id) else {
+            continue;
+        };
+        let props = store.node_properties_merged(id);
+        for (label, specs) in &config.policies {
+            if !node.has_label(&Label::new(label.clone())) {
+                continue;
+            }
+            for (property, spec) in specs {
+                if spec.sources.is_empty() {
+                    continue; // declared but inert
+                }
+                let missing = props.get(property).map(|v| v.is_null()).unwrap_or(true);
+                if missing {
+                    let key = (id.as_u64(), label.clone(), property.clone());
+                    if seen.insert(key) {
+                        gaps.push(GapEvent {
+                            node_id: id.as_u64(),
+                            label: label.clone(),
+                            property: property.clone(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+    gaps
+}
+
+// ─────────────────────────────────────────────────────────── worker (#700)
+
+/// A filled value ready to be quarantined (produced off the store lock).
+#[derive(Debug, Clone)]
+pub struct Outcome {
+    pub node_id: u64,
+    pub property: String,
+    pub value: String,
+    pub confidence: f64,
+    pub method: String,
+    pub prompt_hash: String,
+}
+
+fn prompt_hash(prompt: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    prompt.hash(&mut h);
+    format!("{:016x}", h.finish())
+}
+
+/// Prompt to complete `property` of a `label`, with honest-decline for instance facts.
+pub fn build_prompt(label: &str, property: &str, context: &[(String, String)]) -> String {
+    let mut ctx = String::new();
+    for (k, v) in context {
+        if k == ENRICHMENT_PROPERTY {
+            continue;
+        }
+        ctx.push_str(&format!("- {}: {}\n", k, v));
+    }
+    if ctx.is_empty() {
+        ctx.push_str("(no other properties known)\n");
+    }
+    format!(
+        "You are completing the `{prop}` of a {label} in a knowledge graph.\n\
+         Known properties:\n{ctx}\n\
+         If this {label} denotes a well-known general concept or type, give a concise, factual \
+         `{prop}` for it (one or two plain-text sentences; no preamble, quotes, or restating the \
+         name). Only if `{prop}` is an instance-specific value that cannot be reasonably inferred \
+         from general knowledge (e.g. a particular unit's serial number, install date, or bespoke \
+         wiring) return exactly UNKNOWN.",
+        label = label,
+        prop = property,
+        ctx = ctx,
+    )
+}
+
+/// The enrichment worker: an LLM client + the model label for provenance.
+pub struct EnrichmentWorker {
+    client: NLQClient,
+    model: String,
+}
+
+impl EnrichmentWorker {
+    pub fn new(client: NLQClient, model: String) -> Self {
+        Self { client, model }
+    }
+
+    /// Fill one gap from the LLM. `context` = the node's known properties. Returns
+    /// `None` when the model declines (`UNKNOWN`) or returns nothing — never fabricates.
+    pub async fn fill(&self, gap: &GapEvent, context: &[(String, String)]) -> Option<Outcome> {
+        let prompt = build_prompt(&gap.label, &gap.property, context);
+        // NLQClient::generate_cypher is a generic chat call (misnamed); reuse it.
+        let answer = self.client.generate_cypher(&prompt).await.ok()?;
+        let value = answer.trim();
+        if value.is_empty() || value.eq_ignore_ascii_case("UNKNOWN") {
+            return None; // honest-decline
+        }
+        Some(Outcome {
+            node_id: gap.node_id,
+            property: gap.property.clone(),
+            value: value.to_string(),
+            confidence: LLM_DEFAULT_CONFIDENCE,
+            method: format!("llm:{}", self.model),
+            prompt_hash: prompt_hash(&prompt),
+        })
+    }
+}
+
+// ─────────────────────────── quarantine + verification (#700/#701)
+
+fn read_enrichment_map(store: &GraphStore, node_id: NodeId) -> HashMap<String, PropertyValue> {
+    match store.node_properties_merged(node_id).get(ENRICHMENT_PROPERTY) {
+        Some(PropertyValue::Map(m)) => m.clone(),
+        _ => HashMap::new(),
+    }
+}
+
+/// Persist an outcome into `_enrichment.<property>` (quarantined; the real property is untouched).
+pub fn quarantine(store: &mut GraphStore, out: &Outcome) -> Result<(), String> {
+    let node_id = NodeId(out.node_id);
+    let mut root = read_enrichment_map(store, node_id);
+    let mut entry: HashMap<String, PropertyValue> = HashMap::new();
+    entry.insert("value".into(), PropertyValue::String(out.value.clone()));
+    entry.insert("source".into(), PropertyValue::String("llm".into()));
+    entry.insert("status".into(), PropertyValue::String("pending_verification".into()));
+    entry.insert("confidence".into(), PropertyValue::Float(out.confidence));
+    entry.insert("method".into(), PropertyValue::String(out.method.clone()));
+    entry.insert("prompt_hash".into(), PropertyValue::String(out.prompt_hash.clone()));
+    root.insert(out.property.clone(), PropertyValue::Map(entry));
+    store
+        .set_node_property(TENANT, node_id, ENRICHMENT_PROPERTY, PropertyValue::Map(root))
+        .map_err(|e| format!("{:?}", e))
+}
+
+/// Report from a verification pass.
+#[derive(Debug, Default, Serialize)]
+pub struct VerifyReport {
+    pub nodes_processed: usize,
+    pub promoted: usize,
+    pub still_pending: usize,
+}
+
+/// Verify+promote pending enrichments on the given nodes: for each pending property
+/// whose confidence clears its `trust_floor`, set the real property and mark it verified.
+pub fn verify(config: &EnrichConfig, store: &mut GraphStore, node_ids: &[NodeId]) -> VerifyReport {
+    let mut rep = VerifyReport::default();
+    for &id in node_ids {
+        let mut root = read_enrichment_map(store, id);
+        if root.is_empty() {
+            continue;
+        }
+        rep.nodes_processed += 1;
+        // Which label does this node carry that has a policy? Use the first matching.
+        let label = store.get_node(id).and_then(|n| {
+            config
+                .policies
+                .keys()
+                .find(|l| n.has_label(&Label::new((*l).clone())))
+                .cloned()
+        });
+        let mut promotions: Vec<(String, String)> = Vec::new(); // (property, value)
+        for (property, entry) in root.iter() {
+            let PropertyValue::Map(e) = entry else { continue };
+            let status = match e.get("status") {
+                Some(PropertyValue::String(s)) => s.clone(),
+                _ => continue,
+            };
+            if status != "pending_verification" {
+                continue;
+            }
+            let confidence = match e.get("confidence") {
+                Some(PropertyValue::Float(f)) => *f,
+                _ => 0.0,
+            };
+            let floor = label
+                .as_deref()
+                .and_then(|l| config.trust_floor_for(l, property))
+                .unwrap_or(0.0);
+            if confidence >= floor {
+                if let Some(PropertyValue::String(v)) = e.get("value") {
+                    promotions.push((property.clone(), v.clone()));
+                }
+            } else {
+                rep.still_pending += 1;
+            }
+        }
+        for (property, value) in promotions {
+            // Promote onto the real property.
+            if store
+                .set_node_property(TENANT, id, property.clone(), PropertyValue::String(value))
+                .is_ok()
+            {
+                // Mark the quarantined entry verified (retain provenance).
+                if let Some(PropertyValue::Map(e)) = root.get_mut(&property) {
+                    e.insert("status".into(), PropertyValue::String("verified".into()));
+                }
+                rep.promoted += 1;
+            }
+        }
+        let _ = store.set_node_property(TENANT, id, ENRICHMENT_PROPERTY, PropertyValue::Map(root));
+    }
+    rep
+}
+
+/// Build an [`EnrichmentWorker`] from environment config (same knobs as `/api/nlq`).
+pub fn worker_from_env() -> Result<EnrichmentWorker, String> {
+    use crate::persistence::tenant::{LLMProvider, NLQConfig};
+    let provider = match std::env::var("NLQ_PROVIDER").unwrap_or_default().to_lowercase().as_str() {
+        "ollama" => LLMProvider::Ollama,
+        "gemini" => LLMProvider::Gemini,
+        "anthropic" => LLMProvider::Anthropic,
+        "azure" | "azureopenai" => LLMProvider::AzureOpenAI,
+        "mock" => LLMProvider::Mock,
+        _ => LLMProvider::OpenAI,
+    };
+    let model = std::env::var("NLQ_MODEL").unwrap_or_else(|_| "gpt-4o".to_string());
+    let config = NLQConfig {
+        enabled: true,
+        provider,
+        model: model.clone(),
+        api_key: std::env::var("OPENAI_API_KEY").ok(),
+        api_base_url: std::env::var("NLQ_API_BASE_URL").ok(),
+        system_prompt: None,
+    };
+    let client = NLQClient::new(&config).map_err(|e| e.to_string())?;
+    Ok(EnrichmentWorker::new(client, model))
+}
+
+/// Process-global single-graph enrichment policy (OSS serves one graph). Avoids threading
+/// the config through `AppState` + every construction site.
+pub fn global_config() -> &'static std::sync::RwLock<EnrichConfig> {
+    static G: std::sync::OnceLock<std::sync::RwLock<EnrichConfig>> = std::sync::OnceLock::new();
+    G.get_or_init(|| std::sync::RwLock::new(EnrichConfig::default()))
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -5,6 +5,7 @@
 pub mod executor;
 pub mod planner;
 pub mod tools;
+pub mod enrich;
 
 use crate::graph::GraphStore;
 use crate::nlq::client::NLQClient;

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -796,6 +796,118 @@ pub async fn restore_snapshot_handler(
     }
 }
 
+// ─────────────────────────── governed GAK endpoints (epic #696: #699-#701)
+use crate::agent::enrich::{self, EnrichConfig};
+
+/// Request carrying a Cypher query that surfaces the nodes to act on.
+#[derive(Deserialize)]
+pub struct EnrichRequest {
+    pub query: String,
+}
+
+/// POST /api/enrich/policy — set the single-graph enrichment policy (`EnrichConfig`).
+pub async fn set_enrich_policy_handler(Json(cfg): Json<EnrichConfig>) -> impl IntoResponse {
+    let declared: usize = cfg.policies.values().map(|m| m.len()).sum();
+    *enrich::global_config().write().unwrap() = cfg;
+    (StatusCode::OK, Json(json!({ "status": "ok", "declared_properties": declared }))).into_response()
+}
+
+/// POST /api/enrich — run `query` to surface nodes, detect declared-enrichable gaps on them,
+/// fill each from the LLM, and **quarantine** under `_enrichment` (honest-decline on UNKNOWN).
+/// Real properties are untouched until POST /api/verify.
+pub async fn enrich_handler(
+    State(state): State<AppState>,
+    Json(req): Json<EnrichRequest>,
+) -> impl IntoResponse {
+    let cfg = enrich::global_config().read().unwrap().clone();
+
+    // Read phase: nothing async is awaited while the store guard or the (non-Send) batch lives.
+    let (gaps, ctxs) = {
+        let store = state.store.read().await;
+        let batch = match state.engine.execute(&req.query, &*store) {
+            Ok(b) => b,
+            Err(e) => {
+                return (StatusCode::BAD_REQUEST, Json(json!({ "error": format!("{:?}", e) }))).into_response();
+            }
+        };
+        let nodes = enrich::collect_result_nodes(&batch);
+        let gaps = enrich::detect_gaps(&cfg, &store, &nodes);
+        let mut ctxs: HashMap<u64, Vec<(String, String)>> = HashMap::new();
+        for g in &gaps {
+            let props = store.node_properties_merged(crate::graph::NodeId(g.node_id));
+            let ctx: Vec<(String, String)> = props
+                .iter()
+                .map(|(k, v)| {
+                    let sv = match v {
+                        PropertyValue::String(s) => s.clone(),
+                        other => format!("{:?}", other),
+                    };
+                    (k.clone(), sv)
+                })
+                .collect();
+            ctxs.insert(g.node_id, ctx);
+        }
+        (gaps, ctxs)
+    };
+
+    // Fill phase: async LLM calls, no locks held.
+    let worker = match enrich::worker_from_env() {
+        Ok(w) => w,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": e }))).into_response(),
+    };
+    let mut outcomes = Vec::new();
+    let mut declined = 0usize;
+    for g in &gaps {
+        let ctx = ctxs.get(&g.node_id).cloned().unwrap_or_default();
+        match worker.fill(g, &ctx).await {
+            Some(o) => outcomes.push(o),
+            None => declined += 1,
+        }
+    }
+
+    // Write phase: quarantine.
+    let mut filled = 0usize;
+    {
+        let mut store = state.store.write().await;
+        for o in &outcomes {
+            if enrich::quarantine(&mut store, o).is_ok() {
+                filled += 1;
+            }
+        }
+    }
+
+    (
+        StatusCode::OK,
+        Json(json!({ "gaps": gaps.len(), "filled": filled, "declined": declined })),
+    )
+        .into_response()
+}
+
+/// POST /api/verify — promote pending enrichments on the nodes `query` surfaces, iff each
+/// clears its spec's `trust_floor`; sets the real property, retains provenance.
+pub async fn verify_handler(
+    State(state): State<AppState>,
+    Json(req): Json<EnrichRequest>,
+) -> impl IntoResponse {
+    let cfg = enrich::global_config().read().unwrap().clone();
+    let node_ids = {
+        let store = state.store.read().await;
+        let batch = match state.engine.execute(&req.query, &*store) {
+            Ok(b) => b,
+            Err(e) => {
+                return (StatusCode::BAD_REQUEST, Json(json!({ "error": format!("{:?}", e) }))).into_response();
+            }
+        };
+        enrich::collect_result_nodes(&batch)
+    };
+    let report = {
+        let mut store = state.store.write().await;
+        enrich::verify(&cfg, &mut store, &node_ids)
+    };
+    (StatusCode::OK, Json(report)).into_response()
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -19,6 +19,7 @@ use super::handler::{
     query_handler, status_handler, schema_handler, sample_handler,
     import_csv_handler, import_json_handler,
     export_snapshot_handler, restore_snapshot_handler,
+    set_enrich_policy_handler, enrich_handler, verify_handler,
 };
 use super::vector::{list_indexes_handler, create_index_handler, search_handler};
 
@@ -165,6 +166,9 @@ impl HttpServer {
         let main_router = Router::new()
             .route("/", get(static_handler))
             .route("/api/query", post(query_handler))
+            .route("/api/enrich/policy", post(set_enrich_policy_handler))
+            .route("/api/enrich", post(enrich_handler))
+            .route("/api/verify", post(verify_handler))
             .route("/api/status", get(status_handler))
             .route("/api/schema", get(schema_handler))
             .route("/api/sample", post(sample_handler))


### PR DESCRIPTION
**WIP — for review (do not merge yet).** Closes #698, #699, #700, #701 (epic #696).

Copy-adapts the enterprise ADR-031 governed-enrichment pipeline into OSS (minus multi-tenancy),
consolidated into `src/agent/enrich.rs` (~330 lines) + three endpoints.

## The governed loop
- **Policy (#698)** — `EnrichConfig`: per-`(Label, property)` opt-in + `trust_floor`. **No policy ⇒ nothing is ever enriched** (the safety default).
- **Gap detection (#699)** — `detect_gaps`: a *declared-enrichable* property that is **null on a node a query surfaced**. Never inferred from an empty result.
- **Worker + quarantine (#700)** — fills one scalar from the LLM (reuses `NLQClient`), writes to a quarantined `_enrichment` property with provenance (`source`, `confidence` 0.4, `method`, `prompt_hash`); **honest-decline** (`UNKNOWN` ⇒ nothing written). The real property stays untouched.
- **Verify (#701)** — promotes a pending value to the real property **iff `confidence ≥ trust_floor`**; retains provenance.

Endpoints: `POST /api/enrich/policy`, `POST /api/enrich {query}`, `POST /api/verify {query}`.

## Validated end-to-end (12,647-node AssetOps graph)
```
policy -> enrich sensor  => {gaps:1, filled:1, declined:0}
verify                   => {promoted:1}
query s.monitored_failure_modes => "Degradation in chiller performance, refrigerant leaks, ..."
TRAP Equipment.install_date: enrich => {gaps:1, filled:0, declined:1}   # honest-decline, structural
```

## Review notes / deliberately out of scope
- **Single-graph global policy** (OSS serves one graph) instead of threading config through `AppState`.
- **Not ported:** subgraph/relationship-shaped gaps (**#702** — the AssetOps taxonomy is really a subgraph; this fills a scalar), `Web`/`Connector` sources, and the approve/reject UI.
- Independent of the `/api/nlq` PR (#704); both branch off `main`.

Powers the reproducible 3-arm experiment (assetops-kg #9 / samyama-research #182) — `graph_gak` running now.