### PR TITLE
merge_frozen_segments: rebuild the frozen tier and release the retired ids (#740)

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -3356,6 +3356,122 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         true
     }
 
+    /// Rebuild the frozen tiers into a single segment, dropping dead entries.
+    ///
+    /// `compact_adjacency` only ever **appends** a segment, which leaves two
+    /// costs behind (#740):
+    ///
+    /// * A deleted edge's adjacency entry survives in an immutable segment,
+    ///   hidden only by the `EDGE_TYPE_UNSET` tombstone. #739 stopped that id
+    ///   being recycled — reuse overwrote the tombstone and resurrected the
+    ///   edge — at the price of **retiring the id permanently**, and
+    ///   `edge_type_ids` / `edge_endpoints` are indexed by id, so churn against
+    ///   a compacted store grows them without bound.
+    /// * `for_each_outgoing_neighbor` loops over every segment for every node,
+    ///   so a store compacted N times pays N offset lookups per node on every
+    ///   expand.
+    ///
+    /// This merges all segments plus the write buffer into one, keeping only
+    /// live edges, and then **releases the ids of the dropped ones** and lowers
+    /// the watermark — which is the part that makes the growth bounded rather
+    /// than merely slower.
+    ///
+    /// O(edges) and it allocates a whole new CSR, so it is an explicit
+    /// operation, not something a query triggers.
+    pub fn merge_frozen_segments(&mut self) {
+        if self.frozen_outgoing.is_empty() && self.frozen_incoming.is_empty() {
+            return;
+        }
+        self.invalidate_statistics_cache();
+
+        let capacity = self
+            .frozen_outgoing
+            .node_capacity()
+            .max(self.frozen_incoming.node_capacity())
+            .max(self.outgoing.len())
+            .max(self.incoming.len());
+
+        let live = |st: &Self, eid: EdgeId| -> bool {
+            st.edge_type_ids
+                .get(eid.as_u64() as usize)
+                .copied()
+                .unwrap_or(Self::EDGE_TYPE_UNSET)
+                != Self::EDGE_TYPE_UNSET
+        };
+
+        let mut out: Vec<Vec<(NodeId, EdgeId)>> = vec![Vec::new(); capacity];
+        let mut inc: Vec<Vec<(NodeId, EdgeId)>> = vec![Vec::new(); capacity];
+        let mut kept: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        for idx in 0..capacity {
+            for seg in &self.frozen_outgoing.segments {
+                for &(t, e) in seg.neighbors(idx) {
+                    if live(self, e) {
+                        out[idx].push((t, e));
+                        kept.insert(e.as_u64());
+                    }
+                }
+            }
+            if let Some(buf) = self.outgoing.get(idx) {
+                for &(t, e) in buf {
+                    if live(self, e) {
+                        out[idx].push((t, e));
+                        kept.insert(e.as_u64());
+                    }
+                }
+            }
+            for seg in &self.frozen_incoming.segments {
+                for &(sv, e) in seg.neighbors(idx) {
+                    if live(self, e) {
+                        inc[idx].push((sv, e));
+                    }
+                }
+            }
+            if let Some(buf) = self.incoming.get(idx) {
+                for &(sv, e) in buf {
+                    if live(self, e) {
+                        inc[idx].push((sv, e));
+                    }
+                }
+            }
+        }
+
+        let (fo, fi) = rayon::join(
+            || FrozenAdjacency::from_vec_of_vec(&out),
+            || FrozenAdjacency::from_vec_of_vec(&inc),
+        );
+        self.frozen_outgoing.clear();
+        self.frozen_incoming.clear();
+        self.frozen_outgoing.push(fo);
+        self.frozen_incoming.push(fi);
+        for v in &mut self.outgoing {
+            v.clear();
+            v.shrink_to_fit();
+        }
+        for v in &mut self.incoming {
+            v.clear();
+            v.shrink_to_fit();
+        }
+
+        // Nothing references a dead id any more, so it can be reused — which is
+        // what #739's watermark had to forbid. Ids below the new watermark that
+        // are *not* in `kept` are free.
+        for id in 0..self.next_edge_id {
+            if !kept.contains(&id)
+                && self
+                    .edge_type_ids
+                    .get(id as usize)
+                    .copied()
+                    .unwrap_or(Self::EDGE_TYPE_UNSET)
+                    == Self::EDGE_TYPE_UNSET
+            {
+                self.free_edge_ids.push(id);
+            }
+        }
+        self.free_edge_ids.sort_unstable();
+        self.free_edge_ids.dedup();
+        self.frozen_edge_watermark = 0;
+    }
+
     /// Compact the write buffer into the frozen CSR tier.
     /// After compaction, the write buffer is cleared and all adjacency data
     /// lives in the memory-efficient CSR format.

--- a/tests/frozen_adjacency_after_delete.rs
+++ b/tests/frozen_adjacency_after_delete.rs
@@ -67,3 +67,82 @@ fn a_deleted_edge_does_not_reappear_when_its_id_is_reused() {
     store.for_each_outgoing_neighbor(a, Some(&[r]), |t, _| typed.push(t));
     assert!(typed.is_empty(), "typed walk from `a` also sees the stale entry: {typed:?}");
 }
