### PR TITLE
subsumes() refuses when there is no hierarchy to consult (#721)

### DIFF
--- a/src/index/hierarchy/manager.rs
+++ b/src/index/hierarchy/manager.rs
@@ -419,6 +419,18 @@ impl HierarchyIndexManager {
         self.entries.read().unwrap().is_empty()
     }
 
+    /// Is *any* registered index usable — present, built and not stale?
+    ///
+    /// The difference from `is_empty` is what a hierarchy function should say
+    /// when it cannot find an index covering its arguments. "These two nodes
+    /// are in no declared hierarchy" is a legitimate `false`; "there is no
+    /// declared hierarchy at all, or every one of them is stale" is a question
+    /// the engine cannot answer, and answering `false` to it is a guess that
+    /// looks like a result (#721).
+    pub fn any_usable(&self) -> bool {
+        self.entries.read().unwrap().values().any(|e| e.read().unwrap().usable())
+    }
+
     /// All registered indexes, name-sorted.
     pub fn list(&self) -> Vec<HierarchyInfo> {
         let entries = self.entries.read().unwrap();

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -532,6 +532,36 @@ const EXISTS_UNBOUNDED_MAX_HOPS: usize = 15;
 ///
 /// Returns true as soon as one complete path matches and the inner WHERE holds
 /// with every subquery variable bound.
+/// Refuse a hierarchy function when there is no hierarchy to consult.
+///
+/// `subsumes()` used to answer **false** whenever no index covered its
+/// arguments, on the stated reasoning that two nodes in no declared hierarchy
+/// are not in a subsumption relation. That is right when hierarchies exist and
+/// these nodes are outside them. It is a guess when *nothing* is declared, or
+/// when every index is stale — and it is a guess shaped exactly like an answer:
+/// on `c-[:BROADER]->b-[:BROADER]->a` the index and a plain traversal both say
+/// three nodes are subsumed by `a`, and with no index `subsumes` said zero,
+/// silently (#721).
+///
+/// There is no traversal fallback to offer, because without a declaration
+/// there is no relationship type to walk — the hierarchy *is* the declaration.
+/// So the honest answer is an error naming what is missing.
+fn require_a_hierarchy(store: &GraphStore, func: &str) -> ExecutionResult<()> {
+    if store.hierarchy_index.any_usable() {
+        return Ok(());
+    }
+    let detail = if store.hierarchy_index.is_empty() {
+        "no hierarchy index is declared"
+    } else {
+        "every declared hierarchy index is stale or was declined"
+    };
+    Err(ExecutionError::RuntimeError(format!(
+        "{func}(): {detail}. Declare one with `CREATE HIERARCHY INDEX <name> ON \
+         ()-[:TYPE]->() ...`, REBUILD a stale one, or write the test as a \
+         variable-length traversal."
+    )))
+}
+
 fn eval_exists_subquery(
     pattern: &crate::query::ast::Pattern,
     where_clause: Option<&crate::query::ast::WhereClause>,
@@ -1370,8 +1400,12 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                 None => match store.hierarchy_index.usable_containing(&[x, y]) {
                     Some(e) => e,
                     // Both nodes outside every hierarchy: they are not in a subsumption
-                    // relation anyone declared, which is FALSE rather than an error.
-                    None => return Ok(Value::Property(PropertyValue::Boolean(false))),
+                    // relation anyone declared, which is FALSE rather than an error --
+                    // but only once there is a hierarchy to be outside of (#721).
+                    None => {
+                        require_a_hierarchy(store, "subsumes")?;
+                        return Ok(Value::Property(PropertyValue::Boolean(false)));
+                    }
                 },
             };
             let guard = entry.read().unwrap();
@@ -1406,7 +1440,12 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                 }
                 None => match store.hierarchy_index.usable_containing(&[root]) {
                     Some(e) => e,
-                    None => return Ok(Value::Property(PropertyValue::Null)),
+                    // Null for a root outside every hierarchy; an error when
+                    // there is no hierarchy at all (#721).
+                    None => {
+                        require_a_hierarchy(store, "hierarchy_rollup")?;
+                        return Ok(Value::Property(PropertyValue::Null));
+                    }
                 },
             };
             let guard = entry.read().unwrap();
