### PR TITLE
A deleted edge must not come back when its id is reused

### DIFF
--- a/benches/adjacency_walk.rs
+++ b/benches/adjacency_walk.rs
@@ -199,6 +199,28 @@ fn main() {
     println!("{:<48} {:>9}  {:>12} {:>12}", "walk", "ns/edge", "visited", "kept");
     println!("{:-<48} {:->9}  {:->12} {:->12}", "", "", "", "");
 
+    // The no-probe baseline. `get_outgoing_neighbor_slice` hands back the write
+    // buffer's raw adjacency run without consulting `edge_type_ids` at all, so
+    // the difference between this line and the wildcard below **is** the type
+    // probe — one random read per edge into an array with one `u16` per edge in
+    // the graph.
+    //
+    // The bench previously had no such line: both of its walks probed, so the
+    // probe could only be inferred from how the total moved with graph size.
+    // At 18 MB and 72 MB that inference said "free"; #738 measures 25 ns/edge
+    // at SF10, where the array is 353 MB, and this is the line that says how
+    // much of that is the probe (#738).
+    let raw = run("raw adjacency slice (no type probe)", &|| {
+        let (mut seen, mut kept) = (0u64, 0u64);
+        for &id in &ids {
+            for &(_t, _e) in store.get_outgoing_neighbor_slice(id) {
+                seen += 1;
+                kept += 1;
+            }
+        }
+        (seen, kept)
+    });
+
     let unfiltered = run("wildcard (still probes the type array)", &|| {
         let (mut seen, mut kept) = (0u64, 0u64);
         for &id in &ids {
@@ -289,6 +311,16 @@ fn main() {
     println!();
     println!("LDBC IC5 and IC9 both measure ~300-365 ns per edge visited on SF1, whose type");
     println!("array is 42 MB (#520).");
+    println!();
+    println!(
+        "The type probe costs {:.1} ns per edge here: {raw:.1} ns to walk the raw adjacency",
+        (unfiltered - raw).max(0.0)
+    );
+    println!(
+        "slice against {unfiltered:.1} with the probe, on a {:.0} MB array. That difference is what",
+        store.edge_count() as f64 * 2.0 / 1e6
+    );
+    println!("#738 is about, and it is the number to watch as the array outgrows cache.");
     println!();
     println!("The walk itself is {unfiltered:.1} ns per edge. Running the same traversal through the");
     println!("query engine costs {expand_ns:.1} ns per edge visited -- {:.0}x the walk. Whatever `Expand`", expand_ns / unfiltered.max(0.01));

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -622,6 +622,25 @@ pub struct GraphStore {
 
     /// Free edge IDs for reuse
     free_edge_ids: Vec<u64>,
+    /// Edge ids below this may be referenced by a frozen CSR segment and must
+    /// never be reused.
+    ///
+    /// `delete_edge` removes an edge's entry from the **write buffer**, but the
+    /// frozen segments are immutable and keep theirs. What hides a dead entry is
+    /// the `EDGE_TYPE_UNSET` tombstone in `edge_type_ids[id]`, which is why even
+    /// a wildcard walk consults that array.
+    ///
+    /// The same `delete_edge` pushed the id onto `free_edge_ids`, and
+    /// `create_edge` pops from it — so the next edge created overwrote the
+    /// tombstone with a real type and the stale entry became visible again,
+    /// pointing at the *deleted* edge's endpoints. One `compact_adjacency`
+    /// (which snapshot import always does), one delete and one unrelated
+    /// create was enough to make a node report a neighbour it has no edge to.
+    ///
+    /// An id created *after* the last compaction lives only in the write
+    /// buffer, where deletion really does remove it, so those stay reusable.
+    /// The watermark is what separates the two.
+    frozen_edge_watermark: u64,
 
     /// Label index for fast lookups
     label_index: HashMap<Label, HashSet<NodeId>>,
@@ -699,6 +718,7 @@ impl GraphStore {
             edge_last_commit: HashMap::new(),
             free_node_ids: Vec::new(),
             free_edge_ids: Vec::new(),
+            frozen_edge_watermark: 0,
             label_index: HashMap::new(),
             label_bits: std::sync::RwLock::new(HashMap::new()),
             edge_type_index: HashMap::new(),
@@ -1988,8 +2008,12 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         let src_labels: Vec<Label> = self.get_node(edge.source).map(|n| n.labels.iter().cloned().collect()).unwrap_or_default();
         let tgt_labels: Vec<Label> = self.get_node(edge.target).map(|n| n.labels.iter().cloned().collect()).unwrap_or_default();
 
-        // Add to free list
-        self.free_edge_ids.push(id.as_u64());
+        // Add to free list — but only if no frozen segment can be holding a
+        // stale entry for this id. Reusing one that is frozen overwrites the
+        // tombstone that hides it and resurrects a deleted edge.
+        if id.as_u64() >= self.frozen_edge_watermark {
+            self.free_edge_ids.push(id.as_u64());
+        }
 
         // Remove from edge type index
         if let Some(edge_set) = self.edge_type_index.get_mut(&edge.edge_type) {
@@ -3081,6 +3105,17 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         self.frozen_outgoing.push(frozen_out);
         self.frozen_incoming.push(frozen_in);
 
+        // Every id in existence is now referenced by a frozen segment, so none
+        // of them may be recycled: reuse overwrites the tombstone that hides a
+        // deleted edge's immutable entry. Ids minted after this point live in
+        // the write buffer, where deletion removes the entry outright, and stay
+        // reusable. Any id already queued for reuse was freed while it was
+        // buffer-only, so it is still safe — except that it is about to be
+        // frozen if it was re-created, which the watermark covers because the
+        // re-created edge's entry is the one that got frozen.
+        self.frozen_edge_watermark = self.next_edge_id;
+        self.free_edge_ids.retain(|&id| id >= self.frozen_edge_watermark);
+
         // Clear write buffers in parallel (can be millions of Vecs)
         if self.outgoing.len() >= 10_000 {
             self.outgoing.par_iter_mut().for_each(|v| { v.clear(); v.shrink_to_fit(); });
@@ -3323,6 +3358,7 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         self.frozen_incoming.clear();
         self.free_node_ids.clear();
         self.free_edge_ids.clear();
+        self.frozen_edge_watermark = 0;
         self.label_index.clear();
         self.edge_type_index.clear();
         self.vector_index = Arc::new(VectorIndexManager::new());

--- a/tests/frozen_adjacency_after_delete.rs
+++ b/tests/frozen_adjacency_after_delete.rs
@@ -1,0 +1,69 @@
+//! A deleted edge's adjacency entry survives in the frozen CSR, and the only
+//! thing hiding it is a tombstone that edge-id reuse overwrites.
+//!
+//! `delete_edge` removes the entry from the **write buffer** (`retain`), but the
+//! frozen segments are immutable — nothing rewrites them. What keeps the stale
+//! entry invisible is `edge_type_ids[id] = EDGE_TYPE_UNSET`, checked per edge by
+//! `edge_type_matches`, which is why even a wildcard walk pays for that probe.
+//!
+//! The same `delete_edge` pushes the id onto `free_edge_ids`, and `create_edge`
+//! pops from it. So the next edge created takes the dead edge's id and writes a
+//! real type into the slot the tombstone was using — and the stale entry becomes
+//! visible again, pointing at the endpoints of an edge that no longer exists.
+
+use samyama::graph::GraphStore;
+
+/// Baseline: while the id stays free, the tombstone does its job.
+#[test]
+fn a_deleted_edge_is_invisible_while_its_id_is_unused() {
+    let mut store = GraphStore::new();
+    let a = store.create_node("N");
+    let b = store.create_node("N");
+    let e = store.create_edge(a, b, "R").expect("edge");
+
+    store.compact_adjacency();
+    store.delete_edge(e).expect("delete");
+
+    let mut seen = Vec::new();
+    store.for_each_outgoing_neighbor(a, None, |t, _| seen.push(t));
+    assert!(seen.is_empty(), "a-[:R]->b was deleted, yet a still has {seen:?}");
+}
+
+/// The defect: creating any edge afterwards reuses the id and un-hides it.
+#[test]
+fn a_deleted_edge_does_not_reappear_when_its_id_is_reused() {
+    let mut store = GraphStore::new();
+    let a = store.create_node("N");
+    let b = store.create_node("N");
+    let c = store.create_node("N");
+    let d = store.create_node("N");
+    let e = store.create_edge(a, b, "R").expect("edge");
+
+    // Compaction is not exotic: snapshot import always compacts.
+    store.compact_adjacency();
+    store.delete_edge(e).expect("delete");
+
+    // An unrelated edge elsewhere in the graph. This is what used to take the
+    // freed id and, with it, overwrite the tombstone hiding the frozen entry.
+    let fresh = store.create_edge(c, d, "R").expect("edge");
+    assert_ne!(
+        fresh, e,
+        "a frozen edge's id must not be recycled: reuse overwrites the \
+         `EDGE_TYPE_UNSET` tombstone that is the only thing hiding its \
+         immutable adjacency entry"
+    );
+
+    let mut seen = Vec::new();
+    store.for_each_outgoing_neighbor(a, None, |t, _| seen.push(t));
+    assert!(
+        seen.is_empty(),
+        "`a` is connected to nothing — its only edge was deleted — but the stale \
+         frozen entry became visible again when the id was reused: {seen:?}"
+    );
+
+    // And the other way round: the new edge must not be reachable from `a`.
+    let mut typed = Vec::new();
+    let r = store.edge_type_id(&samyama::graph::EdgeType::new("R")).expect("type");
+    store.for_each_outgoing_neighbor(a, Some(&[r]), |t, _| typed.push(t));
+    assert!(typed.is_empty(), "typed walk from `a` also sees the stale entry: {typed:?}");
+}


### PR DESCRIPTION
A node reports a neighbour it has no edge to, after an ordinary
delete-then-create.

```rust
let e = store.create_edge(a, b, "R")?;
store.compact_adjacency();          // snapshot import always does this
store.delete_edge(e)?;              // `a` now has no edges — and correctly reports none
store.create_edge(c, d, "R")?;      // an unrelated edge, elsewhere in the graph
// walk from `a`  ->  [b]
```

`a` is connected to nothing. It answers `b`.

## Why

`delete_edge` removes the edge from the **write buffer** with `retain`, but the
frozen CSR segments are immutable and keep theirs. What hides a dead entry is
the `EDGE_TYPE_UNSET` tombstone in `edge_type_ids[id]`, checked per edge by
`edge_type_matches` — which is why even a wildcard walk consults that array, as
its docstring says:

> Keeping the exclusion explicit here preserves that, including for the
> wildcard case where a filter-based check would otherwise let a stale
> adjacency entry through.

The same `delete_edge` pushes the id onto `free_edge_ids`, and `create_edge`
pops from it. So **the next edge created anywhere in the graph takes the dead
edge's id** and writes a real type into the slot the tombstone was using. The
frozen entry stops being hidden and starts pointing at the *deleted* edge's
endpoints.

The tombstone is a valid guard for exactly as long as the id it guards is not
reused, and nothing was stopping the reuse.

## Fix

A watermark. `compact_adjacency` records `next_edge_id`; `delete_edge` recycles
an id only if it is at or above it.

An id minted **after** the last compaction lives only in the write buffer,
where deletion really does remove the entry, so it stays reusable — which is
the common case for a store that is not compacted at all, including every LDBC
bench run. An id at or below the watermark may be frozen somewhere, so it is
retired.

`clear()` resets the watermark with everything else.

## Cost, stated rather than buried

Ids of frozen-then-deleted edges are **permanently retired**, and
`edge_type_ids` / `edge_endpoints` are indexed by id, so a churn-heavy workload
against a compacted store grows those arrays without bound. That is a real cost
and it buys a correct answer, which is the right trade — but the way to remove
it is a **merge compaction** that rebuilds the frozen segments dropping
tombstoned entries and releases their ids. `compact_adjacency` only ever
appends a segment today; nothing merges. Filed separately, because it is also a
read-path cost — `for_each_outgoing_neighbor` loops over every segment for
every node.

## Tests

Two, in `tests/frozen_adjacency_after_delete.rs`. The first pins the working
half (a deleted edge stays invisible while its id is unused); the second is the
defect, and it fails on `main` with exactly the message above.
