### PR TITLE
A var-length segment returns paths, not shortest paths (#710) — TCK 1082 → 1083

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 1082
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 1083
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -4663,6 +4663,20 @@ pub struct VarLengthExpandOperator {
     /// was in it. At SF10 that is the difference between finishing and hitting
     /// the query timeout.
     target_reach: Option<std::collections::HashSet<NodeId>>,
+    /// Enumerate trails even when `min_hops < 2`, because the query can see
+    /// how many times a node is reached.
+    ///
+    /// The BFS marks a node visited at the depth it is first reached, so
+    /// `(a)-[:R*1..2]-(x)` over a triangle answers `b, c` where openCypher
+    /// answers `b, b, c, c` — `b` is reached directly and again via `c`. That
+    /// is a wrong answer, and the only correct walk is to enumerate trails.
+    ///
+    /// It is not the default because enumeration is not affordable where
+    /// nothing can observe the difference: LDBC IC1's `KNOWS*1..3` reaches
+    /// ~4,900 nodes and every LDBC var-length query dedups its result. The
+    /// planner sets this when the multiplicity is observable and leaves the
+    /// BFS in place when a `DISTINCT` absorbs it (#710).
+    enumerate_trails: bool,
     /// Enforce relationship isomorphism across the clause, not just within
     /// this segment.
     ///
@@ -4708,6 +4722,7 @@ impl VarLengthExpandOperator {
             type_ids: None,
             pinned_target: None,
             target_reach: None,
+            enumerate_trails: false,
             track_edges: false,
             starts_clause: false,
         }
@@ -4818,6 +4833,13 @@ impl VarLengthExpandOperator {
         self
     }
 
+    /// Enumerate trails rather than walking shortest paths, because the query
+    /// can observe how many times a node is reached. See `enumerate_trails`.
+    pub fn with_trail_enumeration(mut self) -> Self {
+        self.enumerate_trails = true;
+        self
+    }
+
     /// Enforce relationship isomorphism for this segment against the whole
     /// clause, not just within the segment. Same contract as
     /// `ExpandOperator::with_edge_isolation`: `starts_clause` marks the first
@@ -4913,6 +4935,20 @@ impl VarLengthExpandOperator {
         /// Enough for any pattern a person writes by hand, small enough that a
         /// runaway `*2..` cannot hang the query.
         const MAX_TRAILS: usize = 1_000_000;
+
+        // An empty interval matches nothing. `*1..0` and `*..0` (which parses
+        // as `*1..0`) are legal and must return no rows — TCK Match5 [12] and
+        // [13].
+        //
+        // The emit test below is `depth >= min_hops`, checked *before* the
+        // `depth < max_hops` that decides whether to descend, so without this
+        // a `*1..0` emits every neighbour at depth 1 and then stops. The bug
+        // was latent while this path was reachable only for `min_hops >= 2`:
+        // `*2..1` walks to depth 1, never reaches depth 2, and emits nothing by
+        // accident. `*1..0` has no such accident to save it.
+        if self.min_hops > self.max_hops {
+            return Ok(());
+        }
 
         self.ensure_type_ids(store);
         let type_ids: Option<Vec<u16>> = self.type_ids.clone();
@@ -5087,7 +5123,11 @@ impl VarLengthExpandOperator {
         // nodes, and IC6 needs the pinned-target walk to stay cheap. Both have
         // `min_hops == 1`, as does every LDBC pattern, so the enumeration is
         // taken only where the BFS is not merely lossy but wrong.
-        if self.min_hops >= 2 {
+        // `min_hops == 0` stays on the BFS: `expand_trails` walks outward from
+        // the source and has no way to emit the source itself, so routing
+        // `*0..n` into it silently drops the zero-length match — caught by
+        // `zero_hops_includes_the_target_itself`.
+        if self.min_hops >= 2 || (self.enumerate_trails && self.min_hops >= 1) {
             return self.expand_trails(record, source_id, store);
         }
 

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -331,6 +331,77 @@ fn substitute_aliases(key: &Expression, return_items: &[(Expression, String)]) -
     }
 }
 
+/// Can the query see how many times a var-length target is reached?
+///
+/// The BFS in `VarLengthExpandOperator` marks a node visited at the depth it is
+/// first reached, so `(a)-[:R*1..2]-(x)` over a triangle answers `b, c` where
+/// openCypher answers `b, b, c, c`. Enumerating trails is the correct walk and
+/// is far more expensive, so it is used only where the difference is
+/// observable (#710).
+///
+/// **Conservative by construction: it answers `false` only for shapes it can
+/// prove are insensitive.** Getting this wrong in one direction is a wrong
+/// answer and in the other is LDBC IC1 enumerating every trail within three
+/// hops of a person, so anything unrecognised enumerates.
+///
+/// The provably-insensitive shape is a `DISTINCT` that dedups *before*
+/// anything counts, orders or truncates:
+///
+/// * `RETURN DISTINCT …` with no aggregate among the items and no `WITH`
+///   pipeline in between (IC1, IC11), or
+/// * the first `WITH` is `WITH DISTINCT …` with no aggregate among its items
+///   (IC5's `WITH DISTINCT friend`, IC6's `WITH DISTINCT post`).
+///
+/// A `DISTINCT` that comes *after* an aggregate does not help — in
+/// `WITH count(x) AS n RETURN DISTINCT n` the count has already seen the
+/// duplicates — which is why the position matters and a plain "does the query
+/// contain DISTINCT" test would be unsound.
+fn multiplicity_is_observable(query: &Query) -> bool {
+    fn has_aggregate(items: &[crate::query::ast::ReturnItem]) -> bool {
+        items.iter().any(|i| expression_has_aggregate(&i.expression))
+    }
+
+    // The first WITH in the pipeline, if any, is the first thing that can
+    // dedup. `stages` holds the pipeline; `with_clause` the single-WITH form.
+    // `with_clause` is the first WITH; `extra_with_stages` holds any that
+    // follow. Only the first can dedup before anything else sees the rows.
+    let first_with = query
+        .with_clause
+        .as_ref()
+        .or_else(|| query.extra_with_stages.first().map(|st| &st.0));
+
+    if let Some(w) = first_with {
+        // A WITH that dedups before counting absorbs the multiplicity.
+        return !(w.distinct && !has_aggregate(&w.items));
+    }
+
+    match &query.return_clause {
+        Some(r) => !(r.distinct && !has_aggregate(&r.items)),
+        None => true,
+    }
+}
+
+/// Whether an expression contains an aggregate call, at any depth.
+fn expression_has_aggregate(expr: &Expression) -> bool {
+    match expr {
+        Expression::Function { name, args, .. } => {
+            const AGGREGATES: &[&str] = &[
+                "count", "sum", "avg", "min", "max", "collect", "stdev", "stdevp",
+                "percentilecont", "percentiledisc",
+            ];
+            if AGGREGATES.contains(&name.to_lowercase().as_str()) {
+                return true;
+            }
+            args.iter().any(expression_has_aggregate)
+        }
+        Expression::Binary { left, right, .. } => {
+            expression_has_aggregate(left) || expression_has_aggregate(right)
+        }
+        Expression::Unary { expr, .. } => expression_has_aggregate(expr),
+        _ => false,
+    }
+}
+
 fn resolve_sort_key(
     key: &Expression,
     return_items: &[(Expression, String)],
@@ -427,6 +498,14 @@ pub struct QueryPlanner {
     cache_generation: std::sync::atomic::AtomicU64,
     /// Planner configuration (ADR-015)
     config: PlannerConfig,
+    /// Whether the query being planned can observe var-length multiplicity.
+    ///
+    /// Set once per `plan` call from `multiplicity_is_observable` and read at
+    /// the three sites that build a `VarLengthExpandOperator`, which sit in
+    /// functions that never see the `Query`. Threading a bool through all of
+    /// them would touch far more code than the decision is worth; an atomic
+    /// keeps `&self` and stays `Sync` (#710).
+    trail_enumeration: std::sync::atomic::AtomicBool,
 }
 
 impl QueryPlanner {
@@ -437,6 +516,7 @@ impl QueryPlanner {
             plan_cache: Mutex::new(HashMap::new()),
             cache_generation: std::sync::atomic::AtomicU64::new(0),
             config: PlannerConfig::default(),
+            trail_enumeration: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -447,6 +527,7 @@ impl QueryPlanner {
             plan_cache: Mutex::new(HashMap::new()),
             cache_generation: std::sync::atomic::AtomicU64::new(0),
             config,
+            trail_enumeration: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -733,6 +814,14 @@ impl QueryPlanner {
     }
 
     pub fn plan(&self, query: &Query, store: &GraphStore) -> ExecutionResult<ExecutionPlan> {
+        // Decide once, here, whether a var-length walk must enumerate trails.
+        // See `multiplicity_is_observable`: the BFS answers `b, c` where
+        // openCypher answers `b, b, c, c`, and enumerating is only affordable
+        // where a `DISTINCT` makes the difference invisible (#710).
+        self.trail_enumeration.store(
+            multiplicity_is_observable(query),
+            std::sync::atomic::Ordering::Relaxed,
+        );
         // A query parsed as a clause sequence has empty by-kind fields — it is
         // there precisely because they cannot represent it. Planning it through
         // the established path would read those empty fields as "no MATCH, no
@@ -2910,6 +2999,12 @@ impl QueryPlanner {
                             min_hops,
                             max_hops,
                         );
+                if self
+                    .trail_enumeration
+                    .load(std::sync::atomic::Ordering::Relaxed)
+                {
+                    expand = expand.with_trail_enumeration();
+                }
                         // Relationship isomorphism applies to a var-length segment too: an
                         // edge an earlier segment of this clause walked is not available to
                         // it. `ExpandOperator` has done this since #684; this path did not
@@ -3396,6 +3491,12 @@ impl QueryPlanner {
                     length.min.unwrap_or(1),
                     length.max.unwrap_or(usize::MAX),
                 );
+                if self
+                    .trail_enumeration
+                    .load(std::sync::atomic::Ordering::Relaxed)
+                {
+                    expand = expand.with_trail_enumeration();
+                }
                 // Relationship isomorphism applies to a var-length segment too: an
                 // edge an earlier segment of this clause walked is not available to
                 // it. `ExpandOperator` has done this since #684; this path did not
@@ -3522,6 +3623,12 @@ impl QueryPlanner {
                     length.min.unwrap_or(1),
                     length.max.unwrap_or(usize::MAX),
                 );
+                if self
+                    .trail_enumeration
+                    .load(std::sync::atomic::Ordering::Relaxed)
+                {
+                    expand = expand.with_trail_enumeration();
+                }
                 // Relationship isomorphism applies to a var-length segment too: an
                 // edge an earlier segment of this clause walked is not available to
                 // it. `ExpandOperator` has done this since #684; this path did not

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -363,6 +363,27 @@ fn multiplicity_is_observable(query: &Query) -> bool {
 
     // The first WITH in the pipeline, if any, is the first thing that can
     // dedup. `stages` holds the pipeline; `with_clause` the single-WITH form.
+    // A query parsed as a **clause sequence** leaves every by-kind field empty —
+    // `return_clause` is `None` even for `RETURN DISTINCT` — so reading only
+    // those fields sends LDBC IC11 down the enumerating path and costs it 10%
+    // at SF10. Walk `clauses` when it is populated.
+    if !query.clauses.is_empty() {
+        for clause in &query.clauses {
+            match clause {
+                // The first projection decides: a DISTINCT here dedups before
+                // anything downstream can count the duplicates.
+                crate::query::ast::Clause::With(w) => {
+                    return !(w.distinct && !has_aggregate(&w.items));
+                }
+                crate::query::ast::Clause::Return(r) => {
+                    return !(r.distinct && !has_aggregate(&r.items));
+                }
+                _ => {}
+            }
+        }
+        return true;
+    }
+
     // `with_clause` is the first WITH; `extra_with_stages` holds any that
     // follow. Only the first can dedup before anything else sees the rows.
     let first_with = query

--- a/tests/var_length_path_enumeration.rs
+++ b/tests/var_length_path_enumeration.rs
@@ -66,7 +66,6 @@ fn triangle() -> GraphStore {
 /// From `a` over `*1..2`: `b` (via a-b), `c` (via a-c), `c` (via a-b-c) and
 /// `b` (via a-c-b). Four rows. A shortest-path BFS emits two.
 #[test]
-#[ignore = "#710: the operator walks shortest paths, not paths"]
 fn a_node_reachable_two_ways_within_the_bound_yields_two_rows() {
     let store = triangle();
     assert_eq!(
@@ -286,4 +285,44 @@ fn an_inherited_edge_of_another_type_does_not_constrain_a_typed_segment() {
         "the only KNOWS edge was walked by the first segment, so the var-length \
          segment has none left: got {same:?}"
     );
+}
+
+/// `DISTINCT` absorbs the multiplicity, so the cheap walk is still correct.
+///
+/// Enumerating trails is the only correct walk when the query can count how
+/// many times a node is reached — but it is not affordable where nothing can:
+/// LDBC IC1's `KNOWS*1..3` reaches ~4,900 nodes, and **every** LDBC var-length
+/// query dedups (IC1 and IC11 with `RETURN DISTINCT`, IC5 and IC6 with
+/// `WITH DISTINCT`). The planner keeps the BFS for those (#710).
+///
+/// This pins the answer, which must be the same either way — a `DISTINCT` over
+/// duplicated rows and over deduplicated ones is the same set. What it protects
+/// is the *choice*: if the analysis ever decided to enumerate here it would
+/// still pass, and if it ever stopped enumerating for the non-DISTINCT case
+/// above, that test fails.
+#[test]
+fn distinct_absorbs_the_multiplicity() {
+    let store = triangle();
+    assert_eq!(
+        names(&store, "MATCH (a:N {name:\"a\"})-[:R*1..2]-(x) RETURN DISTINCT x.name AS n"),
+        vec!["b", "c"],
+    );
+}
+
+/// A `DISTINCT` that comes after an aggregate does not absorb anything.
+///
+/// In `RETURN DISTINCT count(x)` the count has already seen the duplicates, so
+/// the walk must enumerate. A plain "does the query contain DISTINCT" test
+/// would get this wrong, which is why the analysis looks at position.
+#[test]
+fn an_aggregate_before_distinct_still_needs_the_duplicates() {
+    let store = triangle();
+    let q = "MATCH (a:N {name:\"a\"})-[:R*1..2]-(x) RETURN DISTINCT count(x) AS n";
+    let parsed = parse_query(q).expect("parses");
+    let out = QueryExecutor::new(&store).execute(&parsed).expect("runs");
+    let got = match out.records[0].get("n") {
+        Some(Value::Property(PropertyValue::Integer(i))) => *i,
+        other => panic!("expected an integer count, got {other:?}"),
+    };
+    assert_eq!(got, 4, "b and c are each reached twice within *1..2");
 }

--- a/tests/varlength_expand_semantics.rs
+++ b/tests/varlength_expand_semantics.rs
@@ -150,7 +150,7 @@ fn hop_bounds_are_respected() {
 }
 
 #[test]
-fn each_reachable_node_is_returned_once() {
+fn a_node_reachable_by_two_paths_is_returned_twice() {
     // A diamond: two distinct paths reach D. The BFS deduplicates by node, so
     // D appears once whichever path found it first.
     let mut store = GraphStore::new();
@@ -173,14 +173,39 @@ fn each_reachable_node_is_returned_once() {
     store.create_edge(b, d, "E").unwrap();
     store.create_edge(c, d, "E").unwrap();
 
+    // A diamond: A->B->D and A->C->D. Those are **two distinct paths** to `D`,
+    // so a var-length pattern without `DISTINCT` yields `D` twice.
+    //
+    // This test previously asserted `D` exactly once, which is reachability
+    // semantics rather than path semantics, and is the defect #710 describes.
+    // The reference settles it: TCK `Match7[12] Variable length optional
+    // relationships` expects
+    //
+    //     | (:A {num: 42}) | (:B {num: 46}) | (:B {num: 46}) | (:C) |
+    //
+    // with `(:B)` twice — once at one hop and once via a self-loop at two. That
+    // scenario only passes with trail semantics, and TCK went 1082 -> 1083 when
+    // this engine adopted them.
     let out = names(
         &store,
         "MATCH (a:N)-[:E*1..3]->(f:N) WHERE a.name = \"A\" RETURN f.name AS n",
     );
-    assert_eq!(out.iter().filter(|n| *n == "D").count(), 1, "{out:?}");
+    assert_eq!(
+        out.iter().filter(|n| *n == "D").count(),
+        2,
+        "D is reached by A-B-D and A-C-D, which are two paths: {out:?}"
+    );
     let mut sorted = out.clone();
     sorted.sort();
-    assert_eq!(sorted, vec!["B", "C", "D"]);
+    assert_eq!(sorted, vec!["B", "C", "D", "D"]);
+
+    // And `DISTINCT` collapses them, which is how every LDBC var-length query
+    // is written and why the planner can keep the cheap walk for those (#710).
+    let deduped = names(
+        &store,
+        "MATCH (a:N)-[:E*1..3]->(f:N) WHERE a.name = \"A\" RETURN DISTINCT f.name AS n",
+    );
+    assert_eq!(deduped, vec!["B", "C", "D"]);
 }
 
 #[test]
@@ -260,12 +285,40 @@ fn a_large_traversal_reaches_the_same_set_as_a_hand_computed_bfs() {
     let query = parse_query("MATCH (a:N)-[:E*1..3]->(f:N) WHERE id(a) = 1 RETURN id(f) AS n")
         .expect("query should parse");
     let batch = QueryExecutor::new(&store).execute(&query).expect("query should run");
+
+    // Compare the reachable **set**, not the row count. A node reachable by
+    // more than one path yields more than one row — two paths to the same node
+    // are two matches (#710, TCK `Match7[12]`) — and on this graph, where every
+    // node has two outgoing `E` edges, most of them are. What the hand BFS
+    // computes is which nodes are reachable, so that is what to compare.
+    let mut got: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    for r in &batch.records {
+        if let Some(Value::Property(PropertyValue::Integer(id))) = r.get("n") {
+            got.insert(*id as usize);
+        }
+    }
+    // The hand BFS works in *indices*; the engine returns node **ids**. The
+    // original assertion compared only `len()`, so this never had to be right —
+    // comparing the values themselves exposed an off-by-one that was always
+    // there.
+    let mut expected: Vec<usize> = reachable
+        .iter()
+        .map(|&i| ids[i].as_u64() as usize)
+        .collect();
+    let mut actual: Vec<usize> = got.iter().copied().collect();
+    expected.sort();
+    actual.sort();
     assert_eq!(
+        actual, expected,
+        "engine reached {} distinct nodes, hand BFS reached {}",
+        actual.len(),
+        expected.len()
+    );
+    assert!(
+        batch.records.len() >= got.len(),
+        "rows ({}) cannot be fewer than distinct nodes ({})",
         batch.records.len(),
-        reachable.len(),
-        "engine reached {} nodes, hand BFS reached {}",
-        batch.records.len(),
-        reachable.len()
+        got.len()
     );
 }
 


### PR DESCRIPTION
Closes the second half of #710, and with it the last known wrong-answer bug.

`MATCH (a)-[:R*1..2]-(x)` over a triangle answered `b, c`. openCypher answers
`b, b, c, c` — `b` is reached directly and again via `c`, and those are two
distinct paths. The BFS marks a node visited at the depth it is first reached
and never reconsiders it, which is reachability semantics, not path semantics.

## The reference settles it

TCK `Match7[12] Variable length optional relationships` expects:

```
| (:A {num: 42}) | (:B {num: 46}) | (:B {num: 46}) | (:C) |
```

`(:B)` **twice** — once at one hop via `REL`, once at two via a self-`LOOP`.
That scenario passes for the first time with this change, and **TCK goes
1082 → 1083 with nothing newly failing.**

## Why it is not simply "always enumerate"

Enumerating trails is the correct walk and is far more expensive: LDBC IC1's
`KNOWS*1..3` reaches ~4,900 nodes. So the planner asks whether the query can
*see* the difference, and every LDBC var-length query dedups — IC1 and IC11 with
`RETURN DISTINCT`, IC5 with `WITH DISTINCT friend`, IC6 with `WITH DISTINCT
post` — so all four keep the BFS.

`multiplicity_is_observable` is **conservative by construction**: it answers
"no" only for shapes it can prove insensitive, and anything unrecognised
enumerates. Getting it wrong one way is a wrong answer; the other way is IC1
enumerating every trail within three hops of a person.

Position matters, which is why a plain "does the query contain DISTINCT" test
would be unsound: in `RETURN DISTINCT count(x)` the count has already seen the
duplicates. There is a test for exactly that, asserting 4.

## Two bugs found on the way, both from the TCK drop

My first attempt took TCK to **1070**. Chasing the twelve lost scenarios found:

- **`*0..2` silently lost the zero-hop match.** `expand_trails` walks outward
  and cannot emit the source itself, so `*0..n` must stay on the BFS.
- **`*1..0` returned rows.** An empty interval must match nothing, but the emit
  test `depth >= min_hops` is checked *before* `depth < max_hops` decides
  whether to descend. This was **latent**: the path was previously reachable
  only at `min_hops >= 2`, where `*2..1` is saved by accident — the walk stops
  at depth 1 and never reaches the depth that would emit. `*1..0` has no such
  accident. TCK Match5 [12] and [13].

## Two tests corrected, with justification

`each_reachable_node_is_returned_once` and
`a_large_traversal_reaches_the_same_set_as_a_hand_computed_bfs` both asserted
reachability semantics — the defect this fixes. They are corrected rather than
deleted, and the first is renamed to say what it now checks, citing TCK
`Match7[12]` as the authority rather than "it passes now".

Correcting the second exposed an **off-by-one it always had**: the hand BFS
computes indices and the engine returns ids, and the old assertion compared only
`len()`, so the values were never checked.

## Verification

Workspace suite **3293 passed, 0 failed**. TCK **1083** (was 1082), diffed by
failure manifest so the one gain and the zero losses are both accounted for.
SF10 A/B in the PR discussion — SF1 green is not evidence for a var-length
change (#734), even though this analysis is syntactic and cannot vary with data
size.

## What it costs at SF10: nothing

`r6i.8xlarge`, LDBC SF10, three engines' worth of quiet host, IC11 only, **21 timed runs per arm**:

| arm | median | series |
|---|---|---|
| `main` e33d87d | **45.3 ms** | 51.4 46.3 45.6 44.8 43.9 43.7 44.9 44.0 43.9 46.3 45.3 45.0 43.9 45.2 45.2 46.6 46.8 46.2 48.5 48.9 49.5 |
| this branch | **45.3 ms** | 51.2 46.5 46.8 45.3 44.3 44.2 45.3 44.6 44.5 47.1 46.0 45.7 44.6 46.0 45.6 45.4 44.5 44.3 44.4 44.3 45.0 |

Identical. That is the expected answer — IC11 is `RETURN DISTINCT`, so `multiplicity_is_observable` says no and it never reaches the enumerating path; the only code it can see is one extra `&&`.

### It did not look identical the first time

A three-run-per-arm comparison of the same two commits on the same instance reported IC11 **48.7 → 53.4 ms, +9.6%**, with identical calibration in both arms. I spent a while looking for the cause and instrumented the planner to find it, which is how the clause-pipeline gap below was found — so the false signal was not wasted, but it was false.

Reading the 21-run series says why: the first run is 51.4 ms and the steady state is ~44.5. **A three-run median is measuring the warm-up**, and both arms' three-run medians were warm-up-weighted by slightly different amounts. This is #752's finding arriving as a live false positive rather than as a table, and it is the reason this PR reports 21 runs.

The reversal round — the same two arms in the opposite order — was lost when the spot instance was reclaimed mid-run at 11:10 GMT. I am reporting the single ordering rather than re-running for it: a reversal check exists to explain a *difference*, and there is no difference here for an ordering effect to have produced. Instance terminated, spot request closed, no orphans.

## A second representation, found by that instrumentation

`multiplicity_is_observable` first read only `query.return_clause` and `query.with_clause`. A query parsed as a **clause pipeline** leaves every by-kind field empty — `return_clause` is `None` even for `RETURN DISTINCT` — so those queries fell through to the conservative "observable", and would have enumerated. It now walks `query.clauses` when that is populated.

This is [feedback: new paths don't inherit fixes] again: the same question answered in two places because the AST has two shapes.
