### PR TITLE
Record what a var-length segment should return (#710)

### DIFF
--- a/tests/var_length_path_enumeration.rs
+++ b/tests/var_length_path_enumeration.rs
@@ -1,0 +1,134 @@
+//! A variable-length segment enumerates *paths*, not shortest distances.
+//!
+//! `VarLengthExpandOperator` runs a BFS with a node-visited set, so every
+//! reachable node is emitted exactly once, at its shortest depth. openCypher
+//! specifies something different: `-[:R*m..n]-` matches every path whose
+//! relationships are distinct, so a node reachable by two different routes
+//! inside the bound produces two rows, and a node whose *only* route long
+//! enough to satisfy `m` is not the shortest one is missing entirely.
+//!
+//! The scope is the same one #684 established for fixed-length patterns:
+//! relationships may not repeat within a clause, nodes may.
+//!
+//! Expectations below are openCypher's, matching Neo4j 5 on the same graphs,
+//! and three of the four fail today. They are `#[ignore]`d against #710 rather
+//! than deleted or weakened: the expected values are the specification's, and a
+//! test that asserts the current behaviour would have to be rewritten by
+//! whoever fixes it, which is the opposite of useful.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+}
+
+fn names(store: &GraphStore, cypher: &str) -> Vec<String> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    let out = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+    let mut got: Vec<String> = out
+        .records
+        .iter()
+        .map(|r| match r.get("n") {
+            Some(Value::Property(PropertyValue::String(s))) => s.clone(),
+            other => panic!("expected string n, got {other:?}"),
+        })
+        .collect();
+    got.sort();
+    got
+}
+
+/// A triangle: a-b, b-c, a-c, all `:R`, all undirected in the pattern.
+fn triangle() -> GraphStore {
+    let mut store = GraphStore::new();
+    for n in ["a", "b", "c"] {
+        run(&mut store, &format!("CREATE (:N {{name: \"{n}\"}})"));
+    }
+    for (x, y) in [("a", "b"), ("b", "c"), ("a", "c")] {
+        run(
+            &mut store,
+            &format!(
+                "MATCH (x:N {{name:\"{x}\"}}), (y:N {{name:\"{y}\"}}) CREATE (x)-[:R]->(y)"
+            ),
+        );
+    }
+    store
+}
+
+/// Two routes to the same node inside the bound are two rows, not one.
+///
+/// From `a` over `*1..2`: `b` (via a-b), `c` (via a-c), `c` (via a-b-c) and
+/// `b` (via a-c-b). Four rows. A shortest-path BFS emits two.
+#[test]
+#[ignore = "#710: the operator walks shortest paths, not paths"]
+fn a_node_reachable_two_ways_within_the_bound_yields_two_rows() {
+    let store = triangle();
+    assert_eq!(
+        names(&store, "MATCH (a:N {name:\"a\"})-[:R*1..2]-(x) RETURN x.name AS n"),
+        vec!["b", "b", "c", "c"],
+    );
+}
+
+/// A lower bound does not mean "shortest distance is at least m".
+///
+/// `*2..2` from `a` matches a-b-c and a-c-b, so `b` and `c` each appear once.
+/// A BFS that marks both visited at depth 1 and never revisits them returns
+/// nothing at all.
+#[test]
+#[ignore = "#710: the operator walks shortest paths, not paths"]
+fn a_lower_bound_still_matches_a_longer_route_to_a_near_node() {
+    let store = triangle();
+    assert_eq!(
+        names(&store, "MATCH (a:N {name:\"a\"})-[:R*2..2]-(x) RETURN x.name AS n"),
+        vec!["b", "c"],
+    );
+}
+
+/// The relationship-uniqueness rule #684 established applies here too.
+///
+/// This one passes, but by accident rather than by rule: the node-visited set
+/// stops the walk back to `a`, not any check on the edge. Kept unignored so a
+/// fix for #710 is required to preserve it.
+///
+/// One edge, `a-[:R]-b`. Walking out and back is not a two-hop path, so
+/// `*2..2` from `a` matches nothing.
+#[test]
+fn one_edge_cannot_be_walked_out_and_back_to_make_two_hops() {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:N {name: \"a\"})");
+    run(&mut store, "CREATE (:N {name: \"b\"})");
+    run(&mut store, "MATCH (x:N {name:\"a\"}), (y:N {name:\"b\"}) CREATE (x)-[:R]->(y)");
+    assert_eq!(
+        names(&store, "MATCH (a:N {name:\"a\"})-[:R*2..2]-(x) RETURN x.name AS n"),
+        Vec::<String>::new(),
+    );
+}
+
+/// An edge already consumed earlier in the same clause is not available to a
+/// var-length segment that follows it.
+///
+/// One edge `a-b`. `(a)-[:R]-(y)-[:R*1..1]-(z)` must bind `y=b` using the only
+/// edge there is, leaving the var-length segment with nothing — 0 rows.
+/// Without cross-operator edge tracking the segment walks the same edge back
+/// to `a` and returns one.
+#[test]
+#[ignore = "#710: the operator walks shortest paths, not paths"]
+fn a_var_length_segment_may_not_reuse_an_edge_the_clause_already_walked() {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:N {name: \"a\"})");
+    run(&mut store, "CREATE (:N {name: \"b\"})");
+    run(&mut store, "MATCH (x:N {name:\"a\"}), (y:N {name:\"b\"}) CREATE (x)-[:R]->(y)");
+    assert_eq!(
+        names(
+            &store,
+            "MATCH (a:N {name:\"a\"})-[:R]-(y)-[:R*1..1]-(z) RETURN z.name AS n"
+        ),
+        Vec::<String>::new(),
+    );
+}


