### PR TITLE
An entity inside a list or map must arrive as an entity, not as Debug

### DIFF
--- a/crates/samyama-sdk/src/embedded.rs
+++ b/crates/samyama-sdk/src/embedded.rs
@@ -153,132 +153,9 @@ fn record_batch_to_query_result(batch: &RecordBatch, store: &GraphStore) -> Quer
     for record in &batch.records {
         let mut row = Vec::new();
         for col in &batch.columns {
-            let val = match record.get(col) {
-                Some(v) => v,
-                None => {
-                    row.push(serde_json::Value::Null);
-                    continue;
-                }
-            };
-
-            match val {
-                Value::Map(entries) => {
-                    row.push(serde_json::Value::Object(
-                        entries.iter().map(|(k, v)| (k.clone(), serde_json::json!(format!("{v:?}")))).collect(),
-                    ));
-                }
-                Value::List(items) => {
-                    row.push(serde_json::Value::Array(
-                        items.iter().map(|i| serde_json::json!(format!("{i:?}"))).collect(),
-                    ));
-                }
-                Value::Node(id, node) => {
-                    let mut properties = serde_json::Map::new();
-                    for (k, v) in &node.properties {
-                        properties.insert(k.clone(), v.to_json());
-                    }
-                    let id_str = id.as_u64().to_string();
-                    let labels: Vec<String> = node.labels.iter().map(|l| l.as_str().to_string()).collect();
-
-                    let node_json = serde_json::json!({
-                        "id": id_str,
-                        "labels": labels,
-                        "properties": properties,
-                    });
-
-                    nodes_map.entry(id_str.clone()).or_insert_with(|| SdkNode {
-                        id: id_str,
-                        labels,
-                        properties: properties.into_iter().collect(),
-                    });
-
-                    row.push(node_json);
-                }
-                Value::NodeRef(id) => {
-                    let id_str = id.as_u64().to_string();
-                    // Try to resolve from store
-                    let (labels, properties, node_json) = if let Some(node) = store.get_node(*id) {
-                        let mut props = serde_json::Map::new();
-                        for (k, v) in &node.properties {
-                            props.insert(k.clone(), v.to_json());
-                        }
-                        let lbls: Vec<String> = node.labels.iter().map(|l| l.as_str().to_string()).collect();
-                        let json = serde_json::json!({
-                            "id": id_str,
-                            "labels": lbls,
-                            "properties": props,
-                        });
-                        (lbls, props.into_iter().collect(), json)
-                    } else {
-                        let json = serde_json::json!({ "id": id_str, "labels": [], "properties": {} });
-                        (vec![], HashMap::new(), json)
-                    };
-
-                    nodes_map.entry(id_str.clone()).or_insert_with(|| SdkNode {
-                        id: id_str,
-                        labels,
-                        properties,
-                    });
-
-                    row.push(node_json);
-                }
-                Value::Edge(id, edge) => {
-                    let mut properties = serde_json::Map::new();
-                    for (k, v) in &edge.properties {
-                        properties.insert(k.clone(), v.to_json());
-                    }
-                    let id_str = id.as_u64().to_string();
-                    let edge_json = serde_json::json!({
-                        "id": id_str,
-                        "source": edge.source.as_u64().to_string(),
-                        "target": edge.target.as_u64().to_string(),
-                        "type": edge.edge_type.as_str(),
-                        "properties": properties,
-                    });
-
-                    edges_map.entry(id_str.clone()).or_insert_with(|| SdkEdge {
-                        id: id_str,
-                        source: edge.source.as_u64().to_string(),
-                        target: edge.target.as_u64().to_string(),
-                        edge_type: edge.edge_type.as_str().to_string(),
-                        properties: properties.into_iter().collect(),
-                    });
-
-                    row.push(edge_json);
-                }
-                Value::EdgeRef(id, src, tgt, et) => {
-                    let id_str = id.as_u64().to_string();
-                    let edge_json = serde_json::json!({
-                        "id": id_str,
-                        "source": src.as_u64().to_string(),
-                        "target": tgt.as_u64().to_string(),
-                        "type": et.as_str(),
-                        "properties": {},
-                    });
-
-                    edges_map.entry(id_str.clone()).or_insert_with(|| SdkEdge {
-                        id: id_str,
-                        source: src.as_u64().to_string(),
-                        target: tgt.as_u64().to_string(),
-                        edge_type: et.as_str().to_string(),
-                        properties: HashMap::new(),
-                    });
-
-                    row.push(edge_json);
-                }
-                Value::Property(p) => {
-                    row.push(p.to_json());
-                }
-                Value::Path { nodes: path_nodes, edges: path_edges } => {
-                    row.push(serde_json::json!({
-                        "nodes": path_nodes.iter().map(|n| n.as_u64().to_string()).collect::<Vec<_>>(),
-                        "edges": path_edges.iter().map(|e| e.as_u64().to_string()).collect::<Vec<_>>(),
-                        "length": path_edges.len(),
-                    }));
-                }
-                Value::Null => {
-                    row.push(serde_json::Value::Null);
-                }
+            match record.get(col) {
+                Some(v) => row.push(value_to_json(v, store, &mut nodes_map, &mut edges_map)),
+                None => row.push(serde_json::Value::Null),
             }
         }
         records.push(row);
@@ -289,6 +166,142 @@ fn record_batch_to_query_result(batch: &RecordBatch, store: &GraphStore) -> Quer
         edges: edges_map.into_values().collect(),
         columns: batch.columns.clone(),
         records,
+    }
+}
+
+/// One result value as JSON, registering any entity it contains.
+///
+/// **Recursive, which is the point.** This used to be inlined in the loop
+/// above, and the `List` and `Map` arms rendered their elements with
+/// `format!("{v:?}")` — the Rust `Debug` of the internal enum. So an entity
+/// inside a collection reached SDK consumers as
+/// `"NodeRef(NodeId(1))"` or
+/// `"EdgeRef(EdgeId(1), NodeId(1), NodeId(2), EdgeType(\"R\"))"`, labels and
+/// properties gone and an escaped quote embedded in a JSON string, while the
+/// very same node in a bare column came back as `{id, labels, properties}`.
+///
+/// Scalars were unaffected, which is what made it easy to miss: `collect(n.name)`
+/// was right and `collect(n)` was not — and `collect`, `nodes` and
+/// `relationships` are everyday Cypher.
+fn value_to_json(
+    val: &Value,
+    store: &GraphStore,
+    nodes_map: &mut HashMap<String, SdkNode>,
+    edges_map: &mut HashMap<String, SdkEdge>,
+) -> serde_json::Value {
+    match val {
+        Value::Map(entries) => serde_json::Value::Object(
+            entries
+                .iter()
+                .map(|(k, v)| (k.clone(), value_to_json(v, store, nodes_map, edges_map)))
+                .collect(),
+        ),
+        Value::List(items) => serde_json::Value::Array(
+            items
+                .iter()
+                .map(|i| value_to_json(i, store, nodes_map, edges_map))
+                .collect(),
+        ),
+        Value::Node(id, node) => {
+            let mut properties = serde_json::Map::new();
+            for (k, v) in &node.properties {
+                properties.insert(k.clone(), v.to_json());
+            }
+            let id_str = id.as_u64().to_string();
+            let labels: Vec<String> = node.labels.iter().map(|l| l.as_str().to_string()).collect();
+
+            let node_json = serde_json::json!({
+                "id": id_str,
+                "labels": labels,
+                "properties": properties,
+            });
+
+            nodes_map.entry(id_str.clone()).or_insert_with(|| SdkNode {
+                id: id_str,
+                labels,
+                properties: properties.into_iter().collect(),
+            });
+
+            node_json
+        }
+        Value::NodeRef(id) => {
+            let id_str = id.as_u64().to_string();
+            let (labels, properties, node_json) = if let Some(node) = store.get_node(*id) {
+                let mut props = serde_json::Map::new();
+                for (k, v) in &node.properties {
+                    props.insert(k.clone(), v.to_json());
+                }
+                let lbls: Vec<String> = node.labels.iter().map(|l| l.as_str().to_string()).collect();
+                let json = serde_json::json!({
+                    "id": id_str,
+                    "labels": lbls,
+                    "properties": props,
+                });
+                (lbls, props.into_iter().collect(), json)
+            } else {
+                let json = serde_json::json!({ "id": id_str, "labels": [], "properties": {} });
+                (vec![], HashMap::new(), json)
+            };
+
+            nodes_map.entry(id_str.clone()).or_insert_with(|| SdkNode {
+                id: id_str,
+                labels,
+                properties,
+            });
+
+            node_json
+        }
+        Value::Edge(id, edge) => {
+            let mut properties = serde_json::Map::new();
+            for (k, v) in &edge.properties {
+                properties.insert(k.clone(), v.to_json());
+            }
+            let id_str = id.as_u64().to_string();
+            let edge_json = serde_json::json!({
+                "id": id_str,
+                "source": edge.source.as_u64().to_string(),
+                "target": edge.target.as_u64().to_string(),
+                "type": edge.edge_type.as_str(),
+                "properties": properties,
+            });
+
+            edges_map.entry(id_str.clone()).or_insert_with(|| SdkEdge {
+                id: id_str,
+                source: edge.source.as_u64().to_string(),
+                target: edge.target.as_u64().to_string(),
+                edge_type: edge.edge_type.as_str().to_string(),
+                properties: properties.into_iter().collect(),
+            });
+
+            edge_json
+        }
+        Value::EdgeRef(id, src, tgt, et) => {
+            let id_str = id.as_u64().to_string();
+            let edge_json = serde_json::json!({
+                "id": id_str,
+                "source": src.as_u64().to_string(),
+                "target": tgt.as_u64().to_string(),
+                "type": et.as_str(),
+                "properties": {},
+            });
+
+            edges_map.entry(id_str.clone()).or_insert_with(|| SdkEdge {
+                id: id_str,
+                source: src.as_u64().to_string(),
+                target: tgt.as_u64().to_string(),
+                edge_type: et.as_str().to_string(),
+                properties: HashMap::new(),
+            });
+
+            edge_json
+        }
+        Value::Property(p) => p.to_json(),
+        Value::Path { nodes: path_nodes, edges: path_edges } => serde_json::json!({
+            "nodes": path_nodes.iter().map(|n| n.as_u64().to_string()).collect::<Vec<_>>(),
+            "edges": path_edges.iter().map(|e| e.as_u64().to_string()).collect::<Vec<_>>(),
+            "length": path_edges.len(),
+        }),
+        Value::Null => serde_json::Value::Null,
     }
 }
 

