### PR TITLE
The TCK value parser always advances: an unmatched ')' was a 36 GB OOM (#761)

### DIFF
--- a/examples/tck_runner.rs
+++ b/examples/tck_runner.rs
@@ -233,6 +233,21 @@ impl Cursor {
             Some('<') => self.parse_path(),
             _ => {
                 let word = self.take_while(|c| !matches!(c, ',' | ']' | '}' | ')' | ' '));
+                // A parser may decline to understand its input. It may not
+                // decline to *advance*.
+                //
+                // `(` is not a stop character, so `relativedelta(seconds=+13)`
+                // is consumed as far as the `)` and the `(` is swallowed into
+                // the word untracked. The scan then sits on an orphaned `)`,
+                // which is no collection's terminator, and every caller loop
+                // asks for another value at the same offset forever --
+                // `parse_list` pushing an empty item each time, which is
+                // 2.5 GB/s and an OOM-killed machine (#761).
+                if word.is_empty() {
+                    let c = self.peek();
+                    self.i += 1;
+                    return Tck::Opaque(c.map(String::from).unwrap_or_default());
+                }
                 match word.as_str() {
                     "null" => Tck::Null,
                     "true" => Tck::Bool(true),
@@ -301,6 +316,7 @@ impl Cursor {
         self.eat('[');
         let mut items = Vec::new();
         loop {
+            let before = self.i;
             self.skip_ws();
             if self.eat(']') || self.peek().is_none() {
                 break;
@@ -308,6 +324,14 @@ impl Cursor {
             items.push(self.parse());
             self.skip_ws();
             let _ = self.eat(',');
+            // Belt and braces over the progress guarantee in `parse`. This
+            // parser is a test *oracle*: it is fed whatever four engines
+            // choose to render, including things no one has seen yet. An
+            // unrecognised rendering must become a wrong answer, never a
+            // hang (#761).
+            if self.i == before {
+                break;
+            }
         }
         Tck::List(items)
     }
@@ -370,7 +394,15 @@ impl Cursor {
             match self.s[self.i] {
                 '<' => depth += 1,
                 '>' => {
-                    depth -= 1;
+                    // Saturating rather than `-= 1`. Unreachable today: this
+                    // function is only entered sitting on a `<`, so depth is
+                    // at least 1 before any `>` is seen. Hardened anyway
+                    // because a caller that stopped guaranteeing that would
+                    // wrap the counter in release and panic in debug, and the
+                    // guarantee is three call sites away. Deliberately without
+                    // a test -- there is no input that reaches it, and a test
+                    // that cannot fail is worse than none.
+                    depth = depth.saturating_sub(1);
                     if depth == 0 {
                         self.i += 1;
                         break;
@@ -426,6 +458,7 @@ impl Cursor {
         let mut m = BTreeMap::new();
         self.eat('{');
         loop {
+            let before = self.i;
             self.skip_ws();
             if self.eat('}') || self.peek().is_none() {
                 break;
@@ -444,6 +477,12 @@ impl Cursor {
             m.insert(key, val);
             self.skip_ws();
             let _ = self.eat(',');
+            // See `parse_list`. This loop is the one that hung without growing
+            // memory -- it re-inserts under the same empty key, so the map
+            // stays one entry wide while the process spins (#761).
+            if self.i == before {
+                break;
+            }
         }
         m
     }
@@ -1446,6 +1485,70 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The parser must terminate on input no one anticipated.
+    ///
+    /// Both strings below are real engine output, recorded during the
+    /// cross-engine run. Both are perfectly *balanced* -- which is why a
+    /// bracket-matching check finds nothing wrong with them. The imbalance is
+    /// in the scanner: `(` is not a stop character for a bare word, so
+    /// `relativedelta(seconds=+13` is swallowed whole and the parser is left
+    /// sitting on an orphaned `)` that terminates no collection.
+    ///
+    /// Before the fix these did not fail, they **hung**: `parse_list` pushed an
+    /// empty item per iteration at ~2.5 GB/s until systemd-oomd killed the
+    /// machine, and `parse_props` spun at 87% CPU for 27 minutes without
+    /// growing, because it re-inserts under the same empty key (#761).
+    ///
+    /// A `#[timeout]` attribute would be the natural way to pin this; Rust's
+    /// test harness has none, so these assert on the *value* and rely on the
+    /// suite's own wall-clock to catch a regression. That is weaker than I
+    /// would like and is the honest state of it.
+    #[test]
+    fn an_unmatched_paren_does_not_hang_the_parser() {
+        // FalkorDB, Temporal4 [12] — a Python repr leaking through the driver.
+        let v = parse_expected("[relativedelta(seconds=+13)]");
+        match v {
+            Tck::List(items) => assert!(
+                items.len() < 8,
+                "a two-token list must not expand without bound, got {} items",
+                items.len()
+            ),
+            other => panic!("expected a list, got {other:?}"),
+        }
+
+        // Samyama, WithOrderBy1 [33] — our own Debug output where a TCK
+        // temporal literal belongs (#689).
+        let v = parse_expected("(:A {date: DateTime(-1882656000000)})");
+        match v {
+            Tck::Node(labels, props) => {
+                assert_eq!(labels, vec!["A".to_string()]);
+                assert!(props.len() < 8, "got {} props", props.len());
+            }
+            other => panic!("expected a node, got {other:?}"),
+        }
+    }
+
+    /// Every bare `parse` advances, whatever it is handed.
+    ///
+    /// This is the invariant the two hangs violated, stated directly rather
+    /// than through a caller. A character the scanner has no rule for is
+    /// consumed and reported as `Opaque` — declining to understand is fine,
+    /// declining to move is not.
+    #[test]
+    fn parse_always_consumes_at_least_one_character() {
+        for input in [")", "}", "]", ",", ")x", "}}}", "%", "\u{1f600}"] {
+            let mut p = Cursor::new(input);
+            let before = p.i;
+            let _ = p.parse();
+            assert!(
+                p.i > before,
+                "`{input}` left the cursor at {before}; every caller loop then \
+                 asks again at the same offset, forever"
+            );
+        }
+    }
+
 
     /// A `Background:` block applies to every scenario in its file.
     ///


### PR DESCRIPTION
Closes #761.

## Impact

`tck_runner --judge actuals-falkordb.json` grew **~2.5 GB/s to ~36 GB in about fourteen seconds**, exhausted 46 GB of RAM plus swap, and systemd-oomd then killed the enclosing terminal scope — taking the desktop session down **four times in eleven minutes**. rustc was 0.7 GB per process at the same moment, so it was not the build.

## Cause

`parse`'s bare-word scan stops at `,`, `]`, `}`, `)` and space. **`(` is not in that set.** So `relativedelta(seconds=+13)` is consumed as far as the `)`, with the `(` swallowed into the word and never tracked, leaving the parser on an orphaned `)` that terminates no collection:

```rust
loop {
    self.skip_ws();
    if self.eat(']') || self.peek().is_none() { break; }  // ')' is neither
    items.push(self.parse());                             // Opaque("") — no progress
    self.skip_ws();
    let _ = self.eat(',');                                // no comma either
}
```

Same offset forever, one empty item pushed per iteration.

## Why it looked like two bugs

| engine | value | loop | symptom |
|---|---|---|---|
| falkordb | `[relativedelta(seconds=+13)]` | `parse_list` | **36 GB, OOM** |
| samyama | `(:A {date: DateTime(-1882656000000)})` | `parse_props` | **27 min at 87% CPU, flat memory** |
| neo4j | — | — | completes in <1 s |
| memgraph | — | — | completes in <1 s |

`parse_props` re-inserts under the same empty key, so the map never grows and the process merely spins. One infinite loop, two faces — and I initially read the spinning one as "the judge is slow" and moved on, which is what let the OOM recur.

Three things that look like the cause and are not: falkordb's actuals are the **smallest** input (873 KB vs 1.0/1.26 MB) and the **shallowest** (max nesting 22 vs 40+); all four engines carry the same 58-element list; and a bracket-balance check over every cell finds **nothing**. The strings are balanced. Only the scanner is.

## Fix

1. **`parse` consumes a character it has no rule for** and returns it as `Opaque`. A parser may decline to understand its input; it may not decline to advance.
2. **A no-progress break in `parse_list` and `parse_props` anyway.** This parser is a test *oracle*, fed whatever four engines choose to render, including things nobody has seen. (1) fixes both known inputs; (2) makes the next unrecognised rendering a wrong answer rather than a dead machine.
3. `consume_opaque_path` decremented a `usize` with no zero check. Unreachable today — the function is only entered sitting on a `<` — so it is hardened with `saturating_sub` and **deliberately left untested**, because no input reaches it and a test that cannot fail is worse than none. (I wrote that test first, traced the path, and deleted it.)

## How it was found

Porting the parser to Python with a no-progress assertion and running *that* over the recorded actuals, instead of re-running the Rust parser — which is the thing that kills the machine. It named both inputs in seconds. Bisecting the actuals under a memory-capped cgroup then confirmed the single offending scenario, `Temporal4 [12]`.

## Verification

Both guards removed, re-run under a 4 GB cap:

```
test tests::parse_always_consumes_at_least_one_character ... FAILED
```

and `an_unmatched_paren_does_not_hang_the_parser` **never reports at all** — the run hangs until the timeout kills cargo (exit 143). That is the bug reproducing.

With the fix, FalkorDB's judge — which had never completed — finishes in seconds at **1,113/1,249 = 89.1%**, exactly its previously recorded figure, which is a good check that the binary is otherwise unchanged.

- TCK: **1,083 of 1,244, unchanged.** This alters only how malformed input is handled.
- `cargo test --workspace --release`: exit 0, **3,295 passed, 0 failed**.

## Follow-up, not fixed here

The two renderings that trigger it are themselves defects — a Python `repr` leaking through `tck_render.py`'s fallback, and our own `Debug` output where a TCK temporal literal belongs (#689). They are *inputs* to this bug. The harness must survive an engine rendering something it does not recognise; that is what `Opaque` is for.