### PR TITLE
A var-length segment may not retake an edge its clause already walked (#710)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 1081
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 1082
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -4536,6 +4536,21 @@ pub struct VarLengthExpandOperator {
     /// was in it. At SF10 that is the difference between finishing and hitting
     /// the query timeout.
     target_reach: Option<std::collections::HashSet<NodeId>>,
+    /// Enforce relationship isomorphism across the clause, not just within
+    /// this segment.
+    ///
+    /// The BFS already cannot repeat an edge *inside* one walk — a node-visited
+    /// set makes every emitted path simple — but it never knew what the rest of
+    /// the clause had walked. `MATCH (a)-[:R]-(y)-[:R*1..1]-(z)` over a single
+    /// edge therefore answered one row where openCypher answers none: the
+    /// segment took the same edge back (#710).
+    ///
+    /// `ExpandOperator` has carried this since #684; the var-length operator is
+    /// the path that did not inherit it.
+    track_edges: bool,
+    /// Marks the first expand of a MATCH clause, which starts with a clean
+    /// history rather than inheriting one from an earlier clause.
+    starts_clause: bool,
 }
 
 impl VarLengthExpandOperator {
@@ -4566,6 +4581,8 @@ impl VarLengthExpandOperator {
             type_ids: None,
             pinned_target: None,
             target_reach: None,
+            track_edges: false,
+            starts_clause: false,
         }
     }
 
@@ -4665,14 +4682,22 @@ impl VarLengthExpandOperator {
         }
     }
 
-    /// BFS from the source bound in `record`, buffering one output record per
-    /// distinct reachable target in `[min_hops, max_hops]`.
     /// Pin the target to a single node the planner resolved at plan time.
     ///
     /// Only valid when the destination really is that one node; the operator
     /// then answers "can this source reach it" rather than enumerating.
     pub fn with_pinned_target(mut self, target: NodeId) -> Self {
         self.pinned_target = Some(target);
+        self
+    }
+
+    /// Enforce relationship isomorphism for this segment against the whole
+    /// clause, not just within the segment. Same contract as
+    /// `ExpandOperator::with_edge_isolation`: `starts_clause` marks the first
+    /// expand of a MATCH, which begins with a clean history.
+    pub fn with_edge_isolation(mut self, starts_clause: bool) -> Self {
+        self.track_edges = true;
+        self.starts_clause = starts_clause;
         self
     }
 
