### PR TITLE
Namespaced function calls: TCK 2,570 → 2,889 (+319) (#769)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 2570
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 2889
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/examples/tck_runner.rs
+++ b/examples/tck_runner.rs
@@ -549,7 +549,10 @@ fn prop_to_tck(p: &PropertyValue) -> Tck {
         // `DateTime(-1882656000000)`, which is not a TCK literal, is not
         // anything, and is what fed #761 an input its value parser could not
         // consume.
-        PropertyValue::Date(_)
+        // A Duration is an ISO-8601 string too, and fell to the same `Debug`
+        // arm -- `Duration { months: 0, days: 0, ... }` where `'PT6H'` belongs.
+        PropertyValue::Duration { .. }
+        | PropertyValue::Date(_)
         | PropertyValue::LocalTime(_)
         | PropertyValue::Time { .. }
         | PropertyValue::LocalDateTime { .. }

--- a/src/graph/property.rs
+++ b/src/graph/property.rs
@@ -691,6 +691,44 @@ pub(crate) fn fmt_local_date_time(secs: i64, nanos: u32) -> String {
 }
 
 
+
+/// A duration as openCypher writes it: `PT6H`, `P1Y2M3DT4H5M6.5S`, `PT0S`.
+///
+/// Zero components are omitted, and an all-zero duration is `PT0S` rather than
+/// the empty `P`. Components keep their own sign — Cypher does not normalise
+/// `PT-1H30M` into a single signed quantity, because months and days have no
+/// fixed length and so cannot be carried into each other.
+pub(crate) fn fmt_duration(months: i64, days: i64, seconds: i64, nanos: i32) -> String {
+    let (years, rem_months) = (months / 12, months % 12);
+    let (hours, rem) = (seconds / 3600, seconds % 3600);
+    let (minutes, secs) = (rem / 60, rem % 60);
+
+    let mut out = String::from("P");
+    if years != 0 { out.push_str(&format!("{years}Y")); }
+    if rem_months != 0 { out.push_str(&format!("{rem_months}M")); }
+    if days != 0 { out.push_str(&format!("{days}D")); }
+
+    let has_time = hours != 0 || minutes != 0 || secs != 0 || nanos != 0;
+    if has_time {
+        out.push('T');
+        if hours != 0 { out.push_str(&format!("{hours}H")); }
+        if minutes != 0 { out.push_str(&format!("{minutes}M")); }
+        if secs != 0 || nanos != 0 {
+            if nanos == 0 {
+                out.push_str(&format!("{secs}S"));
+            } else {
+                // The fraction belongs to the seconds and carries the sign with
+                // them: -1.5s is `-1.5S`, not `-1.-5S`.
+                let sign = if secs < 0 || (secs == 0 && nanos < 0) { "-" } else { "" };
+                let frac = format!("{:09}", nanos.abs());
+                out.push_str(&format!("{sign}{}.{}S", secs.abs(), frac.trim_end_matches('0')));
+            }
+        }
+    }
+    if out == "P" { out.push_str("T0S"); }
+    out
+}
+
 impl PropertyValue {
     /// How openCypher writes this value — the string `toString()` returns and
     /// the TCK compares against.
@@ -708,6 +746,9 @@ impl PropertyValue {
                 format!("{}{}", fmt_time_of_day(*nanos), fmt_offset(*offset_seconds))
             }
             PropertyValue::LocalDateTime { secs, nanos } => fmt_local_date_time(*secs, *nanos),
+            PropertyValue::Duration { months, days, seconds, nanos } => {
+                fmt_duration(*months, *days, *seconds, *nanos)
+            }
             PropertyValue::ZonedDateTime { secs, nanos, offset_seconds, zone } => {
                 // `secs` is the UTC instant; render it in the stored offset.
                 let local = fmt_local_date_time(secs + *offset_seconds as i64, *nanos);

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -326,7 +326,23 @@ property_access = { ("(" ~ variable ~ ")" | variable) ~ "." ~ property_key }
 // where a nested path would mean something this engine does not implement.
 nested_property_access = { variable ~ "." ~ property_key ~ ("." ~ property_key)+ }
 function_call = { function_name ~ "(" ~ distinct? ~ (expression ~ ("," ~ expression)*)? ~ ")" }
-function_name = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
+// A function name may carry one namespace segment: `date.truncate`,
+// `duration.between`, `duration.inSeconds`.
+//
+// Without this the whole namespaced family was a **parse error**, which is why
+// every scenario in Temporal9 (truncation, 322) and Temporal10
+// (duration.between, 131) failed -- 453 of them, none reaching the evaluator.
+// `duration.between` was already implemented and had been unreachable from
+// Cypher the entire time.
+//
+// Safe against property access because `function_call` requires a `(` straight
+// after the name, so `n.name` fails the rule and the PEG backtracks to
+// `property_access` as before -- and `function_call` is already tried first in
+// `primary`, so the ordering does not change either (#769).
+function_name = @{
+    (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")*
+    ~ ("." ~ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")*)?
+}
 
 // Operators
 pow_op = { "^" }

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -6987,14 +6987,46 @@ mod tests {
         } else { panic!("toString(datetime) should return string"); }
     }
 
+    /// ISO-8601, as openCypher writes a duration.
+    ///
+    /// This asserted `P2M5DT3600S`, which is wrong twice over: years are split
+    /// out of months, and the seconds are broken into hours/minutes/seconds.
+    /// Checked against the TCK rather than against the new code — Temporal8
+    /// expects forms like `P12Y10M43DT18H9M3.500000003S` and
+    /// `P12Y6MT32H2M20.000000001S`, which pin the year split, the H/M/S
+    /// breakdown, the omission of zero components, and the fraction riding on
+    /// the seconds.
     #[test]
     fn test_tostring_duration() {
         use crate::query::executor::operator::eval_function;
-        let d = Value::Property(PropertyValue::Duration { months: 2, days: 5, seconds: 3600, nanos: 0 });
-        let r = eval_function("tostring", &[d], None).unwrap();
-        if let Value::Property(PropertyValue::String(s)) = r {
-            assert_eq!(s, "P2M5DT3600S");
-        } else { panic!("toString(duration) should return string"); }
+        let cases = [
+            (
+                PropertyValue::Duration { months: 2, days: 5, seconds: 3600, nanos: 0 },
+                "P2M5DT1H",
+            ),
+            // Years split out of months, and a fractional second.
+            (
+                PropertyValue::Duration { months: 154, days: 43, seconds: 65_343, nanos: 500_000_003 },
+                "P12Y10M43DT18H9M3.500000003S",
+            ),
+            // Zero components are omitted; an all-zero duration is not empty.
+            (PropertyValue::Duration { months: 0, days: 0, seconds: 0, nanos: 0 }, "PT0S"),
+            (PropertyValue::Duration { months: 0, days: 0, seconds: 0, nanos: 1 }, "PT0.000000001S"),
+            // Each component keeps its own sign: months and days have no fixed
+            // length, so they cannot be carried into one another.
+            (
+                PropertyValue::Duration { months: -154, days: -43, seconds: -65_343, nanos: -500_000_003 },
+                "P-12Y-10M-43DT-18H-9M-3.500000003S",
+            ),
+        ];
+        for (d, want) in cases {
+            let r = eval_function("tostring", &[Value::Property(d.clone())], None).unwrap();
+            if let Value::Property(PropertyValue::String(s)) = r {
+                assert_eq!(s, want, "toString({d:?})");
+            } else {
+                panic!("toString(duration) should return string");
+            }
+        }
     }
 
     // ==================== CY-32: WITH...RETURN ====================

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1777,9 +1777,10 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                         .map(|dt| dt.to_rfc3339())
                         .unwrap_or_else(|| format!("DateTime({})", millis))
                 }
-                Value::Property(PropertyValue::Duration { months, days, seconds, nanos }) => {
-                    format!("P{}M{}DT{}S", months, days, seconds)
-                }
+                // Through the one function that owns the format (#769). The old
+                // `P{}M{}DT{}S` emitted `P0M0DT0S` for a zero duration where
+                // Cypher writes `PT0S`, and dropped nanoseconds entirely.
+                Value::Property(p @ PropertyValue::Duration { .. }) => p.to_cypher_string(),
                 // The five temporal types render through the one function that
                 // owns the format, so `toString()` and the TCK harness cannot
                 // disagree about what a value looks like (#689).
@@ -2408,21 +2409,94 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
             }
         }
         // duration component accessors
+        // `<type>.truncate(unit, value, map)` for all five namespaces (#769).
+        // The namespace names the *result* type, so `date.truncate` over a
+        // datetime returns a Date.
+        "date.truncate" | "time.truncate" | "localtime.truncate"
+        | "localdatetime.truncate" | "datetime.truncate" => {
+            if args.len() < 2 {
+                return Err(ExecutionError::RuntimeError(format!("{lowered}() requires a unit and a temporal value")));
+            }
+            let unit = match &args[0] {
+                Value::Property(PropertyValue::String(u)) => u.clone(),
+                _ => return Err(ExecutionError::TypeError(
+                    "the first argument of truncate() is the unit, as a string".to_string(),
+                )),
+            };
+            let value = match &args[1] {
+                Value::Property(PropertyValue::Null) | Value::Null => {
+                    return Ok(Value::Property(PropertyValue::Null))
+                }
+                Value::Property(p) => p.clone(),
+                _ => return Err(ExecutionError::TypeError(
+                    "truncate() needs a temporal value".to_string(),
+                )),
+            };
+            let empty = std::collections::HashMap::new();
+            let overrides = match args.get(2) {
+                Some(Value::Property(PropertyValue::Map(m))) => m.clone(),
+                _ => empty,
+            };
+            let target = lowered.split('.').next().unwrap_or("date");
+            Ok(Value::Property(crate::query::executor::temporal::truncate(
+                target, &unit, &value, &overrides,
+            )?))
+        }
+        // `duration.inSeconds/inDays/inMonths(a, b)` — the difference between
+        // two temporals, expressed in one unit. `duration.between` was already
+        // implemented; these three were not, and all four were unreachable from
+        // Cypher until the grammar learned to parse a dotted name.
+        "duration.inseconds" | "duration.indays" | "duration.inmonths" => {
+            if args.len() < 2 {
+                return Err(ExecutionError::RuntimeError(format!("{lowered}() requires 2 arguments")));
+            }
+            let (a, b) = match (&args[0], &args[1]) {
+                (Value::Property(PropertyValue::Null), _) | (_, Value::Property(PropertyValue::Null))
+                | (Value::Null, _) | (_, Value::Null) => {
+                    return Ok(Value::Property(PropertyValue::Null))
+                }
+                (Value::Property(a), Value::Property(b)) => (a.clone(), b.clone()),
+                _ => return Err(ExecutionError::TypeError(format!("{lowered}() needs two temporal values"))),
+            };
+            let diff = temporal_difference(&a, &b)?;
+            let (days, seconds, nanos) = match diff {
+                PropertyValue::Duration { days, seconds, nanos, .. } => (days, seconds, nanos),
+                _ => (0, 0, 0),
+            };
+            Ok(Value::Property(match lowered.as_str() {
+                // Seconds carries the whole difference in seconds plus the
+                // sub-second remainder; days and months carry only whole units,
+                // with the remainder discarded rather than rounded.
+                "duration.inseconds" => PropertyValue::Duration {
+                    months: 0, days: 0, seconds: days * 86_400 + seconds, nanos,
+                },
+                "duration.indays" => PropertyValue::Duration {
+                    months: 0, days: days + seconds / 86_400, seconds: 0, nanos: 0,
+                },
+                _ => PropertyValue::Duration {
+                    months: (days + seconds / 86_400) / 30, days: 0, seconds: 0, nanos: 0,
+                },
+            }))
+        }
         "duration_between" | "duration.between" => {
             if args.len() < 2 { return Err(ExecutionError::RuntimeError("duration.between() requires 2 arguments".to_string())); }
+            // Accepts any two temporals, not only the legacy millisecond
+            // `DateTime`. It matched that one variant alone, so the moment the
+            // constructors started returning real types (#689) every
+            // `duration.between(date(...), date(...))` became a type error --
+            // and the grammar fix (#769) that finally made this function
+            // reachable from Cypher exposed exactly that on 20 scenarios.
+            //
+            // Argument order is (from, to): `between(a, b)` is b - a.
             match (&args[0], &args[1]) {
-                (Value::Property(PropertyValue::DateTime(a)), Value::Property(PropertyValue::DateTime(b))) => {
-                    let diff_ms = b - a;
-                    let total_seconds = diff_ms / 1000;
-                    let remaining_days = total_seconds / 86400;
-                    Ok(Value::Property(PropertyValue::Duration {
-                        months: 0,
-                        days: remaining_days,
-                        seconds: total_seconds % 86400,
-                        nanos: ((diff_ms % 1000) * 1_000_000) as i32,
-                    }))
+                (Value::Property(a), Value::Property(b)) => {
+                    Ok(Value::Property(temporal_difference(b, a).map_err(|_| {
+                        ExecutionError::TypeError(
+                            "duration.between() requires two temporal arguments".to_string(),
+                        )
+                    })?))
                 }
-                _ => Err(ExecutionError::TypeError("duration.between() requires two datetime arguments".to_string())),
+                _ => Err(ExecutionError::TypeError("duration.between() requires two temporal arguments".to_string())),
             }
         }
         // CY-20: properties() — return all properties as a map

--- a/src/query/executor/temporal.rs
+++ b/src/query/executor/temporal.rs
@@ -253,3 +253,166 @@ pub fn reject_unknown_map(
         KNOWN_KEYS.join(", ")
     )))
 }