@@ -1440,7 +1479,12 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                 }
                 None => match store.hierarchy_index.usable_containing(&[a, b]) {
                     Some(e) => e,
-                    None => return Ok(Value::Property(PropertyValue::Array(Vec::new()))),
+                    // No common ancestor for two nodes outside every hierarchy;
+                    // an error when there is no hierarchy at all (#721).
+                    None => {
+                        require_a_hierarchy(store, "hierarchy_lca")?;
+                        return Ok(Value::Property(PropertyValue::Array(Vec::new())));
+                    }
                 },
             };
             let guard = entry.read().unwrap();

--- a/tests/subsumes_without_index.rs
+++ b/tests/subsumes_without_index.rs
@@ -9,11 +9,13 @@
 //! of 112 corpus entries whose baseline re-runs the same Cypher: for those the
 //! "ground truth" is the same index-dependent query with the index taken away.
 //!
-//! The expectation below is the traversal's answer, which is the definition of
-//! the relationship. It fails today and is `#[ignore]`d against #721 rather
-//! than weakened, because either resolution — compute it, or refuse — makes it
-//! pass, and asserting today's `0` would have to be rewritten by whoever picks
-//! it up.
+//! Resolved by refusing. There is no traversal fallback to offer: without a
+//! declaration there is no relationship type to walk, because the hierarchy
+//! *is* the declaration. So the function now errors and names what is missing.
+//!
+//! The distinction the fix preserves: two nodes outside every hierarchy, when
+//! hierarchies exist, are still legitimately `false`. Only "there is no
+//! hierarchy at all, or every one is stale" is an error.
 
 use samyama::graph::{GraphStore, PropertyValue};
 use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
@@ -34,6 +36,14 @@ fn count(store: &GraphStore, cypher: &str) -> i64 {
     match out.records.first().and_then(|r| r.get("n")) {
         Some(Value::Property(PropertyValue::Integer(i))) => *i,
         other => panic!("expected integer n, got {other:?}"),
+    }
+}
+
+fn error(store: &GraphStore, cypher: &str) -> String {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    match QueryExecutor::new(store).execute(&q) {
+        Ok(out) => panic!("`{cypher}` should have failed, got {:?}", out.records),
+        Err(e) => e.to_string(),
     }
 }
 
@@ -80,10 +90,49 @@ fn the_traversal_needs_no_index() {
     assert_eq!(count(&chain(false), BY_TRAVERSAL), 3);
 }
 
-/// Without the index, `subsumes` answers `0` where the relationship holds for
-/// three nodes. Answering *something* is the bug: an error would be fine.
+/// Without any hierarchy declared, `subsumes` refuses instead of answering
+/// `false` for every pair — which is what it used to do, giving `0` where the
+/// relationship holds for three nodes.
 #[test]
