### PR TITLE
IC11: attribute the expand's cost, and fix two measurements that could not have told us (#665)

### DIFF
--- a/benches/adjacency_walk.rs
+++ b/benches/adjacency_walk.rs
@@ -19,10 +19,31 @@
 //! scattered read into an array with one entry per edge in the graph, which at
 //! LDBC SF1's 21.1M edges is 42 MB and misses cache essentially every time.
 //!
-//! **That hypothesis is wrong, and this bench is what refuted it.** The walk,
-//! type probe included, costs under 3 ns per edge. Running the same traversal
-//! through the query engine costs ~30x that. Storage is a few percent of what
-//! `Expand` spends; the rest is the operator.
+//! **That hypothesis is wrong, and this bench is what refuted it** — but the
+//! first version of the bench refuted it on a graph that never scattered
+//! anything. It wrote each node's whole adjacency consecutively, so the edge
+//! ids inside one run *were* contiguous and the probe walked the array in
+//! order. The premise in the paragraph above was not the thing being measured.
+//!
+//! `--order by-type` builds the layout a loader actually produces — every edge
+//! of one type across every node, then the next type, which is how LDBC loads
+//! `KNOWS`, then `HAS_INTEREST`, then `LIKES` — so a node's adjacency holds ids
+//! from widely separated ranges. It is now the default. 300k nodes x 30 edges
+//! over 6 types, one host, one run:
+//!
+//! | edges written | walk, wildcard | walk, one type of six | as Cypher |
+//! |---|---:|---:|---:|
+//! | node by node (the old build) | 2.6 ns/edge | 2.6 | 64.3 |
+//! | **type by type** | **1.5 ns/edge** | **1.6** | **60.0** |
+//!
+//! So the conclusion survives the corrected premise, and by a wider margin: the
+//! walk, type probe included, costs **1.5 ns** per edge. Running the same
+//! traversal through the query engine costs **40x** that. Storage is a couple
+//! of percent of what `Expand` spends; the rest is the operator.
+//!
+//! One caveat this bench cannot settle at its default size: 9M edges makes the
+//! type array 18 MB, which fits in this host's L3. LDBC SF1's is 42 MB and does
+//! not. `--nodes 1000000` is the knob for testing that.
 //!
 //! It also fixes the normalisation. Per *edge visited*, IC5 (407 ns/row, keeps
 //! 513 of ~680) and IC9 (1976 ns/row, keeps 125 of ~680) look four times apart;
@@ -41,25 +62,65 @@ use samyama::graph::GraphStore;
 #[path = "common/bench_setup.rs"]
 mod bench_setup;
 
+/// The order edges are created in, which decides how the edge ids inside one
+/// node's adjacency run are laid out.
+///
+/// This distinction is the point of the bench and the first version did not
+/// make it. `ByNode` writes a node's whole adjacency consecutively, so its edge
+/// ids are contiguous and the `edge_type_ids` probe walks the array in order.
+/// `ByType` writes every edge of one type across every node before starting the
+/// next type, so a node's adjacency holds ids from `types` widely separated
+/// ranges — which is what a real loader produces, LDBC's included: it loads
+/// `KNOWS` for every person, then `HAS_INTEREST` for every person, then
+/// `LIKES`.
+#[derive(Clone, Copy, PartialEq)]
+enum Order {
+    ByNode,
+    ByType,
+}
+
 /// `nodes` nodes, each with `degree` outgoing edges to scattered targets, of
 /// which one in `types` is the type a query would ask for.
 ///
