### PR TITLE
The HIER results say where they came from, and subsumes() gets a test (#476, #721)

### DIFF
--- a/examples/hier_benchmark.rs
+++ b/examples/hier_benchmark.rs
@@ -213,7 +213,77 @@ fn main() {
         ));
     }
     std::fs::write(&index_csv, ix.join("\n") + "\n").expect("write index stats");
-    eprintln!("[hier] wrote {out} and {}", index_csv.display());
+
+    // Who produced these numbers, written beside them.
+    //
+    // `results.csv` went a release out of step with `docs/BENCHMARKS.md` and
+    // nothing in either said so: the CSV had H1 at 0.25x where the prose had
+    // 1.1x, and a reader doing the right thing — going to the artifact rather
+    // than trusting the prose — got the worse, older number (#476). A file
+    // that cannot say when or where it came from cannot be checked against
+    // anything.
+    //
+    // Deliberately not a claim that the numbers are good: a run on a laptop
+    // writes a laptop here, which is exactly the fact a reader needs in order
+    // to decide whether to quote it.
+    let provenance = std::path::Path::new(&out)
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .join("PROVENANCE.json");
+    let git = |args: &[&str]| -> String {
+        std::process::Command::new("git")
+            .args(args)
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .unwrap_or_default()
+    };
+    let field_after_colon = |path: &str, prefix: &str| -> String {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|t| {
+                t.lines()
+                    .find(|l| l.starts_with(prefix))
+                    .and_then(|l| l.split(':').nth(1))
+                    .map(|v| v.trim().to_string())
+            })
+            .unwrap_or_default()
+    };
+    let whole_file = |path: &str| -> String {
+        std::fs::read_to_string(path).map(|t| t.trim().to_string()).unwrap_or_default()
+    };
+    let dirty = !git(&["status", "--porcelain"]).is_empty();
+    let cores = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(0);
+    let load = std::fs::read_to_string("/proc/loadavg")
+        .ok()
+        .and_then(|s| s.split_whitespace().next().map(|v| v.to_string()))
+        .unwrap_or_default();
+    std::fs::write(
+        &provenance,
+        format!(
+            "{{\n  \"commit\": \"{}\",\n  \"dirty\": {},\n  \"host\": \"{}\",\n  \
+             \"cpu\": \"{}\",\n  \"cores\": {},\n  \"load_average_1m\": \"{}\",\n  \
+             \"reps\": {},\n  \"corpus\": \"{}\",\n  \"queries\": {},\n  \
+             \"agreed\": {}\n}}\n",
+            git(&["rev-parse", "--short=7", "HEAD"]),
+            dirty,
+            whole_file("/proc/sys/kernel/hostname"),
+            field_after_colon("/proc/cpuinfo", "model name"),
+            cores,
+            load,
+            reps,
+            corpus_path,
+            total,
+            agreed,
+        ),
+    )
+    .expect("write provenance");
+    eprintln!(
+        "[hier] wrote {out}, {} and {}",
+        index_csv.display(),
+        provenance.display()
+    );
 
     if !skipped.is_empty() {
         println!();

--- a/tests/subsumes_without_index.rs
+++ b/tests/subsumes_without_index.rs
@@ -1,0 +1,89 @@
+//! `subsumes()` with no hierarchy index declared (#721).
+//!
+//! The predicate is backed by the hierarchy index. With no index it does not
+//! fall back to a traversal and does not complain — it answers **false for
+//! every pair**, so a query returns a smaller, wrong number that looks like a
+//! legitimate empty result.
+//!
+//! That also disables `examples/hier_benchmark`'s correctness gate for the 31
+//! of 112 corpus entries whose baseline re-runs the same Cypher: for those the
+//! "ground truth" is the same index-dependent query with the index taken away.
+//!
+//! The expectation below is the traversal's answer, which is the definition of
+//! the relationship. It fails today and is `#[ignore]`d against #721 rather
+//! than weakened, because either resolution — compute it, or refuse — makes it
+//! pass, and asserting today's `0` would have to be rewritten by whoever picks
+//! it up.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+}
+
+fn count(store: &GraphStore, cypher: &str) -> i64 {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    let out = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+    match out.records.first().and_then(|r| r.get("n")) {
+        Some(Value::Property(PropertyValue::Integer(i))) => *i,
+        other => panic!("expected integer n, got {other:?}"),
+    }
+}
+
+/// `c -[:BROADER]-> b -[:BROADER]-> a`, optionally with the index declared.
+fn chain(with_index: bool) -> GraphStore {
+    let mut store = GraphStore::new();
+    for c in ["a", "b", "c"] {
+        run(&mut store, &format!("CREATE (:Term {{code: \"{c}\"}})"));
+    }
+    for (x, y) in [("b", "a"), ("c", "b")] {
+        run(
+            &mut store,
+            &format!(
+                "MATCH (x:Term {{code:\"{x}\"}}), (y:Term {{code:\"{y}\"}}) \
+                 CREATE (x)-[:BROADER]->(y)"
+            ),
+        );
+    }
+    if with_index {
+        run(
+            &mut store,
+            "CREATE HIERARCHY INDEX t ON ()-[:BROADER]->() MEASURE units AGGREGATE sum, count",
+        );
+    }
+    store
+}
+
+const SUBSUMED: &str =
+    "MATCH (d:Term), (r:Term {code:\"a\"}) WHERE subsumes(d, r) RETURN count(d) AS n";
+const BY_TRAVERSAL: &str =
+    "MATCH (r:Term {code:\"a\"})<-[:BROADER*0..]-(d:Term) RETURN count(d) AS n";
+
+/// The index and the traversal agree — this is what "subsumed by a" means.
+#[test]
+fn the_index_agrees_with_the_traversal() {
+    let store = chain(true);
+    assert_eq!(count(&store, SUBSUMED), 3);
+    assert_eq!(count(&store, BY_TRAVERSAL), 3);
+}
+
+/// The traversal does not need the index, so the answer does not change.
+#[test]
+fn the_traversal_needs_no_index() {
+    assert_eq!(count(&chain(false), BY_TRAVERSAL), 3);
+}
+
+/// Without the index, `subsumes` answers `0` where the relationship holds for
+/// three nodes. Answering *something* is the bug: an error would be fine.
+#[test]
+#[ignore = "#721: subsumes answers false for everything with no hierarchy index"]
+fn subsumes_without_an_index_does_not_quietly_answer_no() {
+    assert_eq!(count(&chain(false), SUBSUMED), 3);
+}


### PR DESCRIPTION
Closes the second of #476's three suggestions. Files #721's reproduction as a
test. Does **not** regenerate the CSVs.

## Provenance

`benchmarks/hier/results/results.csv` went a release out of step with
`docs/BENCHMARKS.md` — H1 at 0.25× in the artifact against 1.1× in the prose —
and neither file could say when or where it came from, so a reader doing the
right thing got the worse, older number.

The runner now writes `PROVENANCE.json` beside the CSVs:

```json
{ "commit": "fc09f4c", "dirty": true, "host": "vm-1",
  "cpu": "13th Gen Intel(R) Core(TM) i7-13620H", "cores": 16,
  "load_average_1m": "0.72", "reps": 1,
  "corpus": "benchmarks/hier/queries.json", "queries": 112, "agreed": 108 }
```

It is not a quality claim. A run on a laptop writes a laptop, and `dirty` says
the tree had uncommitted changes — which is the fact a reader needs to decide
whether to quote it.

**Suggestion (1) is deliberately not done.** #476 says not to regenerate on
whatever machine is handy; this is a laptop, and the re-run still wants the
hardware the doc documents.

## What the run turned up

The corpus is **112 queries and 108 agree**, not 108/108:

```
[hier] 4 DISAGREEMENTS — the index is wrong, not fast:
  H9-01: indexed=n=Integer(28) baseline=n=Integer(0)
  H9-02: indexed=n=Integer(2)  baseline=n=Integer(0)
  H9-03: indexed=n=Integer(39) baseline=n=Integer(0)
  H9-04: indexed=n=Integer(200) baseline=n=Integer(0)
```

The index is not wrong. H9 has **no separate baseline**, so the runner's
"ground truth" is the same index-dependent query with the index taken away —
and `subsumes()` with no hierarchy index declared answers **false for every
pair**, silently. On `c -[:BROADER]-> b -[:BROADER]-> a`:

| | result |
|---|---:|
| no index | **0** |
| with the hierarchy index | 3 |
| plain traversal | 3 |

Filed as **#721**. `tests/subsumes_without_index.rs` pins all three; the third
is `#[ignore]`d against it, asserting the traversal's answer rather than
today's `0`, because either resolution — compute it, or refuse — makes it pass.

**31 of 112 corpus entries share that same-query baseline shape** and want the
same scrutiny. Until H9's baseline is written index-free its speedup is a ratio
against a query that returns nothing, so the blank `speedup` cells #476 noticed
in the committed CSV were closer to the truth than a number would have been.

## Verification

`cargo test --workspace --no-fail-fast` → **3,244 passed, 0 failed, exit 0**.