### PR TITLE
The five temporal types: TCK 2,345 → 2,570 (+225) (#689)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 2345
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 2570
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/examples/tck_runner.rs
+++ b/examples/tck_runner.rs
@@ -541,6 +541,19 @@ fn prop_to_tck(p: &PropertyValue) -> Tck {
         PropertyValue::Map(m) => {
             Tck::Map(m.iter().map(|(k, v)| (k.clone(), prop_to_tck(v))).collect())
         }
+        // Temporal values render as the TCK writes them -- a quoted ISO-8601
+        // string -- via the engine's own `to_cypher_string`, so the harness and
+        // `toString()` cannot disagree (#689).
+        //
+        // These previously fell to the `Debug` arm below and produced
+        // `DateTime(-1882656000000)`, which is not a TCK literal, is not
+        // anything, and is what fed #761 an input its value parser could not
+        // consume.
+        PropertyValue::Date(_)
+        | PropertyValue::LocalTime(_)
+        | PropertyValue::Time { .. }
+        | PropertyValue::LocalDateTime { .. }
+        | PropertyValue::ZonedDateTime { .. } => Tck::Str(p.to_cypher_string()),
         other => Tck::Opaque(format!("{other:?}")),
     }
 }

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -93,6 +93,10 @@ fn prop_to_json(p: &crate::graph::PropertyValue) -> Value {
         P::Float(f) => json!(f),
         P::Boolean(b) => json!(b),
         P::DateTime(ts) => json!(ts),
+        // Rendered, not decomposed: this feeds an LLM tool response, where
+        // "2015-07-21" is usable and {"days": 16637} is not (#689).
+        P::Date(_) | P::LocalTime(_) | P::Time { .. }
+        | P::LocalDateTime { .. } | P::ZonedDateTime { .. } => json!(p.to_cypher_string()),
         P::Null => Value::Null,
         P::Array(a) => Value::Array(a.iter().map(prop_to_json).collect()),
         P::Map(m) => Value::Object(m.iter().map(|(k, v)| (k.clone(), prop_to_json(v))).collect()),

--- a/src/graph/property.rs
+++ b/src/graph/property.rs
@@ -84,7 +84,43 @@ pub enum PropertyValue {
     Integer(i64),
     Float(f64),
     Boolean(bool),
-    DateTime(i64), // Unix timestamp in milliseconds
+    /// **Legacy.** A Unix timestamp in milliseconds, with no type identity and
+    /// no sub-millisecond precision.
+    ///
+    /// Kept so that snapshots written before the five real temporal types
+    /// existed still deserialize. Nothing new should produce it: read it as a
+    /// UTC `ZonedDateTime`, which is lossless because milliseconds fit
+    /// exactly. See `into_zoned` (#689).
+    DateTime(i64),
+    /// A calendar date: days since 1970-01-01, no time and no zone.
+    ///
+    /// `i32` days spans roughly ±5.8 million years, which is far past what
+    /// `chrono::NaiveDate` accepts, so the representation is not the limit.
+    Date(i32),
+    /// A time of day with nanosecond precision and no zone: nanoseconds since
+    /// midnight, `0..86_400_000_000_000`.
+    ///
+    /// Nanoseconds, not milliseconds, because the TCK's own values require it
+    /// — `12:31:14.645876123` cannot be represented in millis at all, and the
+    /// value is destroyed at construction rather than merely displayed wrongly.
+    LocalTime(i64),
+    /// A time of day with a UTC offset. `nanos` is the *local* time of day.
+    Time { nanos: i64, offset_seconds: i32 },
+    /// A date and time with no zone: seconds since 1970-01-01T00:00:00 read as
+    /// a wall clock, plus nanoseconds `0..1_000_000_000`.
+    LocalDateTime { secs: i64, nanos: u32 },
+    /// A date and time with a zone. `secs`/`nanos` are the instant in UTC;
+    /// `offset_seconds` and the optional IANA `zone` say how to render it.
+    ///
+    /// Both are carried because Cypher distinguishes them: an offset alone
+    /// cannot survive a DST boundary, and a named zone alone cannot represent
+    /// `+05:30` with no zone attached. Dropping either loses a TCK scenario.
+    ZonedDateTime {
+        secs: i64,
+        nanos: u32,
+        offset_seconds: i32,
+        zone: Option<String>,
+    },
     Array(Vec<PropertyValue>),
     Map(HashMap<String, PropertyValue>),
     Vector(Vec<f32>),
@@ -134,6 +170,11 @@ pub fn cypher_order(a: &PropertyValue, b: &PropertyValue) -> Ordering {
             String(_) => 2,
             Boolean(_) => 3,
             Integer(_) | Float(_) | DateTime(_) | Duration { .. } => 4,
+            Date(_)
+            | LocalTime(_)
+            | Time { .. }
+            | LocalDateTime { .. }
+            | ZonedDateTime { .. } => 4,
             Null => 5,
         }
     }
@@ -207,11 +248,20 @@ impl Ord for PropertyValue {
                 Integer(_) | Float(_) => 1,
                 String(_) => 2,
                 DateTime(_) => 3,
-                Array(_) => 4,
-                Map(_) => 5,
-                Vector(_) => 6,
-                Duration { .. } => 7,
-                Null => 8,
+                // Each temporal type is its own bucket: a Date is not a
+                // LocalTime, and the index must not collapse them. They sit
+                // beside the legacy DateTime so an index built before #689
+                // keeps its shape for every non-temporal key.
+                Date(_) => 4,
+                LocalTime(_) => 5,
+                Time { .. } => 6,
+                LocalDateTime { .. } => 7,
+                ZonedDateTime { .. } => 8,
+                Array(_) => 9,
+                Map(_) => 10,
+                Vector(_) => 11,
+                Duration { .. } => 12,
+                Null => 13,
             }
         }
 
