### PR TITLE
is7_probe: print the plan for the count shape too (#711)

### DIFF
--- a/examples/is7_probe.rs
+++ b/examples/is7_probe.rs
@@ -125,11 +125,15 @@ RETURN count(f) AS c"
         println!("{label:<44} median {:>8.3} ms   rows {rows}", times[times.len() / 2]);
     }
 
-    println!("\n--- plan of IS7 as written ---");
-    let q = parse_query(&format!("EXPLAIN {full}"))?;
-    for r in &QueryExecutor::new(&graph).execute(&q)?.records {
-        if let Some(v) = r.get("plan") {
-            println!("{}", format!("{v:?}").replace("\\n", "\n"));
+    // Plans for both, because the `count` shape is the slow one and #711
+    // described its plan by inference from IS7's rather than reading it.
+    for (label, cypher) in [("IS7 as written", &full), ("op's KNOWS degree, counted", &knows_only)] {
+        println!("\n--- plan of {label} ---");
+        let q = parse_query(&format!("EXPLAIN {cypher}"))?;
+        for r in &QueryExecutor::new(&graph).execute(&q)?.records {
+            if let Some(v) = r.get("plan") {
+                println!("{}", format!("{v:?}").replace("\\n", "\n"));
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
Refs #711. Probe output only — no engine change.

#711 described the plan behind

```cypher
MATCH (m:Post {id: $postId})-[:HAS_CREATOR]->(op:Person)
MATCH (op)-[:KNOWS]-(f:Person)
RETURN count(f) AS c
```

by inference from IS7's neighbouring plan, and said so. The probe now prints it,
and the inference was right:

```
Project (__agg_0 AS c)
+- Aggregate (aggs=[count(f) AS __agg_0])
   +- HashJoin (on=op)
      +- Expand ((m)-[:HAS_CREATOR]->(op))
         +- IndexScan (var=m, Post.id = 2336467349151)   <-- one node, microseconds
      +- Expand ((op)--[:KNOWS]--(f))
         +- NodeScan (var=op, labels=["Person"])         <-- all 10,620 Persons
```

The second clause does not start from the `op` the first one bound: it scans
the whole `:Person` label, expands `:KNOWS` from all 10,620 of them — walking
essentially all 219,450 `KNOWS` edges — and hash-joins on `op` to keep the ~23
that were ever wanted. 99 ms for a count of one person's friends.

Turning the issue from "the plan is inferred, `EXPLAIN` is the first step" into
"here is the plan" is worth the four lines it costs.