### PR TITLE
Ask every engine the same IS7 and IC10 (#725)

### DIFF
--- a/benches/ldbc_benchmark.rs
+++ b/benches/ldbc_benchmark.rs
@@ -214,12 +214,21 @@ RETURN f.id, f.title, mod.id, mod.firstName, mod.lastName",
             id: "IS7",
             name: "Replies to Post",
             category: "short",
-            // LDBC IS7: replies with isKnows check — uses EXISTS subquery (equivalent to OPTIONAL MATCH + CASE)
-            // Note: OPTIONAL MATCH version is semantically correct but triggers full Post scan in planner
+            // LDBC IS7: replies, with an isKnows check on the original poster.
+            //
+            // This is the `OPTIONAL MATCH` form the competitor corpus uses,
+            // character for character. It used to be an `EXISTS` subquery here
+            // and the comment said why: "OPTIONAL MATCH version is
+            // semantically correct but triggers full Post scan in planner".
+            // That was true and it made the cross-engine ratio meaningless —
+            // Samyama was answering an easier question than Neo4j and
+            // FalkorDB, by 21,000x on the same data (#725). #726 removed the
+            // reason, so the corpus can be one query again.
             cypher: "\
 MATCH (m:Post {id: {{postId}}})<-[:REPLY_OF]-(c:Comment)-[:HAS_CREATOR]->(author:Person)
 MATCH (m)-[:HAS_CREATOR]->(op:Person)
-RETURN c.id, c.content, c.creationDate, author.id, author.firstName, author.lastName, EXISTS { MATCH (op)-[:KNOWS]-(author) } AS isKnows
+OPTIONAL MATCH (op)-[k:KNOWS]-(author)
+RETURN c.id, c.content, c.creationDate, author.id, author.firstName, author.lastName, (k IS NOT NULL) AS isKnows
 ORDER BY c.creationDate DESC
 LIMIT 20",
         },
@@ -361,8 +370,8 @@ LIMIT 20",
             category: "complex",
             // Full LDBC IC10: friends-of-friends NOT already friends, ranked by shared interests
             cypher: "\
-MATCH (p:Person {id: {{personId}}})-[:KNOWS*2]-(stranger:Person)
-WHERE stranger.id <> {{personId}} AND NOT EXISTS { MATCH (p)-[:KNOWS]-(stranger) }
+MATCH (p:Person {id: {{personId}}})-[:KNOWS*2..2]-(stranger:Person)
+WHERE stranger.id <> {{personId}} AND NOT (p)-[:KNOWS]-(stranger)
 WITH DISTINCT stranger
 MATCH (stranger)-[:HAS_INTEREST]->(tag:Tag)
 RETURN stranger.id, stranger.firstName, stranger.lastName, count(tag) AS commonInterests


### PR DESCRIPTION
Closes #725 on the engine side. The competitor-file half is in
samyama-graph-competitor-benchmarks#24, which also adds `CH-BENCH-PARITY`.

The SNB-I corpus was not one corpus. Diffed against the competitor `.cypher`
files, **five of 21 Samyama queries differed from FalkorDB's and three from
Neo4j's**. Most was quote dialect. Two were not:

**IS7** — Samyama got `EXISTS { MATCH (op)-[:KNOWS]-(author) }`, the
competitors got `OPTIONAL MATCH … (k IS NOT NULL)`. The comment above it said
why: *"OPTIONAL MATCH version is semantically correct but triggers full Post
scan in planner"*. That was worth **21,000×** — 0.020 ms against 422.635 ms at
SF1 — so the published ratio ran the competitors on the form we had avoided,
and yesterday's "IS7 is fastest of the three" was withdrawn. #726 removed the
reason; this removes the divergence.

**IC10** — Samyama got `NOT EXISTS { MATCH (p)-[:KNOWS]-(stranger) }` and `*2`
where both competitors use `NOT (p)-[:KNOWS]-(stranger)` and `*2..2`.
Equivalent, and our parser has supported pattern predicates all along, so the
difference had no reason at all.

## Asking the fair question costs nothing

SF1, 3 runs, same host, before and after:

| | before | after |
|---|---:|---:|
| IS7 | 0.03 ms | 0.04 ms |
| IC10 | 28.6 ms | 27.4 ms |

Both within noise. 21/21 passed, 0 empty, 0 errors.

## Verification

`cargo test --workspace --no-fail-fast` → **3,255 passed, 0 failed, exit 0**.

The SF10 ratios still need a re-run before they can be requoted — the published
numbers were measured on the old text — and that needs a spot host.