### PR TITLE
A var-length segment must not be constrained by edges it cannot walk (#734)

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -2208,6 +2208,18 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
     /// Keeping the exclusion explicit here preserves that, including for the
     /// wildcard case where a filter-based check would otherwise let a stale
     /// adjacency entry through.
+    /// Public form of [`GraphStore::edge_type_matches`], for callers that need
+    /// to ask whether a *particular* edge could be traversed by a type-filtered
+    /// pattern segment.
+    ///
+    /// Used to decide whether relationship isomorphism can bite at all: an edge
+    /// an earlier segment walked is only a candidate for re-traversal if this
+    /// segment's type filter would accept it (#734).
+    #[inline]
+    pub fn edge_traversable_by(&self, edge_id: EdgeId, type_ids: Option<&[u16]>) -> bool {
+        self.edge_type_matches(edge_id, type_ids)
+    }
+
     #[inline]
     fn edge_type_matches(&self, edge_id: EdgeId, type_ids: Option<&[u16]>) -> bool {
         let id = self

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -4795,9 +4795,15 @@ impl VarLengthExpandOperator {
         // enforces relationship uniqueness.
         let mut path: Vec<(NodeId, crate::graph::EdgeId)> = Vec::new();
         // Seeded with what the clause has already walked, so a trail cannot
-        // retake an edge an earlier segment used (#710).
+        // retake an edge an earlier segment used (#710) — filtered to the edges
+        // this segment could actually walk, for the reason in `expand_from`.
         let mut edges: Vec<crate::graph::EdgeId> = if self.track_edges && !self.starts_clause {
-            record.used_edge_slice().to_vec()
+            record
+                .used_edge_slice()
+                .iter()
+                .copied()
+                .filter(|&e| store.edge_traversable_by(e, type_filter))
+                .collect()
         } else {
             Vec::new()
         };
@@ -4884,10 +4890,33 @@ impl VarLengthExpandOperator {
 
         // Edges an earlier segment of this clause already walked. This segment
         // may not retake them (#710). Empty for the first segment of a clause
-        // and for any single-segment pattern, which is why isolation costs
-        // nothing on the shapes LDBC actually runs.
+        // and for any single-segment pattern.
+        //
+        // **Filtered by this segment's own type filter**, which is not a
+        // refinement but the difference between IC6 taking 226 ms and taking
+        // over forty minutes. The planner reverses IC6 to anchor on its
+        // selective `:Tag`, so the var-length segment runs *last*:
+        //
+        //   VarLengthExpand ((friend)-[:KNOWS*1..2]-(p) [target pinned])
+        //
+        // The edges it inherits are `HAS_TAG` and `HAS_CREATOR`; the segment
+        // walks `:KNOWS`. They can never collide, so isolation has nothing to
+        // do here — but a non-empty `inherited` disabled the pinned-target
+        // shortcut below and turned one membership test per row into a whole
+        // BFS per row (#734).
+        //
+        // An edge of a type this segment cannot traverse is not a candidate for
+        // re-traversal, so dropping it changes no answer. An untyped segment
+        // filters nothing, which is correct: it can walk anything.
         let inherited: Vec<crate::graph::EdgeId> = if self.track_edges && !self.starts_clause {
-            record.used_edge_slice().to_vec()
+            self.ensure_type_ids(store);
+            let types = self.type_ids.clone();
+            record
+                .used_edge_slice()
+                .iter()
+                .copied()
+                .filter(|&e| store.edge_traversable_by(e, types.as_deref()))
+                .collect()
         } else {
             Vec::new()
         };

--- a/tests/var_length_path_enumeration.rs
+++ b/tests/var_length_path_enumeration.rs
@@ -239,3 +239,51 @@ fn a_range_above_the_lower_bound_keeps_matching() {
         vec!["a", "a", "b", "c"],
     );
 }
+
+/// A var-length segment must not be slowed by edges it could never walk.
+///
+/// The planner reverses LDBC IC6 to anchor on its selective `:Tag`, which puts
+/// the `KNOWS*1..2` segment **last** — so it inherits the `HAS_TAG` and
+/// `HAS_CREATOR` edges the earlier segments walked. Those can never be
+/// re-traversed by a `:KNOWS` segment, but a non-empty inherited set disabled
+/// the pinned-target shortcut and turned one membership test per row into a
+/// BFS per row: IC6 went from 226 ms to over forty minutes at SF10 (#734).
+///
+/// This asserts the answer, not the timing — a timing test would be a
+/// wall-clock assertion on a shared machine. What it pins is that the shape
+/// still resolves through the pinned-target path *and* still isolates edges of
+/// its own type, which the two assertions below separate.
+#[test]
+fn an_inherited_edge_of_another_type_does_not_constrain_a_typed_segment() {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:N {name: \"a\"})");
+    run(&mut store, "CREATE (:N {name: \"b\"})");
+    run(&mut store, "CREATE (:M {name: \"t\"})");
+    // a -[:KNOWS]- b, and both tagged with t via a different type.
+    run(&mut store, "MATCH (a:N {name: \"a\"}), (b:N {name: \"b\"}) CREATE (a)-[:KNOWS]->(b)");
+    run(&mut store, "MATCH (b:N {name: \"b\"}), (t:M {name: \"t\"}) CREATE (b)-[:TAGGED]->(t)");
+
+    // The reversed shape: start at the selective far end, walk back through a
+    // different edge type, then take the var-length segment.
+    let rows = names(
+        &store,
+        "MATCH (t:M {name: \"t\"})<-[:TAGGED]-(b:N)-[:KNOWS*1..1]-(a:N) RETURN a.name AS n",
+    );
+    assert_eq!(
+        rows,
+        vec!["a".to_string()],
+        "the TAGGED edge the clause already walked cannot be walked by a KNOWS \
+         segment, so it must not constrain it"
+    );
+
+    // And the isolation itself still holds for an edge of the *same* type.
+    let same = names(
+        &store,
+        "MATCH (a:N {name: \"a\"})-[:KNOWS]-(b:N)-[:KNOWS*1..1]-(c:N) RETURN c.name AS n",
+    );
+    assert!(
+        same.is_empty(),
+        "the only KNOWS edge was walked by the first segment, so the var-length \
+         segment has none left: got {same:?}"
+    );
+}


### PR DESCRIPTION
**#734 regressed LDBC IC6 from 226 ms to over forty minutes at SF10. SF1 did
not catch it, and neither did TCK or the workspace suite.** This restores it to
309 ms.

## What went wrong

#734 taught `VarLengthExpandOperator` to honour relationship isomorphism across
a clause, and skipped the pinned-target shortcut when the clause had already
walked edges — because that shortcut answers "is the target reachable" from a
set built **once, before any row**, so it cannot know which edges a given row is
forbidden.

That guard is correct. It is also, on IC6, catastrophic, and the reason is the
plan:

```
Limit (10)
+- ... Expand ((post)-[:HAS_TAG]->(otherTag))
      +- Filter (p.id = …)
         +- VarLengthExpand ((friend)-[:KNOWS*1..2]-(p) [target pinned to node 34082])
            +- Filter (friend.id <> …)
```

The planner **reverses** IC6 to anchor on its selective `:Tag`, which puts the
var-length segment **last**. Being last, it inherits the `HAS_TAG` and
`HAS_CREATOR` edges the earlier segments walked, so `inherited` is never empty,
so the shortcut never fires — and one membership test per row became a whole
BFS per row.

I asserted the opposite in #734's own description: *"every LDBC var-length
pattern is the first segment of its clause"*. That was read off the query text.
It is not true of the plan, and the plan is what runs.

## The fix

Filter the inherited set by **this segment's own type filter**. A `HAS_TAG`
edge is not a candidate for re-traversal by a `:KNOWS` segment, so it cannot
constrain it and must not disable the shortcut. An untyped segment filters
nothing, which is right — it can walk anything.

This is not a special case for IC6. Relationship isomorphism can only bite
where the same edge could be walked twice, and a type-filtered segment cannot
walk an edge of another type. Dropping those changes no answer.

## Measured

| | IC6 at SF10, median of 3 |
|---|---:|
| `199e33d`, before #734 | 226 ms |
| `main` with #734 | **did not finish** — killed after 40 min, still in `VarLengthExpandOperator` |
| this branch, full suite | **239 ms** |

Both full-suite runs, both opening at 37 ms calibration; this one closes at
36 ms (1.00× drift) where the `199e33d` run closed at 41 ms, so if anything the
comparison favours the older number. **21/21 passed, 0 empty, 0 errors.**

An isolated `--query IC6` run measured 309 ms, on a CPU that had settled to
2606 MHz against this suite's 2954 MHz opening. The full-suite figure is the
comparable one.

## The residual, which this PR does not fix

Several multi-segment queries are 10–20% slower than on `199e33d` — IC9
3,629 → 4,340 ms, IC11 253 → 299, IC5 4,838 → 5,391 — on a run whose clock was
*faster*. That is #710's bookkeeping: every expand in a multi-segment clause
tests `used_edges.contains(&eid)` **per candidate edge**, and inherits edges of
types it can never walk.

The same filter applied to `ExpandOperator` should recover most of it. It is a
separate PR with its own SF10 measurement, deliberately not stacked onto a
hotfix — shipping a second change on the strength of the same reasoning that
produced this regression is the mistake, not the fix.

## Tests

`an_inherited_edge_of_another_type_does_not_constrain_a_typed_segment` pins
both halves: an inherited edge of a different type must not constrain the
segment, and an inherited edge of the **same** type still must. It asserts
answers rather than timings.

It would not, by itself, have caught this regression — the answers were always
right, only the plan got slow. What would have caught it is running SF10 before
merging, and that is the process lesson: **a var-length change cannot be
validated at SF1**, because SF1 is cheap enough that the wrong plan still
finishes.
