### PR TITLE
Refuse a repeated flag, and let --query repeat on purpose (#733)

### DIFF
--- a/benches/ldbc_benchmark.rs
+++ b/benches/ldbc_benchmark.rs
@@ -711,6 +711,20 @@ async fn main() -> Result<(), Error> {
         std::process::exit(64);
     }
 
+    // A *known* flag given twice is the same defect as an unknown one, and the
+    // refusal above did not cover it: every option is read with `position`,
+    // which finds the first and drops the rest (#733).
+    let repeated = ldbc_common::cli::repeated_single_valued(&args);
+    if !repeated.is_empty() {
+        eprintln!("option(s) given more than once: {}", repeated.join(" "));
+        eprintln!(
+            "\nRefusing to run: only the first is read and the rest are dropped, so the\n\
+             run would use a setting you did not choose and the output could not say so.\n\
+             (`--query` may repeat; these may not.)"
+        );
+        std::process::exit(64);
+    }
+
     let default_dir = "data/ldbc-sf1/social_network-sf1-CsvBasic-LongDateFormatter";
     let explicit_data_dir = args.iter().any(|a| a == "--data-dir");
     let data_dir = if let Some(pos) = args.iter().position(|a| a == "--data-dir") {
@@ -725,11 +739,33 @@ async fn main() -> Result<(), Error> {
         5
     };
 
-    let filter_query: Option<String> = if let Some(pos) = args.iter().position(|a| a == "--query") {
-        Some(args.get(pos + 1).expect("--query requires a query ID (e.g. IS1, IC3)").to_uppercase())
-    } else {
-        None
-    };
+    // Repeatable: `--query IC2 --query IC12` names two queries. It used to run
+    // IC2 and drop IC12 without a word (#733).
+    let filter_queries: Vec<String> = ldbc_common::cli::selected_query_ids(&args);
+
+    // A named query that does not exist is a refusal, not a silent omission:
+    // `--query IC2 --query IC99` would otherwise run IC2 and say nothing about
+    // IC99, which is the same defect one level down (#733).
+    //
+    // Checked here rather than beside the query list below, because the list
+    // is built after the dataset is loaded — a typo would otherwise cost a full
+    // SF10 load before anything said so. The id set is a pure function of the
+    // corpus and the two flags that extend it.
+    {
+        let mut known: Vec<&str> = ldbc_queries().iter().map(|q| q.id).collect();
+        known.extend(ldbc_updates().iter().map(|q| q.id));
+        known.extend(ldbc_deletes().iter().map(|q| q.id));
+        let missing: Vec<&str> = filter_queries
+            .iter()
+            .filter(|f| !known.contains(&f.as_str()))
+            .map(|s| s.as_str())
+            .collect();
+        if !missing.is_empty() {
+            eprintln!("ERROR: no such query: {}", missing.join(" "));
+            eprintln!("Available: IS1-IS7, IC1-IC14, INS1-INS8 (with --updates), DEL1-DEL8 (with --deletes)");
+            std::process::exit(1);
+        }
+    }
 
     // `--profile` runs each selected query once under PROFILE and prints the
     // per-operator breakdown instead of a timing table. This is the
@@ -892,14 +928,16 @@ async fn main() -> Result<(), Error> {
         }
         all_queries.extend(ldbc_deletes());
     }
-    let queries: Vec<&LdbcQuery> = if let Some(ref filter) = filter_query {
-        all_queries.iter().filter(|q| q.id == filter.as_str()).collect()
-    } else {
+    // Corpus order, not command-line order, so two runs asking for the same set
+    // print the same table.
+    let queries: Vec<&LdbcQuery> = if filter_queries.is_empty() {
         all_queries.iter().collect()
+    } else {
+        all_queries.iter().filter(|q| filter_queries.iter().any(|f| f == q.id)).collect()
     };
 
     if queries.is_empty() {
-        eprintln!("ERROR: No matching query found for filter '{}'", filter_query.unwrap_or_default());
+        eprintln!("ERROR: no query selected");
         eprintln!("Available: IS1-IS7, IC1-IC14, INS1-INS8 (with --updates), DEL1-DEL8 (with --deletes)");
         std::process::exit(1);
     }

--- a/benches/ldbc_common/cli.rs
+++ b/benches/ldbc_common/cli.rs
@@ -1,0 +1,106 @@
+//! Argument checks the LDBC benches share, kept where they can be tested.
+//!
+//! `ldbc_benchmark` is `harness = false` with no `test = true`, so a
+//! `#[cfg(test)]` block inside it never runs. These live here instead, in a
+//! module `examples/ldbc_loader.rs` pulls in — that target *is* tested, which
+//! is how `params::tests` already runs (#733).
+
+/// Single-valued flags, which may not be given twice.
+///
+/// `--query` is deliberately absent: it is repeatable, and
+/// [`selected_query_ids`] collects every occurrence.
+pub const SINGLE_VALUED: &[&str] = &[
+    "--data-dir", "--derive-params", "--params-file", "--runs", "--write-params",
+];
+
+/// Which single-valued flags appear more than once.
+///
+/// Every option in these benches is read with
+/// `args.iter().position(|a| a == "--x")`, which finds the **first** and
+/// ignores the rest. So `--runs 3 --runs 10` runs three times, and
+/// `--params-file a.json --params-file b.json` decides which dataset the
+/// numbers describe — silently, in both cases.
+///
+/// The bench already refuses an *unknown* flag, with the reason spelled out in
+/// its own message: an ignored flag produces a number measured under settings
+/// nobody chose, and the output cannot tell you that happened. A known flag
+/// given twice is the same defect, and the check did not cover it.
+pub fn repeated_single_valued(args: &[String]) -> Vec<&'static str> {
+    SINGLE_VALUED
+        .iter()
+        .filter(|f| args.iter().filter(|a| a.as_str() == **f).count() > 1)
+        .copied()
+        .collect()
+}
+
+/// Every `--query` value, upper-cased, in the order given.
+///
+/// Repeatable on purpose: `--query IC2 --query IC12` names two queries, which
+/// is the only reading of that command line anyone intends. It used to run IC2
+/// and drop IC12 without a word.
+pub fn selected_query_ids(args: &[String]) -> Vec<String> {
+    args.iter()
+        .enumerate()
+        .filter(|(_, a)| a.as_str() == "--query")
+        .map(|(i, _)| {
+            args.get(i + 1)
+                .unwrap_or_else(|| panic!("--query requires a query ID (e.g. IS1, IC3)"))
+                .to_uppercase()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(xs: &[&str]) -> Vec<String> {
+        xs.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn a_flag_given_once_is_not_a_repeat() {
+        assert!(repeated_single_valued(&args(&["bench", "--runs", "3"])).is_empty());
+    }
+
+    /// The defect this exists for: the second value is dropped and the run
+    /// uses the first, with nothing in the output to say so.
+    #[test]
+    fn a_single_valued_flag_given_twice_is_reported() {
+        assert_eq!(
+            repeated_single_valued(&args(&["bench", "--runs", "3", "--runs", "10"])),
+            vec!["--runs"]
+        );
+    }
+
+    #[test]
+    fn every_repeated_flag_is_reported_not_just_the_first() {
+        let got = repeated_single_valued(&args(&[
+            "bench", "--runs", "3", "--runs", "10", "--data-dir", "a", "--data-dir", "b",
+        ]));
+        assert_eq!(got, vec!["--data-dir", "--runs"]);
+    }
+
+    /// `--query` is the one flag that may repeat, so it must not be caught by
+    /// the check that forbids repeating.
+    #[test]
+    fn query_may_repeat() {
+        assert!(repeated_single_valued(&args(&[
+            "bench", "--query", "IC2", "--query", "IC12"
+        ]))
+        .is_empty());
+    }
+
+    #[test]
+    fn no_query_flag_selects_nothing_which_the_caller_reads_as_everything() {
+        assert!(selected_query_ids(&args(&["bench", "--runs", "3"])).is_empty());
+    }
+
+    #[test]
+    fn a_repeated_query_flag_names_every_query() {
+        assert_eq!(
+            selected_query_ids(&args(&["bench", "--query", "ic2", "--query", "IC12"])),
+            vec!["IC2".to_string(), "IC12".to_string()]
+        );
+    }
+}

--- a/benches/ldbc_common/mod.rs
+++ b/benches/ldbc_common/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Used by both `ldbc_loader` and `ldbc_benchmark` examples.
 
+pub mod cli;
 pub mod params;
 
 use std::collections::HashMap;


### PR DESCRIPTION
`ldbc_benchmark` refuses to run on an unknown flag, and says why: an ignored
flag produces a number measured under settings nobody chose, and the output
cannot tell you that happened. It then did exactly that for a *known* flag
given twice. Every option is read with `args.iter().position(...)`, which finds
the first and drops the rest, so `--runs 3 --runs 10` runs three times and
`--params-file a --params-file b` decides which dataset the numbers describe —
silently, in both cases.

Two changes:

- `--data-dir`, `--derive-params`, `--params-file`, `--runs` and
  `--write-params` refuse when repeated, with the same exit code as an unknown
  flag.
- `--query` becomes genuinely repeatable: `--query IC2 --query IC12` runs both,
  in corpus order so the table does not depend on argument order. It used to
  run IC2 and say nothing about IC12. I hit this queueing the #716 variance
  experiment and caught it only by reading the parser.

A named query that does not exist now refuses too, and refuses **before** the
dataset is loaded — the check used to sit beside the query list, which is built
after the load, so a typo cost a full SF10 import before anything said so.

The checks live in `benches/ldbc_common/cli.rs` rather than in the bench,
because the bench is `harness = false` with no `test = true`: a `#[cfg(test)]`
block inside it never runs. `ldbc_common` is pulled in by a tested example,
which is how `params::tests` already runs. Six unit tests, and the binary was
exercised directly: repeated `--runs` exits 64, `--query IC99` exits 1 with
nothing loaded.

Workspace suite 3270 passed, 0 failed.