@@ -4769,7 +4794,14 @@ impl VarLengthExpandOperator {
         // The path so far, as (node, edge-that-reached-it). `edges` is what
         // enforces relationship uniqueness.
         let mut path: Vec<(NodeId, crate::graph::EdgeId)> = Vec::new();
-        let mut edges: Vec<crate::graph::EdgeId> = Vec::new();
+        // Seeded with what the clause has already walked, so a trail cannot
+        // retake an edge an earlier segment used (#710).
+        let mut edges: Vec<crate::graph::EdgeId> = if self.track_edges && !self.starts_clause {
+            record.used_edge_slice().to_vec()
+        } else {
+            Vec::new()
+        };
+        let inherited_len = edges.len();
         // Frontier per depth: the neighbours still to try at each level.
         let mut stack: Vec<Vec<(NodeId, crate::graph::EdgeId)>> = Vec::new();
 
@@ -4794,7 +4826,9 @@ impl VarLengthExpandOperator {
             let Some((nb, eid)) = frontier.pop() else {
                 stack.pop();
                 path.pop();
-                edges.pop();
+                if edges.len() > inherited_len {
+                    edges.pop();
+                }
                 continue;
             };
             path.push((nb, eid));
@@ -4832,6 +4866,8 @@ impl VarLengthExpandOperator {
         Ok(())
     }
 
+    /// BFS from the source bound in `record`, buffering one output record per
+    /// distinct reachable target in `[min_hops, max_hops]`.
     fn expand_from(&mut self, record: &Record, store: &GraphStore) -> ExecutionResult<()> {
         let source_val = record
             .get(&self.source_var)
@@ -4846,10 +4882,33 @@ impl VarLengthExpandOperator {
             ExecutionError::TypeError(format!("{} is not a node", self.source_var))
         })?;
 
+        // Edges an earlier segment of this clause already walked. This segment
+        // may not retake them (#710). Empty for the first segment of a clause
+        // and for any single-segment pattern, which is why isolation costs
+        // nothing on the shapes LDBC actually runs.
+        let inherited: Vec<crate::graph::EdgeId> = if self.track_edges && !self.starts_clause {
+            record.used_edge_slice().to_vec()
+        } else {
+            Vec::new()
+        };
+
         // Pinned target: one membership test instead of a BFS per row. The
         // planner only sets this when the destination resolves to a single
         // node, there is no path variable, and `min_hops <= 1`.
-        if let Some(target) = self.pinned_target {
+        //
+        // Skipped when the clause has already walked edges: the reachability
+        // set is built once, before any row, so it cannot know which edges this
+        // row is forbidden. Falling through to the BFS below answers the same
+        // question with the ban applied.
+        //
+        // The shortcut still does not *record* what it walked — it answers
+        // "reachable" without knowing by which route — so a later segment of
+        // the same clause may retake one of those edges. That is the behaviour
+        // this operator had everywhere before isolation existed, so it is a
+        // remaining gap and not a regression; closing it means either
+        // reconstructing the route (which is what the shortcut exists to avoid)
+        // or knowing at plan time that no segment follows. #710.
+        if let (true, Some(target)) = (inherited.is_empty(), self.pinned_target) {
             if self.target_reaches(source_id, store) && self.emit_ok(target, store) {
                 let empty: std::collections::HashMap<NodeId, (NodeId, crate::graph::EdgeId)> =
                     std::collections::HashMap::new();
@@ -4905,6 +4964,11 @@ impl VarLengthExpandOperator {
                 // separated. The emission order is unchanged: `next` is filled
                 // in exactly the order the old code emitted in.
                 self.for_each_neighbor(cur, type_filter, store, |nb, eid| {
+                    // An edge an earlier segment of this clause already walked
+                    // is not available to this one (#710).
+                    if inherited.contains(&eid) {
+                        return;
+                    }
                     if visited.insert(nb) {
                         parent.insert(nb, (cur, eid));
                         next.push(nb);
@@ -4945,6 +5009,20 @@ impl VarLengthExpandOperator {
     ) {
         let mut rec = base.clone();
         rec.bind(self.target_var.clone(), Value::NodeRef(target));
+
+        // Record what this segment walked, so a later segment of the same
+        // clause cannot retake it (#710). Reconstructed from `parent` rather
+        // than from the path variable, because isolation applies whether or not
+        // the pattern names the path.
+        if self.track_edges {
+            if self.starts_clause {
+                rec.clear_used_edges();
+            }
+            let (_, walked) = reconstruct_path(parent, source, target);
+            for e in walked {
+                rec.mark_edge_used(e);
+            }
+        }
         if self.path_variable.is_some() || self.rel_variable.is_some() {
             let (nodes, edges) = reconstruct_path(parent, source, target);
             if let Some(ref rv) = self.rel_variable {

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2909,6 +2909,15 @@ impl QueryPlanner {
                             min_hops,
                             max_hops,
                         );
+                        // Relationship isomorphism applies to a var-length segment too: an
+                        // edge an earlier segment of this clause walked is not available to
+                        // it. `ExpandOperator` has done this since #684; this path did not
+                        // inherit it, so `(a)-[:R]-(y)-[:R*1..1]-(z)` over one edge answered
+                        // a row where openCypher answers none (#710).
+                        if track_edges {
+                            expand = expand.with_edge_isolation(first_expand);
+                            first_expand = false;
+                        }
                         if let Some(ref pv) = path.path_variable {
                             expand = expand.with_path_variable(pv.clone());
                         }
@@ -3380,6 +3389,15 @@ impl QueryPlanner {
                     length.min.unwrap_or(1),
                     length.max.unwrap_or(usize::MAX),
                 );
+                // Relationship isomorphism applies to a var-length segment too: an
+                // edge an earlier segment of this clause walked is not available to
+                // it. `ExpandOperator` has done this since #684; this path did not
+                // inherit it, so `(a)-[:R]-(y)-[:R*1..1]-(z)` over one edge answered
+                // a row where openCypher answers none (#710).
+                if track_edges {
+                    expand = expand.with_edge_isolation(first_expand);
+                    first_expand = false;
+                }
                 // `MATCH (a)-[r:T*]->(b)` binds `r` to the list of
                 // relationships traversed. Dropping it made the query fail
                 // with "Variable not found: r" (#652).
@@ -3497,6 +3515,15 @@ impl QueryPlanner {
                     length.min.unwrap_or(1),
                     length.max.unwrap_or(usize::MAX),
                 );
+                // Relationship isomorphism applies to a var-length segment too: an
+                // edge an earlier segment of this clause walked is not available to
+                // it. `ExpandOperator` has done this since #684; this path did not
+                // inherit it, so `(a)-[:R]-(y)-[:R*1..1]-(z)` over one edge answered
+                // a row where openCypher answers none (#710).
+                if track_edges {
+                    expand = expand.with_edge_isolation(first_expand);
+                    first_expand = false;
+                }
                 // `MATCH (a)-[r:T*]->(b)` binds `r` to the list of
                 // relationships traversed. Dropping it made the query fail
                 // with "Variable not found: r" (#652).

--- a/tests/var_length_path_enumeration.rs
+++ b/tests/var_length_path_enumeration.rs
@@ -117,7 +117,6 @@ fn one_edge_cannot_be_walked_out_and_back_to_make_two_hops() {
 /// Without cross-operator edge tracking the segment walks the same edge back
 /// to `a` and returns one.
 #[test]
-#[ignore = "#710: the operator walks shortest paths, not paths"]
 fn a_var_length_segment_may_not_reuse_an_edge_the_clause_already_walked() {
     let mut store = GraphStore::new();
     run(&mut store, "CREATE (:N {name: \"a\"})");


### PR DESCRIPTION
Closes half of #710.

`MATCH (a)-[:R]-(y)-[:R*1..1]-(z)` over a graph holding **one** edge returned a
row. openCypher returns none: relationship isomorphism is per *clause*, and the
only edge in the graph had already been walked by the first segment, so the
var-length segment had nothing left to take. It took the same edge back.

`ExpandOperator` has enforced this since #684. `VarLengthExpandOperator` is the
path that did not inherit it — it cannot repeat an edge *within* one walk (a
node-visited set makes every emitted path simple) but it never knew what the
rest of the clause had walked.

## What changed

`VarLengthExpandOperator` gains the same `with_edge_isolation(starts_clause)`
contract `ExpandOperator` has, wired at all three planner sites that build one:

- the **BFS** skips an inherited edge when expanding a frontier;
- **`expand_trails`** seeds its `edges` vector with the inherited set, so a
  trail cannot retake one either, and unwinding stops at the seeded prefix;
- **`buffer`** reconstructs the walked path from `parent` and marks its edges,
  so the *next* segment inherits them. Reconstructed rather than read off the
  path variable, because isolation applies whether or not the pattern names
  the path.

The **pinned-target shortcut is skipped when the clause has already walked
edges**. Its reachability set is built once, before any row, so it cannot know
which edges a given row is forbidden; falling through to the BFS answers the
same question with the ban applied. The shortcut still fires for every
first-segment expand, which is every one LDBC runs.

## Cost

None on the shapes that matter, and that is not luck: `inherited` is empty for
the first segment of a clause and for any single-segment pattern, so the check
never runs on them. **Every LDBC var-length pattern is the first segment of its
clause.**

| | before | after |
|---|---:|---:|
| LDBC SNB-I SF1, 21 queries | 1054.6 ms | 1077.4 ms (1.02×, noise) |
| Rows returned | — | **no row-count change in any of the 21** |
| openCypher TCK 2024.3 | 1081 | **1082** |

## What is still open

The **multiplicity half** of #710: `*1..2` under-reports when a node is
reachable two ways within the bound, because the BFS marks a node visited at
the depth it is first reached. `expand_trails` answers it correctly and runs
only when `min_hops >= 2`, since enumerating trails is not affordable on IC1's
`KNOWS*1..3`. Deciding *when* multiplicity is observable — it is not under
`RETURN DISTINCT`, an existence test, or a pinned reachability check — is a
planner rule, and #710 stays open for it. Its test stays `#[ignore]`d and named
for what it asserts.