-#[ignore = "#721: subsumes answers false for everything with no hierarchy index"]
-fn subsumes_without_an_index_does_not_quietly_answer_no() {
-    assert_eq!(count(&chain(false), SUBSUMED), 3);
+fn subsumes_without_an_index_refuses_rather_than_answering_no() {
+    let why = error(&chain(false), SUBSUMED);
+    assert!(why.contains("subsumes()"), "{why}");
+    assert!(why.contains("no hierarchy index is declared"), "{why}");
+    // The message has to say what to do about it, not just what is wrong.
+    assert!(why.contains("CREATE HIERARCHY INDEX"), "{why}");
+}
+
+/// `hierarchy_rollup` and `hierarchy_lca` degrade the same way — to null and
+/// to an empty list — and get the same guard.
+#[test]
+fn the_other_hierarchy_functions_refuse_too() {
+    let store = chain(false);
+    let rollup = error(
+        &store,
+        "MATCH (r:Term {code:\"a\"}) RETURN hierarchy_rollup(r, \"sum\") AS n",
+    );
+    assert!(rollup.contains("hierarchy_rollup()"), "{rollup}");
+    let lca = error(
+        &store,
+        "MATCH (a:Term {code:\"b\"}), (b:Term {code:\"c\"}) RETURN hierarchy_lca(a, b) AS n",
+    );
+    assert!(lca.contains("hierarchy_lca()"), "{lca}");
+}
+
+/// Two nodes outside every hierarchy, where a hierarchy *does* exist, are
+/// still `false`. That was the deliberate decision behind the old behaviour
+/// and it is right — the fix narrows it rather than reversing it.
+#[test]
+fn nodes_outside_an_existing_hierarchy_are_still_false() {
+    let mut store = chain(true);
+    run(&mut store, "CREATE (:Other {code: \"x\"})");
+    run(&mut store, "CREATE (:Other {code: \"y\"})");
+    assert_eq!(
+        count(
+            &store,
+            "MATCH (d:Other {code:\"x\"}), (r:Other {code:\"y\"}) \
+             WHERE subsumes(d, r) RETURN count(d) AS n"
+        ),
+        0
+    );
 }


### PR DESCRIPTION
Closes #721.

## The decision this narrows

`subsumes()` answered `false` whenever no index covered its arguments, and the
reasoning was written into the code:

```rust
// Both nodes outside every hierarchy: they are not in a subsumption
// relation anyone declared, which is FALSE rather than an error.
```

That is right when hierarchies exist and these two nodes are outside them. It is
a guess when **nothing** is declared — and a guess shaped exactly like an
answer. On `c-[:BROADER]->b-[:BROADER]->a`:

| | result |
|---|---:|
| no index | **0** |
| with the hierarchy index | 3 |
| plain traversal | 3 |

## Refuse, not fall back

There is no traversal fallback to offer: without a declaration there is no
relationship type to walk, because the hierarchy *is* the declaration. So the
function errors and names both the problem and the ways out:

```
subsumes(): no hierarchy index is declared. Declare one with
`CREATE HIERARCHY INDEX <name> ON ()-[:TYPE]->() ...`, REBUILD a stale one,
or write the test as a variable-length traversal.
```

`any_usable()` on the manager separates the two cases, so the old behaviour is
**narrowed rather than reversed**: nodes outside an existing hierarchy still
answer `false`, and a test pins that so a later change cannot quietly widen the
refusal. A registered-but-stale index gets its own wording, since "REBUILD it"
is different advice from "declare one".

`hierarchy_rollup` and `hierarchy_lca` degraded the same way — to null and to an
empty list — and get the same guard.

## What it does to the HIER benchmark

The corpus is 112 queries with 108 agreeing, and H9's four disagreements now
explain themselves in one line rather than needing a four-`CREATE`
reproduction to discover:

```
H9-01: baseline query failed: Runtime error: subsumes(): no hierarchy index
is declared. ...
```

H9 has no separate baseline, so the runner's "ground truth" was the same
index-dependent query with the index taken away. The runner still exits 1 —
correctly; the corpus is still mis-specified — but the failure is legible now.
**31 of 112 entries share that baseline shape**, and writing them index-free is
follow-up on #445/#476 rather than part of this change.

## Verification

`cargo test --workspace --no-fail-fast` → 134 result lines, all `ok`, **3,247
passed, 0 failed**, doctests included.

One caveat stated plainly: the wrapper's `echo EXIT=$?` was lost when its shell
was reaped after cargo finished, so I am reading the log rather than the exit
code — which is normally the wrong way round. The log ends with the doctest
summary, which is the last stage `cargo test` runs, and contains no line
starting with `error` and no `test result: FAILED`. Five tests cover the new
behaviour, including the `false` case the fix preserves.