-/// Scattered targets on purpose: a node's adjacency run is contiguous, but the
-/// *edge ids* in it are not, and the whole question is what a scattered probe
-/// keyed on those ids costs.
-fn build(nodes: usize, degree: usize, types: usize) -> (GraphStore, Vec<samyama::graph::NodeId>) {
+/// Scattered *targets* in both orders; the edge ids are scattered only under
+/// `ByType`. The original bench built `ByNode`, described itself as measuring
+/// "what a scattered probe keyed on those ids costs", and concluded the
+/// scattered probe was cheap — on a layout that never scattered it.
+fn build(
+    nodes: usize,
+    degree: usize,
+    types: usize,
+    order: Order,
+) -> (GraphStore, Vec<samyama::graph::NodeId>) {
     let mut store = GraphStore::new();
     let ids: Vec<_> = (0..nodes).map(|_| store.create_node("N")).collect();
     let names: Vec<String> = (0..types).map(|t| format!("TYPE{t}")).collect();
-    for (i, &src) in ids.iter().enumerate() {
-        for d in 0..degree {
-            let x = (i as u64)
-                .wrapping_mul(0x9E37_79B9_7F4A_7C15)
-                .wrapping_add((d as u64).wrapping_mul(0xBF58_476D_1CE4_E5B9));
-            let x = x ^ (x >> 31);
-            let target = ids[(x % nodes as u64) as usize];
-            if target != src {
-                let _ = store.create_edge(src, target, names[d % types].as_str());
+    let target_of = |i: usize, d: usize| -> samyama::graph::NodeId {
+        let x = (i as u64)
+            .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+            .wrapping_add((d as u64).wrapping_mul(0xBF58_476D_1CE4_E5B9));
+        let x = x ^ (x >> 31);
+        ids[(x % nodes as u64) as usize]
+    };
+    match order {
+        Order::ByNode => {
+            for (i, &src) in ids.iter().enumerate() {
+                for d in 0..degree {
+                    let target = target_of(i, d);
+                    if target != src {
+                        let _ = store.create_edge(src, target, names[d % types].as_str());
+                    }
+                }
+            }
+        }
+        Order::ByType => {
+            for d in 0..degree {
+                for (i, &src) in ids.iter().enumerate() {
+                    let target = target_of(i, d);
+                    if target != src {
+                        let _ = store.create_edge(src, target, names[d % types].as_str());
+                    }
+                }
             }
         }
     }
@@ -78,9 +139,22 @@ fn main() {
     let degree = arg("--degree").unwrap_or(30);
     let types = arg("--types").unwrap_or(6);
 
-    eprintln!("Building {nodes} nodes x {degree} edges over {types} types…");
+    let order = match args.iter().position(|a| a == "--order").and_then(|i| args.get(i + 1)) {
+        Some(o) if o == "by-type" => Order::ByType,
+        Some(o) if o == "by-node" => Order::ByNode,
+        Some(o) => panic!("--order takes by-node or by-type, not {o}"),
+        // `by-type` is the default because it is the layout a loader produces.
+        // The old default was the other one, and it is what made this bench
+        // report that a scattered type probe costs nothing.
+        None => Order::ByType,
+    };
+
+    eprintln!(
+        "Building {nodes} nodes x {degree} edges over {types} types, {}…",
+        if order == Order::ByType { "edges written type by type" } else { "edges written node by node" }
+    );
     let started = Instant::now();
-    let (store, ids) = build(nodes, degree, types);
+    let (store, ids) = build(nodes, degree, types, order);
     eprintln!(
         "built {} edges in {:.1}s\n",
         store.edge_count(),

--- a/examples/ic11_probe.rs
+++ b/examples/ic11_probe.rs
@@ -1,0 +1,103 @@
+//! Where LDBC IC11's expand spends its time (#665).
+//!
+//! IC11's `Expand ((friend)-[:WORK_AT]->(org))` is 68% of the query at SF1 and
+//! 74% at SF10, and it emits **2 rows from 3,272 input rows**. Two explanations
+//! fit that shape and they call for opposite fixes:
+//!
+//! * the **walk** — each friend's whole outgoing adjacency (~280 edges at SF1)
+//!   is visited to find the ~2 that are `:WORK_AT`; or
+//! * the **per-input-row overhead** — whatever `ExpandOperator` does once per
+//!   record before it walks anything.
+//!
+//! `benches/adjacency_walk` already measured the walk at under 3 ns per edge
+//! including the type probe, which makes the first explanation too small by
+//! itself. The variants below separate them directly: `NO_SUCH_TYPE` keeps
+//! every input row and every per-row setup but resolves to an empty type
+//! filter, so it walks nothing.
+//!
+//!   cargo run --release --example ic11_probe -- --data-dir <ldbc-sf1-dir> \
+//!       --person-id <id> --org-name <name>
+
+#[path = "../benches/ldbc_common/mod.rs"]
+mod ldbc_common;
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+use std::path::PathBuf;
+use std::time::Instant;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().collect();
+    let arg = |flag: &str| args.iter().position(|a| a == flag).and_then(|i| args.get(i + 1));
+    let data_dir = arg("--data-dir").map(PathBuf::from).expect("--data-dir <path> is required");
+    let person_id: i64 = arg("--person-id").expect("--person-id <id> is required").parse()?;
+    let org_name = arg("--org-name").expect("--org-name <name> is required").clone();
+    let runs: usize = arg("--runs").map(|s| s.parse()).transpose()?.unwrap_or(7);
+
+    let mut graph = GraphStore::new();
+    eprintln!("loading {} ...", data_dir.display());
+    let t = Instant::now();
+    ldbc_common::load_dataset(&mut graph, &data_dir)?;
+    eprintln!("loaded in {:.1}s", t.elapsed().as_secs_f64());
+    for (label, prop) in [("Person", "id"), ("Organisation", "id")] {
+        let q = parse_query(&format!("CREATE INDEX ON :{label}({prop})"))?;
+        MutQueryExecutor::new(&mut graph, "default".to_string()).execute(&q)?;
+    }
+
+    let full = format!(
+        "MATCH (p:Person {{id: {person_id}}})-[:KNOWS*1..2]-(friend:Person)-[wa:WORK_AT]->(org:Organisation)
+WHERE friend.id <> {person_id} AND org.name = \"{org_name}\" AND wa.workFrom < 2012
+RETURN DISTINCT friend.id, wa.workFrom ORDER BY wa.workFrom LIMIT 10"
+    );
+    // Same inputs, same per-row setup, nothing to walk: the type resolves to
+    // an empty id set, so the adjacency scan is skipped entirely.
+    let no_such_type = full.replace("[wa:WORK_AT]", "[wa:NO_SUCH_TYPE]");
+    // The input side alone: no expand over WORK_AT at all.
+    let inputs_only = format!(
+        "MATCH (p:Person {{id: {person_id}}})-[:KNOWS*1..2]-(friend:Person)
+WHERE friend.id <> {person_id} RETURN count(friend) AS c"
+    );
+    // The expand without the pushed-down equality, to price the pushdown.
+    let no_org_filter = format!(
+        "MATCH (p:Person {{id: {person_id}}})-[:KNOWS*1..2]-(friend:Person)-[wa:WORK_AT]->(org:Organisation)
+WHERE friend.id <> {person_id} RETURN count(org) AS c"
+    );
+    // The expand with no edge variable bound, to price materialising `wa`.
+    let no_edge_var = format!(
+        "MATCH (p:Person {{id: {person_id}}})-[:KNOWS*1..2]-(friend:Person)-[:WORK_AT]->(org:Organisation)
+WHERE friend.id <> {person_id} AND org.name = \"{org_name}\" RETURN count(org) AS c"
+    );
+
+    for (label, cypher) in [
+        ("IC11 as written", &full),
+        ("  same, type matches nothing", &no_such_type),
+        ("  inputs only (no WORK_AT expand)", &inputs_only),
+        ("  expand, no org.name pushdown", &no_org_filter),
+        ("  expand, no edge variable bound", &no_edge_var),
+    ] {
+        let q = parse_query(cypher)?;
+        let mut times = Vec::with_capacity(runs);
+        let mut rows = 0usize;
+        for _ in 0..runs {
+            let t = Instant::now();
+            match QueryExecutor::new(&graph).execute(&q) {
+                Ok(out) => {
+                    rows = out.records.len();
+                    times.push(t.elapsed().as_secs_f64() * 1000.0);
+                }
+                Err(e) => {
+                    println!("{label:<38} failed: {e}");
+                    times.clear();
+                    break;
+                }
+            }
+        }
+        if times.is_empty() {
+            continue;
+        }
+        times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        println!("{label:<38} median {:>8.3} ms   rows {rows}", times[times.len() / 2]);
+    }
+    Ok(())
+}

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -5641,6 +5641,65 @@ mod tests {
     use super::*;
     use crate::query::parser::parse_query;
 
+    /// `resolve_target_ids` must answer from a label scan when no index exists.
+    ///
+    /// LDBC IC11 pushes `org.name = "..."` into the expand over `:WORK_AT`.
+    /// With the equality resolved to ids the per-candidate test is a hash
+    /// lookup; without it, `target_props` fetches the node and compares a
+    /// property for each of ~29,000 candidate edges, which is 74% of the query
+    /// at SF10 (#665). Nothing asserted that the resolution actually happens.
+    #[test]
+    fn a_target_equality_resolves_to_ids_by_scanning_a_small_label() {
+        use crate::graph::{Label, PropertyValue};
+
+        let mut store = GraphStore::new();
+        let mut wanted = Vec::new();
+        for i in 0..20i64 {
+            let id = store.create_node(Label::new("Organisation"));
+            let name = if i % 5 == 0 { "Acme" } else { "Other" };
+            store
+                .set_node_property("default", id, "name", PropertyValue::String(name.into()))
+                .unwrap();
+            if name == "Acme" {
+                wanted.push(id);
+            }
+        }
+
+        let planner = QueryPlanner::new();
+        let ids = planner
+            .resolve_target_ids(
+                &[Label::new("Organisation")],
+                &[("name".to_string(), PropertyValue::String("Acme".into()))],
+                &store,
+            )
+            .expect("a 20-node label is far under the scan cap");
+
+        let mut got: Vec<_> = ids.into_iter().collect();
+        got.sort();
+        wanted.sort();
+        assert_eq!(got, wanted);
+    }
+
+    /// A label bigger than the cap declines rather than scanning: above it the
+    /// per-candidate check is genuinely cheaper than one whole-label pass.
+    #[test]
+    fn a_target_equality_declines_a_label_over_the_scan_cap() {
+        use crate::graph::{Label, PropertyValue};
+
+        let store = GraphStore::new();
+        let planner = QueryPlanner::new();
+        // No such label, no index: the index loop finds nothing and the scan
+        // finds an empty label, which is a resolvable answer (the empty set) —
+        // not a decline. The decline is the *cap*, exercised in the engine at
+        // scale; asserted here only as "an unknown label is not a wildcard".
+        let ids = planner.resolve_target_ids(
+            &[Label::new("NoSuchLabel")],
+            &[("name".to_string(), PropertyValue::String("Acme".into()))],
+            &store,
+        );
+        assert_eq!(ids, Some(std::collections::HashSet::new()));
+    }
+
     #[test]
     fn test_plan_simple_match() {
         let store = GraphStore::new();


### PR DESCRIPTION
Measurement and tests. No behaviour change. Refs #665.

## The finding

#665 proposed resolving `org.name = "..."` to a node-id set so the per-candidate
test becomes a hash lookup. That shipped, and it helped — **SF10 IC11 went 287 →
229 ms** (measured today on a dedicated r6a.8xlarge at identical host
calibration to the 2026-08-19 run). But the expand is still **73.8%** of the
query at SF10 and 68% at SF1, emitting **2 rows from 3,272 input rows**, so the
remaining cost is somewhere else.

`examples/ic11_probe` separates the candidates at SF1 — 7 runs, median, `id`
indexes built:

| | median | rows |
|---|---:|---:|
| IC11 as written | 16.939 ms | 2 |
| same, type matches nothing | 15.830 ms | 0 |
| inputs only (no WORK_AT expand) | 4.339 ms | 1 |
| expand, no `org.name` pushdown | 22.479 ms | 1 |
| expand, no edge variable bound | 15.659 ms | 1 |

- the expand adds **12.6 ms** over its input side
- the pushdown is **worth 5.5 ms** — it is not the problem
- binding `wa` costs **1.3 ms**
- surviving-edge work is **~1.1 ms**
- the walk visits ~916k edges (an LDBC Person has ~280 outgoing, ~2.1 of them
  `:WORK_AT`), priced by `adjacency_walk` at 1.5 ns/edge = **~1.4 ms**

That leaves **~10 ms across 3,272 input rows — about 3 µs each — before the
operator touches adjacency**. IC11's expand is dominated by per-input-row
overhead. One visible candidate is `self.current_record = Some(record.clone())`
in `ExpandOperator::next`, which clones the whole record for every input row
including the ones that emit nothing, and `record` is owned there. Attributing
the rest needs a profiler, and this PR deliberately stops at the measurement
rather than guessing a third time.

## Two measurements that could not have told us this

**`benches/adjacency_walk` was refuting its own premise.** Its docstring frames
the question as "what a scattered probe keyed on those [edge] ids costs" and
concluded the probe is free — but it built each node's whole adjacency
consecutively, so the edge ids inside one run were contiguous and the probe
walked the array in order. The layout it described never existed in the graph
it measured.

`--order by-type` builds what a loader produces — every edge of one type across
every node, then the next type, which is how LDBC loads `KNOWS`, then
`HAS_INTEREST`, then `LIKES` — and is now the default:

| edges written | wildcard | one type of six | the same as Cypher |
|---|---:|---:|---:|
| node by node (old build) | 2.6 ns/edge | 2.6 | 64.3 |
| **type by type** | **1.5 ns/edge** | **1.6** | **60.0** |

The conclusion survives the corrected premise and by a wider margin — the walk
is 1.5 ns/edge, the engine around it 40× that. One caveat is now written down:
at the default size the type array is 18 MB and fits in this host's L3, where
LDBC SF1's is 42 MB and does not; `--nodes 1000000` is the knob.

**`resolve_target_ids` had no test.** Two now — an equality resolves to ids by
scanning a small label when no index exists, and an unknown label resolves to
the empty set rather than becoming a wildcard. Both pass, which is what ruled
the resolution out as the explanation and is why the probe was written next.

## Verification

`cargo test --workspace --no-fail-fast` → **3,221 passed, 0 failed, exit 0**.