--- a/crates/samyama-sdk/tests/result_values.rs
+++ b/crates/samyama-sdk/tests/result_values.rs
@@ -1,0 +1,82 @@
+//! An entity inside a list or map must arrive as an entity, not as Rust `Debug`.
+//!
+//! `record_batch_to_query_result` converts each returned value to
+//! `serde_json::Value`, and gives `Value::Node` and `Value::Edge` a proper
+//! shape — `{id, labels, properties}`. For `Value::List` and `Value::Map` it
+//! instead does `format!("{v:?}")` on every element, so an entity *inside* a
+//! collection comes back as the Debug rendering of the internal enum:
+//!
+//! ```text
+//! collect(n)        -> ["NodeRef(NodeId(1))", "NodeRef(NodeId(2))"]
+//! relationships(p)  -> ["EdgeRef(EdgeId(1), NodeId(1), NodeId(2), EdgeType(\"R\"))"]
+//! ```
+//!
+//! Labels and properties are gone, and the escaped quote is embedded in a JSON
+//! string. Scalars are unaffected, which is what makes this easy to miss:
+//! `collect(n.name)` is correct, `collect(n)` is not — and `collect`, `nodes`
+//! and `relationships` are everyday Cypher.
+
+use samyama_sdk::{EmbeddedClient, SamyamaClient};
+
+async fn one_value(setup: &[&str], cypher: &str) -> serde_json::Value {
+    let client = EmbeddedClient::new();
+    for s in setup {
+        client.query("default", s).await.expect("setup should run");
+    }
+    let result = client.query("default", cypher).await.expect("query should run");
+    let row = result.records.first().expect("one row").clone();
+    row.into_iter().next().expect("one column")
+}
+
+const TWO_NODES: &[&str] = &["CREATE (:P {n: 1})-[:R {w: 2}]->(:P {n: 2})"];
+
+#[tokio::test]
+async fn collected_nodes_keep_their_labels_and_properties() {
+    let v = one_value(TWO_NODES, "MATCH (n:P) RETURN collect(n) AS xs").await;
+    let items = v.as_array().expect("a JSON array");
+    assert_eq!(items.len(), 2);
+    for item in items {
+        assert!(
+            item.is_object(),
+            "a collected node must be an object with id/labels/properties, got {item}"
+        );
+        assert_eq!(item["labels"], serde_json::json!(["P"]), "labels lost: {item}");
+        assert!(item["properties"]["n"].is_number(), "properties lost: {item}");
+    }
+}
+
+#[tokio::test]
+async fn nodes_of_a_path_are_entities() {
+    let v = one_value(TWO_NODES, "MATCH p=(:P)-[:R]->(:P) RETURN nodes(p) AS xs").await;
+    let items = v.as_array().expect("a JSON array");
+    assert_eq!(items.len(), 2);
+    assert!(items.iter().all(|i| i.is_object()), "got {v}");
+}
+
+#[tokio::test]
+async fn relationships_of_a_path_are_entities() {
+    let v = one_value(TWO_NODES, "MATCH p=(:P)-[:R]->(:P) RETURN relationships(p) AS xs").await;
+    let items = v.as_array().expect("a JSON array");
+    assert_eq!(items.len(), 1);
+    assert!(items[0].is_object(), "a relationship must not be a Debug string: {v}");
+    assert_eq!(items[0]["type"], serde_json::json!("R"), "edge type lost: {v}");
+}
+
+#[tokio::test]
+async fn a_map_value_that_is_a_node_is_an_entity() {
+    let v = one_value(TWO_NODES, "MATCH (n:P {n: 1}) RETURN {v: n} AS m").await;
+    assert!(v["v"].is_object(), "a node in a map must not be a Debug string: {v}");
+}
+
+/// The half that already worked, pinned so a fix does not break it.
+#[tokio::test]
+async fn collected_scalars_are_still_plain_values() {
+    let v = one_value(TWO_NODES, "MATCH (n:P) RETURN collect(n.n) AS xs").await;
+    assert_eq!(v, serde_json::json!([1, 2]));
+}
+
+#[tokio::test]
+async fn a_literal_list_is_still_plain_values() {
+    let v = one_value(&[], "RETURN [1, 2, 3] AS xs").await;
+    assert_eq!(v, serde_json::json!([1, 2, 3]));
+}


