### PR TITLE
ExpandOperator: inherited edges filtered by the type it can walk

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -4183,8 +4183,27 @@ impl ExpandOperator {
         // Relationship isomorphism (#684): an edge this pattern already walked
         // is not a candidate. Checked here, during the adjacency walk, so a
         // rejected edge never becomes a record.
+        //
+        // Filtered to the edges this expand could actually walk. An edge of a
+        // type outside `type_filter` is not a candidate for re-traversal, so
+        // keeping it only lengthens a `contains` that runs **per candidate
+        // edge**. On LDBC IC6 the clause walks `HAS_TAG`, `HAS_CREATOR` and
+        // `KNOWS`, so each expand inherits edges it could never take; the same
+        // reasoning applied to `VarLengthExpandOperator` is what took IC6 from
+        // forty minutes back to 309 ms (#734).
+        let used_owned: Vec<crate::graph::EdgeId>;
         let used_edges: &[crate::graph::EdgeId] = if self.track_edges && !self.starts_clause {
-            record.used_edge_slice()
+            let inherited = record.used_edge_slice();
+            if inherited.is_empty() {
+                &[]
+            } else {
+                used_owned = inherited
+                    .iter()
+                    .copied()
+                    .filter(|&e| store.edge_traversable_by(e, type_filter))
+                    .collect();
+                &used_owned
+            }
         } else {
             &[]
         };


### PR DESCRIPTION
#741 did this for `VarLengthExpandOperator` and left the residual: every expand in a multi-segment clause tests `used_edges.contains(&eid)` **per candidate edge**, over a set that includes edges of types it can never traverse. On IC6 the clause walks `HAS_TAG`, `HAS_CREATOR` and `KNOWS`, so each expand carries two it cannot use.

Same argument as #741: an edge of a type this expand cannot walk is not a candidate for re-traversal, so dropping it changes no answer.

## Measured at SF10, full suite, 21/21, calibration 37 → 36 ms

| | IC11 | IC9 | IC5 | IC6 | IS3 |
|---|---:|---:|---:|---:|---:|
| `199e33d`, before #710's bookkeeping | 253 | 3,629 | 4,838 | 226 | 1.5 |
| with it (#741) | 299 | 4,340 | 5,391 | 239 | 1.8 |
| **this branch** | **256** | **3,934** | **5,075** | **230** | **1.5** |

That recovers most of what #710's correctness fix cost. **IC11 matters most** — it is the only complex read outside PERF-01's 5× and therefore the query H1 gate condition 2 turns on, so 299 → 256 moves the published ratio from 13.9× to 11.9×.

Workspace suite 3273 passed, 0 failed. TCK 1082, unchanged.

## What this does not do

It makes the *bookkeeping* cheap. It does not touch why IC11 is 11.9× in the first place, which is #738: a typed expand visits ~6.6M edges to use ~29,000, because an LDBC `Person` has ~495 outgoing edges and 2.2 of them are `WORK_AT`.