### PR TITLE
ORDER BY accepts ASCENDING and DESCENDING: +31 TCK scenarios (#758)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 2103
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 2134
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -219,7 +219,14 @@ star_item = { "*" }
 // ORDER BY items
 order_items = { order_item ~ ("," ~ order_item)* }
 order_item = { expression ~ order_direction? }
-order_direction = { ^"ASC" | ^"DESC" }
+// `ASCENDING` and `DESCENDING` are the long forms openCypher spells out, and
+// the TCK uses them throughout: 56 scenarios across WithOrderBy1/2/3 failed to
+// *parse* on them alone. `^"ASC"` matched the first three letters of
+// `ASCENDING` and left `ENDING` for the next rule, so the failure was a syntax
+// error rather than a wrong sort -- which is why it never showed up as a
+// wrong answer. Longest alternative first, and a trailing boundary so a bare
+// `ASC` cannot be clipped out of a longer word (#758).
+order_direction = @{ (^"ASCENDING" | ^"DESCENDING" | ^"ASC" | ^"DESC") ~ !(ASCII_ALPHANUMERIC | "_") }
 
 // Expressions
 // `NOT` is an expression-level prefix, not part of `term`. Inside `term` it bound to a

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -3206,6 +3206,54 @@ mod tests {
         assert!(ret.distinct);
     }
 
+    /// `ASCENDING` and `DESCENDING` are the long forms, and the grammar only
+    /// had the short ones.
+    ///
+    /// `^"ASC"` matched the first three letters of `ASCENDING` and left
+    /// `ENDING` unconsumed, so this was a **parse error**, not a mis-sort --
+    /// and a parse error is invisible to any test that checks sort order. The
+    /// openCypher TCK uses the long forms throughout: 56 scenarios across
+    /// WithOrderBy1, WithOrderBy2 and WithOrderBy3 failed on this one rule.
+    #[test]
+    fn order_by_accepts_the_long_direction_keywords() {
+        for (q, want_asc) in [
+            ("MATCH (n) RETURN n ORDER BY n.age ASCENDING", true),
+            ("MATCH (n) RETURN n ORDER BY n.age DESCENDING", false),
+            ("MATCH (n) RETURN n ORDER BY n.age ascending", true),
+            ("MATCH (n) RETURN n ORDER BY n.age descending", false),
+            ("MATCH (n) RETURN n ORDER BY n.age ASC", true),
+            ("MATCH (n) RETURN n ORDER BY n.age DESC", false),
+        ] {
+            let parsed = parse_query(q).unwrap_or_else(|e| panic!("`{q}` should parse: {e:?}"));
+            let items = &parsed
+                .order_by
+                .as_ref()
+                .unwrap_or_else(|| panic!("`{q}` should have an ORDER BY"))
+                .items;
+            assert_eq!(
+                items[0].ascending, want_asc,
+                "`{q}` sorts the wrong way -- parsing the keyword is not enough, \
+                 it has to reach `ascending`"
+            );
+        }
+    }
+
+    /// The long forms are only useful if they sort. A grammar that accepts
+    /// `DESCENDING` but hands the Rust side something it compares against
+    /// `\"DESC\"` would parse every scenario and silently sort all of them
+    /// ascending -- turning 56 parse errors into 56 wrong answers, which is
+    /// worse, because a parse error is loud.
+    #[test]
+    fn a_mixed_direction_list_keeps_each_direction_with_its_own_key() {
+        let q = "MATCH (n) RETURN n ORDER BY n.a DESCENDING, n.b ASCENDING, n.c DESC";
+        let parsed = parse_query(q).expect("should parse");
+        let items = &parsed.order_by.as_ref().expect("ORDER BY").items;
+        assert_eq!(items.len(), 3);
+        assert!(!items[0].ascending, "n.a DESCENDING");
+        assert!(items[1].ascending, "n.b ASCENDING");
+        assert!(!items[2].ascending, "n.c DESC");
+    }
+
     #[test]
     fn test_parse_order_by_desc() {
         let query = "MATCH (n:Person) RETURN n.name ORDER BY n.age DESC";


### PR DESCRIPTION
Closes #758.

## The defect

```
order_direction = { ^"ASC" | ^"DESC" }
```

openCypher spells the long forms too. `^"ASC"` matches the first three letters of `ASCENDING` and leaves `ENDING` for the next rule, so

```cypher
MATCH (a) WITH a, a.num AS num WITH a, num ORDER BY num ASCENDING LIMIT 3 RETURN a, num
```

is a **parse error, not a mis-sort** — which is exactly why no ordering test could ever have caught it. A test asserting that `DESCENDING` sorts descending never runs far enough to check the sort.

The Rust side had handled the long forms all along:

```rust
ascending = inner.as_str().eq_ignore_ascii_case("ASC") ||
           inner.as_str().eq_ignore_ascii_case("ASCENDING");
```

So someone implemented them and the grammar never let one through.

## Fix

```
order_direction = @{ (^"ASCENDING" | ^"DESCENDING" | ^"ASC" | ^"DESC") ~ !(ASCII_ALPHANUMERIC | "_") }
```

Longest alternative first, with a trailing word boundary so a bare `ASC` cannot be clipped out of a longer identifier.

## Measured

**TCK 2,103 → 2,134 (+31).** CI floor raised to 2,134.

Not +56, though 56 scenarios across `WithOrderBy1/2/3` were blocked on this rule. The other 25 parse now and fail on their own merits — 40 of the remaining `WithOrderBy*` failures expect a `SyntaxError` we do not raise, and the rest are temporal (#689). "Blocked by" and "fixed by" are different claims and only the first was 56.

These were invisible until #756 expanded `Scenario Outline` blocks: the sort direction is exactly the sort of thing an outline parameterises, so every one of the 56 sat inside the 274 outlines the harness had been skipping.

## Tests

Two. The second is the one that matters: a grammar that accepted `DESCENDING` but handed the Rust side something compared against `"DESC"` would parse every scenario and sort all of them **ascending** — turning 56 loud parse errors into 56 silent wrong answers, which is worse. `a_mixed_direction_list_keeps_each_direction_with_its_own_key` pins each key to its own direction.

`cargo test --workspace --release`: exit 0, **3,302 passed, 0 failed**.