+
+/// `<type>.truncate(unit, value, map)` — round a temporal down to a unit, then
+/// apply the map's components as overrides.
+///
+/// The namespace decides the *result* type, not the input type: `date.truncate`
+/// over a `datetime` returns a `Date`. That is why this takes the target
+/// separately rather than reading it off the value.
+///
+/// Units coarser than a day zero the clock and move the date to the start of
+/// the period; units finer than a day keep the date and zero everything below
+/// the unit. `week` goes to Monday, and `weekYear` to the first day of the ISO
+/// week-year — which is not 1 January, and is the one that a "just zero the
+/// smaller fields" implementation silently gets wrong.
+pub fn truncate(
+    target: &str,
+    unit: &str,
+    value: &PropertyValue,
+    overrides: &std::collections::HashMap<String, PropertyValue>,
+) -> Result<PropertyValue, ExecutionError> {
+    use chrono::{Datelike, NaiveDate};
+
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).expect("epoch is a date");
+    let (days, tod, offset, zone) = decompose(value)?;
+    let date = epoch
+        .checked_add_signed(chrono::Duration::days(days.unwrap_or(0)))
+        .ok_or_else(|| err("date out of range"))?;
+
+    // How much of the clock survives, and where the date lands.
+    let (new_date, mut new_tod) = match unit.to_ascii_lowercase().as_str() {
+        "millennium" => (ymd(date.year() - date.year().rem_euclid(1000), 1, 1)?, 0),
+        "century" => (ymd(date.year() - date.year().rem_euclid(100), 1, 1)?, 0),
+        "decade" => (ymd(date.year() - date.year().rem_euclid(10), 1, 1)?, 0),
+        "year" => (ymd(date.year(), 1, 1)?, 0),
+        "weekyear" => (
+            NaiveDate::from_isoywd_opt(date.iso_week().year(), 1, chrono::Weekday::Mon)
+                .ok_or_else(|| err("week-year out of range"))?,
+            0,
+        ),
+        "quarter" => (ymd(date.year(), (date.month() - 1) / 3 * 3 + 1, 1)?, 0),
+        "month" => (ymd(date.year(), date.month(), 1)?, 0),
+        "week" => (
+            date - chrono::Duration::days(date.weekday().num_days_from_monday() as i64),
+            0,
+        ),
+        "day" => (date, 0),
+        "hour" => (date, tod.unwrap_or(0) / 3_600_000_000_000 * 3_600_000_000_000),
+        "minute" => (date, tod.unwrap_or(0) / 60_000_000_000 * 60_000_000_000),
+        "second" => (date, tod.unwrap_or(0) / NANOS_PER_SEC * NANOS_PER_SEC),
+        "millisecond" => (date, tod.unwrap_or(0) / 1_000_000 * 1_000_000),
+        "microsecond" => (date, tod.unwrap_or(0) / 1_000 * 1_000),
+        other => return Err(err(format!("unknown truncation unit: {other}"))),
+    };
+
+    // Overrides are applied *after* truncation, so `{day: 2}` on a millennium
+    // truncation gives 2000-01-02 rather than being rounded away.
+    let mut new_days = new_date.signed_duration_since(epoch).num_days();
+    if !overrides.is_empty() {
+        let mut y = new_date.year();
+        let mut m = new_date.month();
+        let mut d = new_date.day();
+        if let Some(v) = field(overrides, "year") { y = v as i32; }
+        if let Some(v) = field(overrides, "month") { m = v as u32; }
+        if let Some(v) = field(overrides, "day") { d = v as u32; }
+        if overrides.contains_key("dayOfWeek") {
+            let want = field(overrides, "dayOfWeek").unwrap_or(1) as i64;
+            let base = ymd(y, m, d)?;
+            let cur = base.weekday().num_days_from_monday() as i64;
+            new_days = (base + chrono::Duration::days(want - 1 - cur))
+                .signed_duration_since(epoch)
+                .num_days();
+        } else {
+            new_days = ymd(y, m, d)?.signed_duration_since(epoch).num_days();
+        }
+        // Clock overrides add on top of what truncation left.
+        for (key, mult) in [
+            ("hour", 3_600_000_000_000i64),
+            ("minute", 60_000_000_000),
+            ("second", NANOS_PER_SEC),
+            ("millisecond", 1_000_000),
+            ("microsecond", 1_000),
+            ("nanosecond", 1),
+        ] {
+            if let Some(v) = field(overrides, key) {
+                let unit_span = match key {
+                    "hour" => 86_400 * NANOS_PER_SEC,
+                    "minute" => 3_600_000_000_000,
+                    "second" => 60_000_000_000,
+                    _ => mult * 1_000,
+                };
+                // Replace that field rather than adding to it.
+                let below = new_tod % mult;
+                let above = new_tod / unit_span * unit_span;
+                new_tod = above + v * mult + below;
+            }
+        }
+    }
+
+    build(target, new_days, new_tod, offset, zone)
+}
+
+fn ymd(y: i32, m: u32, d: u32) -> Result<chrono::NaiveDate, ExecutionError> {
+    chrono::NaiveDate::from_ymd_opt(y, m, d).ok_or_else(|| err(format!("invalid date {y}-{m}-{d}")))
+}
+
+/// Split any temporal into (days, time-of-day, offset, zone), each optional.
+#[allow(clippy::type_complexity)]
+fn decompose(
+    v: &PropertyValue,
+) -> Result<(Option<i64>, Option<i64>, Option<i32>, Option<String>), ExecutionError> {
+    Ok(match v {
+        PropertyValue::Date(d) => (Some(*d as i64), None, None, None),
+        PropertyValue::LocalTime(n) => (None, Some(*n), None, None),
+        PropertyValue::Time { nanos, offset_seconds } => (None, Some(*nanos), Some(*offset_seconds), None),
+        PropertyValue::LocalDateTime { secs, nanos } => (
+            Some(secs.div_euclid(86_400)),
+            Some(secs.rem_euclid(86_400) * NANOS_PER_SEC + *nanos as i64),
+            None,
+            None,
+        ),
+        PropertyValue::ZonedDateTime { secs, nanos, offset_seconds, zone } => {
+            let local = secs + *offset_seconds as i64;
+            (
+                Some(local.div_euclid(86_400)),
+                Some(local.rem_euclid(86_400) * NANOS_PER_SEC + *nanos as i64),
+                Some(*offset_seconds),
+                zone.clone(),
+            )
+        }
+        other => return Err(err(format!("not a temporal value: {}", other.type_name()))),
+    })
+}
+
+/// Assemble the type the namespace asked for.
+fn build(
+    target: &str,
+    days: i64,
+    tod: i64,
+    offset: Option<i32>,
+    zone: Option<String>,
+) -> Result<PropertyValue, ExecutionError> {
+    Ok(match target {
+        "date" => PropertyValue::Date(days as i32),
+        "localtime" => PropertyValue::LocalTime(tod.rem_euclid(NANOS_PER_DAY)),
+        "time" => PropertyValue::Time {
+            nanos: tod.rem_euclid(NANOS_PER_DAY),
+            offset_seconds: offset.unwrap_or(0),
+        },
+        "localdatetime" => PropertyValue::LocalDateTime {
+            secs: days * 86_400 + tod.div_euclid(NANOS_PER_SEC),
+            nanos: tod.rem_euclid(NANOS_PER_SEC) as u32,
+        },
+        "datetime" => {
+            let off = offset.unwrap_or(0);
+            PropertyValue::ZonedDateTime {
+                secs: days * 86_400 + tod.div_euclid(NANOS_PER_SEC) - off as i64,
+                nanos: tod.rem_euclid(NANOS_PER_SEC) as u32,
+                offset_seconds: off,
+                zone,
+            }
+        }
+        other => return Err(err(format!("cannot truncate to {other}"))),
+    })
+}

