### PR TITLE
A lower bound above one returned nothing where Cypher returns rows (#710)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -4623,6 +4623,102 @@ impl VarLengthExpandOperator {
         self.target_reach.as_ref().is_some_and(|r| r.contains(&source))
     }
 
+    /// Enumerate every path from `source` of length `min_hops..=max_hops`
+    /// whose relationships are distinct, and emit its far end.
+    ///
+    /// Used only when `min_hops >= 2`, where the shortest-path walk in
+    /// `expand_from` returns an empty result rather than a smaller one (#710).
+    /// Nodes may repeat along the path; relationships may not — that is
+    /// openCypher's rule, and the same one #684 established for fixed-length
+    /// patterns.
+    ///
+    /// Depth-first with an explicit stack, so the working set is one path
+    /// rather than one frontier. An unbounded upper bound is still bounded in
+    /// practice by edge-distinctness, but the number of trails is not, so
+    /// `MAX_TRAILS` caps the walk and the cap is reported rather than
+    /// silently truncating: a benchmark that quietly runs a subset reports a
+    /// denominator that does not exist (#683), and the same is true of a
+    /// query.
+    fn expand_trails(
+        &mut self,
+        record: &Record,
+        source_id: NodeId,
+        store: &GraphStore,
+    ) -> ExecutionResult<()> {
+        /// Enough for any pattern a person writes by hand, small enough that a
+        /// runaway `*2..` cannot hang the query.
+        const MAX_TRAILS: usize = 1_000_000;
+
+        self.ensure_type_ids(store);
+        let type_ids: Option<Vec<u16>> = self.type_ids.clone();
+        let type_filter = type_ids.as_deref();
+
+        // The path so far, as (node, edge-that-reached-it). `edges` is what
+        // enforces relationship uniqueness.
+        let mut path: Vec<(NodeId, crate::graph::EdgeId)> = Vec::new();
+        let mut edges: Vec<crate::graph::EdgeId> = Vec::new();
+        // Frontier per depth: the neighbours still to try at each level.
+        let mut stack: Vec<Vec<(NodeId, crate::graph::EdgeId)>> = Vec::new();
+
+        // Not a closure over `self`: `buffer` below needs `&mut self`, and a
+        // captured `&self` would still be alive.
+        macro_rules! collect {
+            ($cur:expr, $used:expr) => {{
+                let mut out = Vec::new();
+                self.for_each_neighbor($cur, type_filter, store, |nb, eid| {
+                    if !$used.contains(&eid) {
+                        out.push((nb, eid));
+                    }
+                });
+                out
+            }};
+        }
+
+        stack.push(collect!(source_id, edges));
+        let mut trails = 0usize;
+
+        while let Some(frontier) = stack.last_mut() {
+            let Some((nb, eid)) = frontier.pop() else {
+                stack.pop();
+                path.pop();
+                edges.pop();
+                continue;
+            };
+            path.push((nb, eid));
+            edges.push(eid);
+            let depth = path.len();
+
+            if depth >= self.min_hops && self.emit_ok(nb, store) {
+                trails += 1;
+                if trails > MAX_TRAILS {
+                    return Err(ExecutionError::PlanningError(format!(
+                        "variable-length pattern produced more than {MAX_TRAILS} paths; \
+                         bound it with an upper hop limit or a more selective start"
+                    )));
+                }
+                // `parent` reconstructs the path for a bound path or
+                // relationship variable. Built from the current stack, so it
+                // describes *this* trail rather than a shortest route.
+                let mut parent: std::collections::HashMap<NodeId, (NodeId, crate::graph::EdgeId)> =
+                    std::collections::HashMap::new();
+                let mut prev = source_id;
+                for (n, e) in &path {
+                    parent.insert(*n, (prev, *e));
+                    prev = *n;
+                }
+                self.buffer(record, nb, &parent, source_id, store);
+            }
+
+            if depth < self.max_hops {
+                stack.push(collect!(nb, edges));
+            } else {
+                path.pop();
+                edges.pop();
+            }
+        }
+        Ok(())
+    }
+
     fn expand_from(&mut self, record: &Record, store: &GraphStore) -> ExecutionResult<()> {
         let source_val = record
             .get(&self.source_var)
@@ -4647,6 +4743,24 @@ impl VarLengthExpandOperator {
                 self.buffer(record, target, &empty, source_id, store);
             }
             return Ok(());
+        }
+
+        // A lower bound above one cannot be answered by a shortest-path walk.
+        //
+        // The BFS below marks a node visited at the depth it is first reached
+        // and never reconsiders it, so `*2..2` over a triangle finds `b` and
+        // `c` at depth 1, declines to emit them (depth < min_hops), and then
+        // has nothing left at depth 2 — **zero rows, no error**, where
+        // openCypher matches `a-b-c` and `a-c-b`. Nodes may repeat in a
+        // variable-length match; only relationships may not.
+        //
+        // Enumerating trails is the general answer and is not affordable on
+        // the shapes that matter (#710): LDBC IC1's `KNOWS*1..3` reaches ~4,900
+        // nodes, and IC6 needs the pinned-target walk to stay cheap. Both have
+        // `min_hops == 1`, as does every LDBC pattern, so the enumeration is
+        // taken only where the BFS is not merely lossy but wrong.
+        if self.min_hops >= 2 {
+            return self.expand_trails(record, source_id, store);
         }
 
         // parent[node] = (predecessor, edge used) for path reconstruction.

