### PR TITLE
A generic query probe, and say which adjacency layout the LDBC numbers used

### DIFF
--- a/benches/ldbc_common/mod.rs
+++ b/benches/ldbc_common/mod.rs
@@ -646,5 +646,30 @@ pub fn load_dataset(graph: &mut GraphStore, data_dir: &Path) -> Result<LoadResul
     print_done(&format!("  REPLY_OF (Comment->Post):              {:>12} edges ({})", format_num(n), format_duration(t.elapsed())));
     total_edges += n;
 
+    // Which adjacency layout the timings below were taken on, said out loud.
+    //
+    // The store keeps two: a frozen CSR, and a per-node write buffer that
+    // `compact_adjacency` folds into it. Snapshot import has always compacted;
+    // this loader never has, so every LDBC number ever published was measured
+    // on the buffer without saying so — and #504 claims CSR is "~2x faster",
+    // which would have made that a large undisclosed handicap.
+    //
+    // Measured, it is not: compacting SF1 costs 697 ms and buys **4%** overall
+    // (21 queries, 1216.6 ms -> 1166.9 ms), inside the run-to-run band the
+    // SF10 write-up already documents. So the layout is left alone and simply
+    // reported; `SAMYAMA_LDBC_COMPACT=1` measures the other one.
+    if std::env::var("SAMYAMA_LDBC_COMPACT").as_deref() == Ok("1") {
+        let t = std::time::Instant::now();
+        graph.compact_adjacency();
+        print_done(&format!(
+            "  adjacency layout: frozen CSR (compacted in {})",
+            format_duration(t.elapsed())
+        ));
+    } else {
+        print_done(
+            "  adjacency layout: per-node write buffer (set SAMYAMA_LDBC_COMPACT=1 for CSR)",
+        );
+    }
+
     Ok(LoadResult { total_nodes, total_edges })
 }