--- a/tests/temporal_truncation.rs
+++ b/tests/temporal_truncation.rs
@@ -1,0 +1,141 @@
+//! `<type>.truncate(unit, value, map)` and the namespaced function family (#769).
+//!
+//! Every scenario in `Temporal9` (truncation, 322) and `Temporal10`
+//! (`duration.between`, 131) was a **parse error** — 453 of them, none
+//! reaching the evaluator. `function_name` in the grammar had no dot, so the
+//! whole namespaced family was unreachable from Cypher. `duration.between` had
+//! been *implemented* the entire time and could never be called.
+//!
+//! The tests below are mostly about the two rules that are easy to get subtly
+//! wrong: the namespace decides the result type, and the override map is
+//! applied *after* truncation rather than being rounded away by it.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn one(cypher: &str) -> Result<PropertyValue, String> {
+    let store = GraphStore::new();
+    let q = parse_query(cypher).map_err(|e| format!("parse: {e:?}"))?;
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .map_err(|e| format!("exec: {e:?}"))?;
+    Ok(match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.clone(),
+        _ => PropertyValue::Null,
+    })
+}
+
+fn rendered(cypher: &str) -> String {
+    one(cypher).unwrap_or_else(|e| panic!("{cypher}\n  -> {e}")).to_cypher_string()
+}
+
+/// A dotted function name parses at all. This is the whole unlock.
+#[test]
+fn a_namespaced_function_call_parses() {
+    assert!(parse_query("RETURN date.truncate('year', date('2017-10-11')) AS r").is_ok());
+    assert!(parse_query("RETURN duration.between(date('2017-10-11'), date('2018-10-11')) AS r").is_ok());
+}
+
+/// Property access is unaffected: `n.name` has no `(` after it, so
+/// `function_call` fails the rule and the parser falls back as before.
+///
+/// This is the risk the grammar change carries, and the reason the namespace
+/// segment is optional and the rule still demands a paren.
+#[test]
+fn property_access_still_parses_as_property_access() {
+    let store = GraphStore::new();
+    let q = parse_query("MATCH (n) WHERE n.name = 'x' RETURN n.name AS r, n.age AS a").expect("parses");
+    // Executing over an empty store is enough: it must plan and run, not error.
+    QueryExecutor::new(&store).execute(&q).expect("runs");
+
+    // A nested access is the harder case, and also unchanged.
+    assert!(parse_query("MATCH (n) RETURN n.address.city AS r").is_ok());
+}
+
+/// Truncation to each unit coarser than a day moves the date to the start of
+/// the period and zeroes the clock.
+#[test]
+fn coarse_units_move_to_the_start_of_the_period() {
+    let d = "date({year: 2017, month: 10, day: 11})";
+    assert_eq!(rendered(&format!("RETURN date.truncate('millennium', {d}) AS r")), "2000-01-01");
+    assert_eq!(rendered(&format!("RETURN date.truncate('century', {d}) AS r")), "2000-01-01");
+    assert_eq!(rendered(&format!("RETURN date.truncate('decade', {d}) AS r")), "2010-01-01");
+    assert_eq!(rendered(&format!("RETURN date.truncate('year', {d}) AS r")), "2017-01-01");
+    assert_eq!(rendered(&format!("RETURN date.truncate('quarter', {d}) AS r")), "2017-10-01");
+    assert_eq!(rendered(&format!("RETURN date.truncate('month', {d}) AS r")), "2017-10-01");
+    // 2017-10-11 is a Wednesday; the week starts on the Monday.
+    assert_eq!(rendered(&format!("RETURN date.truncate('week', {d}) AS r")), "2017-10-09");
+}
+
+/// The override map is applied **after** truncation, so a component the unit
+/// would have zeroed survives.
+///
+/// `{day: 2}` on a millennium truncation is `2000-01-02`. An implementation
+/// that applied the map first, or that treated truncation as "zero everything
+/// below the unit" and ignored the map, gives `2000-01-01` — which looks
+/// entirely reasonable and is wrong.
+#[test]
+fn the_override_map_is_applied_after_truncation() {
+    let d = "date({year: 2017, month: 10, day: 11})";
+    assert_eq!(rendered(&format!("RETURN date.truncate('millennium', {d}, {{day: 2}}) AS r")), "2000-01-02");
+    assert_eq!(rendered(&format!("RETURN date.truncate('year', {d}, {{month: 5}}) AS r")), "2017-05-01");
+}
+
+/// The **namespace** decides the result type, not the input.
+///
+/// `date.truncate` over a datetime returns a Date. Reading the type off the
+/// input instead would return a datetime and render with a clock attached.
+#[test]
+fn the_namespace_decides_the_result_type() {
+    let dt = "datetime({year: 2017, month: 10, day: 11, hour: 12, minute: 31, second: 14, timezone: '+01:00'})";
+    assert_eq!(rendered(&format!("RETURN date.truncate('year', {dt}) AS r")), "2017-01-01");
+
+    let got = one(&format!("RETURN date.truncate('year', {dt}) AS r")).unwrap();
+    assert!(matches!(got, PropertyValue::Date(_)), "expected a Date, got {got:?}");
+
+    let got = one(&format!("RETURN localdatetime.truncate('day', {dt}) AS r")).unwrap();
+    assert!(matches!(got, PropertyValue::LocalDateTime { .. }), "got {got:?}");
+}
+
+/// Units finer than a day keep the date and zero only what is below them.
+#[test]
+fn fine_units_keep_the_date_and_zero_below() {
+    let dt = "localdatetime({year: 2017, month: 10, day: 11, hour: 12, minute: 31, second: 14, nanosecond: 645876123})";
+    assert_eq!(rendered(&format!("RETURN localdatetime.truncate('day', {dt}) AS r")), "2017-10-11T00:00");
+    assert_eq!(rendered(&format!("RETURN localdatetime.truncate('hour', {dt}) AS r")), "2017-10-11T12:00");
+    assert_eq!(rendered(&format!("RETURN localdatetime.truncate('minute', {dt}) AS r")), "2017-10-11T12:31");
+    assert_eq!(rendered(&format!("RETURN localdatetime.truncate('second', {dt}) AS r")), "2017-10-11T12:31:14");
+    assert_eq!(
+        rendered(&format!("RETURN localdatetime.truncate('millisecond', {dt}) AS r")),
+        "2017-10-11T12:31:14.645"
+    );
+    assert_eq!(
+        rendered(&format!("RETURN localdatetime.truncate('microsecond', {dt}) AS r")),
+        "2017-10-11T12:31:14.645876"
+    );
+}
+
+/// An unknown unit is an error, not a silent no-op.
+#[test]
+fn an_unknown_unit_is_refused() {
+    let e = one("RETURN date.truncate('fortnight', date('2017-10-11')) AS r").unwrap_err();
+    assert!(e.contains("fortnight"), "the message should name the unit: {e}");
+}
+
+/// `duration.between` was implemented all along and unreachable. These are the
+/// scenarios the grammar alone unblocked.
+#[test]
+fn duration_between_is_reachable_now() {
+    let r = one("RETURN duration.between(date('2017-10-11'), date('2017-10-13')) AS r").unwrap();
+    match r {
+        PropertyValue::Duration { days, .. } => assert_eq!(days, 2),
+        other => panic!("expected a Duration, got {other:?}"),
+    }
+}
+
+/// Null in, null out — truncation included.
+#[test]
+fn truncation_propagates_null() {
+    assert_eq!(one("RETURN date.truncate('year', null) AS r").unwrap(), PropertyValue::Null);
+}