--- a/tests/exists_subquery_test.rs
+++ b/tests/exists_subquery_test.rs
@@ -128,7 +128,20 @@ fn one_hop_traversal_with_exclusion_filter() {
 }
 
 /// 3-hop traversal + exclusion, to cover depth beyond the reported case.
-/// Shortest-path distance 3 from A is {E}; E is not a direct neighbour of A.
+///
+/// `*3` means *paths of exactly three relationships*, not "shortest distance
+/// three". Over `A-B, B-C, B-D, A-C, D-E` there are two such endpoints once
+/// `A` is excluded: `E` via `A-B, B-D, D-E`, and **`D` via `A-C, C-B, B-D`** —
+/// three distinct relationships, revisiting no edge. Nodes may repeat in a
+/// variable-length match; relationships may not.
+///
+/// This test asserted `["E"]` and its doc comment said "shortest-path distance
+/// 3 from A is {E}", which is true and is not what the query asks. It was
+/// encoding the engine's shortest-path walk rather than openCypher, and it
+/// went red the moment that walk was replaced for lower bounds above one
+/// (#710). Checked against the TCK, whose `Match6` scenario [14] expects four
+/// rows from a `*3..3` pattern that revisits a node and closes on an endpoint
+/// one hop away.
 #[test]
 fn three_hop_traversal_with_exclusion_filter() {
     let store = setup();
@@ -139,7 +152,7 @@ fn three_hop_traversal_with_exclusion_filter() {
          RETURN DISTINCT s.name AS name",
         "name",
     );
-    assert_eq!(got, vec!["E"]);
+    assert_eq!(got, vec!["D", "E"]);
 }
 
 /// Fixed-length 2-hop chain written out explicitly, rather than `*2`. This is a

