### PR TITLE
A label is a bit, not a hash probe: LDBC SF1 13% faster (#730)

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -626,6 +626,21 @@ pub struct GraphStore {
     /// Label index for fast lookups
     label_index: HashMap<Label, HashSet<NodeId>>,
 
+    /// `label_index` as a dense bitset per label, built on demand.
+    ///
+    /// The membership test on the expand's hot path is per **candidate edge**,
+    /// and probing the `HashSet` above means a random probe into a structure
+    /// the size of the label. Measured with `benches/adjacency_walk`, that cost
+    /// grows 10.2 -> 36.7 ns/edge as the label goes from 300k to 1.2M nodes —
+    /// 35% of the whole traversal — while everything under it stays flat
+    /// (#730). A bit per node is 150 KB for 1.2M and a load-shift-mask.
+    ///
+    /// Derived, never authoritative: `label_index` remains the representation
+    /// and this is dropped wholesale whenever it changes. Two structures that
+    /// can disagree is #491's shape, and the single `invalidate_label_bits`
+    /// call site per mutation is what keeps that from happening here.
+    label_bits: std::sync::RwLock<HashMap<Label, std::sync::Arc<Vec<u64>>>>,
+
     /// Edge type index for fast lookups
     edge_type_index: HashMap<EdgeType, HashSet<EdgeId>>,
 
@@ -685,6 +700,7 @@ impl GraphStore {
             free_node_ids: Vec::new(),
             free_edge_ids: Vec::new(),
             label_index: HashMap::new(),
+            label_bits: std::sync::RwLock::new(HashMap::new()),
             edge_type_index: HashMap::new(),
             vector_index: Arc::new(VectorIndexManager::new()),
             property_index: Arc::new(IndexManager::new()),
@@ -1011,6 +1027,8 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         let mut node = Node::with_labels(node_id, labels.iter().cloned());
         node.version = self.current_version;
 
+        // `label_index` changes here, so the derived bitsets are stale (#730).
+        self.invalidate_label_bits();
         for label in &labels {
             self.label_index
                 .entry(label.clone())
@@ -1093,6 +1111,8 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         node.version = self.current_version;
 
         // Add to label indices
+        // `label_index` changes here, so the derived bitsets are stale (#730).
+        self.invalidate_label_bits();
         for label in &labels {
             self.label_index
                 .entry(label.clone())
@@ -1213,6 +1233,8 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         let mut node = Node::new_stub(node_id, label.clone());
         node.version = self.current_version;
 
+        // `label_index` changes here, so the derived bitsets are stale (#730).
+        self.invalidate_label_bits();
         self.label_index
             .entry(label.clone())
             .or_insert_with(HashSet::new)
@@ -1454,6 +1476,8 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         // But to keep history, we should NOT remove from the Vec.
         
         // Remove from label indices and update catalog
+        // `label_index` changes here, so the derived bitsets are stale (#730).
+        self.invalidate_label_bits();
         for label in &latest_node.labels {
             if let Some(node_set) = self.label_index.get_mut(label) {
                 node_set.remove(&id);
@@ -1534,6 +1558,8 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             return Ok(false);
         }
 
+        // `label_index` changes here, so the derived bitsets are stale (#730).
+        self.invalidate_label_bits();
         if let Some(members) = self.label_index.get_mut(label) {
             members.remove(&node_id);
             // An empty set is not the same as an absent one to the expansion
@@ -1558,6 +1584,11 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         let idx = node_id.as_u64() as usize;
 
         // Get the node and add the label
+        // Invalidated before the mutable borrow below, not after: the derived
+        // bitsets are stale either way, and taking `&self` while `node` is
+        // borrowed mutably does not compile (#730).
+        self.invalidate_label_bits();
+
         let node = self.nodes.get_mut(idx).and_then(|v| v.last_mut()).ok_or(GraphError::NodeNotFound(node_id))?;
         node.add_label(label.clone());
 
@@ -2416,6 +2447,57 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
     /// `None` means no node carries the label, which matches nothing.
     pub fn nodes_with_label(&self, label: &Label) -> Option<&HashSet<NodeId>> {
         self.label_index.get(label)
+    }
+
+    /// `nodes_with_label` as a dense bitset, for callers testing many nodes
+    /// against one label.
+    ///
+    /// Same contract as `nodes_with_label`: `None` means no node carries the
+    /// label, which matches nothing — distinct from "no label required", and
+    /// conflating the two makes `-[:R]->(x:NoSuchLabel)` match everything.
+    ///
+    /// Built on first use and cached until any label changes. Sized by the node
+    /// vector, so a `NodeId` beyond it simply reads as absent rather than
+    /// panicking — which is what a node created after the bitset was built
+    /// would be, and it cannot happen, because creating one invalidates this.
+    pub fn label_bitset(&self, label: &Label) -> Option<std::sync::Arc<Vec<u64>>> {
+        if let Some(bits) = self.label_bits.read().unwrap().get(label) {
+            return Some(bits.clone());
+        }
+        let ids = self.label_index.get(label)?;
+        let words = (self.nodes.len() / 64) + 1;
+        let mut bits = vec![0u64; words];
+        for id in ids {
+            let idx = id.as_u64() as usize;
+            if let Some(w) = bits.get_mut(idx / 64) {
+                *w |= 1u64 << (idx % 64);
+            }
+        }
+        let bits = std::sync::Arc::new(bits);
+        self.label_bits
+            .write()
+            .unwrap()
+            .insert(label.clone(), bits.clone());
+        Some(bits)
+    }
+
+    /// Whether `id` is set in a bitset from `label_bitset`.
+    #[inline]
+    pub fn bitset_contains(bits: &[u64], id: NodeId) -> bool {
+        let idx = id.as_u64() as usize;
+        bits.get(idx / 64).is_some_and(|w| w & (1u64 << (idx % 64)) != 0)
+    }
+
+    /// Drop the derived label bitsets. Called wherever `label_index` changes.
+    ///
+    /// Wholesale rather than per-label on purpose: the cost is rebuilding on
+    /// next use, and the alternative is a second place where the two
+    /// structures can drift apart.
+    fn invalidate_label_bits(&self) {
+        let mut w = self.label_bits.write().unwrap();
+        if !w.is_empty() {
+            w.clear();
+        }
     }
 
     pub fn get_nodes_by_label(&self, label: &Label) -> Vec<&Node> {

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -4161,14 +4161,19 @@ impl ExpandOperator {
         // A label no node carries yields `None`, which matches nothing -- so
         // the whole expansion is empty, which is correct and is why the empty
         // case is distinguished from "no labels required".
-        let label_sets: Option<Vec<&std::collections::HashSet<NodeId>>> =
+        // ...and by a bit rather than a hash, since #592's `HashSet<NodeId>`
+        // probe is itself a random access into a structure the size of the
+        // label. Measured, that grows 10.2 -> 36.7 ns per candidate edge as the
+        // label goes from 300k to 1.2M nodes — 35% of the whole traversal —
+        // while the storage walk under it stays flat (#730).
+        let label_sets: Option<Vec<std::sync::Arc<Vec<u64>>>> =
             if self.target_labels.is_empty() {
                 None
             } else {
                 Some(
                     self.target_labels
                         .iter()
-                        .map(|l| store.nodes_with_label(l))
+                        .map(|l| store.label_bitset(l))
                         .collect::<Option<Vec<_>>>()
                         .unwrap_or_default(),
                 )
@@ -4214,7 +4219,9 @@ impl ExpandOperator {
                 None => true,
                 // `Some(empty)` means a required label exists on no node.
                 Some(sets) if sets.len() < self.target_labels.len() => false,
-                Some(sets) => sets.iter().all(|s| s.contains(&target)),
+                Some(sets) => sets
+                    .iter()
+                    .all(|s| GraphStore::bitset_contains(s, target)),
             };
             if !label_ok {
                 return false;

--- a/tests/label_bitset_invalidation.rs
+++ b/tests/label_bitset_invalidation.rs
@@ -1,0 +1,131 @@
+//! The derived label bitsets must never outlive the label index (#730).
+//!
+//! `ExpandOperator` tests a far-end label with a dense bitset built from
+//! `label_index` and cached. Cached is the dangerous word: two structures that
+//! can disagree is how #491 happened, and here a stale bitset does not crash —
+//! it silently drops rows that should match, or keeps rows that should not.
+//!
+//! So these tests all have the same shape: run a query so the bitset is built,
+//! change the labels underneath it, and run the query again.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+}
+
+fn count(store: &GraphStore, cypher: &str) -> i64 {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    let out = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+    match out.records.first().and_then(|r| r.get("n")) {
+        Some(Value::Property(PropertyValue::Integer(i))) => *i,
+        other => panic!("expected integer n, got {other:?}"),
+    }
+}
+
+const OUT_TO_TARGET: &str = "MATCH (a:Src)-[:R]->(b:Target) RETURN count(b) AS n";
+
+/// One source, one already-`:Target` neighbour.
+fn base() -> GraphStore {
+    let mut s = GraphStore::new();
+    run(&mut s, "CREATE (:Src {name: \"s\"})");
+    run(&mut s, "CREATE (:Target {name: \"t1\"})");
+    run(&mut s, "MATCH (a:Src), (b:Target) CREATE (a)-[:R]->(b)");
+    s
+}
+
+/// A node created after the bitset was built is visible to the next query.
+#[test]
+fn a_node_created_later_is_not_missed() {
+    let mut s = base();
+    assert_eq!(count(&s, OUT_TO_TARGET), 1);
+
+    run(&mut s, "CREATE (:Target {name: \"t2\"})");
+    run(
+        &mut s,
+        "MATCH (a:Src), (b:Target {name:\"t2\"}) CREATE (a)-[:R]->(b)",
+    );
+    assert_eq!(count(&s, OUT_TO_TARGET), 2, "the new :Target was invisible");
+}
+
+/// A label added to an existing node is visible to the next query.
+#[test]
+fn a_label_added_later_is_not_missed() {
+    let mut s = base();
+    run(&mut s, "CREATE (:Other {name: \"o\"})");
+    run(
+        &mut s,
+        "MATCH (a:Src), (b:Other {name:\"o\"}) CREATE (a)-[:R]->(b)",
+    );
+    assert_eq!(count(&s, OUT_TO_TARGET), 1);
+
+    run(&mut s, "MATCH (o:Other {name:\"o\"}) SET o:Target");
+    assert_eq!(
+        count(&s, OUT_TO_TARGET),
+        2,
+        "the newly labelled node was invisible"
+    );
+}
+
+/// A label removed from a node stops matching.
+#[test]
+fn a_label_removed_later_stops_matching() {
+    let mut s = base();
+    assert_eq!(count(&s, OUT_TO_TARGET), 1);
+
+    run(&mut s, "MATCH (t:Target {name:\"t1\"}) REMOVE t:Target");
+    assert_eq!(
+        count(&s, OUT_TO_TARGET),
+        0,
+        "a node kept matching a label it no longer has"
+    );
+}
+
+/// A deleted node stops matching.
+#[test]
+fn a_deleted_node_stops_matching() {
+    let mut s = base();
+    assert_eq!(count(&s, OUT_TO_TARGET), 1);
+
+    run(&mut s, "MATCH (t:Target {name:\"t1\"}) DETACH DELETE t");
+    assert_eq!(count(&s, OUT_TO_TARGET), 0, "a deleted node still matched");
+}
+
+/// Removing the *last* member of a label makes the label absent, which matches
+/// nothing — distinct from "no label required" (#592, #520).
+#[test]
+fn the_last_member_leaving_makes_the_label_match_nothing() {
+    let mut s = base();
+    assert_eq!(count(&s, OUT_TO_TARGET), 1);
+    run(&mut s, "MATCH (t:Target {name:\"t1\"}) REMOVE t:Target");
+    // And a pattern requiring it still matches nothing rather than everything.
+    assert_eq!(count(&s, OUT_TO_TARGET), 0);
+    assert_eq!(count(&s, "MATCH (a:Src)-[:R]->(b) RETURN count(b) AS n"), 1);
+}
+
+/// The bitset is indexed by node id, so a graph whose ids run past one 64-bit
+/// word still answers correctly — an off-by-one in the word index would show
+/// up only past the 64th node.
+#[test]
+fn a_graph_wider_than_one_word_is_indexed_correctly() {
+    let mut s = GraphStore::new();
+    run(&mut s, "CREATE (:Src {name: \"s\"})");
+    for i in 0..200 {
+        run(&mut s, &format!("CREATE (:Filler {{i: {i}}})"));
+    }
+    // The only :Target sits well past the first word.
+    run(&mut s, "CREATE (:Target {name: \"far\"})");
+    run(&mut s, "MATCH (a:Src), (b:Target) CREATE (a)-[:R]->(b)");
+    assert_eq!(count(&s, OUT_TO_TARGET), 1);
+    assert_eq!(
+        count(&s, "MATCH (a:Src)-[:R]->(b:Filler) RETURN count(b) AS n"),
+        0
+    );
+}


### PR DESCRIPTION
Closes #730.

## The cost

`ExpandOperator::keeps` tested a far-end label by probing `nodes_with_label` —
a `HashSet<NodeId>` holding **every node carrying that label** — once per
candidate edge. A label covering much of the graph is a multi-megabyte hash
table, so the cost grew with the label:

| nodes / edges | traversal, unlabelled | **the label probe** | total |
|---|---:|---:|---:|
| 300k / 9M | 52.5 ns/edge | **10.2** | 62.7 |
| 1.2M / 36M | 67.2 ns/edge | **36.7** | ~104 |

3.6× growth, reaching **35% of the whole traversal**, while the storage walk
underneath stayed at 1.4 ns/edge.

This is the *third* form of this check. It started as
`get_node(id).has_label(l)` — a Vec index, a version-chain walk, a 128-byte
`Node`, and a `HashSet<Label>` probe hashing a **string** — 26.7% of a profiled
IC9, replaced by the u64 hash above in #592.

## The fix, and what it buys

A dense bitset: 150 KB for 1.2M nodes, and a load, a shift and a mask whose
locality follows the adjacency run rather than fighting it.

| nodes / edges | the label probe | total |
|---|---|---|
| 300k / 9M | 10.2 → **−0.5** ns/edge | 62.7 → **49.3** (−21%) |
| 1.2M / 36M | 36.7 → **2.6** | ~104 → **63.4** (−39%) |

It no longer scales with the label, which was the point.

**LDBC SF1, 3 runs, identical row counts: 1216.6 → 1054.6 ms — 13% faster.**

| | before | after | |
|---|---:|---:|---|
| IC3 | 247 ms | 187 | 0.76× |
| IC12 | 27.9 | 23.2 | 0.83× |
| IC9 | 393 | 338 | 0.86× |
| IC2 | 3.20 | 2.60 | 0.81× |
| IS3 | 0.05 | 0.04 | 0.80× |

## Derived, never authoritative

`label_index` stays the representation. The bitsets are built on first use and
**dropped wholesale** when it changes, from one `invalidate_label_bits` call at
each of the six mutation sites. Two structures that can disagree is #491's
shape; wholesale invalidation makes drift impossible rather than unlikely.

`None` still means "no node carries this label" — matches nothing, distinct
from "no label required". Conflating them makes `-[:R]->(x:NoSuchLabel)` match
everything (#520, #592). `tests/expand_target_labels.rs` pins both and was not
touched.

**Six new tests, all the same shape**: build the bitset by running a query,
change the labels underneath it, run it again — a node created later, a label
added, a label removed, a node deleted, the last member of a label leaving, and
a graph wider than one 64-bit word. A stale bitset does not crash; it silently
drops rows or keeps ones it should not.

## Verification

| | |
|---|---|
| `cargo test --workspace --no-fail-fast` | **3,261 passed, 0 failed, exit 0** |
| openCypher TCK 2024.3 | **1081 / 1244 (86.9%) — unchanged**, floor holds |
| LDBC SF1, 3 runs | **21/21, 0 empty, 0 errors**, every row count identical |

Not measured at SF10, where the labels an expand filters on are `:Person`
65,645, `:Post` 7.4M and `:Comment` 21.9M — the effect there should be larger,
and confirming it needs a spot host.