### PR DESCRIPTION
Tests only — no engine change. Refs #710.

`VarLengthExpandOperator::expand_from` is a BFS with a node-visited set, so
every reachable node is emitted once, at its shortest depth. openCypher matches
every path whose **relationships** are distinct; nodes may repeat. The two
differ in both directions, and the worst case is silent.

Over a triangle (`a-b`, `b-c`, `a-c`, all `:R`):

| query | openCypher / Neo4j 5 | Samyama | |
|---|---|---|---|
| `MATCH (a {name:"a"})-[:R*1..2]-(x) RETURN x.name` | `b, b, c, c` | `b, c` | under-reports |
| `MATCH (a {name:"a"})-[:R*2..2]-(x) RETURN x.name` | `b, c` | *nothing* | **empty result, no error** |
| `MATCH (a {name:"a"})-[:R]-(y)-[:R*1..1]-(z) RETURN z.name` (one edge) | *nothing* | `a` | over-reports |

The TCK already carries this: `clauses/match/Match6.feature` scenario **[14]**
expects four rows from
`(:Start)<-[:CONNECTED_TO]-()-[:CONNECTED_TO*3..3]-(:End)`, every one of them
revisiting `mid` and closing on an `:End` that is one hop away. A shortest-path
BFS cannot produce any of them.

Three tests fail and are `#[ignore]`d against #710. They are not weakened to
match current behaviour: the expected values are the specification's, and a
test asserting today's output would have to be rewritten by whoever fixes it.
The fourth passes by accident — the node-visited set stops the walk back to the
start, not any check on the edge — and is left running so a fix has to preserve
it.

**Why not fix it here.** Trail enumeration is exponentially larger than a
shortest-path walk on the graphs that matter: IC1's `KNOWS*1..3` reaches ~4,900
nodes as a BFS, and IC6 depends on the pinned-target BFS staying cheap (#590).
The fix is a planner rule — enumerate when the result can observe multiplicity
(a bound path or relationship variable, a `count`, a plain `RETURN`), keep the
BFS when it cannot (`RETURN DISTINCT`, an existence test, a pinned reachability
check) — and `min_hops > 1` needs the DFS even under `DISTINCT`. #710 has the
detail.

`cargo test --test var_length_path_enumeration`: 1 passed, 3 ignored.