--- a/tests/var_length_path_enumeration.rs
+++ b/tests/var_length_path_enumeration.rs
@@ -81,7 +81,6 @@ fn a_node_reachable_two_ways_within_the_bound_yields_two_rows() {
 /// A BFS that marks both visited at depth 1 and never revisits them returns
 /// nothing at all.
 #[test]
-#[ignore = "#710: the operator walks shortest paths, not paths"]
 fn a_lower_bound_still_matches_a_longer_route_to_a_near_node() {
     let store = triangle();
     assert_eq!(
@@ -130,5 +129,114 @@ fn a_var_length_segment_may_not_reuse_an_edge_the_clause_already_walked() {
             "MATCH (a:N {name:\"a\"})-[:R]-(y)-[:R*1..1]-(z) RETURN z.name AS n"
         ),
         Vec::<String>::new(),
+    );
+}
+
+/// A bound path variable over a lower-bounded segment describes *that* trail.
+///
+/// The shortest-path walk reconstructed a path from a `parent` map keyed on
+/// shortest distance, which has no entry for a longer route. The enumeration
+/// builds the map from the trail it is standing on.
+#[test]
+fn a_named_path_over_a_lower_bounded_segment_has_the_right_length() {
+    let store = triangle();
+    let q = parse_query(
+        "MATCH p = (a:N {name:\"a\"})-[:R*2..2]-(x) RETURN length(p) AS n ORDER BY n",
+    )
+    .unwrap();
+    let out = QueryExecutor::new(&store).execute(&q).unwrap();
+    let lengths: Vec<i64> = out
+        .records
+        .iter()
+        .map(|r| match r.get("n") {
+            Some(Value::Property(PropertyValue::Integer(i))) => *i,
+            other => panic!("expected integer n, got {other:?}"),
+        })
+        .collect();
+    assert_eq!(lengths, vec![2, 2]);
+}
+
+/// A relationship list bound over a lower-bounded segment holds one entry per
+/// hop, and they are distinct.
+#[test]
+fn a_relationship_list_over_a_lower_bounded_segment_has_one_entry_per_hop() {
+    let store = triangle();
+    let q =
+        parse_query("MATCH (a:N {name:\"a\"})-[rs:R*2..2]-(x) RETURN size(rs) AS n ORDER BY n")
+            .unwrap();
+    let out = QueryExecutor::new(&store).execute(&q).unwrap();
+    let sizes: Vec<i64> = out
+        .records
+        .iter()
+        .map(|r| match r.get("n") {
+            Some(Value::Property(PropertyValue::Integer(i))) => *i,
+            other => panic!("expected integer n, got {other:?}"),
+        })
+        .collect();
+    assert_eq!(sizes, vec![2, 2]);
+}
+
+/// Direction is still honoured when the lower bound takes the other path.
+///
+/// A directed cycle a→b→c→a: `*2..2` outgoing from `a` reaches only `c`, and
+/// there is exactly one way to get there.
+#[test]
+fn direction_is_honoured_by_the_lower_bounded_walk() {
+    let mut store = GraphStore::new();
+    for n in ["a", "b", "c"] {
+        run(&mut store, &format!("CREATE (:N {{name: \"{n}\"}})"));
+    }
+    for (x, y) in [("a", "b"), ("b", "c"), ("c", "a")] {
+        run(
+            &mut store,
+            &format!("MATCH (x:N {{name:\"{x}\"}}), (y:N {{name:\"{y}\"}}) CREATE (x)-[:R]->(y)"),
+        );
+    }
+    assert_eq!(
+        names(&store, "MATCH (a:N {name:\"a\"})-[:R*2..2]->(x) RETURN x.name AS n"),
+        vec!["c"],
+    );
+    // Undirected, the same graph has more: a-b-c forward, and a-c-b backward.
+    assert_eq!(
+        names(&store, "MATCH (a:N {name:\"a\"})-[:R*2..2]-(x) RETURN x.name AS n"),
+        vec!["b", "c"],
+    );
+}
+
+/// A target label still filters what may be emitted.
+#[test]
+fn a_target_label_filters_the_lower_bounded_walk() {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:N {name: \"a\"})");
+    run(&mut store, "CREATE (:N {name: \"b\"})");
+    run(&mut store, "CREATE (:M {name: \"c\"})");
+    for (x, xl, y, yl) in [("a", "N", "b", "N"), ("b", "N", "c", "M")] {
+        run(
+            &mut store,
+            &format!(
+                "MATCH (x:{xl} {{name:\"{x}\"}}), (y:{yl} {{name:\"{y}\"}}) CREATE (x)-[:R]->(y)"
+            ),
+        );
+    }
+    assert_eq!(
+        names(&store, "MATCH (a:N {name:\"a\"})-[:R*2..2]->(x:M) RETURN x.name AS n"),
+        vec!["c"],
+    );
+    assert_eq!(
+        names(&store, "MATCH (a:N {name:\"a\"})-[:R*2..2]->(x:N) RETURN x.name AS n"),
+        Vec::<String>::new(),
+    );
+}
+
+/// The upper bound is still an upper bound: `*2..3` over the triangle adds the
+/// three-hop trails that return to the start.
+#[test]
+fn a_range_above_the_lower_bound_keeps_matching() {
+    let store = triangle();
+    // Two-hop: b, c. Three-hop: every trail of three distinct edges from `a`
+    // ends back at `a` (a-b-c-a and a-c-b-a).
+    assert_eq!(
+        names(&store, "MATCH (a:N {name:\"a\"})-[:R*2..3]-(x) RETURN x.name AS n"),
+        vec!["a", "a", "b", "c"],
     );
 }


### PR DESCRIPTION
Partial fix for #710 — the half that returns an **empty result**.

## The bug

```cypher
MATCH (a {name:"a"})-[:R*2..2]-(x) RETURN x.name
```

over a triangle `a-b, b-c, a-c` returns **zero rows and no error**. openCypher
returns `b` and `c`: `a-b-c` and `a-c-b` are both paths of exactly two distinct
relationships. Nodes may repeat in a variable-length match; only relationships
may not.

`expand_from` is a BFS with a **node**-visited set, so it marks `b` and `c`
visited at depth 1, declines to emit them (depth < `min_hops`), and has nothing
left at depth 2. Nothing in the output distinguishes that from "no match".

## The fix, and its deliberate scope

`expand_trails` enumerates paths of length `min_hops..=max_hops` with distinct
relationships — depth-first over an explicit stack, so the working set is one
path rather than one frontier — and runs **only when `min_hops >= 2`**.

That bound is the point. Trail enumeration is far larger than a shortest-path
walk on the shapes that matter: IC1's `KNOWS*1..3` reaches ~4,900 nodes, and
IC6 depends on the pinned-target walk staying cheap (#590). **Every LDBC
pattern has `min_hops == 1`**, so the enumeration runs exactly where the BFS is
wrong rather than merely lossy, and nowhere else.

`MAX_TRAILS` caps the walk at a million paths and **errors** rather than
truncating — a query that silently returns a subset is what this issue is about.

**Still open in #710:** the multiplicity half. `*1..2` under-reports (one row
where two paths exist), and an edge walked earlier in the same clause can still
be reused by a var-length segment. Both need the planner to decide when a
result can observe multiplicity — `RETURN DISTINCT` and existence tests cannot,
a bound path or a `count` can — which is a larger change than this one. The two
tests for those stay `#[ignore]`d against #710.

## One existing test was encoding the defect

`three_hop_traversal_with_exclusion_filter` asserted `["E"]` for `*3` from `A`
over `A-B, B-C, B-D, A-C, D-E`, with a doc comment reading *"shortest-path
distance 3 from A is {E}"* — true, and not what the query asks. **`D` is also
reachable in exactly three distinct relationships**, via `A-C, C-B, B-D`.

It went red on this change, so per the standing rule I checked a reference
before touching it: TCK `clauses/match/Match6.feature` scenario **[14]** expects
four rows from a `*3..3` pattern that revisits a node and closes on an endpoint
one hop away. The expectation was wrong; it is corrected, and the comment now
says why rather than leaving the next reader to re-derive it.

## Verification

| | |
|---|---|
| `cargo test --workspace --no-fail-fast` | **3,242 passed, 0 failed, exit 0** |
| openCypher TCK 2024.3 | **1079 / 1244 evaluated, 86.7% — unchanged**, ratchet floor holds |
| LDBC SF1, 3 runs | **21/21 passed, 0 empty, 0 errors**, row counts unchanged |

Six new tests: a lower bound reaching a near node by a longer route, a named
path's length over such a segment, a relationship list's size, direction in
both the directed and undirected case, a target label filtering it, and a range
above the lower bound.