@@ -231,6 +281,32 @@ impl Ord for PropertyValue {
             (Boolean(a), Boolean(b)) => a.cmp(b),
             (String(a), String(b)) => a.cmp(b),
             (DateTime(a), DateTime(b)) => a.cmp(b),
+            (Date(a), Date(b)) => a.cmp(b),
+            (LocalTime(a), LocalTime(b)) => a.cmp(b),
+            // A zoned time compares on the instant it denotes, so 12:00+01:00
+            // sorts before 12:00Z. Comparing the local reading would order two
+            // times by how they are written rather than by when they are.
+            (
+                Time { nanos: n1, offset_seconds: o1 },
+                Time { nanos: n2, offset_seconds: o2 },
+            ) => (n1 - (*o1 as i64) * 1_000_000_000).cmp(&(n2 - (*o2 as i64) * 1_000_000_000)),
+            (
+                LocalDateTime { secs: s1, nanos: n1 },
+                LocalDateTime { secs: s2, nanos: n2 },
+            ) => s1.cmp(s2).then(n1.cmp(n2)),
+            // `secs`/`nanos` are already the UTC instant, so the offset and
+            // zone do not participate: two ways of writing the same moment
+            // compare equal on time and are then split by offset and zone so
+            // the order stays strict (`Ord`/`Eq` contract -- `PartialEq` is
+            // derived and would call them different).
+            (
+                ZonedDateTime { secs: s1, nanos: n1, offset_seconds: o1, zone: z1 },
+                ZonedDateTime { secs: s2, nanos: n2, offset_seconds: o2, zone: z2 },
+            ) => s1
+                .cmp(s2)
+                .then(n1.cmp(n2))
+                .then(o1.cmp(o2))
+                .then(z1.cmp(z2)),
             (Array(a), Array(b)) => a.cmp(b),
             (Vector(a), Vector(b)) => a
                 .iter()
@@ -295,6 +371,20 @@ impl Ord for PropertyValue {
 impl std::hash::Hash for PropertyValue {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {
+            // Discriminants 10.. so the pre-#689 variants keep their tags and
+            // an existing hash index is not silently reshuffled.
+            PropertyValue::Date(d) => { 10.hash(state); d.hash(state); }
+            PropertyValue::LocalTime(n) => { 11.hash(state); n.hash(state); }
+            PropertyValue::Time { nanos, offset_seconds } => {
+                12.hash(state); nanos.hash(state); offset_seconds.hash(state);
+            }
+            PropertyValue::LocalDateTime { secs, nanos } => {
+                13.hash(state); secs.hash(state); nanos.hash(state);
+            }
+            PropertyValue::ZonedDateTime { secs, nanos, offset_seconds, zone } => {
+                14.hash(state); secs.hash(state); nanos.hash(state);
+                offset_seconds.hash(state); zone.hash(state);
+            }
             PropertyValue::String(s) => {
                 0.hash(state);
                 s.hash(state);
@@ -475,6 +565,11 @@ impl PropertyValue {
     /// Get type name as string
     pub fn type_name(&self) -> &'static str {
         match self {
+            PropertyValue::Date(_) => "Date",
+            PropertyValue::LocalTime(_) => "LocalTime",
+            PropertyValue::Time { .. } => "Time",
+            PropertyValue::LocalDateTime { .. } => "LocalDateTime",
+            PropertyValue::ZonedDateTime { .. } => "DateTime",
             PropertyValue::String(_) => "String",
             PropertyValue::Integer(_) => "Integer",
             PropertyValue::Float(_) => "Float",
@@ -492,6 +587,14 @@ impl PropertyValue {
     pub fn to_json(&self) -> serde_json::Value {
         use serde_json::json;
         match self {
+            // The rendered ISO-8601 string, not the internal components: a
+            // client asking for a property wants `"2015-07-21"`, and JSON has
+            // no temporal type to carry the structure into anyway.
+            PropertyValue::Date(_)
+            | PropertyValue::LocalTime(_)
+            | PropertyValue::Time { .. }
+            | PropertyValue::LocalDateTime { .. }
+            | PropertyValue::ZonedDateTime { .. } => json!(self.to_cypher_string()),
             PropertyValue::String(s) => json!(s),
             PropertyValue::Integer(i) => json!(i),
             PropertyValue::Float(f) => json!(f),
@@ -526,9 +629,131 @@ impl PropertyValue {
     }
 }
 
+
+/// A time of day as openCypher renders it: `10:35`, `12:31:14`,
+/// `12:31:14.645876123`.
+///
+/// Trailing components are dropped when they are zero, which is the rule the
+/// TCK checks — `localtime({hour: 10, minute: 35})` is `'10:35'`, not
+/// `'10:35:00.000000000'`. The fraction keeps only as many digits as it needs,
+/// so `.142` and `.645876123` both round-trip.
+pub(crate) fn fmt_time_of_day(total_nanos: i64) -> String {
+    let secs_of_day = total_nanos.div_euclid(1_000_000_000);
+    let nanos = total_nanos.rem_euclid(1_000_000_000) as u32;
+    let (h, m, sec) = (secs_of_day / 3600, (secs_of_day % 3600) / 60, secs_of_day % 60);
+    let mut out = format!("{h:02}:{m:02}");
+    if sec != 0 || nanos != 0 {
+        out.push_str(&format!(":{sec:02}"));
+    }
+    if nanos != 0 {
+        let frac = format!("{nanos:09}");
+        out.push('.');
+        out.push_str(frac.trim_end_matches('0'));
+    }
+    out
+}
+
+/// A UTC offset as `Z`, `+01:00`, or `+05:30`.
+pub(crate) fn fmt_offset(offset_seconds: i32) -> String {
+    if offset_seconds == 0 {
+        return "Z".to_string();
+    }
+    let sign = if offset_seconds < 0 { '-' } else { '+' };
+    let a = offset_seconds.abs();
+    format!("{sign}{:02}:{:02}", a / 3600, (a % 3600) / 60)
+}
+
+/// A date as `2015-07-21`, from days since the Unix epoch.
+pub(crate) fn fmt_date(days: i32) -> String {
+    match chrono::NaiveDate::from_ymd_opt(1970, 1, 1).and_then(|d| d.checked_add_signed(chrono::Duration::days(days as i64))) {
+        Some(d) => d.format("%Y-%m-%d").to_string(),
+        // Outside chrono's range. Reported rather than silently clamped: a
+        // wrong date that looks like a date is worse than an obvious marker.
+        None => format!("<date out of range: {days} days>"),
+    }
+}
+
+/// A naive date-time as `2015-07-21T21:40:32.142`.
+pub(crate) fn fmt_local_date_time(secs: i64, nanos: u32) -> String {
+    match chrono::DateTime::from_timestamp(secs, nanos) {
+        Some(dt) => {
+            let d = dt.naive_utc();
+            let day = d.format("%Y-%m-%d").to_string();
+            let tod = fmt_time_of_day(
+                (d.time().signed_duration_since(chrono::NaiveTime::MIN))
+                    .num_nanoseconds()
+                    .unwrap_or(0),
+            );
+            format!("{day}T{tod}")
+        }
+        None => format!("<datetime out of range: {secs}s {nanos}ns>"),
+    }
+}
+
+
+impl PropertyValue {
+    /// How openCypher writes this value — the string `toString()` returns and
+    /// the TCK compares against.
+    ///
+    /// One function rather than one per call site, because the previous
+    /// arrangement rendered temporal values through `Debug` in at least two
+    /// places and produced `DateTime(-1882656000000)` where a TCK literal
+    /// belonged. That is what fed samyama-graph#761 an input its parser could
+    /// not consume.
+    pub fn to_cypher_string(&self) -> String {
+        match self {
+            PropertyValue::Date(d) => fmt_date(*d),
+            PropertyValue::LocalTime(n) => fmt_time_of_day(*n),
+            PropertyValue::Time { nanos, offset_seconds } => {
+                format!("{}{}", fmt_time_of_day(*nanos), fmt_offset(*offset_seconds))
+            }
+            PropertyValue::LocalDateTime { secs, nanos } => fmt_local_date_time(*secs, *nanos),
+            PropertyValue::ZonedDateTime { secs, nanos, offset_seconds, zone } => {
+                // `secs` is the UTC instant; render it in the stored offset.
+                let local = fmt_local_date_time(secs + *offset_seconds as i64, *nanos);
+                let base = format!("{local}{}", fmt_offset(*offset_seconds));
+                match zone {
+                    Some(z) => format!("{base}[{z}]"),
+                    None => base,
+                }
+            }
+            other => other.to_string(),
+        }
+    }
+
+    /// Read any temporal value as the UTC instant it denotes, for the legacy
+    /// millisecond API and for snapshot migration.
+    ///
+    /// A `Date` is midnight UTC and a `LocalTime` has no date, so this is lossy
+    /// by construction — it exists to keep old callers working, not as a
+    /// conversion anything new should reach for.
+    pub fn as_epoch_millis(&self) -> Option<i64> {
+        match self {
+            PropertyValue::DateTime(ms) => Some(*ms),
+            PropertyValue::Date(d) => Some(*d as i64 * 86_400_000),
+            PropertyValue::LocalTime(n) => Some(n / 1_000_000),
+            PropertyValue::Time { nanos, offset_seconds } => {
+                Some((nanos - (*offset_seconds as i64) * 1_000_000_000) / 1_000_000)
+            }
+            PropertyValue::LocalDateTime { secs, nanos } => {
+                Some(secs * 1000 + (*nanos as i64) / 1_000_000)
+            }
+            PropertyValue::ZonedDateTime { secs, nanos, .. } => {
+                Some(secs * 1000 + (*nanos as i64) / 1_000_000)
+            }
+            _ => None,
+        }
+    }
+}
+
 impl fmt::Display for PropertyValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            PropertyValue::Date(_)
+            | PropertyValue::LocalTime(_)
+            | PropertyValue::Time { .. }
+            | PropertyValue::LocalDateTime { .. }
+            | PropertyValue::ZonedDateTime { .. } => write!(f, "{}", self.to_cypher_string()),
             PropertyValue::String(s) => write!(f, "\"{}\"", s),
             PropertyValue::Integer(i) => write!(f, "{}", i),
             PropertyValue::Float(fl) => write!(f, "{}", fl),

--- a/src/graph/property.rs
+++ b/src/graph/property.rs
@@ -654,7 +654,7 @@ pub(crate) fn fmt_time_of_day(total_nanos: i64) -> String {
 }
 
 /// A UTC offset as `Z`, `+01:00`, or `+05:30`.
-pub(crate) fn fmt_offset(offset_seconds: i32) -> String {
+pub fn fmt_offset(offset_seconds: i32) -> String {
     if offset_seconds == 0 {
         return "Z".to_string();
     }

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -84,6 +84,7 @@ pub mod semi_join_detector;
 pub mod leapfrog;
 pub mod logical_optimizer;
 pub mod logical_plan;
+pub mod temporal;
 pub mod operator;
 pub mod profile;
 pub mod physical_planner;

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -6826,9 +6826,10 @@ mod tests {
         let result = QueryExecutor::new(&store).execute(
             &parse_query(r#"RETURN date("2024-06-15") AS d"#).unwrap()
         ).unwrap();
-        if let Value::Property(PropertyValue::DateTime(millis)) = result.records[0].get("d").unwrap() {
+        if let Value::Property(p @ PropertyValue::Date(_)) = result.records[0].get("d").unwrap() {
+            assert_eq!(p.to_cypher_string(), "2024-06-15");
             use chrono::{Datelike, TimeZone};
-            let dt = chrono::Utc.timestamp_millis_opt(*millis).unwrap();
+            let dt = chrono::Utc.timestamp_millis_opt(p.as_epoch_millis().unwrap()).unwrap();
             assert_eq!(dt.year(), 2024);
             assert_eq!(dt.month(), 6);
             assert_eq!(dt.day(), 15);
@@ -6841,16 +6842,19 @@ mod tests {
         let result = QueryExecutor::new(&store).execute(
             &parse_query("RETURN date() AS d").unwrap()
         ).unwrap();
-        assert!(matches!(result.records[0].get("d").unwrap(), Value::Property(PropertyValue::DateTime(_))));
+        // A Date, not a timestamp (#689): this assertion used to hold for
+        // `time()` and `datetime()` too, because all three returned the same
+        // variant.
+        assert!(matches!(result.records[0].get("d").unwrap(), Value::Property(PropertyValue::Date(_))));
     }
 
     #[test]
     fn test_time_constructor_string() {
         use crate::query::executor::operator::eval_function;
         let r = eval_function("time", &[Value::Property(PropertyValue::String("10:30:00".to_string()))], None).unwrap();
-        if let Value::Property(PropertyValue::DateTime(millis)) = r {
-            assert_eq!(millis, (10 * 3600 + 30 * 60) * 1000);
-        } else { panic!("time() should return DateTime"); }
+        if let Value::Property(p @ PropertyValue::Time { .. }) = r {
+            assert_eq!(p.to_cypher_string(), "10:30Z");
+        } else { panic!("time() should return Time, got {r:?}"); }
     }
 
     #[test]
@@ -6861,9 +6865,9 @@ mod tests {
         map.insert("minute".to_string(), PropertyValue::Integer(45));
         map.insert("second".to_string(), PropertyValue::Integer(30));
         let r = eval_function("time", &[Value::Property(PropertyValue::Map(map))], None).unwrap();
-        if let Value::Property(PropertyValue::DateTime(millis)) = r {
-            assert_eq!(millis, (14 * 3600 + 45 * 60 + 30) * 1000);
-        } else { panic!("time() should return DateTime"); }
+        if let Value::Property(p @ PropertyValue::Time { .. }) = r {
+            assert_eq!(p.to_cypher_string(), "14:45:30Z");
+        } else { panic!("time() should return Time, got {r:?}"); }
     }
 
     #[test]
@@ -6872,9 +6876,10 @@ mod tests {
         let result = QueryExecutor::new(&store).execute(
             &parse_query(r#"RETURN localdatetime("2024-03-15T14:30:00") AS dt"#).unwrap()
         ).unwrap();
-        if let Value::Property(PropertyValue::DateTime(millis)) = result.records[0].get("dt").unwrap() {
+        if let Value::Property(p @ PropertyValue::LocalDateTime { .. }) = result.records[0].get("dt").unwrap() {
+            assert_eq!(p.to_cypher_string(), "2024-03-15T14:30");
             use chrono::{Datelike, Timelike, TimeZone};
-            let dt = chrono::Utc.timestamp_millis_opt(*millis).unwrap();
+            let dt = chrono::Utc.timestamp_millis_opt(p.as_epoch_millis().unwrap()).unwrap();
             assert_eq!(dt.year(), 2024);
             assert_eq!(dt.month(), 3);
             assert_eq!(dt.hour(), 14);
@@ -7022,11 +7027,11 @@ mod tests {
         let result = QueryExecutor::new(&store).execute(
             &parse_query(r#"RETURN datetime("2024-01-01T00:00:00Z") + duration({days: 1}) AS tomorrow"#).unwrap()
         ).unwrap();
-        if let Value::Property(PropertyValue::DateTime(millis)) = result.records[0].get("tomorrow").unwrap() {
-            use chrono::{Datelike, TimeZone};
-            let dt = chrono::Utc.timestamp_millis_opt(*millis).unwrap();
-            assert_eq!(dt.day(), 2);
-        } else { panic!("datetime + duration should return DateTime"); }
+        // Adding a duration keeps the operand's own type: a ZonedDateTime
+        // plus a duration is a ZonedDateTime, not a bare timestamp.
+        if let Value::Property(p @ PropertyValue::ZonedDateTime { .. }) = result.records[0].get("tomorrow").unwrap() {
+            assert_eq!(p.to_cypher_string(), "2024-01-02T00:00Z");
+        } else { panic!("datetime + duration should return ZonedDateTime, got {:?}", result.records[0].get("tomorrow")); }
     }
 
     #[test]

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -225,6 +225,24 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
             (PropertyValue::Duration { months, days, seconds, .. }, PropertyValue::DateTime(dt)) => {
                 add_duration_to_datetime(*dt, *months, *days, *seconds)
             }
+            // Any of the five temporal types + Duration (#689). Without these
+            // arms, teaching the constructors to produce real types would have
+            // silently removed `datetime(...) + duration(...)`, which Cypher
+            // requires and which the suite already covered.
+            (t @ (PropertyValue::Date(_)
+                | PropertyValue::LocalTime(_)
+                | PropertyValue::Time { .. }
+                | PropertyValue::LocalDateTime { .. }
+                | PropertyValue::ZonedDateTime { .. }),
+             PropertyValue::Duration { months, days, seconds, nanos })
+            | (PropertyValue::Duration { months, days, seconds, nanos },
+               t @ (PropertyValue::Date(_)
+                | PropertyValue::LocalTime(_)
+                | PropertyValue::Time { .. }
+                | PropertyValue::LocalDateTime { .. }
+                | PropertyValue::ZonedDateTime { .. })) => {
+                shift_temporal(t, *months, *days, *seconds, *nanos as i64)?
+            }
             // Duration + Duration
             (PropertyValue::Duration { months: m1, days: d1, seconds: s1, nanos: n1 },
              PropertyValue::Duration { months: m2, days: d2, seconds: s2, nanos: n2 }) => {
@@ -247,6 +265,25 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
             (PropertyValue::DateTime(dt), PropertyValue::Duration { months, days, seconds, .. }) => {
                 add_duration_to_datetime(*dt, -*months, -*days, -*seconds)
             }
+            (t @ (PropertyValue::Date(_)
+                | PropertyValue::LocalTime(_)
+                | PropertyValue::Time { .. }
+                | PropertyValue::LocalDateTime { .. }
+                | PropertyValue::ZonedDateTime { .. }),
+             PropertyValue::Duration { months, days, seconds, nanos }) => {
+                shift_temporal(t, -*months, -*days, -*seconds, -(*nanos as i64))?
+            }
+            // Two temporals of the same kind subtract to a Duration.
+            (a @ (PropertyValue::Date(_)
+                | PropertyValue::LocalTime(_)
+                | PropertyValue::Time { .. }
+                | PropertyValue::LocalDateTime { .. }
+                | PropertyValue::ZonedDateTime { .. }),
+             b @ (PropertyValue::Date(_)
+                | PropertyValue::LocalTime(_)
+                | PropertyValue::Time { .. }
+                | PropertyValue::LocalDateTime { .. }
+                | PropertyValue::ZonedDateTime { .. })) => temporal_difference(a, b)?,
             // DateTime - DateTime = Duration
             (PropertyValue::DateTime(a), PropertyValue::DateTime(b)) => {
                 let diff_ms = a - b;
@@ -2593,6 +2630,140 @@ fn extract_float(val: &Value) -> ExecutionResult<f64> {
 }
 
 /// Add duration components to a DateTime (millis timestamp)
+
+/// Nanoseconds since the epoch that a temporal value denotes, and a way back.
+///
+/// `Date` is midnight and `LocalTime`/`Time` have no date, so these are the
+/// only two functions that decide what "the same value, shifted" means. Keeping
+/// that decision in one place is the point: the shift used to be written inline
+/// per operator, which is how `+` and `-` came to disagree about whether months
+/// were calendar months.
+fn temporal_epoch_nanos(v: &PropertyValue) -> Option<i128> {
+    match v {
+        PropertyValue::Date(d) => Some(*d as i128 * 86_400 * 1_000_000_000),
+        PropertyValue::LocalTime(n) => Some(*n as i128),
+        PropertyValue::Time { nanos, offset_seconds } => {
+            Some(*nanos as i128 - *offset_seconds as i128 * 1_000_000_000)
+        }
+        PropertyValue::LocalDateTime { secs, nanos } => {
+            Some(*secs as i128 * 1_000_000_000 + *nanos as i128)
+        }
+        PropertyValue::ZonedDateTime { secs, nanos, .. } => {
+            Some(*secs as i128 * 1_000_000_000 + *nanos as i128)
+        }
+        PropertyValue::DateTime(ms) => Some(*ms as i128 * 1_000_000),
+        _ => None,
+    }
+}
+
+/// Shift a temporal value by a duration, keeping its own type.
+///
+/// Months are calendar months, so they are applied to the date rather than as
+/// a fixed number of seconds -- adding one month to 31 January is 28 February,
+/// not 3 March. Days and below are exact.
+fn shift_temporal(
+    v: &PropertyValue,
+    months: i64,
+    days: i64,
+    seconds: i64,
+    nanos: i64,
+) -> Result<PropertyValue, ExecutionError> {
+    use chrono::Datelike;
+    let exact = days as i128 * 86_400 * 1_000_000_000
+        + seconds as i128 * 1_000_000_000
+        + nanos as i128;
+
+    // Calendar months first, on whatever date part the value has.
+    let month_shift_nanos = if months == 0 {
+        0i128
+    } else {
+        let day0 = match v {
+            PropertyValue::Date(d) => *d as i64,
+            PropertyValue::LocalDateTime { secs, .. } => secs.div_euclid(86_400),
+            PropertyValue::ZonedDateTime { secs, offset_seconds, .. } => {
+                (secs + *offset_seconds as i64).div_euclid(86_400)
+            }
+            // A time of day has no calendar to move.
+            _ => return Err(ExecutionError::TypeError(
+                "cannot add months to a value with no date part".to_string(),
+            )),
+        };
+        let base = chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
+            .and_then(|e| e.checked_add_signed(chrono::Duration::days(day0)))
+            .ok_or_else(|| ExecutionError::RuntimeError("date out of range".into()))?;
+        let total = base.year() as i64 * 12 + (base.month0() as i64) + months;
+        let (y, m0) = (total.div_euclid(12), total.rem_euclid(12));
+        // Clamp the day into the target month, which is what a calendar month
+        // shift means: 31 Jan + 1 month is 28/29 Feb.
+        let last = days_in_month(y as i32, m0 as u32 + 1);
+        let shifted = chrono::NaiveDate::from_ymd_opt(y as i32, m0 as u32 + 1, base.day().min(last))
+            .ok_or_else(|| ExecutionError::RuntimeError("date out of range".into()))?;
+        (shifted.signed_duration_since(base).num_days() as i128) * 86_400 * 1_000_000_000
+    };
+
+    let total = temporal_epoch_nanos(v)
+        .ok_or_else(|| ExecutionError::TypeError("not a temporal value".to_string()))?
+        + month_shift_nanos
+        + exact;
+    Ok(rebuild_temporal_like(v, total))
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    let (ny, nm) = if month == 12 { (year + 1, 1) } else { (year, month + 1) };
+    let first = chrono::NaiveDate::from_ymd_opt(year, month, 1);
+    let next = chrono::NaiveDate::from_ymd_opt(ny, nm, 1);
+    match (first, next) {
+        (Some(a), Some(b)) => b.signed_duration_since(a).num_days() as u32,
+        _ => 31,
+    }
+}
+
+/// Put an epoch-nanosecond total back into the same type it came from, so a
+/// `Date` plus a duration is still a `Date`.
+fn rebuild_temporal_like(like: &PropertyValue, total_nanos: i128) -> PropertyValue {
+    const DAY: i128 = 86_400 * 1_000_000_000;
+    match like {
+        PropertyValue::Date(_) => PropertyValue::Date(total_nanos.div_euclid(DAY) as i32),
+        PropertyValue::LocalTime(_) => {
+            PropertyValue::LocalTime(total_nanos.rem_euclid(DAY) as i64)
+        }
+        PropertyValue::Time { offset_seconds, .. } => PropertyValue::Time {
+            nanos: (total_nanos + *offset_seconds as i128 * 1_000_000_000).rem_euclid(DAY) as i64,
+            offset_seconds: *offset_seconds,
+        },
+        PropertyValue::LocalDateTime { .. } => PropertyValue::LocalDateTime {
+            secs: total_nanos.div_euclid(1_000_000_000) as i64,
+            nanos: total_nanos.rem_euclid(1_000_000_000) as u32,
+        },
+        PropertyValue::ZonedDateTime { offset_seconds, zone, .. } => PropertyValue::ZonedDateTime {
+            secs: total_nanos.div_euclid(1_000_000_000) as i64,
+            nanos: total_nanos.rem_euclid(1_000_000_000) as u32,
+            offset_seconds: *offset_seconds,
+            zone: zone.clone(),
+        },
+        _ => PropertyValue::DateTime((total_nanos / 1_000_000) as i64),
+    }
+}
+
+/// `a - b` for two temporals: the duration between them.
+fn temporal_difference(
+    a: &PropertyValue,
+    b: &PropertyValue,
+) -> Result<PropertyValue, ExecutionError> {
+    let (na, nb) = match (temporal_epoch_nanos(a), temporal_epoch_nanos(b)) {
+        (Some(x), Some(y)) => (x, y),
+        _ => return Err(ExecutionError::TypeError("not temporal values".to_string())),
+    };
+    let diff = na - nb;
+    let secs_total = diff.div_euclid(1_000_000_000) as i64;
+    Ok(PropertyValue::Duration {
+        months: 0,
+        days: secs_total / 86_400,
+        seconds: secs_total % 86_400,
+        nanos: diff.rem_euclid(1_000_000_000) as i32,
+    })
+}
+
 fn add_duration_to_datetime(dt_millis: i64, months: i64, days: i64, seconds: i64) -> PropertyValue {
     use chrono::{Datelike, Months, Duration, TimeZone};
     let dt = chrono::Utc.timestamp_millis_opt(dt_millis).single();
@@ -12830,10 +13001,13 @@ mod tests {
 
     #[test]
     fn test_eval_function_date_no_args() {
+        // `date()` returns a Date, not a timestamp (#689). Asserting the
+        // *type* is the point: before, every temporal constructor returned the
+        // same `DateTime(millis)` and this test passed for `time()` too.
         let result = eval_function("date", &[], None).unwrap();
         match result {
-            Value::Property(PropertyValue::DateTime(ts)) => assert!(ts > 0),
-            _ => panic!("Expected DateTime"),
+            Value::Property(PropertyValue::Date(days)) => assert!(days > 0),
+            other => panic!("Expected Date, got {other:?}"),
         }
     }
 
@@ -12841,13 +13015,10 @@ mod tests {
     fn test_eval_function_date_string() {
         let result = eval_function("date", &[Value::Property(PropertyValue::String("2024-01-15".to_string()))], None).unwrap();
         match result {
-            Value::Property(PropertyValue::DateTime(ts)) => {
-                // 2024-01-15 00:00:00 UTC
-                let expected = chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap()
-                    .and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp_millis();
-                assert_eq!(ts, expected);
+            Value::Property(p @ PropertyValue::Date(_)) => {
+                assert_eq!(p.to_cypher_string(), "2024-01-15");
             }
-            _ => panic!("Expected DateTime"),
+            other => panic!("Expected Date, got {other:?}"),
         }
     }
 
@@ -12859,10 +13030,8 @@ mod tests {
         map.insert("day".to_string(), PropertyValue::Integer(15));
         let result = eval_function("date", &[Value::Property(PropertyValue::Map(map))], None).unwrap();
         match result {
-            Value::Property(PropertyValue::DateTime(ts)) => {
-                let expected = chrono::NaiveDate::from_ymd_opt(2024, 6, 15).unwrap()
-                    .and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp_millis();
-                assert_eq!(ts, expected);
+            Value::Property(p @ PropertyValue::Date(_)) => {
+                assert_eq!(p.to_cypher_string(), "2024-06-15");
             }
             _ => panic!("Expected DateTime"),
         }
@@ -12894,8 +13063,8 @@ mod tests {
     fn test_eval_function_datetime_no_args() {
         let result = eval_function("datetime", &[], None).unwrap();
         match result {
-            Value::Property(PropertyValue::DateTime(ts)) => assert!(ts > 0),
-            _ => panic!("Expected DateTime"),
+            Value::Property(PropertyValue::ZonedDateTime { secs, .. }) => assert!(secs > 0),
+            other => panic!("Expected ZonedDateTime, got {other:?}"),
         }
     }
 
@@ -12903,11 +13072,10 @@ mod tests {
     fn test_eval_function_datetime_rfc3339() {
         let result = eval_function("datetime", &[Value::Property(PropertyValue::String("2024-01-15T10:30:00Z".to_string()))], None).unwrap();
         match result {
-            Value::Property(PropertyValue::DateTime(ts)) => {
-                let expected = chrono::DateTime::parse_from_rfc3339("2024-01-15T10:30:00Z").unwrap().timestamp_millis();
-                assert_eq!(ts, expected);
+            Value::Property(p @ PropertyValue::ZonedDateTime { .. }) => {
+                assert_eq!(p.to_cypher_string(), "2024-01-15T10:30Z");
             }
-            _ => panic!("Expected DateTime"),
+            other => panic!("Expected ZonedDateTime, got {other:?}"),
         }
     }
 
@@ -12915,8 +13083,10 @@ mod tests {
     fn test_eval_function_datetime_naive() {
         let result = eval_function("datetime", &[Value::Property(PropertyValue::String("2024-01-15T10:30:00".to_string()))], None).unwrap();
         match result {
-            Value::Property(PropertyValue::DateTime(_ts)) => {} // valid
-            _ => panic!("Expected DateTime"),
+            Value::Property(p @ PropertyValue::ZonedDateTime { .. }) => {
+                assert_eq!(p.to_cypher_string(), "2024-01-15T10:30Z");
+            }
+            other => panic!("Expected ZonedDateTime, got {other:?}"),
         }
     }
 
@@ -12931,9 +13101,11 @@ mod tests {
         map.insert("second".to_string(), PropertyValue::Integer(45));
         let result = eval_function("datetime", &[Value::Property(PropertyValue::Map(map))], None).unwrap();
         match result {
-            Value::Property(PropertyValue::DateTime(ts)) => {
+            Value::Property(p @ PropertyValue::ZonedDateTime { .. }) => {
+                assert_eq!(p.to_cypher_string(), "2024-03-15T10:30:45Z");
                 use chrono::TimeZone;
                 let expected = chrono::Utc.with_ymd_and_hms(2024, 3, 15, 10, 30, 45).unwrap().timestamp_millis();
+                let ts = p.as_epoch_millis().unwrap();
                 assert_eq!(ts, expected);
             }
             _ => panic!("Expected DateTime"),

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2293,6 +2293,7 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     Ok(Value::Property(PropertyValue::LocalDateTime { secs, nanos }))
                 }
                 Value::Property(PropertyValue::Map(map)) => {
+                    crate::query::executor::temporal::reject_unknown_map(map)?;
                     let (d, t) = compose_date_and_time(map)?;
                     let total = d as i64 * 86_400 * 1_000_000_000 + t;
                     Ok(Value::Property(PropertyValue::LocalDateTime {
@@ -2336,6 +2337,7 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     }))
                 }
                 Value::Property(PropertyValue::Map(map)) => {
+                    tmp::reject_unknown_map(map)?;
                     // An epoch is a complete specification on its own, and is
                     // handled first: without this the map fell through to the
                     // component defaults and returned 1970-01-01 *silently*,

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1309,6 +1309,36 @@ fn cypher_ordering(left: &PropertyValue, right: &PropertyValue) -> Option<std::c
             Duration { months: m1, days: d1, seconds: s1, nanos: n1 },
             Duration { months: m2, days: d2, seconds: s2, nanos: n2 },
         ) => Some(m1.cmp(m2).then(d1.cmp(d2)).then(s1.cmp(s2)).then(n1.cmp(n2))),
+
+        // The five temporal types compare within their own kind (#689).
+        //
+        // This function is a *second* comparison path -- `cypher_order` in
+        // `graph::property` is the other -- and its `_ => None` fallthrough
+        // meant every new temporal type silently compared as null the moment
+        // the constructors started producing them. Nine `Temporal7` scenarios
+        // that had been passing went red, which is the duplicated-evaluator
+        // shape this codebase keeps producing: patching the copy in front of
+        // you fixes nothing.
+        (Date(l), Date(r)) => Some(l.cmp(r)),
+        (LocalTime(l), LocalTime(r)) => Some(l.cmp(r)),
+        (
+            Time { nanos: n1, offset_seconds: o1 },
+            Time { nanos: n2, offset_seconds: o2 },
+        ) => Some(
+            (n1 - (*o1 as i64) * 1_000_000_000).cmp(&(n2 - (*o2 as i64) * 1_000_000_000)),
+        ),
+        (LocalDateTime { secs: s1, nanos: n1 }, LocalDateTime { secs: s2, nanos: n2 }) => {
+            Some(s1.cmp(s2).then(n1.cmp(n2)))
+        }
+        (
+            ZonedDateTime { secs: s1, nanos: n1, .. },
+            ZonedDateTime { secs: s2, nanos: n2, .. },
+        ) => Some(s1.cmp(s2).then(n1.cmp(n2))),
+
+        // Cross-kind temporal comparison is null in Cypher, not an ordering:
+        // "is this date greater than that time" has no answer. Falls through
+        // to `None` below, which is that null -- spelled out here because the
+        // wildcard is exactly what hid the bug above.
         _ => None,
     }
 }
@@ -1322,6 +1352,110 @@ fn cypher_ordering(left: &PropertyValue, right: &PropertyValue) -> Option<std::c
 ///
 /// This exists because the comparison was implemented twice and both copies
 /// had independently settled on raising instead. Both now call here.
+
+/// Days-since-epoch of any temporal value that has a date part.
+///
+/// `None` for `LocalTime`/`Time`, which genuinely have no date — the caller
+/// turns that into a type error rather than substituting the epoch, because a
+/// substituted 1970-01-01 reads as a real answer (#689).
+fn date_part_of(v: &PropertyValue) -> Option<i32> {
+    match v {
+        PropertyValue::Date(d) => Some(*d),
+        PropertyValue::LocalDateTime { secs, .. } => Some(secs.div_euclid(86_400) as i32),
+        PropertyValue::ZonedDateTime { secs, offset_seconds, .. } => {
+            Some((secs + *offset_seconds as i64).div_euclid(86_400) as i32)
+        }
+        PropertyValue::DateTime(ms) => Some(ms.div_euclid(86_400_000) as i32),
+        _ => None,
+    }
+}
+
+/// Nanoseconds-since-midnight of any temporal value that has a time part.
+fn time_part_of(v: &PropertyValue) -> Option<i64> {
+    match v {
+        PropertyValue::LocalTime(n) => Some(*n),
+        PropertyValue::Time { nanos, .. } => Some(*nanos),
+        PropertyValue::LocalDateTime { secs, nanos } => {
+            Some(secs.rem_euclid(86_400) * 1_000_000_000 + *nanos as i64)
+        }
+        PropertyValue::ZonedDateTime { secs, nanos, offset_seconds, .. } => {
+            let local = secs + *offset_seconds as i64;
+            Some(local.rem_euclid(86_400) * 1_000_000_000 + *nanos as i64)
+        }
+        PropertyValue::DateTime(ms) => Some(ms.rem_euclid(86_400_000) * 1_000_000),
+        _ => None,
+    }
+}
+
+/// The date and time a composite constructor's map describes.
+///
+/// Handles both the component form (`{year, month, day, hour, ...}`) and the
+/// *selection* form (`{date: d, time: t}`), which Cypher allows and which the
+/// TCK's Temporal3 exercises heavily. A map may mix them: `{date: d, hour: 9}`
+/// takes the date from `d` and the clock from the components.
+fn compose_date_and_time(
+    map: &std::collections::HashMap<String, PropertyValue>,
+) -> Result<(i32, i64), ExecutionError> {
+    use crate::query::executor::temporal as tmp;
+
+    let from_date = map
+        .get("date")
+        .or_else(|| map.get("datetime"))
+        .and_then(date_part_of);
+    let from_time = map
+        .get("time")
+        .or_else(|| map.get("datetime"))
+        .and_then(time_part_of);
+
+    let days = match from_date {
+        Some(d) => d,
+        None if map.contains_key("year") => tmp::date_days(map)?,
+        // No date at all. Cypher's composite types need one, and defaulting to
+        // the epoch is exactly the silent-1970 failure #595 was about.
+        None => {
+            return Err(ExecutionError::RuntimeError(
+                "a date-time needs a date: give `year` or `date`".to_string(),
+            ))
+        }
+    };
+    let has_clock = ["hour", "minute", "second", "millisecond", "microsecond", "nanosecond"]
+        .iter()
+        .any(|k| map.contains_key(*k));
+    let nanos = if has_clock {
+        tmp::time_of_day_nanos(map)?
+    } else {
+        from_time.unwrap_or(0)
+    };
+    Ok((days, nanos))
+}
+
+/// Seconds/nanos of a naive date-time string, with no zone.
+fn parse_naive_date_time(s: &str) -> Result<(i64, u32), ExecutionError> {
+    let t = s.trim();
+    for fmt in ["%Y-%m-%dT%H:%M:%S%.f", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M", "%Y-%m-%d"] {
+        if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(t, fmt) {
+            return Ok((dt.and_utc().timestamp(), dt.and_utc().timestamp_subsec_nanos()));
+        }
+        if fmt == "%Y-%m-%d" {
+            if let Ok(d) = chrono::NaiveDate::parse_from_str(t, fmt) {
+                let dt = d.and_hms_opt(0, 0, 0).expect("midnight is a time");
+                return Ok((dt.and_utc().timestamp(), 0));
+            }
+        }
+    }
+    Err(ExecutionError::RuntimeError(format!(
+        "cannot parse date-time: {s}"
+    )))
+}
+
+/// The `PropertyValue` inside a `Value`, when there is one.
+fn value_as_property(v: &Value) -> Option<PropertyValue> {
+    match v {
+        Value::Property(p) => Some(p.clone()),
+        _ => None,
+    }
+}
+
 fn string_position_op(
     op: StringPositionOp,
     left: &PropertyValue,
@@ -1609,6 +1743,14 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                 Value::Property(PropertyValue::Duration { months, days, seconds, nanos }) => {
                     format!("P{}M{}DT{}S", months, days, seconds)
                 }
+                // The five temporal types render through the one function that
+                // owns the format, so `toString()` and the TCK harness cannot
+                // disagree about what a value looks like (#689).
+                Value::Property(p @ PropertyValue::Date(_))
+                | Value::Property(p @ PropertyValue::LocalTime(_))
+                | Value::Property(p @ PropertyValue::Time { .. })
+                | Value::Property(p @ PropertyValue::LocalDateTime { .. })
+                | Value::Property(p @ PropertyValue::ZonedDateTime { .. }) => p.to_cypher_string(),
                 Value::Null | Value::Property(PropertyValue::Null) => "null".to_string(),
                 _ => return Err(ExecutionError::TypeError("Cannot convert to string".to_string())),
             };
@@ -1991,204 +2133,212 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
             Ok(Value::Property(PropertyValue::Array(result)))
         }
         // date/datetime/duration constructors
+        // The five temporal constructors (#689). Each produces its own type
+        // now; before this they all produced `PropertyValue::DateTime(millis)`,
+        // so `date()`, `time()` and `localdatetime()` were indistinguishable
+        // once evaluated and nanoseconds were destroyed at construction.
         "date" => {
+            use crate::query::executor::temporal as tmp;
             if args.is_empty() {
-                // date() — current date as DateTime
-                let now = chrono::Utc::now().timestamp_millis();
-                Ok(Value::Property(PropertyValue::DateTime(now)))
-            } else {
-                match &args[0] {
-                    Value::Property(PropertyValue::String(s)) => {
-                        // Parse ISO date string
-                        if let Ok(dt) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
-                            let millis = dt.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp_millis();
-                            Ok(Value::Property(PropertyValue::DateTime(millis)))
-                        } else {
-                            Err(ExecutionError::RuntimeError(format!("Cannot parse date: {}", s)))
-                        }
-                    }
-                    Value::Property(PropertyValue::Map(map)) => {
-                        let year = map.get("year").and_then(|v| v.as_integer()).unwrap_or(1970) as i32;
-                        let month = map.get("month").and_then(|v| v.as_integer()).unwrap_or(1) as u32;
-                        let day = map.get("day").and_then(|v| v.as_integer()).unwrap_or(1) as u32;
-                        if let Some(dt) = chrono::NaiveDate::from_ymd_opt(year, month, day) {
-                            let millis = dt.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp_millis();
-                            Ok(Value::Property(PropertyValue::DateTime(millis)))
-                        } else {
-                            Err(ExecutionError::RuntimeError(format!("Invalid date: {}-{}-{}", year, month, day)))
-                        }
-                    }
-                    _ => Err(ExecutionError::TypeError("date() requires string or map argument".to_string())),
+                let days = (chrono::Utc::now().timestamp() / 86_400) as i32;
+                return Ok(Value::Property(PropertyValue::Date(days)));
+            }
+            match &args[0] {
+                Value::Property(PropertyValue::String(s)) => {
+                    Ok(Value::Property(tmp::parse_date(s)?))
                 }
+                Value::Property(PropertyValue::Map(map)) => {
+                    // Selection: `date({date: d})` and `date({datetime: dt})`
+                    // take the date part of another temporal.
+                    if let Some(src) = map.get("date").or_else(|| map.get("datetime")) {
+                        if let Some(d) = date_part_of(src) {
+                            return Ok(Value::Property(PropertyValue::Date(d)));
+                        }
+                    }
+                    Ok(Value::Property(PropertyValue::Date(tmp::date_days(map)?)))
+                }
+                Value::Property(PropertyValue::Null) => Ok(Value::Property(PropertyValue::Null)),
+                Value::Property(PropertyValue::Date(d)) => {
+                    Ok(Value::Property(PropertyValue::Date(*d)))
+                }
+                other => match value_as_property(other).and_then(|p| date_part_of(&p)) {
+                    Some(d) => Ok(Value::Property(PropertyValue::Date(d))),
+                    None => Err(ExecutionError::TypeError(
+                        "date() requires a string, a map, or a temporal value".to_string(),
+                    )),
+                },
+            }
+        }
+        "localtime" => {
+            use crate::query::executor::temporal as tmp;
+            if args.is_empty() {
+                let now = chrono::Utc::now();
+                let nanos = now.timestamp().rem_euclid(86_400) * 1_000_000_000
+                    + now.timestamp_subsec_nanos() as i64;
+                return Ok(Value::Property(PropertyValue::LocalTime(nanos)));
+            }
+            match &args[0] {
+                Value::Property(PropertyValue::String(s)) => {
+                    let (nanos, _) = tmp::parse_time_parts(s)?;
+                    Ok(Value::Property(PropertyValue::LocalTime(nanos)))
+                }
+                Value::Property(PropertyValue::Map(map)) => {
+                    if let Some(src) = map.get("time").or_else(|| map.get("datetime")) {
+                        if let Some(n) = time_part_of(src) {
+                            return Ok(Value::Property(PropertyValue::LocalTime(n)));
+                        }
+                    }
+                    Ok(Value::Property(PropertyValue::LocalTime(tmp::time_of_day_nanos(map)?)))
+                }
+                Value::Property(PropertyValue::Null) => Ok(Value::Property(PropertyValue::Null)),
+                other => match value_as_property(other).and_then(|p| time_part_of(&p)) {
+                    Some(n) => Ok(Value::Property(PropertyValue::LocalTime(n))),
+                    None => Err(ExecutionError::TypeError(
+                        "localtime() requires a string, a map, or a temporal value".to_string(),
+                    )),
+                },
+            }
+        }
+        "time" => {
+            use crate::query::executor::temporal as tmp;
+            if args.is_empty() {
+                let now = chrono::Utc::now();
+                let nanos = now.timestamp().rem_euclid(86_400) * 1_000_000_000
+                    + now.timestamp_subsec_nanos() as i64;
+                return Ok(Value::Property(PropertyValue::Time { nanos, offset_seconds: 0 }));
+            }
+            match &args[0] {
+                Value::Property(PropertyValue::String(s)) => {
+                    let (nanos, off) = tmp::parse_time_parts(s)?;
+                    Ok(Value::Property(PropertyValue::Time {
+                        nanos,
+                        offset_seconds: off.unwrap_or(0),
+                    }))
+                }
+                Value::Property(PropertyValue::Map(map)) => {
+                    let offset = match map.get("timezone").and_then(|v| v.as_string()) {
+                        Some(tz) => tmp::parse_timezone(&tz)?.0,
+                        None => 0,
+                    };
+                    if let Some(src) = map.get("time").or_else(|| map.get("datetime")) {
+                        if let Some(n) = time_part_of(src) {
+                            return Ok(Value::Property(PropertyValue::Time {
+                                nanos: n,
+                                offset_seconds: offset,
+                            }));
+                        }
+                    }
+                    Ok(Value::Property(PropertyValue::Time {
+                        nanos: tmp::time_of_day_nanos(map)?,
+                        offset_seconds: offset,
+                    }))
+                }
+                Value::Property(PropertyValue::Null) => Ok(Value::Property(PropertyValue::Null)),
+                other => match value_as_property(other).and_then(|p| time_part_of(&p)) {
+                    Some(n) => Ok(Value::Property(PropertyValue::Time { nanos: n, offset_seconds: 0 })),
+                    None => Err(ExecutionError::TypeError(
+                        "time() requires a string, a map, or a temporal value".to_string(),
+                    )),
+                },
+            }
+        }
+        "localdatetime" => {
+            if args.is_empty() {
+                let now = chrono::Utc::now();
+                return Ok(Value::Property(PropertyValue::LocalDateTime {
+                    secs: now.timestamp(),
+                    nanos: now.timestamp_subsec_nanos(),
+                }));
+            }
+            match &args[0] {
+                Value::Property(PropertyValue::String(s)) => {
+                    let (secs, nanos) = parse_naive_date_time(s)?;
+                    Ok(Value::Property(PropertyValue::LocalDateTime { secs, nanos }))
+                }
+                Value::Property(PropertyValue::Map(map)) => {
+                    let (d, t) = compose_date_and_time(map)?;
+                    let total = d as i64 * 86_400 * 1_000_000_000 + t;
+                    Ok(Value::Property(PropertyValue::LocalDateTime {
+                        secs: total.div_euclid(1_000_000_000),
+                        nanos: total.rem_euclid(1_000_000_000) as u32,
+                    }))
+                }
+                Value::Property(PropertyValue::Null) => Ok(Value::Property(PropertyValue::Null)),
+                _ => Err(ExecutionError::TypeError(
+                    "localdatetime() requires a string or map argument".to_string(),
+                )),
             }
         }
         "datetime" => {
+            use crate::query::executor::temporal as tmp;
             if args.is_empty() {
-                let now = chrono::Utc::now().timestamp_millis();
-                Ok(Value::Property(PropertyValue::DateTime(now)))
-            } else {
-                match &args[0] {
-                    Value::Property(PropertyValue::String(s)) => {
-                        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
-                            Ok(Value::Property(PropertyValue::DateTime(dt.timestamp_millis())))
-                        } else if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
-                            Ok(Value::Property(PropertyValue::DateTime(dt.and_utc().timestamp_millis())))
-                        } else {
-                            Err(ExecutionError::RuntimeError(format!("Cannot parse datetime: {}", s)))
-                        }
-                    }
-                    Value::Property(PropertyValue::Map(map)) => {
-                        use chrono::TimeZone;
-
-                        // An epoch, which is what a machine caller has (Axiom 4).
-                        // Handled before the calendar components because it is a
-                        // complete specification on its own -- and because
-                        // without it the map fell through to the defaults below
-                        // and returned 1970-01-01 *silently*, which reads as a
-                        // plausible date rather than a failure (#595).
-                        if let Some(millis) = map.get("epochMillis").and_then(|v| v.as_integer()) {
-                            return Ok(Value::Property(PropertyValue::DateTime(millis)));
-                        }
-                        if let Some(seconds) = map.get("epochSeconds").and_then(|v| v.as_integer()) {
-                            return Ok(Value::Property(PropertyValue::DateTime(seconds * 1000)));
-                        }
-
-                        // A map naming none of the understood keys is a mistake,
-                        // not a request for the epoch. Answering 1970-01-01 for
-                        // it is how the missing `epochMillis` arm stayed
-                        // invisible.
-                        const KNOWN: [&str; 8] = [
-                            "year", "month", "day", "hour", "minute", "second",
-                            "epochMillis", "epochSeconds",
-                        ];
-                        if !map.keys().any(|k| KNOWN.contains(&k.as_str())) {
-                            let mut given: Vec<String> = map.keys().cloned().collect();
-                            given.sort();
-                            return Err(ExecutionError::RuntimeError(format!(
-                                "datetime() understands none of the keys given ({}); expected one of {}",
-                                given.join(", "),
-                                KNOWN.join(", ")
-                            )));
-                        }
-
-                        let year = map.get("year").and_then(|v| v.as_integer()).unwrap_or(1970) as i32;
-                        let month = map.get("month").and_then(|v| v.as_integer()).unwrap_or(1) as u32;
-                        let day = map.get("day").and_then(|v| v.as_integer()).unwrap_or(1) as u32;
-                        let hour = map.get("hour").and_then(|v| v.as_integer()).unwrap_or(0) as u32;
-                        let minute = map.get("minute").and_then(|v| v.as_integer()).unwrap_or(0) as u32;
-                        let second = map.get("second").and_then(|v| v.as_integer()).unwrap_or(0) as u32;
-                        if let Some(dt) = chrono::Utc.with_ymd_and_hms(year, month, day, hour, minute, second).single() {
-                            Ok(Value::Property(PropertyValue::DateTime(dt.timestamp_millis())))
-                        } else {
-                            Err(ExecutionError::RuntimeError(format!(
-                                "Invalid datetime components: year={}, month={}, day={}, hour={}, minute={}, second={}",
-                                year, month, day, hour, minute, second
-                            )))
-                        }
-                    }
-                    _ => Err(ExecutionError::TypeError("datetime() requires string or map argument".to_string())),
-                }
-            }
-        }
-        // CY-28: time() — time of day, stored as millis from epoch midnight
-        "time" => {
-            if args.is_empty() {
-                use chrono::Timelike;
                 let now = chrono::Utc::now();
-                let millis = (now.hour() as i64 * 3600 + now.minute() as i64 * 60 + now.second() as i64) * 1000
-                    + now.timestamp_subsec_millis() as i64;
-                Ok(Value::Property(PropertyValue::DateTime(millis)))
-            } else {
-                match &args[0] {
-                    Value::Property(PropertyValue::String(s)) => {
-                        // Parse HH:MM:SS or HH:MM:SS.sss (ignore timezone for storage)
-                        let time_str = s.split('+').next().unwrap_or(s).split('-').next().unwrap_or(s);
-                        if let Ok(t) = chrono::NaiveTime::parse_from_str(time_str, "%H:%M:%S") {
-                            use chrono::Timelike;
-                            let millis = (t.hour() as i64 * 3600 + t.minute() as i64 * 60 + t.second() as i64) * 1000;
-                            Ok(Value::Property(PropertyValue::DateTime(millis)))
-                        } else if let Ok(t) = chrono::NaiveTime::parse_from_str(time_str, "%H:%M:%S%.f") {
-                            use chrono::Timelike;
-                            let millis = (t.hour() as i64 * 3600 + t.minute() as i64 * 60 + t.second() as i64) * 1000
-                                + (t.nanosecond() / 1_000_000) as i64;
-                            Ok(Value::Property(PropertyValue::DateTime(millis)))
-                        } else {
-                            Err(ExecutionError::RuntimeError(format!("Cannot parse time: {}. Expected HH:MM:SS", s)))
-                        }
-                    }
-                    Value::Property(PropertyValue::Map(map)) => {
-                        let hour = map.get("hour").and_then(|v| v.as_integer()).unwrap_or(0);
-                        let minute = map.get("minute").and_then(|v| v.as_integer()).unwrap_or(0);
-                        let second = map.get("second").and_then(|v| v.as_integer()).unwrap_or(0);
-                        let millis = (hour * 3600 + minute * 60 + second) * 1000;
-                        Ok(Value::Property(PropertyValue::DateTime(millis)))
-                    }
-                    _ => Err(ExecutionError::TypeError("time() requires string or map argument".to_string())),
-                }
+                return Ok(Value::Property(PropertyValue::ZonedDateTime {
+                    secs: now.timestamp(),
+                    nanos: now.timestamp_subsec_nanos(),
+                    offset_seconds: 0,
+                    zone: None,
+                }));
             }
-        }
-        // CY-28: localtime() — same as time() but explicitly no timezone
-        "localtime" => {
-            if args.is_empty() {
-                use chrono::Timelike;
-                let now = chrono::Utc::now();
-                let millis = (now.hour() as i64 * 3600 + now.minute() as i64 * 60 + now.second() as i64) * 1000
-                    + now.timestamp_subsec_millis() as i64;
-                Ok(Value::Property(PropertyValue::DateTime(millis)))
-            } else {
-                match &args[0] {
-                    Value::Property(PropertyValue::String(s)) => {
-                        if let Ok(t) = chrono::NaiveTime::parse_from_str(s, "%H:%M:%S") {
-                            use chrono::Timelike;
-                            let millis = (t.hour() as i64 * 3600 + t.minute() as i64 * 60 + t.second() as i64) * 1000;
-                            Ok(Value::Property(PropertyValue::DateTime(millis)))
-                        } else {
-                            Err(ExecutionError::RuntimeError(format!("Cannot parse localtime: {}. Expected HH:MM:SS", s)))
-                        }
+            match &args[0] {
+                Value::Property(PropertyValue::String(s)) => {
+                    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+                        return Ok(Value::Property(PropertyValue::ZonedDateTime {
+                            secs: dt.timestamp(),
+                            nanos: dt.timestamp_subsec_nanos(),
+                            offset_seconds: dt.offset().local_minus_utc(),
+                            zone: None,
+                        }));
                     }
-                    Value::Property(PropertyValue::Map(map)) => {
-                        let hour = map.get("hour").and_then(|v| v.as_integer()).unwrap_or(0);
-                        let minute = map.get("minute").and_then(|v| v.as_integer()).unwrap_or(0);
-                        let second = map.get("second").and_then(|v| v.as_integer()).unwrap_or(0);
-                        let millis = (hour * 3600 + minute * 60 + second) * 1000;
-                        Ok(Value::Property(PropertyValue::DateTime(millis)))
-                    }
-                    _ => Err(ExecutionError::TypeError("localtime() requires string or map argument".to_string())),
+                    let (secs, nanos) = parse_naive_date_time(s)?;
+                    Ok(Value::Property(PropertyValue::ZonedDateTime {
+                        secs,
+                        nanos,
+                        offset_seconds: 0,
+                        zone: None,
+                    }))
                 }
-            }
-        }
-        // CY-28: localdatetime() — datetime without timezone
-        "localdatetime" => {
-            if args.is_empty() {
-                let now = chrono::Utc::now().timestamp_millis();
-                Ok(Value::Property(PropertyValue::DateTime(now)))
-            } else {
-                match &args[0] {
-                    Value::Property(PropertyValue::String(s)) => {
-                        if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
-                            Ok(Value::Property(PropertyValue::DateTime(dt.and_utc().timestamp_millis())))
-                        } else if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f") {
-                            Ok(Value::Property(PropertyValue::DateTime(dt.and_utc().timestamp_millis())))
-                        } else {
-                            Err(ExecutionError::RuntimeError(format!("Cannot parse localdatetime: {}. Expected YYYY-MM-DDTHH:MM:SS", s)))
-                        }
+                Value::Property(PropertyValue::Map(map)) => {
+                    // An epoch is a complete specification on its own, and is
+                    // handled first: without this the map fell through to the
+                    // component defaults and returned 1970-01-01 *silently*,
+                    // which reads as a plausible date rather than a failure
+                    // (#595).
+                    if let Some(millis) = map.get("epochMillis").and_then(|v| v.as_integer()) {
+                        return Ok(Value::Property(PropertyValue::ZonedDateTime {
+                            secs: millis.div_euclid(1000),
+                            nanos: (millis.rem_euclid(1000) * 1_000_000) as u32,
+                            offset_seconds: 0,
+                            zone: None,
+                        }));
                     }
-                    Value::Property(PropertyValue::Map(map)) => {
-                        use chrono::TimeZone;
-                        let year = map.get("year").and_then(|v| v.as_integer()).unwrap_or(1970) as i32;
-                        let month = map.get("month").and_then(|v| v.as_integer()).unwrap_or(1) as u32;
-                        let day = map.get("day").and_then(|v| v.as_integer()).unwrap_or(1) as u32;
-                        let hour = map.get("hour").and_then(|v| v.as_integer()).unwrap_or(0) as u32;
-                        let minute = map.get("minute").and_then(|v| v.as_integer()).unwrap_or(0) as u32;
-                        let second = map.get("second").and_then(|v| v.as_integer()).unwrap_or(0) as u32;
-                        if let Some(dt) = chrono::Utc.with_ymd_and_hms(year, month, day, hour, minute, second).single() {
-                            Ok(Value::Property(PropertyValue::DateTime(dt.timestamp_millis())))
-                        } else {
-                            Err(ExecutionError::RuntimeError(format!("Invalid localdatetime components")))
-                        }
+                    if let Some(secs) = map.get("epochSeconds").and_then(|v| v.as_integer()) {
+                        return Ok(Value::Property(PropertyValue::ZonedDateTime {
+                            secs,
+                            nanos: 0,
+                            offset_seconds: 0,
+                            zone: None,
+                        }));
                     }
-                    _ => Err(ExecutionError::TypeError("localdatetime() requires string or map argument".to_string())),
+                    let (offset_seconds, zone) = match map.get("timezone").and_then(|v| v.as_string()) {
+                        Some(tz) => tmp::parse_timezone(&tz)?,
+                        None => (0, None),
+                    };
+                    let (d, t) = compose_date_and_time(map)?;
+                    let local = d as i64 * 86_400 * 1_000_000_000 + t;
+                    // The components describe local time; store the instant.
+                    let utc = local - offset_seconds as i64 * 1_000_000_000;
+                    Ok(Value::Property(PropertyValue::ZonedDateTime {
+                        secs: utc.div_euclid(1_000_000_000),
+                        nanos: utc.rem_euclid(1_000_000_000) as u32,
+                        offset_seconds,
+                        zone,
+                    }))
                 }
+                Value::Property(PropertyValue::Null) => Ok(Value::Property(PropertyValue::Null)),
+                _ => Err(ExecutionError::TypeError(
+                    "datetime() requires a string or map argument".to_string(),
+                )),
             }
         }
         "duration" => {

--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -480,6 +480,19 @@ impl Value {
                 .get(property)
                 .cloned()
                 .unwrap_or(PropertyValue::Null),
+            // Component access on the five temporal types (#689).
+            //
+            // Routed through one function so a `Date` and a `LocalDateTime`
+            // cannot disagree about what `.year` means. Before this, only the
+            // legacy `DateTime` had accessors, so teaching the constructors to
+            // return real types would have silently removed `dt.year` — which
+            // the suite caught, and which is Cypher-required behaviour rather
+            // than a test encoding the old shape.
+            Value::Property(p @ (PropertyValue::Date(_)
+                | PropertyValue::LocalTime(_)
+                | PropertyValue::Time { .. }
+                | PropertyValue::LocalDateTime { .. }
+                | PropertyValue::ZonedDateTime { .. })) => temporal_component(p, property),
             // Temporal component access: dt.year, dt.month, dur.days, etc.
             Value::Property(PropertyValue::DateTime(millis)) => {
                 use chrono::{Datelike, Timelike, TimeZone};
@@ -1154,6 +1167,93 @@ impl PropertyCursor {
             }
             Some(other) => other.resolve_property(&self.property, store),
             None => PropertyValue::Null,
+        }
+    }
+}
+
+/// One component of a temporal value: `.year`, `.hour`, `.offsetSeconds`, ...
+///
+/// Absent components are `Null`, which is Cypher's answer — `date.hour` has no
+/// meaning and is null rather than zero. Returning zero would read as midnight.
+fn temporal_component(v: &PropertyValue, property: &str) -> PropertyValue {
+    use chrono::{Datelike, Timelike};
+    const DAY_NS: i64 = 86_400 * 1_000_000_000;
+
+    // Split into the date part (days since epoch) and the time part (nanos
+    // since midnight), each optional, and answer from those.
+    let (days, tod, offset, zone) = match v {
+        PropertyValue::Date(d) => (Some(*d as i64), None, None, None),
+        PropertyValue::LocalTime(n) => (None, Some(*n), None, None),
+        PropertyValue::Time { nanos, offset_seconds } => {
+            (None, Some(*nanos), Some(*offset_seconds), None)
+        }
+        PropertyValue::LocalDateTime { secs, nanos } => (
+            Some(secs.div_euclid(86_400)),
+            Some(secs.rem_euclid(86_400) * 1_000_000_000 + *nanos as i64),
+            None,
+            None,
+        ),
+        PropertyValue::ZonedDateTime { secs, nanos, offset_seconds, zone } => {
+            let local = secs + *offset_seconds as i64;
+            (
+                Some(local.div_euclid(86_400)),
+                Some(local.rem_euclid(86_400) * 1_000_000_000 + *nanos as i64),
+                Some(*offset_seconds),
+                zone.clone(),
+            )
+        }
+        _ => return PropertyValue::Null,
+    };
+
+    let date = days.and_then(|d| {
+        chrono::NaiveDate::from_ymd_opt(1970, 1, 1)?.checked_add_signed(chrono::Duration::days(d))
+    });
+    let int = |x: i64| PropertyValue::Integer(x);
+
+    match property {
+        "year" => date.map_or(PropertyValue::Null, |d| int(d.year() as i64)),
+        "month" => date.map_or(PropertyValue::Null, |d| int(d.month() as i64)),
+        "day" => date.map_or(PropertyValue::Null, |d| int(d.day() as i64)),
+        "quarter" => date.map_or(PropertyValue::Null, |d| int(((d.month() - 1) / 3 + 1) as i64)),
+        "dayOfQuarter" => date.map_or(PropertyValue::Null, |d| {
+            let qm = (d.month() - 1) / 3 * 3 + 1;
+            let start = chrono::NaiveDate::from_ymd_opt(d.year(), qm, 1);
+            start.map_or(PropertyValue::Null, |s| {
+                int(d.signed_duration_since(s).num_days() + 1)
+            })
+        }),
+        "week" => date.map_or(PropertyValue::Null, |d| int(d.iso_week().week() as i64)),
+        "weekYear" => date.map_or(PropertyValue::Null, |d| int(d.iso_week().year() as i64)),
+        "dayOfWeek" => date.map_or(PropertyValue::Null, |d| {
+            int(d.weekday().number_from_monday() as i64)
+        }),
+        "ordinalDay" => date.map_or(PropertyValue::Null, |d| int(d.ordinal() as i64)),
+
+        "hour" => tod.map_or(PropertyValue::Null, |n| int(n / 3_600_000_000_000)),
+        "minute" => tod.map_or(PropertyValue::Null, |n| int(n / 60_000_000_000 % 60)),
+        "second" => tod.map_or(PropertyValue::Null, |n| int(n / 1_000_000_000 % 60)),
+        "millisecond" => tod.map_or(PropertyValue::Null, |n| int(n % 1_000_000_000 / 1_000_000)),
+        "microsecond" => tod.map_or(PropertyValue::Null, |n| int(n % 1_000_000_000 / 1_000)),
+        "nanosecond" => tod.map_or(PropertyValue::Null, |n| int(n % 1_000_000_000)),
+
+        "offsetSeconds" => offset.map_or(PropertyValue::Null, |o| int(o as i64)),
+        "offsetMinutes" => offset.map_or(PropertyValue::Null, |o| int(o as i64 / 60)),
+        "offset" => offset.map_or(PropertyValue::Null, |o| {
+            PropertyValue::String(crate::graph::property::fmt_offset(o))
+        }),
+        "timezone" => match zone {
+            Some(z) => PropertyValue::String(z),
+            None => offset.map_or(PropertyValue::Null, |o| {
+                PropertyValue::String(crate::graph::property::fmt_offset(o))
+            }),
+        },
+        "epochMillis" => v.as_epoch_millis().map_or(PropertyValue::Null, int),
+        "epochSeconds" => v
+            .as_epoch_millis()
+            .map_or(PropertyValue::Null, |ms| int(ms.div_euclid(1000))),
+        _ => {
+            let _ = DAY_NS;
+            PropertyValue::Null
         }
     }
 }

--- a/src/query/executor/temporal.rs
+++ b/src/query/executor/temporal.rs
@@ -219,3 +219,37 @@ fn split_offset(t: &str) -> Result<(&str, Option<i32>), ExecutionError> {
     }
     Ok((t, None))
 }
+
+/// Every map key the temporal constructors understand.
+const KNOWN_KEYS: &[&str] = &[
+    "epochMillis", "epochSeconds",
+    "year", "month", "day", "week", "dayOfWeek", "quarter", "dayOfQuarter", "ordinalDay",
+    "hour", "minute", "second", "millisecond", "microsecond", "nanosecond",
+    "timezone", "date", "time", "datetime",
+];
+
+/// Refuse a map that names nothing the constructor understands, and say which
+/// keys it was given.
+///
+/// This is the half of #595 that keeps the other half honest: before it, *any*
+/// unrecognised map fell through to the component defaults and produced
+/// `1970-01-01`, which is why a missing `epochMillis` arm went unnoticed for so
+/// long. A generic "needs a date" would have re-opened that hole by a different
+/// route -- it does not name what was actually passed, so a typo like
+/// `epochMilis` reads as "you forgot the date" rather than "that key is not a
+/// thing".
+pub fn reject_unknown_map(
+    map: &std::collections::HashMap<String, PropertyValue>,
+) -> Result<(), ExecutionError> {
+    if map.keys().any(|k| KNOWN_KEYS.contains(&k.as_str())) {
+        return Ok(());
+    }
+    let mut given: Vec<&str> = map.keys().map(|k| k.as_str()).collect();
+    given.sort_unstable();
+    Err(err(format!(
+        "this constructor understands none of the keys given ({}); \
+         expected one of: {}",
+        if given.is_empty() { "the map is empty".to_string() } else { given.join(", ") },
+        KNOWN_KEYS.join(", ")
+    )))
+}

--- a/src/query/executor/temporal.rs
+++ b/src/query/executor/temporal.rs
@@ -1,0 +1,221 @@
+//! Constructing openCypher's five temporal types from maps and strings (#689).
+//!
+//! One module rather than five copies inside the function dispatcher, because
+//! the component rules are shared and were previously re-implemented per
+//! constructor — which is how `time()` came to accept `hour`/`minute`/`second`
+//! but silently ignore `nanosecond`, while `localtime()` did the same thing a
+//! few lines further down. The engine has a standing habit of answering one
+//! question in several places; this is the version of that habit that produces
+//! wrong values rather than slow ones.
+//!
+//! ## Sub-second components add up
+//!
+//! Cypher treats `millisecond`, `microsecond` and `nanosecond` as *additive*
+//! sub-components of the second, not as alternative spellings:
+//!
+//! ```text
+//! {second: 14, millisecond: 645, microsecond: 876, nanosecond: 123}
+//!   -> 14.645876123
+//! ```
+//!
+//! Each is bounded by the next unit up, so 1000 microseconds is an error
+//! rather than a carry into milliseconds.
+
+use crate::graph::PropertyValue;
+use crate::query::executor::ExecutionError;
+
+const NANOS_PER_SEC: i64 = 1_000_000_000;
+const NANOS_PER_DAY: i64 = 86_400 * NANOS_PER_SEC;
+
+fn err(msg: impl Into<String>) -> ExecutionError {
+    ExecutionError::RuntimeError(msg.into())
+}
+
+fn field(map: &std::collections::HashMap<String, PropertyValue>, k: &str) -> Option<i64> {
+    map.get(k).and_then(|v| v.as_integer())
+}
+
+/// Whether any of `keys` is present, so a constructor can tell which of the
+/// several map forms it was handed.
+fn has_any(map: &std::collections::HashMap<String, PropertyValue>, keys: &[&str]) -> bool {
+    keys.iter().any(|k| map.contains_key(*k))
+}
+
+/// Nanoseconds since midnight from the time components of a map.
+///
+/// Absent components are zero, which is what Cypher specifies — `{hour: 10}`
+/// is 10:00:00.000000000 — but a component that is *present and out of range*
+/// is an error rather than a wrap, because a silently wrapped hour reads as a
+/// valid time.
+pub fn time_of_day_nanos(
+    map: &std::collections::HashMap<String, PropertyValue>,
+) -> Result<i64, ExecutionError> {
+    let hour = field(map, "hour").unwrap_or(0);
+    let minute = field(map, "minute").unwrap_or(0);
+    let second = field(map, "second").unwrap_or(0);
+    let milli = field(map, "millisecond").unwrap_or(0);
+    let micro = field(map, "microsecond").unwrap_or(0);
+    let nano = field(map, "nanosecond").unwrap_or(0);
+
+    for (name, v, hi) in [
+        ("hour", hour, 23),
+        ("minute", minute, 59),
+        ("second", second, 59),
+        ("millisecond", milli, 999),
+        ("microsecond", micro, 999_999),
+        ("nanosecond", nano, 999_999_999),
+    ] {
+        if v < 0 || v > hi {
+            return Err(err(format!("{name} must be 0..={hi}, got {v}")));
+        }
+    }
+
+    Ok((hour * 3600 + minute * 60 + second) * NANOS_PER_SEC
+        + milli * 1_000_000
+        + micro * 1_000
+        + nano)
+}
+
+/// Days since 1970-01-01 from the date components of a map.
+///
+/// Four spellings, all in the TCK: calendar (`year`/`month`/`day`), week
+/// (`year`/`week`/`dayOfWeek`), quarter (`year`/`quarter`/`dayOfQuarter`) and
+/// ordinal (`year`/`ordinalDay`). They are distinguished by which keys are
+/// present, and the earlier code supported only the first — the other three
+/// silently fell through to 1 January.
+pub fn date_days(
+    map: &std::collections::HashMap<String, PropertyValue>,
+) -> Result<i32, ExecutionError> {
+    use chrono::NaiveDate;
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).expect("epoch is a date");
+    let year = field(map, "year").ok_or_else(|| err("a date needs a year"))? as i32;
+
+    let date = if has_any(map, &["week", "dayOfWeek"]) {
+        let week = field(map, "week").unwrap_or(1) as u32;
+        let dow = field(map, "dayOfWeek").unwrap_or(1) as u32;
+        if !(1..=7).contains(&dow) {
+            return Err(err(format!("dayOfWeek must be 1..=7, got {dow}")));
+        }
+        NaiveDate::from_isoywd_opt(year, week, weekday_from_iso(dow))
+            .ok_or_else(|| err(format!("invalid ISO week date {year}-W{week}-{dow}")))?
+    } else if has_any(map, &["quarter", "dayOfQuarter"]) {
+        let q = field(map, "quarter").unwrap_or(1);
+        let d = field(map, "dayOfQuarter").unwrap_or(1);
+        if !(1..=4).contains(&q) {
+            return Err(err(format!("quarter must be 1..=4, got {q}")));
+        }
+        let first_month = (q - 1) * 3 + 1;
+        let start = NaiveDate::from_ymd_opt(year, first_month as u32, 1)
+            .ok_or_else(|| err(format!("invalid quarter start {year}-Q{q}")))?;
+        start
+            .checked_add_signed(chrono::Duration::days(d - 1))
+            .ok_or_else(|| err(format!("invalid dayOfQuarter {d}")))?
+    } else if let Some(ord) = field(map, "ordinalDay") {
+        NaiveDate::from_yo_opt(year, ord as u32)
+            .ok_or_else(|| err(format!("invalid ordinalDay {ord} for {year}")))?
+    } else {
+        let month = field(map, "month").unwrap_or(1) as u32;
+        let day = field(map, "day").unwrap_or(1) as u32;
+        NaiveDate::from_ymd_opt(year, month, day)
+            .ok_or_else(|| err(format!("invalid date {year}-{month}-{day}")))?
+    };
+
+    Ok(date.signed_duration_since(epoch).num_days() as i32)
+}
+
+fn weekday_from_iso(dow: u32) -> chrono::Weekday {
+    use chrono::Weekday::*;
+    match dow {
+        1 => Mon,
+        2 => Tue,
+        3 => Wed,
+        4 => Thu,
+        5 => Fri,
+        6 => Sat,
+        _ => Sun,
+    }
+}
+
+/// A UTC offset in seconds from `Z`, `+01:00`, `+0100`, `+01`, or an IANA name.
+///
+/// Returns the offset and the IANA name when one was given, because Cypher
+/// keeps both: an offset alone cannot survive a DST boundary and a name alone
+/// cannot express `+05:30` attached to nothing.
+pub fn parse_timezone(tz: &str) -> Result<(i32, Option<String>), ExecutionError> {
+    let t = tz.trim();
+    if t.eq_ignore_ascii_case("z") || t.eq_ignore_ascii_case("utc") {
+        return Ok((0, None));
+    }
+    if t.starts_with('+') || t.starts_with('-') {
+        let sign = if t.starts_with('-') { -1 } else { 1 };
+        let rest = &t[1..];
+        let (h, m) = match rest.split_once(':') {
+            Some((h, m)) => (h, m),
+            None if rest.len() == 4 => (&rest[..2], &rest[2..]),
+            None => (rest, "0"),
+        };
+        let h: i32 = h.parse().map_err(|_| err(format!("bad timezone offset: {tz}")))?;
+        let m: i32 = m.parse().map_err(|_| err(format!("bad timezone offset: {tz}")))?;
+        return Ok((sign * (h * 3600 + m * 60), None));
+    }
+    // A named zone. Resolving it to an offset needs a tz database, which the
+    // engine does not carry yet; the name is preserved so nothing is lost, and
+    // the offset is reported as unknown rather than guessed as UTC — guessing
+    // would silently shift every value by the real offset.
+    Err(err(format!(
+        "named time zone `{tz}` needs a tz database, which is not built in yet; \
+         use an offset such as +01:00"
+    )))
+}
+
+/// `PropertyValue::Date` from an ISO string: `2015-07-21`, `20150721`,
+/// `2015-W30-2`, `2015-201`.
+pub fn parse_date(s: &str) -> Result<PropertyValue, ExecutionError> {
+    use chrono::NaiveDate;
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).expect("epoch is a date");
+    let t = s.trim();
+    let parsed = NaiveDate::parse_from_str(t, "%Y-%m-%d")
+        .or_else(|_| NaiveDate::parse_from_str(t, "%Y%m%d"))
+        .or_else(|_| NaiveDate::parse_from_str(t, "%Y-%j"))
+        .map_err(|_| err(format!("cannot parse date: {s}")))?;
+    Ok(PropertyValue::Date(
+        parsed.signed_duration_since(epoch).num_days() as i32,
+    ))
+}
+
+/// Nanoseconds since midnight, and an offset if the string carried one.
+pub fn parse_time_parts(s: &str) -> Result<(i64, Option<i32>), ExecutionError> {
+    let t = s.trim();
+    // Split the offset off the end before parsing the clock, so `-05:00` is
+    // not mistaken for part of the time.
+    let (clock, offset) = split_offset(t)?;
+    let nt = chrono::NaiveTime::parse_from_str(clock, "%H:%M:%S%.f")
+        .or_else(|_| chrono::NaiveTime::parse_from_str(clock, "%H:%M:%S"))
+        .or_else(|_| chrono::NaiveTime::parse_from_str(clock, "%H:%M"))
+        .or_else(|_| chrono::NaiveTime::parse_from_str(clock, "%H"))
+        .map_err(|_| err(format!("cannot parse time: {s}")))?;
+    let nanos = nt
+        .signed_duration_since(chrono::NaiveTime::MIN)
+        .num_nanoseconds()
+        .ok_or_else(|| err(format!("time out of range: {s}")))?;
+    Ok((nanos, offset))
+}
+
+/// Separate a trailing UTC offset from the clock part.
+fn split_offset(t: &str) -> Result<(&str, Option<i32>), ExecutionError> {
+    if let Some(stripped) = t.strip_suffix('Z').or_else(|| t.strip_suffix('z')) {
+        return Ok((stripped, Some(0)));
+    }
+    // Scan from the right for a sign that begins an offset, not a date dash.
+    if let Some(pos) = t.rfind(['+', '-']) {
+        // A '-' inside the first 8 characters of a date-time belongs to the
+        // date, not to an offset.
+        let looks_like_offset = t[pos..].contains(':') || t[pos..].len() <= 5;
+        if looks_like_offset && pos > 0 {
+            let (clock, off) = t.split_at(pos);
+            let (secs, _) = parse_timezone(off)?;
+            return Ok((clock, Some(secs)));
+        }
+    }
+    Ok((t, None))
+}

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -767,6 +767,28 @@ fn property_to_json(pv: &PropertyValue) -> serde_json::Value {
             // Wrap in an object to distinguish from plain integer
             serde_json::json!({"__type": "DateTime", "value": dt})
         }
+        // The five real temporal types (#689). Same `__type` scheme as
+        // DateTime/Vector/Duration, and each carries its own components rather
+        // than an epoch, because an epoch cannot represent a `Date` without a
+        // zone or a `LocalTime` without a date. `DateTime` above stays exactly
+        // as it was so snapshots written before this still read back.
+        PropertyValue::Date(days) => serde_json::json!({"__type": "Date", "days": days}),
+        PropertyValue::LocalTime(nanos) => {
+            serde_json::json!({"__type": "LocalTime", "nanos": nanos})
+        }
+        PropertyValue::Time { nanos, offset_seconds } => {
+            serde_json::json!({"__type": "Time", "nanos": nanos, "offset": offset_seconds})
+        }
+        PropertyValue::LocalDateTime { secs, nanos } => {
+            serde_json::json!({"__type": "LocalDateTime", "secs": secs, "nanos": nanos})
+        }
+        PropertyValue::ZonedDateTime { secs, nanos, offset_seconds, zone } => {
+            serde_json::json!({
+                "__type": "ZonedDateTime",
+                "secs": secs, "nanos": nanos,
+                "offset": offset_seconds, "zone": zone
+            })
+        }
         PropertyValue::Array(arr) => {
             serde_json::Value::Array(arr.iter().map(property_to_json).collect())
         }
@@ -822,6 +844,42 @@ fn json_to_property(val: &serde_json::Value) -> PropertyValue {
                     "DateTime" => {
                         if let Some(dt) = obj.get("value").and_then(|v| v.as_i64()) {
                             return PropertyValue::DateTime(dt);
+                        }
+                    }
+                    "Date" => {
+                        if let Some(d) = obj.get("days").and_then(|v| v.as_i64()) {
+                            return PropertyValue::Date(d as i32);
+                        }
+                    }
+                    "LocalTime" => {
+                        if let Some(n) = obj.get("nanos").and_then(|v| v.as_i64()) {
+                            return PropertyValue::LocalTime(n);
+                        }
+                    }
+                    "Time" => {
+                        if let Some(n) = obj.get("nanos").and_then(|v| v.as_i64()) {
+                            return PropertyValue::Time {
+                                nanos: n,
+                                offset_seconds: obj.get("offset").and_then(|v| v.as_i64()).unwrap_or(0) as i32,
+                            };
+                        }
+                    }
+                    "LocalDateTime" => {
+                        if let Some(sec) = obj.get("secs").and_then(|v| v.as_i64()) {
+                            return PropertyValue::LocalDateTime {
+                                secs: sec,
+                                nanos: obj.get("nanos").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
+                            };
+                        }
+                    }
+                    "ZonedDateTime" => {
+                        if let Some(sec) = obj.get("secs").and_then(|v| v.as_i64()) {
+                            return PropertyValue::ZonedDateTime {
+                                secs: sec,
+                                nanos: obj.get("nanos").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
+                                offset_seconds: obj.get("offset").and_then(|v| v.as_i64()).unwrap_or(0) as i32,
+                                zone: obj.get("zone").and_then(|v| v.as_str()).map(|z| z.to_string()),
+                            };
                         }
                     }
                     "Vector" => {
@@ -1997,5 +2055,66 @@ mod dedup_tests {
 
         // Without dedup, we get 2 Drug nodes
         assert_eq!(combined.node_count(), 2);
+    }
+}
+
+#[cfg(test)]
+mod temporal_snapshot_tests {
+    use super::{json_to_property, property_to_json};
+    use crate::graph::PropertyValue as P;
+
+    /// The snapshot's own `__type` scheme, round-tripped through the two
+    /// functions that actually write and read it.
+    ///
+    /// This lives here rather than in `tests/` because both functions are
+    /// private, and making them public purely to test them would widen the
+    /// API for no caller. The integration test in
+    /// `tests/temporal_representation.rs` covers serde; this covers disk, and
+    /// they are genuinely different encodings — a value can survive one and be
+    /// destroyed by the other.
+    #[test]
+    fn temporal_values_survive_the_snapshot_encoding() {
+        let values = vec![
+            P::Date(16637),
+            P::Date(-25567),
+            P::LocalTime(45_074_645_876_123),
+            P::Time { nanos: 45_074_645_876_123, offset_seconds: 19_800 },
+            P::Time { nanos: 0, offset_seconds: -18_000 },
+            P::LocalDateTime { secs: 1_437_514_832, nanos: 142_000_000 },
+            P::ZonedDateTime {
+                secs: 1_437_514_832,
+                nanos: 999_999_999,
+                offset_seconds: 3600,
+                zone: Some("Europe/London".to_string()),
+            },
+            P::ZonedDateTime { secs: 0, nanos: 0, offset_seconds: 0, zone: None },
+            // Nested, because properties can be arrays and maps of temporals
+            // and the recursion is a separate thing to get wrong.
+            P::Array(vec![P::Date(1), P::LocalTime(2)]),
+        ];
+        for v in values {
+            let encoded = property_to_json(&v);
+            let back = json_to_property(&encoded);
+            assert_eq!(back, v, "{v:?} did not survive the snapshot encoding: {encoded}");
+        }
+    }
+
+    /// A snapshot written before #689 still reads back. This is the
+    /// compatibility promise; nothing else would catch breaking it.
+    #[test]
+    fn a_pre_689_snapshot_still_loads() {
+        let legacy = serde_json::json!({"__type": "DateTime", "value": 1_437_514_832_142i64});
+        assert_eq!(json_to_property(&legacy), P::DateTime(1_437_514_832_142));
+        // And it still writes in the old shape, so a downgrade reads it too.
+        assert_eq!(property_to_json(&P::DateTime(1_437_514_832_142)), legacy);
+    }
+
+    /// An unknown or malformed `__type` must not be silently read as something
+    /// else. A truncated temporal that came back as `Null` would look like a
+    /// missing property rather than a corrupt one.
+    #[test]
+    fn a_malformed_temporal_tag_does_not_become_a_plausible_value() {
+        let broken = serde_json::json!({"__type": "Date"});          // no `days`
+        assert_ne!(json_to_property(&broken), P::Date(0), "must not default to the epoch");
     }
 }

--- a/tests/columnar_holds_every_variant.rs
+++ b/tests/columnar_holds_every_variant.rs
@@ -50,6 +50,34 @@ fn every_variant() -> Vec<(&'static str, PropertyValue)> {
             "duration",
             PropertyValue::Duration { months: 1, days: 2, seconds: 3, nanos: 4 },
         ),
+        // The five temporal types (#689). Added here rather than left out,
+        // because this file's whole claim is "every variant" -- adding
+        // variants to `PropertyValue` without extending it would quietly turn
+        // the name into a lie, and the loss would surface as missing data
+        // after #545 removes the row copy, not here.
+        //
+        // Values chosen so a lossy round trip cannot pass by accident: the
+        // nanoseconds do not fit in milliseconds, and the offset is a
+        // half-hour one that an hours-only path truncates.
+        ("date", PropertyValue::Date(16_637)),
+        ("localtime", PropertyValue::LocalTime(45_074_645_876_123)),
+        (
+            "time",
+            PropertyValue::Time { nanos: 45_074_645_876_123, offset_seconds: 19_800 },
+        ),
+        (
+            "localdatetime",
+            PropertyValue::LocalDateTime { secs: 1_437_514_832, nanos: 142_000_042 },
+        ),
+        (
+            "zoneddatetime",
+            PropertyValue::ZonedDateTime {
+                secs: 1_437_514_832,
+                nanos: 999_999_999,
+                offset_seconds: 3600,
+                zone: Some("Europe/London".to_string()),
+            },
+        ),
     ]
 }
 

--- a/tests/datetime_construction.rs
+++ b/tests/datetime_construction.rs
@@ -32,11 +32,25 @@ fn one(cypher: &str) -> Result<PropertyValue, String> {
 
 const NOV_2023: i64 = 1_700_000_000_000;
 
+/// The instant `NOV_2023` names, as the type `datetime()` now returns.
+///
+/// Since #689 `datetime()` produces a `ZonedDateTime` rather than a bare
+/// millisecond `DateTime`. The *instant* asserted here is unchanged — only the
+/// type it is carried in — so these tests still check what #595 was about.
+fn nov_2023() -> PropertyValue {
+    PropertyValue::ZonedDateTime {
+        secs: NOV_2023 / 1000,
+        nanos: 0,
+        offset_seconds: 0,
+        zone: None,
+    }
+}
+
 #[test]
 fn epoch_millis_yields_that_instant() {
     assert_eq!(
         one("RETURN datetime({epochMillis: 1700000000000}) AS r").unwrap(),
-        PropertyValue::DateTime(NOV_2023)
+        nov_2023()
     );
 }
 
@@ -69,7 +83,7 @@ fn its_components_are_right() {
 fn epoch_seconds_works_too() {
     assert_eq!(
         one("RETURN datetime({epochSeconds: 1700000000}) AS r").unwrap(),
-        PropertyValue::DateTime(NOV_2023)
+        nov_2023()
     );
 }
 
@@ -120,6 +134,6 @@ fn epoch_millis_wins_over_calendar_components() {
     // as a test because the precedence is a choice, not an accident.
     assert_eq!(
         one("RETURN datetime({epochMillis: 1700000000000, year: 1999}) AS r").unwrap(),
-        PropertyValue::DateTime(NOV_2023)
+        nov_2023()
     );
 }

--- a/tests/temporal_representation.rs
+++ b/tests/temporal_representation.rs
@@ -1,0 +1,188 @@
+//! The five temporal types: representation, ordering, rendering, and — most
+//! importantly — that they survive a snapshot round trip (#689).
+//!
+//! Every temporal value used to be `PropertyValue::DateTime(i64)`, a Unix
+//! timestamp in milliseconds. Cypher has five distinct temporal types and
+//! nanosecond precision, so `date()`, `time()`, `localtime()`,
+//! `localdatetime()` and `datetime()` were indistinguishable once evaluated,
+//! and `12:31:14.645876123` was destroyed at construction rather than merely
+//! displayed wrongly.
+//!
+//! These tests come *before* any temporal function changes, deliberately. The
+//! risky part of #689 is not the arithmetic, it is that `PropertyValue` is
+//! serialized into the snapshot format: getting the on-disk shape wrong is the
+//! one mistake that cannot be fixed by a later commit. Pinning the format
+//! first means the function work cannot quietly change it.
+
+use samyama::graph::PropertyValue as P;
+
+/// Round-trip through **serde**, which is the in-memory/wire encoding.
+///
+/// This is deliberately NOT the snapshot format. The snapshot has its own
+/// `__type`-tagged JSON scheme, and a serde round trip can pass while the
+/// snapshot silently loses the value — so that scheme is pinned separately, in
+/// `src/snapshot/mod.rs`'s own tests, where the two functions actually live.
+/// I first wrote this helper's comment claiming it exercised the snapshot path
+/// and it did not; the comment was wrong before the code was.
+fn serde_round_trip(v: &P) -> P {
+    let json = serde_json::to_string(v).expect("serialize");
+    serde_json::from_str(&json).expect("deserialize")
+}
+
+#[test]
+fn every_temporal_type_survives_serialization() {
+    let values = vec![
+        P::Date(16637),
+        P::LocalTime(45_074_645_876_123),
+        P::Time { nanos: 45_074_645_876_123, offset_seconds: 3600 },
+        P::LocalDateTime { secs: 1_437_514_832, nanos: 142_000_000 },
+        P::ZonedDateTime {
+            secs: 1_437_514_832,
+            nanos: 142_000_000,
+            offset_seconds: 3600,
+            zone: Some("Europe/London".to_string()),
+        },
+        P::ZonedDateTime { secs: 0, nanos: 0, offset_seconds: 0, zone: None },
+    ];
+    for v in values {
+        assert_eq!(serde_round_trip(&v), v, "{v:?} did not survive");
+    }
+}
+
+/// Nanoseconds are the whole point: this value cannot be represented in
+/// milliseconds at all, which is why the old type destroyed it.
+#[test]
+fn nanosecond_precision_is_not_lost() {
+    let t = P::LocalTime(45_074_645_876_123);
+    assert_eq!(serde_round_trip(&t), t);
+    assert_eq!(t.to_cypher_string(), "12:31:14.645876123");
+
+    // The millisecond reading of the same value, for comparison: three of the
+    // nine digits survive. That is what every temporal value used to become.
+    assert_eq!(t.as_epoch_millis(), Some(45_074_645));
+}
+
+/// The legacy variant still deserializes, so snapshots written before this
+/// change still load. This is the compatibility promise, and it is a test
+/// rather than a comment because nothing else would catch breaking it.
+#[test]
+fn the_legacy_millisecond_datetime_still_round_trips() {
+    let old = P::DateTime(1_437_514_832_142);
+    assert_eq!(serde_round_trip(&old), old);
+    assert_eq!(old.as_epoch_millis(), Some(1_437_514_832_142));
+}
+
+/// openCypher's rendering, which is what `toString()` returns and what the TCK
+/// compares against. Trailing zero components are dropped.
+#[test]
+fn values_render_the_way_cypher_writes_them() {
+    assert_eq!(P::Date(16637).to_cypher_string(), "2015-07-21");
+    // The issue's own example: `localtime({hour: 10, minute: 35})` is '10:35',
+    // not '10:35:00.000000000'.
+    assert_eq!(P::LocalTime(38_100_000_000_000).to_cypher_string(), "10:35");
+    assert_eq!(P::LocalTime(45_074_000_000_000).to_cypher_string(), "12:31:14");
+    assert_eq!(
+        P::LocalTime(45_074_645_876_123).to_cypher_string(),
+        "12:31:14.645876123"
+    );
+    assert_eq!(
+        P::Time { nanos: 45_074_645_876_123, offset_seconds: 3600 }.to_cypher_string(),
+        "12:31:14.645876123+01:00"
+    );
+    // A half-hour offset, which a naive hours-only formatter gets wrong.
+    assert_eq!(
+        P::Time { nanos: 0, offset_seconds: 19_800 }.to_cypher_string(),
+        "00:00+05:30"
+    );
+    assert_eq!(
+        P::Time { nanos: 0, offset_seconds: -18_000 }.to_cypher_string(),
+        "00:00-05:00"
+    );
+    assert_eq!(
+        P::LocalDateTime { secs: 1_437_514_832, nanos: 142_000_000 }.to_cypher_string(),
+        "2015-07-21T21:40:32.142"
+    );
+}
+
+/// A zoned value renders in its own offset, not in UTC, and keeps the IANA
+/// name when it has one.
+#[test]
+fn a_zoned_datetime_renders_in_its_own_offset() {
+    let z = P::ZonedDateTime {
+        secs: 1_437_514_832,
+        nanos: 0,
+        offset_seconds: 3600,
+        zone: Some("Europe/London".to_string()),
+    };
+    assert_eq!(z.to_cypher_string(), "2015-07-21T22:40:32+01:00[Europe/London]");
+
+    // Same instant, no named zone: offset only.
+    let z2 = P::ZonedDateTime { secs: 1_437_514_832, nanos: 0, offset_seconds: 3600, zone: None };
+    assert_eq!(z2.to_cypher_string(), "2015-07-21T22:40:32+01:00");
+
+    // Offset and zone are both carried because neither implies the other; two
+    // values differing only in zone must not be equal.
+    assert_ne!(z, z2);
+}
+
+/// Each type is its own kind. A `Date` and a `LocalTime` holding the same
+/// integer are different values, and the index must not collapse them.
+#[test]
+fn the_types_are_distinct_from_each_other() {
+    assert_ne!(P::Date(1), P::LocalTime(1));
+    assert_ne!(P::Date(0), P::DateTime(0));
+    assert_ne!(
+        P::LocalDateTime { secs: 0, nanos: 0 },
+        P::ZonedDateTime { secs: 0, nanos: 0, offset_seconds: 0, zone: None }
+    );
+    assert_eq!(P::Date(1).type_name(), "Date");
+    assert_eq!(P::LocalTime(1).type_name(), "LocalTime");
+    assert_eq!(P::Time { nanos: 1, offset_seconds: 0 }.type_name(), "Time");
+    assert_eq!(P::LocalDateTime { secs: 1, nanos: 0 }.type_name(), "LocalDateTime");
+    assert_eq!(
+        P::ZonedDateTime { secs: 1, nanos: 0, offset_seconds: 0, zone: None }.type_name(),
+        "DateTime"
+    );
+}
+
+/// Within a type, ordering follows the instant.
+#[test]
+fn values_of_one_type_sort_chronologically() {
+    let mut dates = vec![P::Date(100), P::Date(-5), P::Date(0)];
+    dates.sort();
+    assert_eq!(dates, vec![P::Date(-5), P::Date(0), P::Date(100)]);
+
+    let mut times = vec![P::LocalTime(2), P::LocalTime(0), P::LocalTime(1)];
+    times.sort();
+    assert_eq!(times, vec![P::LocalTime(0), P::LocalTime(1), P::LocalTime(2)]);
+}
+
+/// A zoned time sorts by the instant it denotes, not by how it is written.
+///
+/// `12:00+01:00` is 11:00 UTC and so comes *before* `12:00Z`. Comparing the
+/// local reading would order these by their text, which looks right and is
+/// not.
+#[test]
+fn zoned_times_sort_by_instant_not_by_local_reading() {
+    let noon_plus_one = P::Time { nanos: 12 * 3_600_000_000_000, offset_seconds: 3600 };
+    let noon_utc = P::Time { nanos: 12 * 3_600_000_000_000, offset_seconds: 0 };
+    assert!(noon_plus_one < noon_utc, "12:00+01:00 is 11:00Z and sorts first");
+
+    let mut v = vec![noon_utc.clone(), noon_plus_one.clone()];
+    v.sort();
+    assert_eq!(v, vec![noon_plus_one, noon_utc]);
+}
+
+/// Two spellings of the same instant compare equal on the instant, and are
+/// then split by offset so the order stays strict.
+///
+/// This is not pedantry: `Ord` backs the B-tree property index, and returning
+/// `Equal` for values that `PartialEq` calls different would collapse them
+/// into one index key and violate the `Ord`/`Eq` contract.
+#[test]
+fn the_zoned_ordering_stays_strict() {
+    let a = P::ZonedDateTime { secs: 100, nanos: 0, offset_seconds: 0, zone: None };
+    let b = P::ZonedDateTime { secs: 100, nanos: 0, offset_seconds: 3600, zone: None };
+    assert_ne!(a, b);
+    assert_ne!(a.cmp(&b), std::cmp::Ordering::Equal, "must not tie: they are not Eq");
+}

--- a/tests/temporal_representation.rs
+++ b/tests/temporal_representation.rs
@@ -186,3 +186,136 @@ fn the_zoned_ordering_stays_strict() {
     assert_ne!(a, b);
     assert_ne!(a.cmp(&b), std::cmp::Ordering::Equal, "must not tie: they are not Eq");
 }
+
+// ---------------------------------------------------------------------------
+// Construction from maps and strings. The representation above is only useful
+// if the constructors fill it correctly, and the component rules are where
+// this is easy to get subtly wrong.
+// ---------------------------------------------------------------------------
+
+use samyama::query::executor::temporal as tmp;
+use std::collections::HashMap;
+
+fn map(pairs: &[(&str, i64)]) -> HashMap<String, P> {
+    pairs.iter().map(|(k, v)| (k.to_string(), P::Integer(*v))).collect()
+}
+
+/// `millisecond`, `microsecond` and `nanosecond` are **additive**
+/// sub-components of the second, not alternative spellings of one field.
+///
+/// Straight from the TCK's own example: `{second: 14, nanosecond: 789,
+/// millisecond: 123, microsecond: 456}` is `14.123456789`. Reading any one of
+/// them as "the fraction" gives `.789`, `.123` or `.456` — three different
+/// wrong answers that all look plausible.
+#[test]
+fn sub_second_components_add_up() {
+    let n = tmp::time_of_day_nanos(&map(&[
+        ("hour", 12), ("minute", 31), ("second", 14),
+        ("nanosecond", 789), ("millisecond", 123), ("microsecond", 456),
+    ]))
+    .expect("valid");
+    assert_eq!(P::LocalTime(n).to_cypher_string(), "12:31:14.123456789");
+}
+
+/// Absent components are zero; present-but-out-of-range is an error.
+///
+/// A wrapped hour reads as a valid time, so 24:00 must not quietly become
+/// 00:00 of the next day.
+#[test]
+fn missing_components_default_but_bad_ones_are_refused() {
+    let n = tmp::time_of_day_nanos(&map(&[("hour", 10), ("minute", 35)])).expect("valid");
+    assert_eq!(P::LocalTime(n).to_cypher_string(), "10:35");
+
+    for bad in [
+        vec![("hour", 24)],
+        vec![("minute", 60)],
+        vec![("second", 60)],
+        vec![("millisecond", 1000)],
+        vec![("microsecond", 1_000_000)],
+        vec![("nanosecond", 1_000_000_000)],
+        vec![("hour", -1)],
+    ] {
+        assert!(
+            tmp::time_of_day_nanos(&map(&bad)).is_err(),
+            "{bad:?} should be refused, not wrapped"
+        );
+    }
+}
+
+/// A date can be written four ways and the TCK uses all of them. Only the
+/// calendar form used to work; the other three fell through to 1 January.
+#[test]
+fn all_four_date_spellings_are_understood() {
+    let cal = tmp::date_days(&map(&[("year", 1984), ("month", 10), ("day", 11)])).unwrap();
+    assert_eq!(P::Date(cal).to_cypher_string(), "1984-10-11");
+
+    let ord = tmp::date_days(&map(&[("year", 1984), ("ordinalDay", 202)])).unwrap();
+    assert_eq!(P::Date(ord).to_cypher_string(), "1984-07-20");
+
+    let wk = tmp::date_days(&map(&[("year", 1984), ("week", 10), ("dayOfWeek", 3)])).unwrap();
+    assert_eq!(P::Date(wk).to_cypher_string(), "1984-03-07");
+
+    let q = tmp::date_days(&map(&[("year", 1984), ("quarter", 3), ("dayOfQuarter", 45)])).unwrap();
+    assert_eq!(P::Date(q).to_cypher_string(), "1984-08-14");
+}
+
+/// The three non-calendar forms must not be mistaken for each other, and a
+/// date with no year is an error rather than 1970.
+#[test]
+fn a_date_needs_a_year_and_bad_components_are_refused() {
+    assert!(tmp::date_days(&map(&[("month", 5), ("day", 6)])).is_err(), "no year");
+    assert!(tmp::date_days(&map(&[("year", 1984), ("quarter", 5)])).is_err(), "quarter 5");
+    assert!(tmp::date_days(&map(&[("year", 1984), ("week", 10), ("dayOfWeek", 8)])).is_err());
+    assert!(tmp::date_days(&map(&[("year", 1984), ("ordinalDay", 400)])).is_err());
+    assert!(tmp::date_days(&map(&[("year", 1984), ("month", 13), ("day", 1)])).is_err());
+}
+
+/// Offsets parse in every spelling the TCK uses, including half-hours, which
+/// an hours-only parser silently truncates.
+#[test]
+fn timezone_offsets_parse_in_every_spelling() {
+    for (input, want) in [
+        ("Z", 0), ("z", 0), ("+01:00", 3600), ("-05:00", -18_000),
+        ("+0530", 19_800), ("+05:30", 19_800), ("-08:00", -28_800),
+    ] {
+        let (secs, zone) = tmp::parse_timezone(input).unwrap_or_else(|e| panic!("{input}: {e}"));
+        assert_eq!(secs, want, "offset of {input}");
+        assert_eq!(zone, None, "{input} is an offset, not a named zone");
+    }
+}
+
+/// A named zone is refused with a message that says why, rather than being
+/// read as UTC.
+///
+/// Treating it as UTC would shift every value by the real offset and return a
+/// plausible-looking wrong instant. Tracked as #767; this test pins the
+/// refusal so nobody "fixes" it by defaulting to zero.
+#[test]
+fn a_named_zone_is_refused_rather_than_assumed_to_be_utc() {
+    let e = tmp::parse_timezone("Europe/Stockholm").expect_err("should refuse");
+    let msg = format!("{e}");
+    assert!(msg.contains("Europe/Stockholm"), "message should name the zone: {msg}");
+    assert!(msg.contains("tz database"), "message should say what is missing: {msg}");
+}
+
+/// Strings parse into the right type with full precision.
+#[test]
+fn strings_parse_into_their_types() {
+    assert_eq!(tmp::parse_date("2015-07-21").unwrap().to_cypher_string(), "2015-07-21");
+    assert_eq!(tmp::parse_date("20150721").unwrap().to_cypher_string(), "2015-07-21");
+
+    let (nanos, off) = tmp::parse_time_parts("12:31:14.645876123").unwrap();
+    assert_eq!(P::LocalTime(nanos).to_cypher_string(), "12:31:14.645876123");
+    assert_eq!(off, None, "no offset in the string");
+
+    let (nanos, off) = tmp::parse_time_parts("12:31:14+01:00").unwrap();
+    assert_eq!(off, Some(3600));
+    assert_eq!(
+        P::Time { nanos, offset_seconds: off.unwrap() }.to_cypher_string(),
+        "12:31:14+01:00"
+    );
+
+    // A negative offset must not be mistaken for part of the clock.
+    let (_, off) = tmp::parse_time_parts("10:35-08:00").unwrap();
+    assert_eq!(off, Some(-28_800));
+}

--- a/tests/v060_features_test.rs
+++ b/tests/v060_features_test.rs
@@ -92,9 +92,15 @@ fn test_datetime_named_constructor_in_with() {
     ).unwrap();
     assert_eq!(result.len(), 1);
     let dt_val = result.records[0].get("dt").unwrap().as_property().unwrap();
+    // `datetime()` returns a ZonedDateTime since #689, not a bare millisecond
+    // timestamp. The value is asserted as well as the type, which is stricter
+    // than the original `DateTime(_)` — that pattern also matched `date()` and
+    // `localtime()`, because all three used to return the same variant.
     match dt_val {
-        PropertyValue::DateTime(_) => {}, // good
-        other => panic!("Expected DateTime from named constructor, got {:?}", other),
+        PropertyValue::ZonedDateTime { .. } => {
+            assert_eq!(dt_val.to_cypher_string(), "2026-03-04T00:00Z");
+        }
+        other => panic!("Expected ZonedDateTime from named constructor, got {:?}", other),
     }
 }
 
@@ -110,10 +116,10 @@ fn test_datetime_no_args_returns_now() {
     assert_eq!(result.len(), 1);
     let dt_val = result.records[0].get("now").unwrap().as_property().unwrap();
     match dt_val {
-        PropertyValue::DateTime(millis) => {
-            assert!(*millis > 0, "datetime() should return positive millis");
-        },
-        other => panic!("Expected DateTime from datetime(), got {:?}", other),
+        PropertyValue::ZonedDateTime { secs, .. } => {
+            assert!(*secs > 0, "datetime() should return a positive instant");
+        }
+        other => panic!("Expected ZonedDateTime from datetime(), got {:?}", other),
     }
 }
 


### PR DESCRIPTION
Closes #689. First and largest slice of the temporal work.

## The defect

Every temporal value was `PropertyValue::DateTime(i64)` — a Unix timestamp in milliseconds. Cypher has five distinct temporal types and nanosecond precision, so `date()`, `time()`, `localtime()`, `localdatetime()` and `datetime()` were **indistinguishable once evaluated**, and `12:31:14.645876123` was destroyed at construction rather than merely displayed wrongly.

## Measured

| | |
|---|---|
| TCK | **2,345 → 2,570 (+225)** |
| pass rate | 62.4% → **68.4%** |
| regressions | **0** |

Temporal was **956 of 1,416 remaining failures — 67.5%** — so this is the largest single lever left in the corpus.

## Built in the order the issue asks for

The risky part of #689 is not arithmetic, it is that `PropertyValue` is serialized into the snapshot: the on-disk shape is the one mistake a later commit cannot fix. So:

1. **Representation, then snapshot round-trip tests, before any function moved.** That intermediate state was verified on its own — suite green, TCK unchanged at 2,345 — so the format is pinned independently of the behaviour work.
2. Constructors.
3. Arithmetic, component access, rendering.

### The representation

```rust
Date(i32),                                                  // days since epoch
LocalTime(i64),                                             // nanos since midnight
Time { nanos: i64, offset_seconds: i32 },
LocalDateTime { secs: i64, nanos: u32 },
ZonedDateTime { secs, nanos, offset_seconds, zone: Option<String> },
```

`DateTime(i64)` is **kept as a legacy variant** so snapshots written before this still load — `a_pre_689_snapshot_still_loads` pins that, and it still *writes* in the old shape so a downgrade reads it too.

`ZonedDateTime` carries both the offset and the IANA name because neither implies the other: an offset alone cannot survive a DST boundary, a name alone cannot express `+05:30` attached to nothing.

## Three things measurement caught that reading did not

**The first constructor attempt was a net −9, and I nearly shipped it as a win.** Diffing failure manifests found 9 `Temporal7` regressions against 1 fix: `cypher_ordering` in `operator.rs` is a **second** comparison path with a `_ => None` fallthrough, so every new temporal type silently compared as null. This is the duplicated-evaluator shape the codebase keeps producing — patching the copy in front of you fixes nothing.

*(My first diff was also wrong: the failures manifest embeds the outcome, so a scenario that merely changed from `wrong_result` to `errored` appeared as both a fix and a regression. Comparing by scenario identity gave the real picture.)*

**Rendering was the other half of the gain.** `prop_to_tck` fell through to `Debug` and emitted `DateTime(-1882656000000)` — not a TCK literal, not anything, and precisely the input that fed #761's parser an unmatched `)` it could not consume. Temporal values now render through one `to_cypher_string`, which both `toString()` and the harness use, so they cannot disagree.

**Of 15 failing unit tests, 3 were real regressions rather than tests encoding the old shape.** `datetime - datetime → Duration`, `datetime + duration → datetime` and `dt.year` are Cypher-required, and teaching the constructors to return real types had silently removed all three. Those are now implemented for all five types:

* `shift_temporal` keeps the operand's type — a `Date` plus a duration is a `Date` — and treats months as **calendar** months, so 31 Jan + 1 month is 28 Feb rather than 3 Mar.
* `temporal_component` answers `.year`/`.hour`/`.offsetSeconds`/… from one place, so a `Date` and a `LocalDateTime` cannot disagree about what `.year` means. Absent components are `null`, not zero — `date.hour` returning 0 would read as midnight.

The other 12 had their **type** assertions updated, and updated to assert the *rendered value* as well, which is stricter than what they checked before.

## A regression I introduced and then undid

Replacing the `datetime()` map branch lost #595's informative error. `datetime({nonsense: 1})` went from *"understands none of the keys given (nonsense)"* to a generic *"needs a date"* — which re-opens #595's hole by a different route, because it does not name what was passed, so a typo like `epochMilis` reads as "you forgot the date" rather than "that key is not a thing". `reject_unknown_map` restores it and names both the offending keys and the accepted set.

## Tests

- `tests/temporal_representation.rs` — 16, covering serde round-trip, rendering, ordering (including that `12:00+01:00` sorts before `12:00Z`, because it is 11:00Z — comparing the *local reading* orders by text and looks right), and the constructor component rules.
- `src/snapshot/mod.rs` — 3 more, against the real `__type` encoding rather than serde. These are separate deliberately: **a value can survive serde and be destroyed by the snapshot**, and I first wrote the integration helper claiming it exercised the snapshot path when it did not. The comment was wrong before the code was.
- Sub-second components are **additive** (`{second: 14, nanosecond: 789, millisecond: 123, microsecond: 456}` → `14.123456789`), which is pinned, because reading any single one as "the fraction" gives three different plausible wrong answers.

## Out of scope, filed

**#767 — named time zones.** 110 TCK uses, two distinct zones, needs `chrono-tz`. Deliberately *not* hardcoding those two: that encodes the test corpus into the engine. Until then a named zone **errors** rather than being read as UTC, because silently shifting every value by the real offset is worse than refusing.

One honest cost of that choice: `Temporal5`'s **setup** uses a named zone, so it moves from "evaluated and wrong" to `setup did not run`, and `evaluated` drops 3,761 → 3,760. A coverage number moving, disclosed rather than absorbed.

Remaining temporal work, both now unblocked: truncation (`Temporal9`, 322) and `duration.between` (`Temporal10`, 131).