+
+/// Merging releases the ids that #739 had to retire.
+///
+/// `delete_edge` cannot touch an immutable frozen segment, so #739 stopped
+/// recycling a frozen edge's id — reuse overwrote the `EDGE_TYPE_UNSET`
+/// tombstone that was the only thing hiding its stale entry. That is correct
+/// and it leaks ids, and `edge_type_ids` / `edge_endpoints` are indexed by id.
+///
+/// `merge_frozen_segments` rebuilds the frozen tier from what is live, so
+/// nothing references the dead entry any more and the id is safe again (#740).
+#[test]
+fn merging_frozen_segments_makes_a_retired_id_reusable() {
+    let mut store = GraphStore::new();
+    let a = store.create_node("N");
+    let b = store.create_node("N");
+    let c = store.create_node("N");
+    let d = store.create_node("N");
+    let e = store.create_edge(a, b, "R").expect("edge");
+
+    store.compact_adjacency();
+    store.delete_edge(e).expect("delete");
+
+    // Before the merge: retired, exactly as #739 requires.
+    let fresh = store.create_edge(c, d, "R").expect("edge");
+    assert_ne!(fresh, e, "a frozen id must stay retired until the segment is rebuilt");
+
+    store.merge_frozen_segments();
+
+    // After: the stale entry is gone, so the id is safe to hand out again.
+    let recycled = store.create_edge(c, d, "R2").expect("edge");
+    assert_eq!(recycled, e, "merging should release the id it had to retire");
+
+    // And the point of all of it — `a` still has no edges.
+    let mut seen = Vec::new();
+    store.for_each_outgoing_neighbor(a, None, |t, _| seen.push(t));
+    assert!(seen.is_empty(), "the deleted edge must not reappear after a merge: {seen:?}");
+}
+
+/// A merge must not change any answer.
+#[test]
+fn merging_preserves_every_live_edge() {
+    let mut store = GraphStore::new();
+    let ns: Vec<_> = (0..30).map(|_| store.create_node("N")).collect();
+    let mut edges = Vec::new();
+    for (i, &n) in ns.iter().enumerate() {
+        for j in 1..4 {
+            edges.push(store.create_edge(n, ns[(i + j) % ns.len()], "R").unwrap());
+        }
+    }
+    store.compact_adjacency();
+    // A second segment, so the merge has something to merge.
+    for (i, &n) in ns.iter().enumerate().take(10) {
+        edges.push(store.create_edge(n, ns[(i + 7) % ns.len()], "S").unwrap());
+    }
+    store.compact_adjacency();
+    // Delete a scattering.
+    for e in edges.iter().step_by(7) {
+        let _ = store.delete_edge(*e);
+    }
+
+    let before: Vec<Vec<u64>> = ns
+        .iter()
+        .map(|&n| {
+            let mut v = Vec::new();
+            store.for_each_outgoing_neighbor(n, None, |t, _| v.push(t.as_u64()));
+            v.sort();
+            v
+        })
+        .collect();
+
+    store.merge_frozen_segments();
+
+    for (i, &n) in ns.iter().enumerate() {
+        let mut after = Vec::new();
+        store.for_each_outgoing_neighbor(n, None, |t, _| after.push(t.as_u64()));
+        after.sort();
+        assert_eq!(after, before[i], "merge changed the neighbours of {n:?}");
+    }
+}


### PR DESCRIPTION
`compact_adjacency` only ever **appends** a frozen segment. Nothing merges them
and nothing rebuilds one, which leaves two costs (#740).

**Ids leak.** `delete_edge` cannot touch an immutable segment, so a deleted
edge's adjacency entry survives, hidden only by the `EDGE_TYPE_UNSET` tombstone
in `edge_type_ids[id]`. #739 stopped that id being recycled — reuse overwrote
the tombstone and **resurrected the edge**, a node reporting a neighbour it had
no edge to — and paid for it by retiring the id permanently. `edge_type_ids` and
`edge_endpoints` are indexed by id, so churn against a compacted store grows
them without bound.

**Every walk pays for every segment.** `for_each_outgoing_neighbor` loops over
all segments per node, so a store compacted N times pays N offset lookups on
every expand, for every row.

## What this adds

`merge_frozen_segments()` rebuilds both frozen tiers into a single segment from
what is **live**, folding in the write buffer, then releases the ids of the
edges it dropped and lowers the watermark.

The id release is the part that matters. Without it this is a defragmentation
that makes walks cheaper; with it, the growth #739 introduced is bounded rather
than merely slower — which is the whole reason this issue exists.

O(edges), and it allocates a whole new CSR, so it is an **explicit** operation.
Nothing calls it automatically: a query triggering an O(edges) rebuild is a
pause nobody asked for, and choosing when to run it needs a dead-entry counter
that does not exist yet. That is deliberately left for whoever wires it into a
maintenance path.

## Tests

Two, added to `tests/frozen_adjacency_after_delete.rs` beside #739's:

- **`merging_frozen_segments_makes_a_retired_id_reusable`** — the id stays
  retired before the merge (as #739 requires) and is handed out again after,
  with the deleted edge still invisible.
- **`merging_preserves_every_live_edge`** — two segments, a scattering of
  deletes, and every node's neighbours identical before and after.

The first was checked against a build with the id release removed, and fails
there. My first attempt at that check **did not disable the release** — it cut
the sort and the watermark reset but left the push loop — and the test passed,
which would have left a hollow test in the suite. Worth saying because the
check is only worth as much as the disabling is real.

Workspace suite and TCK: in the PR discussion below.
