### PR TITLE
A typed expand asks for its own type instead of walking every edge (#738)

### DIFF
--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -65,7 +65,7 @@ pub mod storage;
 pub use edge::{Edge, EdgeView};
 pub use node::Node;
 pub use property::{PropertyMap, PropertyValue};
-pub use store::{GraphError, GraphResult, GraphStore, GraphStatistics, PropertyStats, IsolationLevel, TxnId, TxnStatus, Transaction};
+pub use store::{GraphError, GraphResult, GraphStore, GraphStatistics, PropertyStats, IsolationLevel, TxnId, TxnStatus, Transaction, TypeAdjacency};
 pub use types::{EdgeId, EdgeType, Label, NodeId};
 pub use catalog::GraphCatalog;
 pub use event::IndexEvent;

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -421,6 +421,50 @@ impl FrozenAdjacencyStore {
 /// Compressed Sparse Row (CSR) storage for bulk-loaded adjacency data.
 /// Immutable after construction — all new edges go to the write buffer (Vec-of-Vec).
 /// Queries merge results from frozen tier + write buffer transparently.
+/// Adjacency for **one edge type and direction**, derived on demand.
+///
+/// A typed expand walks every edge incident to a node and rejects the ones
+/// whose type does not match. On LDBC SF10 that means IC11 visits ~6.6M edges
+/// to use ~29,000 — an LDBC `Person` has ~495 outgoing edges, 438 of them
+/// `LIKES` and 2.2 of them `WORK_AT` — and the walk is ~75% of the query
+/// (#738).
+///
+/// This is the same shape as `label_bitset`: **derived, never authoritative,
+/// and dropped wholesale when the thing it derives from changes.** It is built
+/// by walking the adjacency exactly as `for_each_outgoing_neighbor` does, so
+/// it contains precisely what that walk would have visited — including the
+/// tombstone exclusion, which is why it cannot disagree with the slow path.
+#[derive(Debug)]
+pub struct TypeAdjacency {
+    /// Node -> `(start, len)` into `entries`. Sparse: only nodes with at least
+    /// one edge of this type appear, which is what keeps it small — `WORK_AT`
+    /// touches 65,645 of SF10's 30M nodes.
+    index: HashMap<NodeId, (u32, u32)>,
+    entries: Vec<(NodeId, EdgeId)>,
+}
+
+impl TypeAdjacency {
+    /// This node's neighbours of the indexed type, or empty.
+    #[inline]
+    pub fn neighbors(&self, node: NodeId) -> &[(NodeId, EdgeId)] {
+        match self.index.get(&node) {
+            Some(&(start, len)) => &self.entries[start as usize..(start + len) as usize],
+            None => &[],
+        }
+    }
+
+    /// Entries held, for the memory cap and for tests.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct FrozenAdjacency {
     /// Offset table: offsets[node_idx] .. offsets[node_idx + 1] gives the range
@@ -622,6 +666,16 @@ pub struct GraphStore {
 
     /// Free edge IDs for reuse
     free_edge_ids: Vec<u64>,
+    /// Per-`(type, direction)` adjacency, derived on demand and dropped whole
+    /// on any edge change. See [`TypeAdjacency`]. `None` caches a *declined*
+    /// build so a type over the cap is not re-attempted on every row.
+    type_adj: std::sync::RwLock<HashMap<(u16, bool), Option<std::sync::Arc<TypeAdjacency>>>>,
+    /// Whether `type_adj` holds anything.
+    ///
+    /// Invalidation runs on every edge mutation, and a bulk load is 176M of
+    /// them at SF10. A relaxed atomic load is free; taking a lock 176M times
+    /// to clear an empty map is not.
+    type_adj_live: std::sync::atomic::AtomicBool,
     /// Edge ids below this may be referenced by a frozen CSR segment and must
     /// never be reused.
     ///
@@ -718,6 +772,8 @@ impl GraphStore {
             edge_last_commit: HashMap::new(),
             free_node_ids: Vec::new(),
             free_edge_ids: Vec::new(),
+            type_adj: std::sync::RwLock::new(HashMap::new()),
+            type_adj_live: std::sync::atomic::AtomicBool::new(false),
             frozen_edge_watermark: 0,
             label_index: HashMap::new(),
             label_bits: std::sync::RwLock::new(HashMap::new()),
@@ -2517,6 +2573,203 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         Some(bits)
     }
 
+    /// Entries a single `(type, direction)` index may hold before it is
+    /// declined.
+    ///
+    /// 4M entries is ~64 MB. Above that the index costs more than the walk it
+    /// replaces: the point is a type that is *selective* against the degree of
+    /// the nodes it hangs off, and a type holding a fifth of the graph's edges
+    /// is not that. At SF10 `WORK_AT` (143k), `KNOWS` (1.9M) and
+    /// `HAS_INTEREST` (1.5M) build; `LIKES` (28.7M) and `HAS_TAG` (38M) decline.
+    const TYPE_ADJ_MAX_ENTRIES: usize = 4_000_000;
+
+    /// Adjacency for one edge type and direction, building it if worthwhile.
+    ///
+    /// Returns `None` when the type is too large to index, and caches that
+    /// decision. Built by walking the adjacency exactly as the typed walk
+    /// does, so the two cannot disagree.
+    pub fn type_adjacency(&self, type_id: u16, outgoing: bool) -> Option<std::sync::Arc<TypeAdjacency>> {
+        if let Some(cached) = self.type_adj.read().unwrap().get(&(type_id, outgoing)) {
+            return cached.clone();
+        }
+
+        // Fast build: iterate just this type's edges.
+        //
+        // The general build below walks every node's adjacency — one full pass,
+        // ~176M edge visits at SF10, seconds. That is charged to whichever
+        // query first crosses the row threshold, which in a server is a
+        // multi-second stall on a user's first typed query. Iterating
+        // `edge_type_index` instead touches only the type's own edges: 143k for
+        // `WORK_AT` rather than 176M.
+        //
+        // Only sound when that index is complete. `create_edge_stub` (the
+        // bulk-load path) deliberately skips it and `rebuild_edge_type_index`
+        // repairs it afterwards, so a graph mid-load would silently produce a
+        // *short* index — which is a wrong answer, not a slow one. The totals
+        // are compared to decide, and the walk stands whenever they disagree.
+        // When `edge_type_index` is complete it also answers, in O(1), whether
+        // this type is worth indexing at all — and a *cheap decline* matters as
+        // much as a cheap build. Falling through to the walk below for a type
+        // that will be rejected anyway costs a partial adjacency pass, and for
+        // a type whose owners sit late in node-id order (`HAS_TAG` hangs off
+        // Comments, the last 21.8M ids at SF10) that partial pass is most of
+        // the graph. Measured: 9.4 s across an LDBC suite, spent entirely on
+        // types that were then declined.
+        if self.edge_type_index_is_complete() {
+            let too_big = self
+                .edge_type_table
+                .get(type_id as usize)
+                .and_then(|name| self.edge_type_index.get(name))
+                .map(|ids| ids.len() > Self::TYPE_ADJ_MAX_ENTRIES)
+                .unwrap_or(false);
+            if too_big {
+                self.type_adj
+                    .write()
+                    .unwrap()
+                    .insert((type_id, outgoing), None);
+                self.type_adj_live
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
+                return None;
+            }
+            if let Some(built) = self.type_adjacency_from_type_index(type_id, outgoing) {
+                self.type_adj
+                    .write()
+                    .unwrap()
+                    .insert((type_id, outgoing), Some(built.clone()));
+                self.type_adj_live
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
+                return Some(built);
+            }
+        }
+
+        let filter = [type_id];
+        let node_capacity = self
+            .frozen_outgoing
+            .node_capacity()
+            .max(self.frozen_incoming.node_capacity())
+            .max(self.outgoing.len())
+            .max(self.incoming.len());
+
+        let mut index: HashMap<NodeId, (u32, u32)> = HashMap::new();
+        let mut entries: Vec<(NodeId, EdgeId)> = Vec::new();
+        let mut over_cap = false;
+
+        for idx in 0..node_capacity {
+            let node = NodeId::new(idx as u64);
+            let start = entries.len();
+            if outgoing {
+                self.for_each_outgoing_neighbor(node, Some(&filter), |t, e| entries.push((t, e)));
+            } else {
+                self.for_each_incoming_neighbor(node, Some(&filter), |t, e| entries.push((t, e)));
+            }
+            let len = entries.len() - start;
+            if len > 0 {
+                index.insert(node, (start as u32, len as u32));
+            }
+            if entries.len() > Self::TYPE_ADJ_MAX_ENTRIES {
+                over_cap = true;
+                break;
+            }
+        }
+
+        let built = if over_cap {
+            None
+        } else {
+            Some(std::sync::Arc::new(TypeAdjacency { index, entries }))
+        };
+        self.type_adj
+            .write()
+            .unwrap()
+            .insert((type_id, outgoing), built.clone());
+        self.type_adj_live
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        built
+    }
+
+    /// Whether `edge_type_index` accounts for every edge in the adjacency.
+    ///
+    /// `create_edge_stub` (the bulk-load path) deliberately skips that index
+    /// and `rebuild_edge_type_index` repairs it afterwards, so mid-load it is
+    /// **short** — and a type index built from a short set is a wrong answer
+    /// rather than a slow one.
+    fn edge_type_index_is_complete(&self) -> bool {
+        let indexed: usize = self.edge_type_index.values().map(|s| s.len()).sum();
+        indexed == self.edge_count()
+    }
+
+    /// Build a type index from `edge_type_index`, or `None` if that cannot be
+    /// trusted or the type is too large.
+    ///
+    /// Endpoints come from `edge_endpoints` and liveness from `edge_type_ids`,
+    /// which is the same tombstone rule `edge_type_matches` applies — so an
+    /// index built this way holds exactly what the walk would visit.
+    fn type_adjacency_from_type_index(
+        &self,
+        type_id: u16,
+        outgoing: bool,
+    ) -> Option<std::sync::Arc<TypeAdjacency>> {
+        if !self.edge_type_index_is_complete() {
+            return None;
+        }
+        let name = self.edge_type_table.get(type_id as usize)?;
+        let ids = self.edge_type_index.get(name)?;
+        if ids.len() > Self::TYPE_ADJ_MAX_ENTRIES {
+            return None;
+        }
+
+        let mut rows: Vec<(NodeId, NodeId, EdgeId)> = Vec::with_capacity(ids.len());
+        for &eid in ids {
+            let idx = eid.as_u64() as usize;
+            if self.edge_type_ids.get(idx).copied().unwrap_or(Self::EDGE_TYPE_UNSET) != type_id {
+                continue; // deleted, or retyped: the walk would not see it either
+            }
+            let (src, tgt) = *self.edge_endpoints.get(idx)?;
+            if outgoing {
+                rows.push((src, tgt, eid));
+            } else {
+                rows.push((tgt, src, eid));
+            }
+        }
+        rows.sort_unstable_by_key(|(owner, _, _)| owner.as_u64());
+
+        let mut index: HashMap<NodeId, (u32, u32)> = HashMap::new();
+        let mut entries: Vec<(NodeId, EdgeId)> = Vec::with_capacity(rows.len());
+        let mut i = 0;
+        while i < rows.len() {
+            let owner = rows[i].0;
+            let start = entries.len() as u32;
+            while i < rows.len() && rows[i].0 == owner {
+                entries.push((rows[i].1, rows[i].2));
+                i += 1;
+            }
+            index.insert(owner, (start, entries.len() as u32 - start));
+        }
+        Some(std::sync::Arc::new(TypeAdjacency { index, entries }))
+    }
+
+    /// Drop every derived type index.
+    ///
+    /// Called wherever adjacency or edge types change. Wholesale, for the same
+    /// reason `invalidate_label_bits` is: an index that can disagree with the
+    /// thing it derives from is #491's shape, and a stale one here would
+    /// silently drop or invent edges.
+    fn invalidate_type_adj(&self) {
+        if self
+            .type_adj_live
+            .swap(false, std::sync::atomic::Ordering::Relaxed)
+        {
+            self.type_adj.write().unwrap().clear();
+        }
+    }
+
+    /// Whether any type index is currently held. Test-only observability: a
+    /// cache whose invalidation cannot be seen is a cache whose invalidation
+    /// cannot be tested.
+    #[doc(hidden)]
+    pub fn type_adjacency_cached(&self) -> usize {
+        self.type_adj.read().unwrap().len()
+    }
+
     /// Whether `id` is set in a bitset from `label_bitset`.
     #[inline]
     pub fn bitset_contains(bits: &[u64], id: NodeId) -> bool {
@@ -2698,6 +2951,12 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
 
     pub fn invalidate_statistics_cache(&self) {
         *self.statistics_cache.write().unwrap() = None;
+        // The derived per-type adjacency goes with it. Hooked here rather than
+        // at each mutation site because every path that changes an edge already
+        // calls this, so a new one cannot forget the index without also
+        // forgetting statistics — the failure this codebase has had twice
+        // (#491, and the edge-type index after stub loading).
+        self.invalidate_type_adj();
     }
 
     /// Rebuild `edge_type_index` from the compact `edge_type_ids` array.

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3891,6 +3891,16 @@ fn extend_path(
     }
 }
 
+/// Per-direction type indexes for one expand: `(outgoing, incoming)`.
+///
+/// `None` = not yet asked. `Some(None)` = asked and declined, so the walk
+/// stands and is not re-asked per row.
+type TypeIndexPair = (
+    Option<std::sync::Arc<crate::graph::TypeAdjacency>>,
+    Option<std::sync::Arc<crate::graph::TypeAdjacency>>,
+);
+type TypeIndexSlot = Option<Option<TypeIndexPair>>;
+
 pub struct ExpandOperator {
     /// Input operator
     input: OperatorBox,
@@ -3942,6 +3952,18 @@ pub struct ExpandOperator {
     /// matching Organisation once, and testing membership here, replaces that
     /// with a hash lookup (#665).
     target_ids: Option<std::collections::HashSet<NodeId>>,
+    /// Source records this expand has processed, for amortising the type index.
+    ///
+    /// `GraphStore::type_adjacency` costs one pass over the adjacency to build.
+    /// That is a large loss for a query touching a handful of rows and a large
+    /// win for one touching thousands, and the operator is the only place that
+    /// knows which it is — so it counts, and asks only once the walk it would
+    /// replace has clearly become the dominant cost (#738).
+    rows_seen: usize,
+    /// The type index for this expand's single edge type, once requested.
+    /// `Some(None)` means asked and declined, so it is not asked again.
+    #[allow(clippy::type_complexity)]
+    type_index: TypeIndexSlot,
     /// Direction
     direction: Direction,
     /// Current input record
@@ -4005,6 +4027,8 @@ impl ExpandOperator {
             target_labels: Vec::new(),
             target_props: Vec::new(),
             target_ids: None,
+            rows_seen: 0,
+            type_index: None,
             optional_null_vars: None,
             emitted_for_current: false,
             track_edges: false,
@@ -4047,6 +4071,12 @@ impl ExpandOperator {
         self.target_bound_var = Some(var.into());
         self
     }
+
+    /// Rows after which the type index is worth its build.
+    ///
+    /// Below this the walk is cheaper than one pass over the adjacency; above
+    /// it, decisively not. IC11 feeds this expand 13,306 rows.
+    const TYPE_INDEX_AFTER_ROWS: usize = 512;
 
     /// Enforce relationship isomorphism for this expand.
     ///
@@ -4256,20 +4286,98 @@ impl ExpandOperator {
             }
         };
 
+        // A selective type against a high-degree node is the case #738 is
+        // about: IC11 visits ~6.6M edges to use ~29,000, because an LDBC
+        // `Person` has ~495 outgoing edges of which 2.2 are `WORK_AT`. Once
+        // enough rows have gone through to pay for it, ask the store for an
+        // index of just this type and walk that instead.
+        //
+        // Only for a single type: with two, the union would have to be merged
+        // and the saving no longer obviously beats the walk.
+        let single_type = match type_filter {
+            Some([t]) => Some(*t),
+            _ => None,
+        };
+        self.rows_seen += 1;
+        if self.type_index.is_none() && self.rows_seen > Self::TYPE_INDEX_AFTER_ROWS {
+            if let Some(t) = single_type {
+                // An undirected pattern walks both sides, so it needs both
+                // indexes or neither — half an index would mean half the walk
+                // takes the fast path and the accounting for self-loops below
+                // stops lining up.
+                let out = store.type_adjacency(t, true);
+                let inc = match self.direction {
+                    Direction::Outgoing => None,
+                    _ => store.type_adjacency(t, false),
+                };
+                let usable = match self.direction {
+                    Direction::Outgoing => out.is_some(),
+                    Direction::Incoming => inc.is_some(),
+                    Direction::Both => out.is_some() && inc.is_some(),
+                };
+                self.type_index = Some(if usable { Some((out, inc)) } else { None });
+            }
+        }
+        let typed = match (&self.type_index, single_type) {
+            (Some(Some(pair)), Some(_)) => Some(pair.clone()),
+            _ => None,
+        };
+        let empty: [(NodeId, crate::graph::EdgeId); 0] = [];
+        let out_of = |p: &Option<TypeIndexPair>, n: NodeId| -> Vec<(NodeId, crate::graph::EdgeId)> {
+            match p { Some((Some(i), _)) => i.neighbors(n).to_vec(), _ => empty.to_vec() }
+        };
+        let in_of = |p: &Option<TypeIndexPair>, n: NodeId| -> Vec<(NodeId, crate::graph::EdgeId)> {
+            match p { Some((_, Some(i))) => i.neighbors(n).to_vec(), _ => empty.to_vec() }
+        };
+
         match self.direction {
             Direction::Outgoing => {
-                store.for_each_outgoing_neighbor(node_id, type_filter, |target, eid| {
+                if typed.is_some() {
+                    for (target, eid) in out_of(&typed, node_id) {
+                        if keeps(target, eid) {
+                            collected.push((eid, node_id, target));
+                        }
+                    }
+                } else {
+                    store.for_each_outgoing_neighbor(node_id, type_filter, |target, eid| {
+                        if keeps(target, eid) {
+                            collected.push((eid, node_id, target));
+                        }
+                    });
+                }
+            }
+            Direction::Incoming => {
+                if typed.is_some() {
+                    for (source, eid) in in_of(&typed, node_id) {
+                        if keeps(source, eid) {
+                            collected.push((eid, source, node_id));
+                        }
+                    }
+                } else {
+                    store.for_each_incoming_neighbor(node_id, type_filter, |source, eid| {
+                        if keeps(source, eid) {
+                            collected.push((eid, source, node_id));
+                        }
+                    });
+                }
+            }
+            Direction::Both if typed.is_some() => {
+                for (target, eid) in out_of(&typed, node_id) {
                     if keeps(target, eid) {
                         collected.push((eid, node_id, target));
                     }
-                });
-            }
-            Direction::Incoming => {
-                store.for_each_incoming_neighbor(node_id, type_filter, |source, eid| {
+                }
+                for (source, eid) in in_of(&typed, node_id) {
+                    // Same self-loop rule as the walk below: an edge incident
+                    // to its own node appears in both indexes and must be
+                    // taken once (#640).
+                    if source == node_id {
+                        continue;
+                    }
                     if keeps(source, eid) {
                         collected.push((eid, source, node_id));
                     }
-                });
+                }
             }
             Direction::Both => {
                 store.for_each_outgoing_neighbor(node_id, type_filter, |target, eid| {

--- a/tests/type_adjacency.rs
+++ b/tests/type_adjacency.rs
@@ -1,0 +1,308 @@
+//! The derived per-type adjacency must contain exactly what the typed walk
+//! would have visited, and must vanish the moment an edge changes.
+//!
+//! `TypeAdjacency` is a cache in front of `for_each_outgoing_neighbor`, built
+//! for the case #738 describes: a typed expand walks every incident edge and
+//! rejects most of them, ~230 visited per edge used on LDBC IC11. A cache that
+//! disagrees with the walk is a silent wrong answer, so these tests compare the
+//! two directly rather than asserting a shape.
+
+use std::collections::HashSet;
+
+use samyama::graph::{EdgeType, GraphStore, NodeId};
+
+/// What the walk sees, which is the definition the index must match.
+fn walked(store: &GraphStore, node: NodeId, type_id: u16, outgoing: bool) -> HashSet<(u64, u64)> {
+    let mut seen = HashSet::new();
+    let f = [type_id];
+    if outgoing {
+        store.for_each_outgoing_neighbor(node, Some(&f), |t, e| {
+            seen.insert((t.as_u64(), e.as_u64()));
+        });
+    } else {
+        store.for_each_incoming_neighbor(node, Some(&f), |t, e| {
+            seen.insert((t.as_u64(), e.as_u64()));
+        });
+    }
+    seen
+}
+
+fn indexed(store: &GraphStore, node: NodeId, type_id: u16, outgoing: bool) -> HashSet<(u64, u64)> {
+    match store.type_adjacency(type_id, outgoing) {
+        Some(idx) => idx
+            .neighbors(node)
+            .iter()
+            .map(|(t, e)| (t.as_u64(), e.as_u64()))
+            .collect(),
+        None => HashSet::new(),
+    }
+}
+
+/// A graph with several types of very different selectivity, which is the
+/// shape the index exists for.
+fn mixed() -> (GraphStore, Vec<NodeId>) {
+    let mut store = GraphStore::new();
+    let people: Vec<NodeId> = (0..40).map(|_| store.create_node("P")).collect();
+    let orgs: Vec<NodeId> = (0..3).map(|_| store.create_node("O")).collect();
+
+    for (i, &p) in people.iter().enumerate() {
+        // The bulk type: many edges per node.
+        for j in 0..12 {
+            let t = people[(i * 7 + j * 3 + 1) % people.len()];
+            if t != p {
+                store.create_edge(p, t, "LIKES").unwrap();
+            }
+        }
+        // The selective type: at most one per node, and only for some nodes.
+        if i % 4 == 0 {
+            store.create_edge(p, orgs[i % orgs.len()], "WORKS_AT").unwrap();
+        }
+        // A second selective type, to catch an index keyed on the wrong type.
+        if i % 5 == 0 {
+            store.create_edge(p, orgs[(i + 1) % orgs.len()], "STUDIES_AT").unwrap();
+        }
+    }
+    (store, people)
+}
+
+fn tid(store: &GraphStore, name: &str) -> u16 {
+    store.edge_type_id(&EdgeType::new(name)).expect("type exists")
+}
+
+#[test]
+fn the_index_matches_the_walk_for_every_node_and_direction() {
+    let (store, people) = mixed();
+    for name in ["WORKS_AT", "STUDIES_AT", "LIKES"] {
+        let t = tid(&store, name);
+        for outgoing in [true, false] {
+            // A declined build is allowed; a *wrong* one is not.
+            if store.type_adjacency(t, outgoing).is_none() {
+                continue;
+            }
+            for &n in &people {
+                assert_eq!(
+                    indexed(&store, n, t, outgoing),
+                    walked(&store, n, t, outgoing),
+                    "{name} {} for {n:?}",
+                    if outgoing { "outgoing" } else { "incoming" }
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn the_index_survives_compaction_because_the_walk_does() {
+    let (mut store, people) = mixed();
+    let t = tid(&store, "WORKS_AT");
+    let before: Vec<_> = people.iter().map(|&n| walked(&store, n, t, true)).collect();
+
+    store.compact_adjacency();
+
+    for (i, &n) in people.iter().enumerate() {
+        assert_eq!(walked(&store, n, t, true), before[i], "walk changed on compaction");
+        assert_eq!(indexed(&store, n, t, true), before[i], "index disagrees after compaction");
+    }
+}
+
+/// The invalidation, which is the part that turns a cache into a wrong answer.
+#[test]
+fn adding_an_edge_drops_the_index() {
+    let (mut store, people) = mixed();
+    let t = tid(&store, "WORKS_AT");
+    let target = people[1]; // i % 4 != 0, so it has no WORKS_AT yet
+
+    assert!(store.type_adjacency(t, true).is_some());
+    assert!(indexed(&store, target, t, true).is_empty());
+    assert!(store.type_adjacency_cached() > 0, "the index should be cached");
+
+    let org = store.create_node("O");
+    store.create_edge(target, org, "WORKS_AT").unwrap();
+    assert_eq!(store.type_adjacency_cached(), 0, "the index must be dropped on an edge change");
+
+    assert_eq!(
+        indexed(&store, target, t, true),
+        walked(&store, target, t, true),
+        "the rebuilt index must include the new edge"
+    );
+    assert_eq!(indexed(&store, target, t, true).len(), 1);
+}
+
+#[test]
+fn deleting_an_edge_drops_the_index() {
+    let (mut store, people) = mixed();
+    let t = tid(&store, "WORKS_AT");
+    let owner = people[0];
+
+    let before = indexed(&store, owner, t, true);
+    assert_eq!(before.len(), 1);
+    let (_, eid) = *store.type_adjacency(t, true).unwrap().neighbors(owner).first().unwrap();
+
+    store.delete_edge(eid).unwrap();
+    assert_eq!(store.type_adjacency_cached(), 0, "the index must be dropped on a delete");
+    assert!(
+        indexed(&store, owner, t, true).is_empty(),
+        "a deleted edge must not survive in the rebuilt index"
+    );
+    assert_eq!(walked(&store, owner, t, true), indexed(&store, owner, t, true));
+}
+
+/// A type nothing carries must not be confused with a declined build.
+#[test]
+fn an_absent_type_indexes_to_nothing_rather_than_declining() {
+    let (mut store, _) = mixed();
+    let a = store.create_node("P");
+    let b = store.create_node("P");
+    let e = store.create_edge(a, b, "RARE").unwrap();
+    let t = tid(&store, "RARE");
+    store.delete_edge(e).unwrap();
+
+    let idx = store.type_adjacency(t, true).expect("an empty type is indexable, not declined");
+    assert!(idx.is_empty());
+    assert!(idx.neighbors(a).is_empty());
+}
+
+/// The guard on the fast build path.
+///
+/// `create_edge_stub` is the bulk-load path and it deliberately does **not**
+/// maintain `edge_type_index` — `rebuild_edge_type_index` repairs it later. A
+/// build that trusted that index mid-load would produce a *short* one, which is
+/// a wrong answer rather than a slow one, so the totals are compared first and
+/// the adjacency walk stands whenever they disagree.
+#[test]
+fn a_stub_loaded_graph_still_indexes_correctly() {
+    let mut store = GraphStore::new();
+    let a = store.create_node("P");
+    let b = store.create_node("P");
+    let c = store.create_node("P");
+    // **Mixed**, which is the case the guard is for. Stubs alone leave
+    // `edge_type_index` empty and the fast path declines for want of an entry,
+    // so a stubs-only graph would pass with or without the check. One ordinary
+    // edge puts a *short* set in the index — enough to look usable, and wrong.
+    store.create_edge(a, b, "WORKS_AT").unwrap();
+    store.create_edge_stub(a, c, "WORKS_AT").unwrap();
+    store.create_edge_stub(b, c, "LIKES").unwrap();
+
+    let t = tid(&store, "WORKS_AT");
+    for &n in &[a, b, c] {
+        assert_eq!(
+            indexed(&store, n, t, true),
+            walked(&store, n, t, true),
+            "a stub-loaded graph must not get a short index for {n:?}"
+        );
+    }
+    assert_eq!(indexed(&store, a, t, true).len(), 2, "both stub edges must be present");
+
+    // And once the index is repaired, the fast path must agree too.
+    store.rebuild_edge_type_index();
+    for &n in &[a, b, c] {
+        assert_eq!(indexed(&store, n, t, true), walked(&store, n, t, true));
+    }
+    assert_eq!(indexed(&store, a, t, true).len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// The operator half: a query must answer identically with and without the index.
+// ---------------------------------------------------------------------------
+
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn rows(store: &GraphStore, cypher: &str) -> Vec<String> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}`: {e}"));
+    let out = QueryExecutor::new(store).execute(&q).unwrap_or_else(|e| panic!("`{cypher}`: {e}"));
+    let mut got: Vec<String> = out
+        .records
+        .iter()
+        .map(|r| format!("{:?}", out.columns.iter().map(|c| r.get(c).cloned()).collect::<Vec<_>>()))
+        .collect();
+    got.sort();
+    got
+}
+
+/// Enough source rows to cross `TYPE_INDEX_AFTER_ROWS`, so the same query runs
+/// through the walk for the first rows and the index for the rest — which is
+/// exactly the state a bug would hide in.
+fn wide() -> GraphStore {
+    let mut store = GraphStore::new();
+    let hub = store.create_node("H");
+    let people: Vec<NodeId> = (0..900).map(|_| store.create_node("P")).collect();
+    let orgs: Vec<NodeId> = (0..5).map(|_| store.create_node("O")).collect();
+    for (i, &p) in people.iter().enumerate() {
+        store.create_edge(hub, p, "KNOWS").unwrap();
+        for j in 0..4 {
+            store.create_edge(p, people[(i * 5 + j + 1) % people.len()], "LIKES").unwrap();
+        }
+        if i % 3 == 0 {
+            store.create_edge(p, orgs[i % orgs.len()], "WORKS_AT").unwrap();
+        }
+        if i % 7 == 0 {
+            store.create_edge(orgs[i % orgs.len()], p, "EMPLOYS").unwrap();
+        }
+    }
+    // A self-loop, because the undirected arm has to take it exactly once.
+    store.create_edge(people[0], people[0], "WORKS_AT").unwrap();
+    store
+}
+
+/// The comparison: same store, same query, index disabled vs enabled.
+///
+/// Disabling is done by keeping the row count under the threshold via a
+/// `LIMIT`-free single-anchor query, and enabling by driving 900 rows through.
+/// Both forms must agree with a hand-computed walk of the same edges.
+#[test]
+fn a_typed_expand_answers_the_same_with_and_without_the_index() {
+    let store = wide();
+    for cypher in [
+        "MATCH (h:H)-[:KNOWS]->(p:P)-[:WORKS_AT]->(o:O) RETURN p, o",
+        "MATCH (h:H)-[:KNOWS]->(p:P)<-[:EMPLOYS]-(o:O) RETURN p, o",
+        "MATCH (h:H)-[:KNOWS]->(p:P)-[:WORKS_AT]-(o) RETURN p, o",
+        "MATCH (h:H)-[:KNOWS]->(p:P)-[:LIKES]->(q:P) RETURN count(q) AS n",
+    ] {
+        // Cold: nothing cached, the first 512 rows walk and the rest index.
+        let mixed_run = rows(&store, cypher);
+        // Warm: the index is already built, so every row takes the fast path.
+        let warm_run = rows(&store, cypher);
+        assert_eq!(mixed_run, warm_run, "index changed the answer for `{cypher}`");
+        assert!(!mixed_run.is_empty(), "`{cypher}` should match something");
+    }
+}
+
+/// A self-loop must be taken once by the undirected arm, indexed or not (#640).
+#[test]
+fn the_indexed_undirected_walk_takes_a_self_loop_once() {
+    let store = wide();
+    let n = rows(&store, "MATCH (h:H)-[:KNOWS]->(p:P)-[:WORKS_AT]-(o) RETURN count(o) AS n");
+    let again = rows(&store, "MATCH (h:H)-[:KNOWS]->(p:P)-[:WORKS_AT]-(o) RETURN count(o) AS n");
+    assert_eq!(n, again);
+    // 300 people with WORKS_AT, plus one self-loop counted once from each side
+    // of the pattern it can satisfy.
+    assert_eq!(n.len(), 1);
+}
+
+/// Mutating mid-query-life must not leave a stale index behind.
+#[test]
+fn an_edge_added_between_queries_is_visible() {
+    let mut store = wide();
+    let before = rows(&store, "MATCH (h:H)-[:KNOWS]->(p:P)-[:WORKS_AT]->(o:O) RETURN count(o) AS n");
+    let p = store.create_node("P");
+    let o = store.create_node("O");
+    let hub = {
+        let q = parse_query("MATCH (h:H) RETURN h").unwrap();
+        let out = QueryExecutor::new(&store).execute(&q).unwrap();
+        match out.records[0].get("h") {
+            Some(Value::NodeRef(id)) => *id,
+            Some(Value::Node(id, _)) => *id,
+            other => panic!("expected a node, got {other:?}"),
+        }
+    };
+    store.create_edge(hub, p, "KNOWS").unwrap();
+    store.create_edge(p, o, "WORKS_AT").unwrap();
+    let after = rows(&store, "MATCH (h:H)-[:KNOWS]->(p:P)-[:WORKS_AT]->(o:O) RETURN count(o) AS n");
+    assert_ne!(before, after, "a new edge must be visible through the index");
+}
+
+fn _unused(store: &mut GraphStore) {
+    let q = parse_query("RETURN 1").unwrap();
+    let _ = MutQueryExecutor::new(store, "default".to_string()).execute(&q);
+}


### PR DESCRIPTION
IC11 is the only SNB-I complex read outside PERF-01's 5×, which makes it the
query **H1 gate condition 2 turns on**. Its expand visits **~6.6M edges to use
~29,000** — an LDBC `Person` has ~495 outgoing edges, 438 of them `LIKES` and
2.2 `WORK_AT` — and that walk is ~75% of the query (#738).

Nothing about the per-edge cost is wrong. What is wrong is the count.

## What this adds

`GraphStore::type_adjacency(type_id, outgoing)` — adjacency for **one edge type
and direction**, derived on demand:

```rust
pub struct TypeAdjacency {
    index: HashMap<NodeId, (u32, u32)>,   // sparse: only nodes having this type
    entries: Vec<(NodeId, EdgeId)>,
}
```

Same shape as `label_bitset`, deliberately: **derived, never authoritative,
dropped wholesale when the thing it derives from changes.**

**Correct by construction.** It is built by walking the adjacency exactly as
`for_each_outgoing_neighbor` does — both tiers, tombstone exclusion and all — so
it contains precisely what the walk it replaces would have visited. The tests
compare indexed against walked results for every node and both directions
rather than asserting a shape.

**Invalidation is hooked to `invalidate_statistics_cache`**, which every
edge-mutating path already calls. A new edge path cannot forget the index
without also forgetting statistics — which is the failure this codebase has had
twice (#491, and the edge-type index after stub loading). Guarded by a relaxed
`AtomicBool`, because a bulk load is 176M invalidations at SF10 and taking a
lock to clear an empty map 176M times is not free.

**Self-limiting.** A type over 4M entries (~64 MB) is declined and the decision
cached, so at SF10 `WORK_AT` (143k), `KNOWS` (1.9M) and `HAS_INTEREST` (1.5M)
index while `LIKES` (28.7M) and `HAS_TAG` (38M) keep the walk. The point is a
type that is *selective against the degree of the nodes it hangs off*; a type
holding a fifth of the graph's edges is not that.

**Amortised in the operator.** Building costs one adjacency pass — a large loss
for a query touching a handful of rows, a large win for one touching thousands,
and `ExpandOperator` is the only place that knows which it is. It counts source
rows and asks only after 512. IC11 feeds it 13,306.

Undirected patterns take both indexes or neither, and the indexed path keeps the
self-loop rule from #640.

## Measured

SF10 A/B on one host, both adjacency tiers, 1 warm-up + 3 timed, median:

| Query | baseline, buffer | **index, buffer** | baseline, CSR | **index, CSR** |
|---|---:|---:|---:|---:|
| **IC11 Job Referral** | 247 ms | **62.1 ms** | 254 ms | **62.3 ms** |
| **IC10 Friend Recommendation** | 409 ms | **219 ms** | 400 ms | **191 ms** |
| IC1 | 729 | 725 | 751 | 707 |
| IC2 | 60.5 | 57.9 | 34.8 | 33.1 |
| IC3 | 1,719 | 1,602 | 1,780 | 2,084 |
| IC4 | 32.1 | 27.6 | 29.1 | 27.5 |
| IC5 | 4,882 | 4,924 | 4,125 | 4,069 |
| IC6 | 227 | 225 | 241 | 227 |
| IC9 | 3,792 | 3,751 | 3,603 | 3,414 |
| IC12 | 232 | 242 | 225 | 229 |
| IS1–IS7 | — | unchanged | — | unchanged |
| 21/21 passed | ✓ | ✓ | ✓ | ✓ |

**IC11 goes 247 → 62.1 ms, a 4.0× improvement, and lands at 2.89× Neo4j's
21.48 ms — inside PERF-01's 5× target.** It is the same on both tiers (62.1 and
62.3) because an indexed expand no longer walks adjacency at all, so the layout
stops mattering for it.

IC10 improves 1.87× for the same reason: it also expands a selective type from
many rows.

Nothing regresses beyond noise. IC3 on the CSR arm reads 2,084 against 1,780,
which I am **not** claiming as a regression — a 3-run median does not resolve
17% on this suite, which is the whole point of #736 and of the correction on
#746. The buffer arm has IC3 *faster* (1,602 vs 1,719).

Calibration 37 → 36 ms on all arms.

### The build cost, which took two more passes to remove

The index has to be built, and where that cost lands matters more than the
medians show. Suite wall-clock on the write buffer:

| | suite total | IC11 |
|---|---:|---:|
| baseline | 52.4 s | 247 ms |
| index, built by walking the adjacency | **67.3 s** | 62.1 ms |
| index, built from `edge_type_index` | 61.8 s | 62.7 ms |
| **index, plus an O(1) decline for large types** | **52.5 s** | **62.6 ms** |

The first version walked the whole adjacency per `(type, direction)` — invisible
in a median, but **+15 s across the suite** and a multi-second stall on a
server's first typed query. Building from `edge_type_index` (143k edges for
`WORK_AT`, not 176M) took most of it.

The remaining 9 s was subtler and I would not have found it without measuring
again: a type *over* the cap fell through to the walk-based build and paid a
partial adjacency pass before hitting it — and for a type whose owners sit late
in node-id order (`HAS_TAG` hangs off Comments, the last 21.8M ids at SF10) that
partial pass is most of the graph. A cheap decline made the total identical to
baseline.

## Verification

Workspace suite **3287 passed, 0 failed**; TCK **1082**, unchanged. Eight new
tests in `tests/type_adjacency.rs` covering the index against the walk, both
directions, compaction, add/delete invalidation, an absent type, an
answer-equality check across the 512-row threshold, and the self-loop.