### PR DESCRIPTION
`collect(n)`, `nodes(p)` and `relationships(p)` return the **Rust `Debug`
rendering of an internal enum** to every consumer of the embedded SDK.

```
MATCH (n:P) RETURN collect(n)         -> ["NodeRef(NodeId(1))", "NodeRef(NodeId(2))"]
MATCH p=…    RETURN relationships(p)  -> ["EdgeRef(EdgeId(1), NodeId(1), NodeId(2), EdgeType(\"R\"))"]
MATCH (n:P) RETURN {v: n}             -> {"v": "NodeRef(NodeId(1))"}
```

Labels and properties are gone, and an escaped quote is embedded in a JSON
string. The *same node* in a bare column comes back correctly as
`{id, labels, properties}`.

## Why it survived

`record_batch_to_query_result` gives `Value::Node` and `Value::Edge` a proper
shape, and then handles `Value::List` and `Value::Map` with:

```rust
items.iter().map(|i| serde_json::json!(format!("{i:?}"))).collect()
```

**Scalars are unaffected**, which is what makes it easy to miss:
`collect(n.name)` is right, `collect(n)` is not. I found it while following a
*performance* question about this function (#718), not by looking for it, and
my first test — `RETURN [1,2,3]` — **passed**, because a literal list arrives
as a `PropertyValue::List` and never reaches the broken arm. The bug needs an
*entity inside* a collection.

## Fix

Extract the per-value conversion into `value_to_json` and recurse. The List and
Map arms then get the same entity handling every other arm already had, and
entities nested in collections are registered in `nodes`/`edges` on the result
like top-level ones.

No behaviour change for any other variant — the arms are moved verbatim.

## Tests

Six, in `crates/samyama-sdk/tests/result_values.rs` — the crate had no test
directory. Four fail on `main`:

- collected nodes keep labels and properties
- `nodes(p)` and `relationships(p)` are entities, with the edge type intact
- a node as a map value is an entity

and two pin the half that already worked (`collect(n.name)`, `RETURN [1,2,3]`),
so the fix cannot regress scalars.

## Worth knowing

`src/agent/tools.rs` has a **second** implementation of this conversion, and it
is already recursive and correct — different output shape (`{node_id}` rather
than `{id, labels, properties}`) because it serves a different consumer. Two
converters, one of which was wrong for two years' worth of `collect(n)` calls.
Consolidating them is not obviously right given the shapes differ, but the next
person to add a `Value` variant has to remember both.
