### PR TITLE
A variable is one kind of entity, not two: +211 TCK scenarios (#765)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 2134
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 2345
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -35,6 +35,12 @@ pub enum ValidationError {
     MergeOnBoundVariable(String),
     MergeRelationshipWithNullProperty(String),
     VariableTypeConflict(String),
+    /// One variable bound to two different kinds of entity.
+    VariableKindConflict {
+        name: String,
+        first: &'static str,
+        second: &'static str,
+    },
     PatternInSetValue,
     /// An ORDER BY naming something the projection did not keep.
     OrderByUndefinedVariable(String),
@@ -69,6 +75,12 @@ impl std::fmt::Display for ValidationError {
                 f,
                 "a relationship pattern cannot be used as a value on the right of SET; \
                  patterns belong in MATCH, WHERE or a pattern comprehension"
+            ),
+            Self::VariableKindConflict { name, first, second } => write!(
+                f,
+                "`{name}` is bound to {first} and then to {second} in the same scope. A \
+                 variable names one entity, and an entity is a node, a relationship or a \
+                 path -- not two of them. Rename one of the two."
             ),
             Self::VariableTypeConflict(name) => write!(
                 f,
@@ -500,7 +512,153 @@ fn column_name_at(item: &ReturnItem, _idx: usize) -> Option<String> {
     })
 }
 
+
+/// What a pattern binds a variable to. A variable may be exactly one of these
+/// for as long as it stays in scope.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum EntityKind {
+    Node,
+    Relationship,
+    Path,
+}
+
+impl EntityKind {
+    fn noun(self) -> &'static str {
+        match self {
+            Self::Node => "a node",
+            Self::Relationship => "a relationship",
+            Self::Path => "a path",
+        }
+    }
+}
+
+/// Record `name` as binding `kind`, or report the clash.
+fn note_kind(
+    seen: &mut std::collections::HashMap<String, EntityKind>,
+    name: &Option<String>,
+    kind: EntityKind,
+) -> Result<(), ValidationError> {
+    let Some(name) = name else { return Ok(()) };
+    match seen.get(name) {
+        Some(prev) if *prev != kind => Err(ValidationError::VariableKindConflict {
+            name: name.clone(),
+            first: prev.noun(),
+            second: kind.noun(),
+        }),
+        _ => {
+            seen.insert(name.clone(), kind);
+            Ok(())
+        }
+    }
+}
+
+/// Collect the kinds one pattern binds.
+fn note_pattern_kinds(
+    seen: &mut std::collections::HashMap<String, EntityKind>,
+    pattern: &crate::query::ast::Pattern,
+) -> Result<(), ValidationError> {
+    for path in &pattern.paths {
+        note_kind(seen, &path.path_variable, EntityKind::Path)?;
+        note_kind(seen, &path.start.variable, EntityKind::Node)?;
+        for seg in &path.segments {
+            note_kind(seen, &seg.edge.variable, EntityKind::Relationship)?;
+            note_kind(seen, &seg.node.variable, EntityKind::Node)?;
+        }
+    }
+    Ok(())
+}
+
+/// A `WITH` opens a new scope. Variables it passes through *by name* keep the
+/// kind they had; anything it computes is a fresh value whose kind this check
+/// no longer claims to know, so it is dropped rather than guessed.
+fn carry_kinds_through_with(
+    seen: &std::collections::HashMap<String, EntityKind>,
+    wc: &crate::query::ast::WithClause,
+) -> std::collections::HashMap<String, EntityKind> {
+    let mut next = std::collections::HashMap::new();
+    for item in &wc.items {
+        if let Expression::Variable(v) = &item.expression {
+            if let Some(kind) = seen.get(v) {
+                // `WITH r AS x` carries the relationship under a new name.
+                next.insert(item.alias.clone().unwrap_or_else(|| v.clone()), *kind);
+            }
+        }
+    }
+    next
+}
+
+/// One variable may not be a node here and a relationship there.
+///
+/// openCypher binds a variable to an entity, and the entity has a kind: a node,
+/// a relationship, or a path. `MATCH (r), ()-[r]-()` asks for `r` to be both,
+/// which has no answer, and the TCK asserts a failure for every arrangement of
+/// it — same pattern, same clause, preceding clause, all three kinds against
+/// each other. **227 scenarios**, all of this one rule, and we returned rows
+/// for every one of them.
+///
+/// Rows, not an error: the second binding simply overwrote the first, so the
+/// query "succeeded" with an answer to a question that was never well-formed.
+///
+/// Only pattern bindings are examined. A `WITH` that recomputes a name is left
+/// alone -- see `carry_kinds_through_with` -- because the cost of being wrong
+/// here is rejecting a valid query, which is worse than accepting an invalid
+/// one (the rule this module opens with).
+fn validate_variable_kinds(query: &Query) -> Result<(), ValidationError> {
+    use crate::query::ast::Clause;
+    let mut seen: std::collections::HashMap<String, EntityKind> = std::collections::HashMap::new();
+
+    if !query.clauses.is_empty() {
+        for clause in &query.clauses {
+            match clause {
+                Clause::Match(mc) => note_pattern_kinds(&mut seen, &mc.pattern)?,
+                Clause::Create(cc) => note_pattern_kinds(&mut seen, &cc.pattern)?,
+                Clause::Merge(mc) => note_pattern_kinds(&mut seen, &mc.pattern)?,
+                Clause::With(wc) => seen = carry_kinds_through_with(&seen, wc),
+                _ => {}
+            }
+        }
+        return Ok(());
+    }
+
+    // The by-kind representation. A query parsed into these fields has an empty
+    // `clauses`, so both shapes have to be walked or the rule holds for half
+    // the queries -- the same split that cost #710 a day.
+    let upto = query.with_split_index.unwrap_or(query.match_clauses.len());
+    for mc in query.match_clauses.iter().take(upto) {
+        note_pattern_kinds(&mut seen, &mc.pattern)?;
+    }
+    if let Some(wc) = &query.with_clause {
+        seen = carry_kinds_through_with(&seen, wc);
+        for mc in query.match_clauses.iter().skip(upto) {
+            note_pattern_kinds(&mut seen, &mc.pattern)?;
+        }
+    }
+    for (wc, _, matches, _) in &query.extra_with_stages {
+        seen = carry_kinds_through_with(&seen, wc);
+        for mc in matches {
+            note_pattern_kinds(&mut seen, &mc.pattern)?;
+        }
+    }
+    // CREATE and MERGE come *after* the WITH stages, so their kinds must be
+    // noted after the scope resets -- walking them first reads them against a
+    // scope they never see. `MATCH (a)-[r]->(b) WITH a CREATE (r:X)` is legal:
+    // `r` is not carried through the WITH, so it is unbound and the CREATE
+    // makes a fresh node. Checked in the old order, that is Relationship vs
+    // Node and a **valid query gets rejected** -- the failure this module's
+    // opening comment warns is the worse one. Caught in review, not by a test,
+    // so `a_write_after_with_may_reuse_a_dropped_name` now pins it.
+    if let Some(cc) = &query.create_clause {
+        note_pattern_kinds(&mut seen, &cc.pattern)?;
+    }
+    if let Some(mc) = &query.merge_clause {
+        note_pattern_kinds(&mut seen, &mc.pattern)?;
+    }
+    Ok(())
+}
+
 pub fn validate(query: &Query) -> Result<(), ValidationError> {
+    validate_variable_kinds(query)?;
+
     // ---- ORDER BY scope after an aggregating or DISTINCT projection.
     if let Some(rc) = &query.return_clause {
         validate_order_by_scope(&rc.items, rc.distinct, query.order_by.as_ref())?;

--- a/tests/variable_kind_conflict.rs
+++ b/tests/variable_kind_conflict.rs
@@ -1,0 +1,119 @@
+//! One variable may not name a node here and a relationship there (#765).
+//!
+//! openCypher binds a variable to an *entity*, and an entity has a kind: a
+//! node, a relationship, or a path. `MATCH (r), ()-[r]-()` asks for `r` to be
+//! two of those at once, which has no answer, and the TCK asserts a failure
+//! for every arrangement of it — same pattern, same clause, preceding clause,
+//! all three kinds against each other.
+//!
+//! **227 scenarios**, all of this one rule, and we returned rows for every one
+//! of them. Rows, not an error: the second binding simply overwrote the first,
+//! so the query "succeeded" with an answer to a question that was never
+//! well-formed.
+//!
+//! The rule is scoped the same way #684 scoped relationship isomorphism, and
+//! for the same reason: getting the scope wrong in the *other* direction
+//! rejects valid queries, which `validate.rs` opens by calling the worse
+//! failure. So the negative cases below matter more than the positive ones.
+
+use samyama::query::parser::parse_query;
+
+fn rejected(cypher: &str) -> bool {
+    parse_query(cypher).is_err()
+}
+
+fn accepted(cypher: &str) -> bool {
+    parse_query(cypher).is_ok()
+}
+
+/// A node variable reused as a relationship in the same pattern.
+#[test]
+fn a_node_variable_may_not_be_a_relationship_in_the_same_pattern() {
+    assert!(rejected("MATCH (r), ()-[r]-() RETURN r"));
+    assert!(rejected("MATCH ()-[r]-(), (r) RETURN r"));
+}
+
+/// ...and across clauses in the same scope. The TCK spells this "in a
+/// preceding MATCH" and it is the larger half of the 227.
+#[test]
+fn the_conflict_is_caught_across_match_clauses() {
+    assert!(rejected("MATCH (r) MATCH ()-[r]-() RETURN r"));
+    assert!(rejected("MATCH ()-[r]-() MATCH (r) RETURN r"));
+}
+
+/// A path variable is a third kind, not a synonym for either.
+#[test]
+fn a_path_variable_conflicts_with_a_node_and_with_a_relationship() {
+    assert!(rejected("MATCH p = ()-[]-(), (p) RETURN p"));
+    assert!(rejected("MATCH p = ()-[]-(), ()-[p]-() RETURN p"));
+}
+
+/// The same kind twice is not a conflict — that is ordinary Cypher and is how
+/// a pattern refers back to something it already bound.
+#[test]
+fn reusing_a_variable_as_the_same_kind_is_fine() {
+    assert!(accepted("MATCH (a)-[:R]->(b) MATCH (a)-[:S]->(c) RETURN a, b, c"));
+    assert!(accepted("MATCH (a)-[r]->(b) RETURN a, r, b"));
+    assert!(accepted("MATCH (a), (b) RETURN a, b"));
+}
+
+/// A `WITH` opens a new scope, and a name it does not carry forward is free
+/// again.
+///
+/// This is the guard against over-rejecting. `r` is a relationship before the
+/// WITH and is not projected through it, so the CREATE binds a *fresh* node
+/// that happens to share the name.
+///
+/// It is also the bug this file was written for. The first version of the
+/// check walked `create_clause` and `merge_clause` **before** applying the
+/// WITH reset — reading a write clause against a scope it never sees — and so
+/// rejected this valid query. Found by reading the code, not by a failing
+/// test, which is exactly why it needs one.
+#[test]
+fn a_pattern_after_with_may_reuse_a_dropped_name() {
+    assert!(accepted("MATCH (a)-[r]->(b) WITH a MATCH (r) RETURN a, r"));
+}
+
+/// The `CREATE`/`MERGE` forms of the same thing are rejected, but **not by
+/// this rule** -- `CreateOnBoundVariable` and `MergeOnBoundVariable` predate
+/// it and are not WITH-aware:
+///
+/// ```text
+/// MATCH (a)-[r]->(b) WITH a CREATE (r:X)
+///   -> Variable `r` already declared; CREATE cannot add labels or properties to it
+/// ```
+///
+/// `r` is *not* carried through that WITH, so it is out of scope and the
+/// CREATE should bind a fresh node. Filed separately (#764) rather than fixed
+/// here, because it is a different rule with its own scope question. Asserting
+/// the current behaviour keeps this file honest about what it does and does
+/// not cover -- and turns red the moment #764 is fixed, which is the point.
+#[test]
+fn create_and_merge_after_with_are_over_rejected_by_an_older_rule() {
+    assert!(rejected("MATCH (a)-[r]->(b) WITH a CREATE (r:X) RETURN a"));
+    assert!(rejected("MATCH (a)-[r]->(b) WITH a MERGE (r:X) RETURN a"));
+    // Not the kind rule: a fresh name is accepted in the same position.
+    assert!(accepted("MATCH (a)-[r]->(b) WITH a CREATE (z:X) RETURN a"));
+}
+
+/// A name carried *through* a WITH keeps its kind, so the conflict still
+/// applies on the far side. Without this the rule would be trivially evaded by
+/// inserting a WITH.
+#[test]
+fn a_name_carried_through_with_keeps_its_kind() {
+    assert!(rejected("MATCH (a)-[r]->(b) WITH r MATCH (r) RETURN r"));
+    assert!(rejected("MATCH (a)-[r]->(b) WITH r AS q MATCH (q) RETURN q"));
+    // The other direction: a *node* carried forward may not become a
+    // relationship. I first wrote this as an `accepted` case in the
+    // dropped-name test above and it failed -- correctly. `a` is projected by
+    // the WITH, so it is still a node on the far side, and the rule is right
+    // to refuse. The test was wrong, not the code.
+    assert!(rejected("MATCH (a)-[r]->(b) WITH a MATCH ()-[a]-() RETURN a"));
+}
+
+/// Anonymous positions bind nothing and cannot conflict.
+#[test]
+fn anonymous_positions_are_not_variables() {
+    assert!(accepted("MATCH (), ()-[]-() RETURN 1"));
+    assert!(accepted("MATCH ()-[]->()-[]->() RETURN 1"));
+}


### PR DESCRIPTION
Closes #765.

## The defect

openCypher binds a variable to an **entity**, and an entity has a kind: a node, a relationship, or a path.

```cypher
MATCH (r), ()-[r]-() RETURN r
```

asks for `r` to be two of them at once. There is no answer, and we returned **rows** — the second binding overwrote the first, so the query "succeeded" with an answer to a question that was never well-formed. No error, no warning.

**227 TCK scenarios, every one of them this single rule**, across `Match1`, `Match2` and `Match6`. They are the largest cluster inside the 386 failures where the TCK expects an error we never raise, and they were invisible until #756 expanded `Scenario Outline` blocks.

## Measured

**TCK 2,134 → 2,345 (+211).** Pass rate 56.7% → 62.4%. CI floor raised to 2,345.

Not +227 — the remainder parse now and fail on their own merits. "Blocked by" and "fixed by" are different claims.

## Scope is the whole difficulty

`validate.rs` opens by saying scope analysis is deliberately absent because getting it slightly wrong

> would reject valid queries, which is a far worse failure than accepting an invalid one

So the negative cases carry more weight than the positive ones here:

* a `WITH` opens a new scope;
* names it **projects** keep their kind (`WITH r`, and `WITH r AS q` under the new name);
* names it **drops** are free again — `MATCH (a)-[r]->(b) WITH a MATCH (r)` is legal, `r` is a fresh node;
* only **pattern bindings** are examined; anything a `WITH` computes is left alone rather than guessed at.

Both AST shapes are walked — the clause pipeline and the by-kind fields — because a query parsed into one leaves the other empty. That split has now cost three separate fixes, #710 most recently.

## Two bugs found before this landed, neither by a failing test

**1. Clause ordering.** `create_clause` and `merge_clause` were walked *before* the `WITH` reset, reading a write clause against a scope it never sees. That rejects the valid `MATCH (a)-[r]->(b) WITH a CREATE (r:X)` — precisely the over-rejection the module warns about. Found by re-reading the diff; `a_pattern_after_with_may_reuse_a_dropped_name` now pins the ordering.

**2. My own test was wrong.** I asserted that a node carried through a `WITH` may become a relationship. It may not — `a` is projected, so it is still a node on the far side, and the rule correctly refused. The test was wrong, not the code. Corrected, moved to the rejection side, and the comment says so rather than quietly flipping it.

## A pre-existing bug this does NOT fix

`create_and_merge_after_with_are_over_rejected_by_an_older_rule` records that `CreateOnBoundVariable` and `MergeOnBoundVariable` are not `WITH`-aware:

```
MATCH (a)-[r]->(b) WITH a CREATE (r:X)
  -> Variable `r` already declared; CREATE cannot add labels or properties to it
```

Reproduces on `main`, so it is unrelated to this change. Filed as #764. Rather than delete my failing assertion I **inverted** it: the test asserts today's behaviour deliberately and turns red the moment #764 is fixed, so whoever fixes it is told to flip it back.

## Tests

8 in `tests/variable_kind_conflict.rs`, weighted toward the ways this rule could over-reject: same-kind reuse, anonymous positions, and names dropped by a `WITH` all stay accepted.

`cargo test --workspace --release`: exit 0, **3,310 passed, 0 failed** (12m30s on a 32-core spot box). Run against `740c97f`; the merged commit differs only in comment text — verified with a non-comment diff, which is empty.