--- a/examples/query_probe.rs
+++ b/examples/query_probe.rs
@@ -1,0 +1,125 @@
+//! Time arbitrary Cypher against an LDBC extract, one line per query.
+//!
+//! `is7_probe` and `ic11_probe` are the same forty lines twice: load the
+//! dataset, build the `id` indexes the bench builds, run a handful of variants
+//! that each remove one thing, print medians, print plans. A third copy for
+//! IS3 would have made it three, so this is the general form.
+//!
+//! Every variant is a separate `--q "<label>=<cypher>"`, and the difference
+//! between two lines is the cost of whatever separates them. That is the whole
+//! method: never one number, always a pair whose difference means something.
+//!
+//! ```bash
+//! cargo run --release --example query_probe -- --data-dir <sf1> \
+//!     --q 'full=MATCH (p:Person {id: 123})-[:KNOWS]-(f) RETURN f.id' \
+//!     --q 'count=MATCH (p:Person {id: 123})-[:KNOWS]-(f) RETURN count(f) AS n'
+//! ```
+//!
+//! `--explain` prints each plan as well. The host calibration and a busy-host
+//! warning are printed first, because a probe sharing the machine with a build
+//! measures the build (#715).
+
+#[path = "../benches/ldbc_common/mod.rs"]
+mod ldbc_common;
+
+#[path = "../benches/common/bench_setup.rs"]
+mod bench_setup;
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+use std::path::PathBuf;
+use std::time::Instant;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    bench_setup::init();
+    let _calibration = bench_setup::report_calibration();
+
+    let args: Vec<String> = std::env::args().collect();
+    let one = |flag: &str| args.iter().position(|a| a == flag).and_then(|i| args.get(i + 1));
+    let data_dir = one("--data-dir").map(PathBuf::from).expect("--data-dir <path> is required");
+    let runs: usize = one("--runs").map(|s| s.parse()).transpose()?.unwrap_or(11);
+    let explain = args.iter().any(|a| a == "--explain");
+
+    // `label=cypher`, repeated. The label is everything before the first `=`,
+    // so a query may contain as many as it likes.
+    let variants: Vec<(String, String)> = args
+        .iter()
+        .enumerate()
+        .filter(|(_, a)| *a == "--q")
+        .filter_map(|(i, _)| args.get(i + 1))
+        .map(|spec| match spec.split_once('=') {
+            Some((label, cypher)) => (label.to_string(), cypher.to_string()),
+            None => (spec.chars().take(28).collect(), spec.clone()),
+        })
+        .collect();
+    if variants.is_empty() {
+        eprintln!("nothing to run: pass at least one --q '<label>=<cypher>'");
+        std::process::exit(2);
+    }
+
+    let mut graph = GraphStore::new();
+    eprintln!("loading {} ...", data_dir.display());
+    let t = Instant::now();
+    ldbc_common::load_dataset(&mut graph, &data_dir)?;
+    eprintln!("loaded in {:.1}s", t.elapsed().as_secs_f64());
+
+    // The same `id` indexes the benchmark builds. Without them every
+    // `MATCH (x:Label {id: ...})` is a full label scan, which drowns whatever
+    // the variants are trying to separate.
+    for label in ["Person", "Post", "Comment", "Forum", "Place", "Organisation", "Tag"] {
+        let q = parse_query(&format!("CREATE INDEX ON :{label}(id)"))?;
+        MutQueryExecutor::new(&mut graph, "default".to_string()).execute(&q)?;
+    }
+
+    let width = variants.iter().map(|(l, _)| l.len()).max().unwrap_or(10).max(10);
+    for (label, cypher) in &variants {
+        let q = match parse_query(cypher) {
+            Ok(q) => q,
+            Err(e) => {
+                println!("{label:<width$}  does not parse: {e}");
+                continue;
+            }
+        };
+        let mut times = Vec::with_capacity(runs);
+        let mut rows = 0usize;
+        for _ in 0..runs {
+            let started = Instant::now();
+            match QueryExecutor::new(&graph).execute(&q) {
+                Ok(out) => {
+                    rows = out.records.len();
+                    times.push(started.elapsed().as_secs_f64() * 1000.0);
+                }
+                Err(e) => {
+                    println!("{label:<width$}  failed: {e}");
+                    times.clear();
+                    break;
+                }
+            }
+        }
+        if times.is_empty() {
+            continue;
+        }
+        times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        println!(
+            "{label:<width$}  median {:>9.3} ms   rows {rows}",
+            times[times.len() / 2]
+        );
+    }
+
+    if explain {
+        for (label, cypher) in &variants {
+            println!("\n--- plan: {label} ---");
+            if let Ok(q) = parse_query(&format!("EXPLAIN {cypher}")) {
+                if let Ok(out) = QueryExecutor::new(&graph).execute(&q) {
+                    for r in &out.records {
+                        if let Some(v) = r.get("plan") {
+                            println!("{}", format!("{v:?}").replace("\\n", "\n"));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
Measurement infrastructure plus one disclosed condition. No behaviour change.
Refs #718, #593, #504.

## `examples/query_probe`

`is7_probe` and `ic11_probe` are the same forty lines twice. A third copy for
IS3 would have made it three, so this is the general form: `--q 'label=cypher'`
repeated, `--explain` for plans, host calibration and a busy-host warning first
(#715). The method it encodes is that a single number means nothing — every
variant removes exactly one thing, and the difference between two lines is the
cost of that thing.

## The LDBC loader never compacted

The store keeps two adjacency layouts. Snapshot import has always folded the
per-node write buffer into the frozen CSR; **this loader never has**, so every
LDBC number the project has published was measured on the buffer and nothing
said so. #504 claims CSR is "~2× faster", which would make that a large
undisclosed handicap.

Measured, SF1, 3 runs, same host, identical row counts throughout:

| | write buffer | frozen CSR | |
|---|---:|---:|---|
| IS3 | 0.05 ms | 0.04 ms | 0.80× |
| IC2 | 3.20 | 2.70 | 0.84× |
| IC9 | 393 | 367 | 0.93× |
| IC4 | 4.70 | 5.10 | **1.09× slower** |
| **all 21** | **1216.6 ms** | **1166.9 ms** | **0.96×** |

**4%**, and compaction costs 697 ms — inside the 4–14% band the SF10 write-up
already documents between two runs of the same build.

So the layout is not switched. A 4% change that shifts every baseline is not
worth the churn, and the buffer is a real layout: a server ingesting via
`CREATE` lives in it. What was wrong is that a reader could not tell which
layout produced a number. The loader prints it now, and
`SAMYAMA_LDBC_COMPACT=1` measures the other one — the table above reproduces
with an environment variable rather than a patch.

## What the probe found on IS3 (#718)

| variant | median | isolates |
|---|---:|---|
| IS3 as written | 0.034 ms | |
| no `ORDER BY` | 0.024 | sort: **29%** |
| one property not three | 0.011 | two projections: **0.013 ms** |
| no label on the far end | 0.007 | label check: 0.003 ms |

A property read is ~0.28 µs. The sort *does* re-read keys the projection will
read again (#593) — and it is 6 µs on 23 rows, about 20%, so it is not what
makes IS3 slow. The term that scales is per-row property access: **1.5 µs/row
at SF1 against 10.2 µs/row at SF10**, on a graph eight times larger. Scattered
reads cost ~1.5× sequential ones at SF1, so the direction is right and the
magnitude needs SF10 to settle. Both recorded on their issues.

`cargo test --workspace --no-fail-fast` → **3,255 passed, 0 failed, exit 0**.