### PR TITLE
result_path_probe: three arms over an LDBC extract, and build the indexes

### DIFF
--- a/examples/result_path_probe.rs
+++ b/examples/result_path_probe.rs
@@ -30,6 +30,9 @@ use samyama_sdk::{EmbeddedClient, SamyamaClient};
 #[path = "../benches/common/bench_setup.rs"]
 mod bench_setup;
 
+#[path = "../benches/ldbc_common/mod.rs"]
+mod ldbc_common;
+
 const ROWS: &[usize] = &[1, 10, 100, 1_000, 10_000];
 const RUNS: usize = 9;
 
@@ -38,10 +41,113 @@ fn median(mut v: Vec<f64>) -> f64 {
     v[v.len() / 2]
 }
 
+/// Three arms, so the two steps between them are separated:
+///
+/// 1. `QueryExecutor::execute` — what `query_probe` times.
+/// 2. `QueryEngine::execute` — adds the cached parse **and a deadline**.
+///    `query_timeout_secs` defaults to **120**, so every call through the
+///    engine installs one, and `check_deadline()` calls `Instant::now()` at
+///    thirteen sites inside operator materialisation loops. The direct
+///    executor installs none.
+/// 3. `client.query_readonly` — adds `record_batch_to_query_result`.
+///
+/// The LDBC bench uses (3) and `query_probe` uses (1), and on IS3 at SF10 they
+/// disagree 3.3×. (2) is the arm that says which half of the gap is which.
+async fn ldbc_mode(data_dir: &std::path::Path, queries: &[(String, String)], runs: usize)
+    -> Result<(), Box<dyn std::error::Error>> {
+    use samyama::query::QueryEngine;
+
+    let mut direct = GraphStore::new();
+    eprintln!("loading {} ...", data_dir.display());
+    ldbc_common::load_dataset(&mut direct, data_dir)?;
+    let client = EmbeddedClient::new();
+    {
+        let mut g = client.store_write().await;
+        ldbc_common::load_dataset(&mut g, data_dir)?;
+    }
+
+    // The same `id` indexes both harnesses build. Without them every
+    // `MATCH (x:Label {id: ...})` is a full label scan, which is 27x IS3's
+    // whole runtime at SF1 and drowns the thing being compared. Leaving them
+    // out is how the first version of this probe reported 1.083 ms for a query
+    // the bench measures at 0.04 ms.
+    for label in ["Person", "Post", "Comment", "Forum", "Place", "Organisation", "Tag", "TagClass"] {
+        let stmt = format!("CREATE INDEX ON :{label}(id)");
+        let q = parse_query(&stmt)?;
+        samyama::query::executor::MutQueryExecutor::new(&mut direct, "default".to_string())
+            .execute(&q)?;
+        client.query("default", &stmt).await?;
+    }
+
+    let engine = QueryEngine::new();
+
+    println!(
+        "\n{:<22} {:>11} {:>11} {:>11}  {:>9} {:>9}",
+        "query", "executor", "engine", "client", "eng/exec", "cli/eng"
+    );
+    println!("{:-<22} {:->11} {:->11} {:->11}  {:->9} {:->9}", "", "", "", "", "", "");
+
+    for (label, cypher) in queries {
+        let q = parse_query(cypher)?;
+        let _ = QueryExecutor::new(&direct).execute(&q)?;
+        let exec_ms = median((0..runs).map(|_| {
+            let t = Instant::now();
+            let _ = QueryExecutor::new(&direct).execute(&q).expect("runs");
+            t.elapsed().as_secs_f64() * 1000.0
+        }).collect());
+
+        let _ = engine.execute(cypher, &direct)?;
+        let engine_ms = median((0..runs).map(|_| {
+            let t = Instant::now();
+            let _ = engine.execute(cypher, &direct).expect("runs");
+            t.elapsed().as_secs_f64() * 1000.0
+        }).collect());
+
+        let _ = client.query_readonly("default", cypher).await?;
+        let mut cts = Vec::with_capacity(runs);
+        for _ in 0..runs {
+            let t = Instant::now();
+            let _ = client.query_readonly("default", cypher).await?;
+            cts.push(t.elapsed().as_secs_f64() * 1000.0);
+        }
+        let client_ms = median(cts);
+
+        println!(
+            "{label:<22} {:>9.3}ms {:>9.3}ms {:>9.3}ms  {:>8.2}x {:>8.2}x",
+            exec_ms, engine_ms, client_ms,
+            engine_ms / exec_ms.max(1e-9),
+            client_ms / engine_ms.max(1e-9),
+        );
+    }
+    println!(
+        "\nexecutor -> engine is the cached parse plus the deadline \
+         (SAMYAMA_QUERY_TIMEOUT=0 removes the deadline);\n\
+         engine -> client is record_batch_to_query_result (#718)."
+    );
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     bench_setup::init();
     let _ = bench_setup::report_calibration();
+
+    let args: Vec<String> = std::env::args().collect();
+    let one = |f: &str| args.iter().position(|a| a == f).and_then(|i| args.get(i + 1));
+    if let Some(dir) = one("--data-dir") {
+        let runs: usize = one("--runs").map(|s| s.parse()).transpose()?.unwrap_or(9);
+        let queries: Vec<(String, String)> = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| a.as_str() == "--q")
+            .map(|(i, _)| {
+                let s = args.get(i + 1).expect("--q needs label=cypher");
+                let (l, c) = s.split_once('=').expect("--q needs label=cypher");
+                (l.to_string(), c.to_string())
+            })
+            .collect();
+        return ldbc_mode(std::path::Path::new(dir), &queries, runs).await;
+    }
 
     // One store, built once, shared by both paths. The client holds its own,
     // so it is loaded with the same CREATEs rather than the same object —


### PR DESCRIPTION
Runs one query through the executor, the engine (parse + deadline) and the client (+ JSON) in one process against one store, so #718's 'which harness' question can be answered rather than inferred across two programs.

At SF1 on IS3: 0.043 / 0.043 / 0.052 ms — the paths are equivalent.

Also fixes the instrument: the first version omitted the `id` indexes both harnesses build and reported 1.083 ms for a query the bench measures at 0.04.