### PR TITLE
OPTIONAL MATCH anchors on bound variables too: 422 ms → 0.022 ms (#726)

### DIFF
--- a/examples/is7_forms.rs
+++ b/examples/is7_forms.rs
@@ -1,0 +1,113 @@
+//! IS7 the way we run it, and the way the competitors run it (#725).
+//!
+//! The SNB-I corpus gives Samyama `EXISTS { MATCH (op)-[:KNOWS]-(author) }`
+//! and gives Neo4j and FalkorDB `OPTIONAL MATCH (op)-[k:KNOWS]-(author)` with
+//! `(k IS NOT NULL)`. The two are semantically equivalent, and
+//! `benches/ldbc_benchmark.rs` says in a comment why ours is the one it is:
+//!
+//!   Note: OPTIONAL MATCH version is semantically correct but triggers full
+//!   Post scan in planner
+//!
+//! So the form was chosen to avoid a weakness of our own planner, and the
+//! published ratio compares it against the form we avoided. This measures how
+//! much that is worth, which is the only way to know whether the ratio
+//! survives being made like-for-like.
+//!
+//!   cargo run --release --example is7_forms -- --data-dir <sf1> --post-id <id>
+
+#[path = "../benches/ldbc_common/mod.rs"]
+mod ldbc_common;
+
+#[path = "../benches/common/bench_setup.rs"]
+mod bench_setup;
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+use std::path::PathBuf;
+use std::time::Instant;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    bench_setup::init();
+    let _c = bench_setup::report_calibration();
+
+    let args: Vec<String> = std::env::args().collect();
+    let arg = |f: &str| args.iter().position(|a| a == f).and_then(|i| args.get(i + 1));
+    let data_dir = arg("--data-dir").map(PathBuf::from).expect("--data-dir <path>");
+    let post_id: i64 = arg("--post-id").expect("--post-id <id>").parse()?;
+    let runs: usize = arg("--runs").map(|s| s.parse()).transpose()?.unwrap_or(11);
+
+    let mut graph = GraphStore::new();
+    eprintln!("loading {} ...", data_dir.display());
+    ldbc_common::load_dataset(&mut graph, &data_dir)?;
+    for (label, prop) in [("Person", "id"), ("Post", "id"), ("Comment", "id")] {
+        let q = parse_query(&format!("CREATE INDEX ON :{label}({prop})"))?;
+        MutQueryExecutor::new(&mut graph, "default".to_string()).execute(&q)?;
+    }
+
+    let head = format!(
+        "MATCH (m:Post {{id: {post_id}}})<-[:REPLY_OF]-(c:Comment)-[:HAS_CREATOR]->(author:Person)
+MATCH (m)-[:HAS_CREATOR]->(op:Person)"
+    );
+    // What the corpus gives Samyama.
+    let ours = format!(
+        "{head}
+RETURN c.id, c.creationDate, author.id, \
+EXISTS {{ MATCH (op)-[:KNOWS]-(author) }} AS isKnows
+ORDER BY c.creationDate DESC
+LIMIT 20"
+    );
+    // What the corpus gives Neo4j and FalkorDB, verbatim.
+    let theirs = format!(
+        "{head}
+OPTIONAL MATCH (op)-[k:KNOWS]-(author)
+RETURN c.id, c.creationDate, author.id, (k IS NOT NULL) AS isKnows
+ORDER BY c.creationDate DESC
+LIMIT 20"
+    );
+
+    for (label, cypher) in [("IS7, EXISTS (ours)", &ours), ("IS7, OPTIONAL MATCH (theirs)", &theirs)] {
+        let q = match parse_query(cypher) {
+            Ok(q) => q,
+            Err(e) => {
+                println!("{label:<32} does not parse: {e}");
+                continue;
+            }
+        };
+        let mut times = Vec::with_capacity(runs);
+        let mut rows = 0usize;
+        for _ in 0..runs {
+            let t = Instant::now();
+            match QueryExecutor::new(&graph).execute(&q) {
+                Ok(o) => {
+                    rows = o.records.len();
+                    times.push(t.elapsed().as_secs_f64() * 1000.0);
+                }
+                Err(e) => {
+                    println!("{label:<32} failed: {e}");
+                    times.clear();
+                    break;
+                }
+            }
+        }
+        if times.is_empty() {
+            continue;
+        }
+        times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        println!("{label:<32} median {:>9.3} ms   rows {rows}", times[times.len() / 2]);
+    }
+
+    for (label, cypher) in [("ours", &ours), ("theirs", &theirs)] {
+        println!("\n--- plan, {label} ---");
+        if let Ok(q) = parse_query(&format!("EXPLAIN {cypher}")) {
+            if let Ok(out) = QueryExecutor::new(&graph).execute(&q) {
+                for r in &out.records {
+                    if let Some(v) = r.get("plan") {
+                        println!("{}", format!("{v:?}").replace("\\n", "\n"));
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3920,6 +3920,19 @@ pub struct ExpandOperator {
     /// the PERF-01 target. Applied here, a non-matching employer never
     /// becomes a row (#656).
     target_props: Vec<(String, PropertyValue)>,
+    /// The variables to bind to null when a source record matches nothing.
+    ///
+    /// `Some` marks this expand as an `OPTIONAL MATCH`: a source row that finds
+    /// no edge still produces a row, with the variables the clause introduces
+    /// set to null. `None` is an ordinary expand, where such a row disappears.
+    ///
+    /// Only the variables the clause *introduces* are listed. In
+    /// `OPTIONAL MATCH (op)-[k:KNOWS]-(author)` with both endpoints already
+    /// bound, that is `k` alone — nulling `author` would erase a binding the
+    /// row already had (#726).
+    optional_null_vars: Option<Vec<String>>,
+    /// Whether the current source record has emitted anything yet.
+    emitted_for_current: bool,
     /// The exact set of nodes the target may be, resolved once at plan time.
     ///
     /// `target_props` above still costs a `get_node` and a property compare per
@@ -3992,6 +4005,8 @@ impl ExpandOperator {
             target_labels: Vec::new(),
             target_props: Vec::new(),
             target_ids: None,
+            optional_null_vars: None,
+            emitted_for_current: false,
             track_edges: false,
             starts_clause: false,
             target_bound_var: None,
@@ -4043,6 +4058,13 @@ impl ExpandOperator {
         self
     }
 
+    /// Make this expand an `OPTIONAL MATCH`: a source row that matches nothing
+    /// still emits, with `null_vars` bound to null.
+    pub fn with_optional(mut self, null_vars: Vec<String>) -> Self {
+        self.optional_null_vars = Some(null_vars);
+        self
+    }
+
     pub fn with_target_ids(mut self, ids: std::collections::HashSet<NodeId>) -> Self {
         self.target_ids = Some(ids);
         self
@@ -4064,6 +4086,25 @@ impl ExpandOperator {
             .filter_map(|t| store.edge_type_id(&EdgeType::new(t.as_str())))
             .collect();
         self.type_ids = Some(ids);
+    }
+
+    /// The null-filled row an `OPTIONAL MATCH` owes a source record that
+    /// matched nothing, or `None` if it owes nothing.
+    ///
+    /// Consumes `current_record`, so it fires at most once per source row; the
+    /// caller then falls through to pulling the next input.
+    fn take_unmatched_optional_row(&mut self) -> Option<Record> {
+        let null_vars = self.optional_null_vars.as_ref()?;
+        if self.emitted_for_current {
+            return None;
+        }
+        let base = self.current_record.take()?;
+        let mut rec = base.clone_with_capacity(null_vars.len());
+        for v in null_vars {
+            rec.bind(v.clone(), Value::Null);
+        }
+        self.emitted_for_current = true;
+        Some(rec)
     }
 
     fn load_edges(&mut self, record: &Record, store: &GraphStore) -> ExecutionResult<()> {
@@ -4300,12 +4341,20 @@ impl PhysicalOperator for ExpandOperator {
                     new_record.mark_edge_used(edge_id);
                 }
 
+                self.emitted_for_current = true;
                 return Ok(Some(new_record));
+            }
+
+            // An OPTIONAL MATCH source row that matched nothing still emits,
+            // once, with the variables this clause introduces set to null.
+            if let Some(row) = self.take_unmatched_optional_row() {
+                return Ok(Some(row));
             }
 
             // Need new input record
             if let Some(record) = self.input.next(store)? {
                 self.current_record = Some(record.clone());
+                self.emitted_for_current = false;
                 self.load_edges(&record, store)?;
             } else {
                 return Ok(None);
@@ -4372,10 +4421,20 @@ impl PhysicalOperator for ExpandOperator {
                     expanded_records.push(new_record);
                 }
                 self.edge_index += take;
+                self.emitted_for_current = true;
             } else {
+                // Same rule as the single-row path: an OPTIONAL MATCH source
+                // row that matched nothing still emits once. Missing it here
+                // would make the answer depend on whether the plan happened to
+                // run batched, which is the shape of #684.
+                if let Some(row) = self.take_unmatched_optional_row() {
+                    expanded_records.push(row);
+                    continue;
+                }
                 // Need new input record
                 if let Some(record) = self.input.next(store)? {
                     self.current_record = Some(record.clone());
+                    self.emitted_for_current = false;
                     self.load_edges(&record, store)?;
                 } else {
                     break;
@@ -4398,6 +4457,9 @@ impl PhysicalOperator for ExpandOperator {
         self.current_record = None;
         self.current_edges.clear();
         self.edge_index = 0;
+        // Without this, a re-run would think the first source record had
+        // already emitted and would swallow its null row (#726).
+        self.emitted_for_current = false;
     }
 
     fn describe(&self) -> OperatorDescription {

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1292,6 +1292,37 @@ impl QueryPlanner {
                 continue;
             }
 
+            // The same idea for `OPTIONAL MATCH`, which `can_pushdown_match`
+            // declines outright because it has to emit a null-filled row when
+            // nothing matches. A single-segment optional clause hanging off a
+            // bound variable can do that inside the expand, and the difference
+            // is not marginal: `OPTIONAL MATCH (op)-[k:KNOWS]-(author)` with
+            // both ends bound scanned every `:Person` and cost 422 ms where
+            // the equivalent `EXISTS` cost 0.02 (#726).
+            //
+            // A `WHERE` on the clause keeps the join: in `OPTIONAL MATCH` the
+            // predicate is part of the optional pattern, so a row failing it
+            // must still emit nulls, and a filter above the expand would
+            // delete exactly that row.
+            if operator.is_some() && per_match_where[match_idx].is_none() {
+                if let Some(null_vars) =
+                    Self::optional_pushdown_vars(match_clause, &known_vars)
+                {
+                    let upstream = operator.take().unwrap();
+                    let path = &match_clause.pattern.paths[0];
+                    let start_var = path.start.variable.clone().unwrap();
+                    operator = Some(self.plan_optional_expand(
+                        path,
+                        &start_var,
+                        null_vars,
+                        &known_vars,
+                        upstream,
+                    ));
+                    known_vars.extend(pre_match_var_sets[match_idx].iter().cloned());
+                    continue;
+                }
+            }
+
             let match_op = self.dispatch_plan_match(match_clause, per_match_where[match_idx].as_ref(), store)?;
 
             let clause_vars = pre_match_var_sets[match_idx].clone();
@@ -5669,6 +5700,127 @@ impl QueryPlanner {
         }
 
         Ok((current_op, new_vars))
+    }
+
+    /// Build the optional expand for a clause `optional_pushdown_vars` accepted.
+    ///
+    /// One segment, so there is exactly one expand and no partial-match
+    /// ambiguity. Everything that decides whether the pattern matches has to
+    /// live *inside* the expand: a `FilterOperator` above it would delete the
+    /// null row the clause owes a source that matched nothing, turning
+    /// `OPTIONAL MATCH` back into `MATCH`. Inline properties therefore go
+    /// through `with_target_props`, which filters during the walk, and the
+    /// caller declines the pushdown when the clause carries a `WHERE`.
+    fn plan_optional_expand(
+        &self,
+        path: &PathPattern,
+        start_var: &str,
+        null_vars: Vec<String>,
+        known_vars: &HashSet<String>,
+        upstream: OperatorBox,
+    ) -> OperatorBox {
+        let segment = &path.segments[0];
+        let target_var = segment
+            .node
+            .variable
+            .clone()
+            .expect("optional_pushdown_vars requires a named far end");
+        let edge_types: Vec<String> =
+            segment.edge.types.iter().map(|t| t.as_str().to_string()).collect();
+
+        let mut expand = ExpandOperator::new(
+            upstream,
+            start_var.to_string(),
+            target_var.clone(),
+            segment.edge.variable.clone(),
+            edge_types,
+            segment.edge.direction.clone(),
+        );
+        // A far end that is already bound is a closing hop: it can only land on
+        // that node, and the pin says so during the walk rather than after it.
+        // This is the `OPTIONAL MATCH (op)-[k:KNOWS]-(author)` case.
+        if known_vars.contains(&target_var) {
+            expand = expand.with_target_bound_var(target_var.clone());
+        }
+        if !segment.node.labels.is_empty() {
+            expand = expand.with_target_labels(segment.node.labels.clone());
+        }
+        if let Some(props) = &segment.node.properties {
+            if !props.is_empty() {
+                let mut pushed: Vec<(String, PropertyValue)> =
+                    props.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                pushed.sort_by(|a, b| a.0.cmp(&b.0));
+                expand = expand.with_target_props(pushed);
+            }
+        }
+        Box::new(expand.with_optional(null_vars))
+    }
+
+    /// Whether an `OPTIONAL MATCH` can be pushed onto the pipeline as an
+    /// optional expand instead of planned standalone and left-outer-joined.
+    ///
+    /// Deliberately narrower than `can_pushdown_match`. An optional clause has
+    /// to emit a null-filled row when it matches nothing, and only a
+    /// **single-segment** path makes that unambiguous: with two segments a
+    /// source row that matches the first hop and not the second still owes one
+    /// null row, not one per partial match, and the chain cannot tell the
+    /// difference. That case keeps the join, which already handles it.
+    ///
+    /// The shape this does cover is the common one — `OPTIONAL MATCH
+    /// (a)-[r:T]->(b)` hanging off something already bound — and it is the one
+    /// that costs 422 ms where the equivalent `EXISTS` costs 0.02 (#726).
+    ///
+    /// Returns the variables the clause introduces, which are the ones the
+    /// operator nulls when nothing matches. `author` in
+    /// `OPTIONAL MATCH (op)-[k:KNOWS]-(author)` with both ends bound is *not*
+    /// among them: nulling it would erase a binding the row already had.
+    fn optional_pushdown_vars(
+        match_clause: &MatchClause,
+        known_vars: &HashSet<String>,
+    ) -> Option<Vec<String>> {
+        if !match_clause.optional {
+            return None;
+        }
+        let [path] = &match_clause.pattern.paths[..] else {
+            return None;
+        };
+        if !matches!(path.path_type, PathType::Normal) || path.path_variable.is_some() {
+            return None;
+        }
+        let [seg] = &path.segments[..] else {
+            return None;
+        };
+        if seg.edge.length.is_some() {
+            return None;
+        }
+        let start = path.start.variable.as_ref()?;
+        if !known_vars.contains(start) {
+            return None;
+        }
+        let mut introduced = Vec::new();
+        // The far node may be bound -- that is the pinned case, and the expand
+        // already knows how to close onto it -- or new, in which case it is
+        // nulled on a miss.
+        if let Some(v) = &seg.node.variable {
+            if !known_vars.contains(v) {
+                introduced.push(v.clone());
+            }
+        } else {
+            // An anonymous far end cannot be observed, so there is nothing to
+            // null and nothing to bind; the join is no worse and is simpler.
+            return None;
+        }
+        // A bound edge variable would have to be matched rather than rebound,
+        // which this path does not do.
+        match &seg.edge.variable {
+            Some(v) if known_vars.contains(v) => return None,
+            Some(v) => introduced.push(v.clone()),
+            None => {}
+        }
+        if introduced.is_empty() {
+            return None;
+        }
+        Some(introduced)
     }
 
     fn can_pushdown_match(match_clause: &MatchClause, known_vars: &HashSet<String>) -> bool {

--- a/tests/optional_match_pushdown.rs
+++ b/tests/optional_match_pushdown.rs
@@ -1,0 +1,209 @@
+//! `OPTIONAL MATCH` pushed onto the pipeline still emits the row that misses (#726).
+//!
+//! An optional clause hanging off a bound variable used to be planned
+//! standalone and left-outer-joined, which meant a full label scan of the far
+//! end: 422 ms at SF1 where the equivalent `EXISTS` costs 0.02. It is now an
+//! expand that null-fills a source row matching nothing.
+//!
+//! That null-filled row is the entire semantics of `OPTIONAL MATCH`, so these
+//! tests are mostly about the miss rather than the hit — and about the cases
+//! where the pushdown must decline, because a wrong answer here looks like a
+//! smaller result rather than an error.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+}
+
+/// Rows as `name=value` strings, sorted, so a bag comparison reads clearly.
+fn rows(store: &GraphStore, cypher: &str, cols: &[&str]) -> Vec<String> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    let out = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+    let mut got: Vec<String> = out
+        .records
+        .iter()
+        .map(|r| {
+            cols.iter()
+                .map(|c| match r.get(c) {
+                    Some(Value::Property(PropertyValue::String(s))) => format!("{c}={s}"),
+                    Some(Value::Property(PropertyValue::Boolean(b))) => format!("{c}={b}"),
+                    Some(Value::Property(PropertyValue::Integer(i))) => format!("{c}={i}"),
+                    Some(Value::Null) | Some(Value::Property(PropertyValue::Null)) | None => {
+                        format!("{c}=null")
+                    }
+                    other => format!("{c}={other:?}"),
+                })
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .collect();
+    got.sort();
+    got
+}
+
+/// `a` and `b` know each other; `c` knows nobody. All three wrote a post.
+fn people() -> GraphStore {
+    let mut s = GraphStore::new();
+    for n in ["a", "b", "c"] {
+        run(&mut s, &format!("CREATE (:Person {{name: \"{n}\"}})"));
+        run(
+            &mut s,
+            &format!("CREATE (:Post {{title: \"p{n}\", author: \"{n}\"}})"),
+        );
+    }
+    run(
+        &mut s,
+        "MATCH (x:Person {name:\"a\"}), (y:Person {name:\"b\"}) CREATE (x)-[:KNOWS {since: 2020}]->(y)",
+    );
+    for n in ["a", "b", "c"] {
+        run(
+            &mut s,
+            &format!(
+                "MATCH (p:Post {{title:\"p{n}\"}}), (q:Person {{name:\"{n}\"}}) \
+                 CREATE (p)-[:HAS_CREATOR]->(q)"
+            ),
+        );
+    }
+    s
+}
+
+/// The miss still produces a row. This is the whole point.
+#[test]
+fn a_source_row_that_matches_nothing_still_emits_with_nulls() {
+    let s = people();
+    assert_eq!(
+        rows(
+            &s,
+            "MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS]->(f:Person) \
+             RETURN p.name AS p, f.name AS f",
+            &["p", "f"],
+        ),
+        vec!["p=a f=b", "p=b f=null", "p=c f=null"],
+    );
+}
+
+/// The far end already bound — the shape from IS7, and the one that cost
+/// 422 ms. Both endpoints are known, so the expand closes onto `f` rather than
+/// scanning the label, and the pairs that do not know each other still emit.
+#[test]
+fn a_bound_far_end_is_matched_not_rescanned_and_misses_still_emit() {
+    let s = people();
+    assert_eq!(
+        rows(
+            &s,
+            "MATCH (p:Person {name:\"a\"}), (f:Person) \
+             OPTIONAL MATCH (p)-[k:KNOWS]-(f) \
+             RETURN f.name AS f, (k IS NOT NULL) AS knows",
+            &["f", "knows"],
+        ),
+        vec!["f=a knows=false", "f=b knows=true", "f=c knows=false"],
+    );
+}
+
+/// An edge variable bound on the hit is readable; on the miss it is null.
+#[test]
+fn the_edge_variable_is_bound_on_a_hit_and_null_on_a_miss() {
+    let s = people();
+    assert_eq!(
+        rows(
+            &s,
+            "MATCH (p:Person) OPTIONAL MATCH (p)-[k:KNOWS]->(:Person) \
+             RETURN p.name AS p, k.since AS since",
+            &["p", "since"],
+        ),
+        vec!["p=a since=2020", "p=b since=null", "p=c since=null"],
+    );
+}
+
+/// A label on the far end is part of the pattern, so failing it is a miss —
+/// a null row — not a dropped row.
+#[test]
+fn a_far_end_label_that_excludes_everything_is_a_miss_not_a_drop() {
+    let s = people();
+    assert_eq!(
+        rows(
+            &s,
+            "MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS]->(f:Nonexistent) \
+             RETURN p.name AS p, f.name AS f",
+            &["p", "f"],
+        ),
+        vec!["p=a f=null", "p=b f=null", "p=c f=null"],
+    );
+}
+
+/// An inline property on the far end has to filter *inside* the expand. As a
+/// filter above it, the null row would be deleted and the miss would vanish.
+#[test]
+fn an_inline_property_on_the_far_end_still_leaves_a_null_row() {
+    let s = people();
+    assert_eq!(
+        rows(
+            &s,
+            "MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS]->(f:Person {name: \"zzz\"}) \
+             RETURN p.name AS p, f.name AS f",
+            &["p", "f"],
+        ),
+        vec!["p=a f=null", "p=b f=null", "p=c f=null"],
+    );
+}
+
+/// A `WHERE` on the optional clause belongs to the optional pattern: a row
+/// failing it still emits nulls. The pushdown declines this shape and the join
+/// handles it; the answer is what matters.
+#[test]
+fn a_where_on_the_optional_clause_still_leaves_a_null_row() {
+    let s = people();
+    assert_eq!(
+        rows(
+            &s,
+            "MATCH (p:Person) OPTIONAL MATCH (p)-[k:KNOWS]->(f:Person) \
+             WHERE k.since > 3000 RETURN p.name AS p, f.name AS f",
+            &["p", "f"],
+        ),
+        vec!["p=a f=null", "p=b f=null", "p=c f=null"],
+    );
+}
+
+/// Two hops: a source matching the first and not the second owes one null row,
+/// not one per partial match. The pushdown declines multi-segment paths for
+/// exactly this reason.
+#[test]
+fn a_two_segment_optional_path_emits_one_null_row_per_source() {
+    let s = people();
+    assert_eq!(
+        rows(
+            &s,
+            "MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS]->(:Person)-[:KNOWS]->(g:Person) \
+             RETURN p.name AS p, g.name AS g",
+            &["p", "g"],
+        ),
+        vec!["p=a g=null", "p=b g=null", "p=c g=null"],
+    );
+}
+
+/// Several matches produce several rows, and no extra null row alongside them.
+#[test]
+fn several_matches_produce_several_rows_and_no_null() {
+    let mut s = people();
+    run(
+        &mut s,
+        "MATCH (x:Person {name:\"a\"}), (y:Person {name:\"c\"}) CREATE (x)-[:KNOWS]->(y)",
+    );
+    assert_eq!(
+        rows(
+            &s,
+            "MATCH (p:Person {name:\"a\"}) OPTIONAL MATCH (p)-[:KNOWS]->(f:Person) \
+             RETURN p.name AS p, f.name AS f",
+            &["p", "f"],
+        ),
+        vec!["p=a f=b", "p=a f=c"],
+    );
+}


### PR DESCRIPTION
Closes #726. Unblocks #725.

## The bug

#724 taught a `MATCH` clause to start from a variable the pipeline already
bound. `OPTIONAL MATCH` was excluded by the first line of
`can_pushdown_match`, so it still planned standalone and joined:

```
LeftOuterJoin (on=author,op)
  +- Expand ((m)-[:HAS_CREATOR]->(op))          <- op and author both bound here
     ...
  +- Expand ((op)--[:KNOWS]--(author))
     +- NodeScan (var=op, labels=["Person"])    <- all 10,620 Persons
```

Measured at SF1, quiet host, 11 runs, median — the same question two ways:

| | before | after |
|---|---:|---:|
| `EXISTS { MATCH (op)-[:KNOWS]-(author) }` | 0.020 ms | 0.021 ms |
| `OPTIONAL MATCH (op)-[k:KNOWS]-(author)` | **422.635 ms** | **0.022 ms** |

**19,000×**, and the two forms are now within noise of each other.

## Why it is not #724 with the guard deleted

An optional clause must emit a row when nothing matches. `ExpandOperator` grows
an `optional_null_vars` list: a source record producing no edge emits once,
with the variables the clause *introduces* bound to null — only those, since
nulling a far end that was already bound would erase a binding the row had.

Both emit paths are wired; missing `next_batch` would make the answer depend on
whether the plan ran batched, which is the shape of #684. `reset` clears the
flag or a re-run swallows the first null row.

## Where it declines, and why each would otherwise be a wrong answer

`optional_pushdown_vars` is deliberately narrower than `can_pushdown_match`:

| declines | because |
|---|---|
| more than one segment | a source matching hop 1 and not hop 2 owes *one* null row, not one per partial match |
| a `WHERE` on the clause | the predicate is part of the optional pattern; a filter above the expand deletes the null row |
| an anonymous far end | nothing to null, nothing to observe — the join is no worse |
| bound edge variable, path variable, var-length | would have to be matched rather than rebound |

Everything the pattern decides happens **inside** the expand for the same
reason: labels via `with_target_labels`, inline properties via
`with_target_props`, and a bound far end via `with_target_bound_var` — the pin
from #684/#195, which is exactly the both-ends-known case.

## Tests

Eight, mostly about the miss rather than the hit, because the miss is the whole
semantics: a source matching nothing; a bound far end matched not rescanned; an
edge variable null on a miss; a far-end label that excludes everything; an
inline property that must not become a filter; a `WHERE` that keeps the join; a
two-segment path owing one null row per source; and several matches producing
no stray null.

## Verification

| | |
|---|---|
| `cargo test --workspace --no-fail-fast` | **3,255 passed, 0 failed** |
| openCypher TCK 2024.3 | **1081 / 1244 (86.9%) — unchanged**, floor holds |
| LDBC SF1, 3 runs | **21/21, 0 empty, 0 errors** |

## Why this matters beyond one query

`OPTIONAL MATCH` is how ordinary Cypher says "and this, if it exists". Every
such clause hanging off a bound variable was paying a label scan.

It also unblocks #725: the SNB-I corpus gives Samyama `EXISTS` on IS7 and gives
the competitors `OPTIONAL MATCH` **because of this defect** — the bench source
says so in a comment — which is why yesterday's IS7 ratio was withdrawn.
Aligning the corpus is a separate change, kept separate so it stays clear which
of the two moved the number.