### PR DESCRIPTION
## The finding is bigger than the fix

Every failure in `Temporal9` (truncation, 322) and `Temporal10` (`duration.between`, 131) was a **parse error**. All 453 of them. None reached the evaluator.

```
function_name = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
```

No dot. So the entire namespaced function family — `date.truncate`, `datetime.truncate`, `duration.between`, `duration.inSeconds` — was unreachable from Cypher.

**`duration.between` had been implemented the whole time:**

```rust
"duration_between" | "duration.between" => { ... }
```

That arm has existed for as long as the function has, and could never be called, because nothing that reached the evaluator could ever be spelled with a dot. The grammar change alone is **+19** with no new code.

## Measured

| | TCK | Δ |
|---|---|---|
| `main` | 2,570 | |
| grammar only | 2,589 | +19 |
| \+ truncation | 2,876 | +287 |
| \+ duration rendering | **2,889** | +13 |

**+319 total, zero regressions**, checked by manifest diff against `main` rather than against the previous step. Pass rate 68.4% → **76.8%**.

## The grammar change, and why it is safe

```
function_name = @{
    (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")*
    ~ ("." ~ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")*)?
}
```

The obvious risk is property access: does `n.name` now parse as a function? No — `function_call` requires a `(` immediately after the name, so `n.name` fails the rule and the PEG backtracks to `property_access` exactly as before. `function_call` was *already* ordered before `property_access` in `primary`, so the precedence is unchanged too. `property_access_still_parses_as_property_access` pins both the simple and nested forms.

## Truncation

`<type>.truncate(unit, value, map)`. Two rules that are easy to get subtly wrong, and both are tested:

* **The namespace decides the result type, not the input.** `date.truncate('year', datetime(...))` returns a `Date`. Reading the type off the input gives a datetime with a clock attached.
* **The override map applies *after* truncation.** `date.truncate('millennium', d, {day: 2})` is `2000-01-02`. Applying the map first — or treating truncation as "zero everything below the unit" and ignoring the map — gives `2000-01-01`, which looks entirely reasonable and is wrong.

`weekYear` is the other trap: it truncates to the first day of the ISO week-year, which is not 1 January, and a "zero the smaller fields" implementation gets it silently wrong.

## Two bugs my own earlier change caused

**`duration.between` matched only the legacy `DateTime` variant.** #768 taught the constructors to return real types, which silently turned every `duration.between(date(...), date(...))` into a type error. Invisible until this PR made the function reachable at all — then it surfaced on 20 scenarios. Now routed through the shared `temporal_difference`.

**`Duration` still rendered through `Debug`.** `Duration { months: 0, days: 0, ... }` where `'PT6H'` belongs — the same fallback that fed #761's parser an input it could not consume, which I fixed for the five temporal types in #768 and did not notice applied to `Duration` too. And `toString`'s hand-rolled `format!("P{}M{}DT{}S", ...)` emitted `P0M0DT0S` for a zero duration (Cypher writes `PT0S`) and dropped nanoseconds entirely.

Both now go through one `to_cypher_string`, so the harness and `toString()` cannot disagree.

## A test corrected against the reference, not against the new code

`test_tostring_duration` asserted `P2M5DT3600S`. That is wrong twice: years are split out of months, and seconds break into hours/minutes/seconds. The TCK settles it — `Temporal8` expects `P12Y10M43DT18H9M3.500000003S` and `P12Y6MT32H2M20.000000001S` — so the test encoded the defect and the code is right. Rewritten with five cases pinning the year split, the H/M/S breakdown, omission of zero components, `PT0S` for all-zero, and per-component signs (`P-12Y-10M-43DT-18H-9M-3.500000003S`), because months and days have no fixed length and cannot be carried into one another.

## Tests

`tests/temporal_truncation.rs`, 9 tests, weighted toward the two subtle rules above plus the grammar-safety check on property access.

## Still open in this area

`Temporal10` retains parse gaps this PR does not close: date-time strings carrying a `[Europe/Stockholm]` suffix (blocked on #767) and extreme years like `-999999999-01-01`. `Temporal3` (selection, 174) is now the largest remaining cluster.
