### PR TITLE
Temporal selection: TCK 2,889 → 2,981 (+92) (#772)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 2889
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 2981
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1390,6 +1390,35 @@ fn cypher_ordering(left: &PropertyValue, right: &PropertyValue) -> Option<std::c
 /// This exists because the comparison was implemented twice and both copies
 /// had independently settled on raising instead. Both now call here.
 
+/// The map a temporal constructor was handed, whichever shape it arrived in.
+///
+/// A map *literal* containing variables evaluates to `Value::Map`, not
+/// `Value::Property(PropertyValue::Map)` — so `datetime({date: d, time: t})`
+/// never matched the map arm and fell through to "requires a string or map
+/// argument". That is 174 `Temporal3` scenarios: the selection form was
+/// implemented and unreachable through the shape the executor actually
+/// produces (#772).
+fn temporal_arg_map(v: &Value) -> Option<std::collections::HashMap<String, PropertyValue>> {
+    match v {
+        Value::Property(PropertyValue::Map(m)) => Some(m.clone()),
+        Value::Map(entries) => {
+            let mut out = std::collections::HashMap::new();
+            for (k, val) in entries {
+                match val {
+                    Value::Property(p) => { out.insert(k.clone(), p.clone()); }
+                    Value::Null => { out.insert(k.clone(), PropertyValue::Null); }
+                    // A node or a path inside a temporal map is not something
+                    // to coerce; leave it out so the component reader reports
+                    // the missing field rather than inventing a value.
+                    _ => {}
+                }
+            }
+            Some(out)
+        }
+        _ => None,
+    }
+}
+
 /// Days-since-epoch of any temporal value that has a date part.
 ///
 /// `None` for `LocalTime`/`Time`, which genuinely have no date — the caller
@@ -1434,34 +1463,71 @@ fn compose_date_and_time(
     map: &std::collections::HashMap<String, PropertyValue>,
 ) -> Result<(i32, i64), ExecutionError> {
     use crate::query::executor::temporal as tmp;
+    use chrono::Datelike;
 
-    let from_date = map
-        .get("date")
-        .or_else(|| map.get("datetime"))
-        .and_then(date_part_of);
-    let from_time = map
-        .get("time")
-        .or_else(|| map.get("datetime"))
-        .and_then(time_part_of);
+    // A selected value is the *base*; individual components then override
+    // parts of it. `{date: d, time: t, second: 42}` keeps 12:31 from `t` and
+    // replaces only the second -- reading the components as a whole clock
+    // instead gives 00:00:42, which is a plausible-looking wrong answer.
+    let base_date = map.get("date").or_else(|| map.get("datetime")).and_then(date_part_of);
+    let base_time = map.get("time").or_else(|| map.get("datetime")).and_then(time_part_of);
 
-    let days = match from_date {
+    let mut days = match base_date {
         Some(d) => d,
         None if map.contains_key("year") => tmp::date_days(map)?,
-        // No date at all. Cypher's composite types need one, and defaulting to
-        // the epoch is exactly the silent-1970 failure #595 was about.
         None => {
             return Err(ExecutionError::RuntimeError(
                 "a date-time needs a date: give `year` or `date`".to_string(),
             ))
         }
     };
-    let has_clock = ["hour", "minute", "second", "millisecond", "microsecond", "nanosecond"]
-        .iter()
-        .any(|k| map.contains_key(*k));
-    let nanos = if has_clock {
-        tmp::time_of_day_nanos(map)?
-    } else {
-        from_time.unwrap_or(0)
+
+    // Date overrides on top of a selected date.
+    if base_date.is_some()
+        && ["year", "month", "day", "ordinalDay", "week", "dayOfWeek", "quarter", "dayOfQuarter"]
+            .iter()
+            .any(|k| map.contains_key(*k))
+    {
+        let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1).expect("epoch");
+        let cur = epoch
+            .checked_add_signed(chrono::Duration::days(days as i64))
+            .ok_or_else(|| ExecutionError::RuntimeError("date out of range".into()))?;
+        let y = map.get("year").and_then(|v| v.as_integer()).unwrap_or(cur.year() as i64) as i32;
+        let mo = map.get("month").and_then(|v| v.as_integer()).unwrap_or(cur.month() as i64) as u32;
+        let d = map.get("day").and_then(|v| v.as_integer()).unwrap_or(cur.day() as i64) as u32;
+        days = chrono::NaiveDate::from_ymd_opt(y, mo, d)
+            .ok_or_else(|| ExecutionError::RuntimeError(format!("invalid date {y}-{mo}-{d}")))?
+            .signed_duration_since(epoch)
+            .num_days() as i32;
+    }
+
+    let clock_keys = ["hour", "minute", "second", "millisecond", "microsecond", "nanosecond"];
+    let has_clock = clock_keys.iter().any(|k| map.contains_key(*k));
+    let nanos = match (base_time, has_clock) {
+        // Nothing selected: read the components as a whole clock.
+        (None, _) => {
+            if has_clock { tmp::time_of_day_nanos(map)? } else { 0 }
+        }
+        (Some(t), false) => t,
+        // Selected *and* overridden: replace only the fields named.
+        (Some(t), true) => {
+            let mut hour = t / 3_600_000_000_000;
+            let mut minute = t / 60_000_000_000 % 60;
+            let mut second = t / 1_000_000_000 % 60;
+            let mut sub = t % 1_000_000_000;
+            if let Some(v) = map.get("hour").and_then(|v| v.as_integer()) { hour = v; }
+            if let Some(v) = map.get("minute").and_then(|v| v.as_integer()) { minute = v; }
+            if let Some(v) = map.get("second").and_then(|v| v.as_integer()) { second = v; }
+            // The three sub-second fields are additive with each other, and
+            // together replace the selected fraction only if any is given.
+            if ["millisecond", "microsecond", "nanosecond"].iter().any(|k| map.contains_key(*k)) {
+                let ms = map.get("millisecond").and_then(|v| v.as_integer()).unwrap_or(0);
+                let us = map.get("microsecond").and_then(|v| v.as_integer()).unwrap_or(0);
+                let ns = map.get("nanosecond").and_then(|v| v.as_integer()).unwrap_or(0);
+                sub = ms * 1_000_000 + us * 1_000 + ns;
+            }
+            (hour * 3600 + minute * 60 + second) * 1_000_000_000 + sub
+        }
     };
     Ok((days, nanos))
 }
@@ -2185,7 +2251,8 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                 Value::Property(PropertyValue::String(s)) => {
                     Ok(Value::Property(tmp::parse_date(s)?))
                 }
-                Value::Property(PropertyValue::Map(map)) => {
+                Value::Map(_) | Value::Property(PropertyValue::Map(_)) => {
+                    let map = &temporal_arg_map(&args[0]).expect("matched a map arm");
                     // Selection: `date({date: d})` and `date({datetime: dt})`
                     // take the date part of another temporal.
                     if let Some(src) = map.get("date").or_else(|| map.get("datetime")) {
@@ -2220,7 +2287,8 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     let (nanos, _) = tmp::parse_time_parts(s)?;
                     Ok(Value::Property(PropertyValue::LocalTime(nanos)))
                 }
-                Value::Property(PropertyValue::Map(map)) => {
+                Value::Map(_) | Value::Property(PropertyValue::Map(_)) => {
+                    let map = &temporal_arg_map(&args[0]).expect("matched a map arm");
                     if let Some(src) = map.get("time").or_else(|| map.get("datetime")) {
                         if let Some(n) = time_part_of(src) {
                             return Ok(Value::Property(PropertyValue::LocalTime(n)));
@@ -2253,7 +2321,8 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                         offset_seconds: off.unwrap_or(0),
                     }))
                 }
-                Value::Property(PropertyValue::Map(map)) => {
+                Value::Map(_) | Value::Property(PropertyValue::Map(_)) => {
+                    let map = &temporal_arg_map(&args[0]).expect("matched a map arm");
                     let offset = match map.get("timezone").and_then(|v| v.as_string()) {
                         Some(tz) => tmp::parse_timezone(&tz)?.0,
                         None => 0,
@@ -2293,7 +2362,8 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     let (secs, nanos) = parse_naive_date_time(s)?;
                     Ok(Value::Property(PropertyValue::LocalDateTime { secs, nanos }))
                 }
-                Value::Property(PropertyValue::Map(map)) => {
+                Value::Map(_) | Value::Property(PropertyValue::Map(_)) => {
+                    let map = &temporal_arg_map(&args[0]).expect("matched a map arm");
                     crate::query::executor::temporal::reject_unknown_map(map)?;
                     let (d, t) = compose_date_and_time(map)?;
                     let total = d as i64 * 86_400 * 1_000_000_000 + t;
@@ -2303,8 +2373,21 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     }))
                 }
                 Value::Property(PropertyValue::Null) => Ok(Value::Property(PropertyValue::Null)),
+                // A bare temporal value: take its date and time parts.
+                // `date()` and `time()` already accepted this; the composite
+                // constructors did not, so `localdatetime(other)` was a type
+                // error for every `other` the TCK hands it (#772).
+                Value::Property(p) if date_part_of(p).is_some() => {
+                    let d = date_part_of(p).unwrap_or(0);
+                    let t = time_part_of(p).unwrap_or(0);
+                    let total = d as i64 * 86_400 * 1_000_000_000 + t;
+                    Ok(Value::Property(PropertyValue::LocalDateTime {
+                        secs: total.div_euclid(1_000_000_000),
+                        nanos: total.rem_euclid(1_000_000_000) as u32,
+                    }))
+                }
                 _ => Err(ExecutionError::TypeError(
-                    "localdatetime() requires a string or map argument".to_string(),
+                    "localdatetime() requires a string, a map, or a temporal value".to_string(),
                 )),
             }
         }
@@ -2337,8 +2420,9 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                         zone: None,
                     }))
                 }
-                Value::Property(PropertyValue::Map(map)) => {
-                    tmp::reject_unknown_map(map)?;
+                Value::Map(_) | Value::Property(PropertyValue::Map(_)) => {
+                    let map = &temporal_arg_map(&args[0]).expect("matched a map arm");
+                    crate::query::executor::temporal::reject_unknown_map(map)?;
                     // An epoch is a complete specification on its own, and is
                     // handled first: without this the map fell through to the
                     // component defaults and returned 1970-01-01 *silently*,
@@ -2376,8 +2460,31 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     }))
                 }
                 Value::Property(PropertyValue::Null) => Ok(Value::Property(PropertyValue::Null)),
+                // A bare temporal value. A value with no zone of its own is
+                // read as UTC, which is what Cypher specifies for widening a
+                // local value into a zoned one.
+                Value::Property(p) if date_part_of(p).is_some() => {
+                    let off = match p {
+                        PropertyValue::ZonedDateTime { offset_seconds, .. } => *offset_seconds,
+                        _ => 0,
+                    };
+                    let zone = match p {
+                        PropertyValue::ZonedDateTime { zone, .. } => zone.clone(),
+                        _ => None,
+                    };
+                    let d = date_part_of(p).unwrap_or(0);
+                    let t = time_part_of(p).unwrap_or(0);
+                    let local = d as i64 * 86_400 * 1_000_000_000 + t;
+                    let utc = local - off as i64 * 1_000_000_000;
+                    Ok(Value::Property(PropertyValue::ZonedDateTime {
+                        secs: utc.div_euclid(1_000_000_000),
+                        nanos: utc.rem_euclid(1_000_000_000) as u32,
+                        offset_seconds: off,
+                        zone,
+                    }))
+                }
                 _ => Err(ExecutionError::TypeError(
-                    "datetime() requires a string or map argument".to_string(),
+                    "datetime() requires a string, a map, or a temporal value".to_string(),
                 )),
             }
         }

--- a/tests/temporal_selection.rs
+++ b/tests/temporal_selection.rs
@@ -1,0 +1,116 @@
+//! Building one temporal type out of another (#772).
+//!
+//! `datetime({date: d, time: t})` — the *selection* form. Two independent
+//! things were wrong and each accounted for a share of `Temporal3`'s 174
+//! failures:
+//!
+//! 1. A map literal containing variables evaluates to `Value::Map`, not
+//!    `Value::Property(PropertyValue::Map)`, so the map arm never matched and
+//!    every selection was "requires a string or map argument". The feature was
+//!    implemented and unreachable through the shape the executor produces —
+//!    the same class of gap as #769, one layer in.
+//! 2. Overrides replaced the whole clock instead of layering onto the selected
+//!    value, so `{date: d, time: t, second: 42}` gave `00:00:42` rather than
+//!    keeping `12:31` from `t`. A plausible-looking wrong answer.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn rendered(cypher: &str) -> String {
+    let store = GraphStore::new();
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.to_cypher_string(),
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+const D: &str = "date({year: 1984, month: 10, day: 11})";
+const T: &str = "localtime({hour: 12, minute: 31, second: 14, nanosecond: 645876123})";
+
+/// The straightforward selection, and the case that never matched at all.
+#[test]
+fn a_date_and_a_time_select_into_a_datetime() {
+    assert_eq!(
+        rendered(&format!("WITH {D} AS d, {T} AS t RETURN datetime({{date: d, time: t}}) AS r")),
+        "1984-10-11T12:31:14.645876123Z"
+    );
+    assert_eq!(
+        rendered(&format!("WITH {D} AS d, {T} AS t RETURN localdatetime({{date: d, time: t}}) AS r")),
+        "1984-10-11T12:31:14.645876123"
+    );
+}
+
+/// An offset given alongside the selection is applied to it.
+#[test]
+fn a_timezone_can_be_given_with_the_selection() {
+    assert_eq!(
+        rendered(&format!(
+            "WITH {D} AS d, {T} AS t RETURN datetime({{date: d, time: t, timezone: '+05:00'}}) AS r"
+        )),
+        "1984-10-11T12:31:14.645876123+05:00"
+    );
+}
+
+/// **Overrides layer onto the selected value; they do not replace it.**
+///
+/// `{date: d, time: t, day: 28, second: 42}` keeps the year and month from `d`
+/// and the hour, minute and fraction from `t`, replacing only the day and the
+/// second. Reading the components as a whole clock gives `1984-10-28T00:00:42`
+/// — which is exactly what this returned before, and looks entirely reasonable.
+#[test]
+fn overrides_replace_only_the_fields_they_name() {
+    assert_eq!(
+        rendered(&format!(
+            "WITH {D} AS d, {T} AS t RETURN datetime({{date: d, time: t, day: 28, second: 42}}) AS r"
+        )),
+        "1984-10-28T12:31:42.645876123Z"
+    );
+    // Only the hour, with the fraction preserved.
+    assert_eq!(
+        rendered(&format!("WITH {D} AS d, {T} AS t RETURN datetime({{date: d, time: t, hour: 1}}) AS r")),
+        "1984-10-11T01:31:14.645876123Z"
+    );
+}
+
+/// With nothing selected, the components *are* the whole clock — the other
+/// half of the rule above.
+#[test]
+fn without_a_selection_the_components_are_the_whole_value() {
+    assert_eq!(
+        rendered("RETURN datetime({year: 1984, month: 10, day: 11, second: 42}) AS r"),
+        "1984-10-11T00:00:42Z"
+    );
+}
+
+/// A bare temporal value widens into a composite type.
+#[test]
+fn a_bare_temporal_value_can_be_widened() {
+    let ldt = "localdatetime({year: 1984, month: 3, day: 7, hour: 12, minute: 31, second: 14, millisecond: 645})";
+    assert_eq!(rendered(&format!("RETURN datetime({ldt}) AS r")), "1984-03-07T12:31:14.645Z");
+    assert_eq!(rendered(&format!("RETURN localdatetime({ldt}) AS r")), "1984-03-07T12:31:14.645");
+    assert_eq!(rendered(&format!("RETURN date({ldt}) AS r")), "1984-03-07");
+}
+
+/// Selecting out of a datetime takes both parts from it.
+#[test]
+fn a_datetime_selects_into_its_parts() {
+    let dt = "datetime({year: 1984, month: 10, day: 11, hour: 12, minute: 31, second: 14, timezone: '+01:00'})";
+    assert_eq!(rendered(&format!("WITH {dt} AS x RETURN date({{date: x}}) AS r")), "1984-10-11");
+    assert_eq!(rendered(&format!("WITH {dt} AS x RETURN localtime({{time: x}}) AS r")), "12:31:14");
+}
+
+/// A map naming nothing the constructor understands is still refused, and the
+/// selection work did not weaken that (#595).
+#[test]
+fn an_unrecognised_map_is_still_refused() {
+    let store = GraphStore::new();
+    let q = parse_query("RETURN datetime({nonsense: 1}) AS r").expect("parses");
+    let e = QueryExecutor::new(&store).execute(&q).expect_err("should be refused");
+    let msg = format!("{e:?}");
+    assert!(msg.contains("nonsense"), "the message should name what was given: {msg}");
+}


### PR DESCRIPTION
Closes #772.

## Two bugs, and the quiet one matters more

**1. The selection form was unreachable.** A map literal containing variables evaluates to `Value::Map`, not `Value::Property(PropertyValue::Map)`, so every constructor's map arm missed it:

```
datetime({date: d, time: t})
  -> TypeError("datetime() requires a string or map argument")
```

`compose_date_and_time` had implemented selection all along. This is the fourth gap this week where the capability existed and something upstream could not reach it — after #758 (grammar vs `ASCENDING`), #769 (grammar vs the dot, with `duration.between` fully implemented), and #756 (harness vs outlines).

**2. Overrides replaced the selected clock instead of layering onto it.**

```
datetime({date: d, time: t, day: 28, second: 42})
  expected  1984-10-28T12:31:42.645876123Z
  got       1984-10-28T00:00:42Z
```

This one is the more dangerous of the two: the first announces itself with a `TypeError`, and this returns a perfectly plausible time. The rule now implemented is that a selected value is the **base** and components replace only the fields they name — and with nothing selected, the components *are* the whole value. Both halves are pinned, because implementing one without the other is easy and silent.

## Measured

**2,889 → 2,981 (+92), zero regressions**, by manifest diff against the merged baseline. Pass rate 76.8% → **79.3%**.

Of that, +89 from the two fixes above and +3 from letting the composite constructors accept a bare temporal value — `datetime(someLocalDateTime)` — which `date()` and `time()` already did.

## Tests

`tests/temporal_selection.rs`, 7 tests. The two that carry weight are `overrides_replace_only_the_fields_they_name` and `without_a_selection_the_components_are_the_whole_value`: together they pin the rule from both directions, and either alone would let the other regress silently.

`an_unrecognised_map_is_still_refused` checks that this work did not weaken #595 — a map naming nothing understood must still error rather than default to the epoch.

`cargo test --workspace --release`: exit 0, **3,347 passed, 0 failed**.

## What remains in this area

`Temporal3`'s last 82 are mostly named time zones (#767, needs `chrono-tz`) plus offset-rendering mismatches. `Temporal10` at 122 is now the largest cluster — date-time string parse gaps, including `[Europe/Stockholm]` suffixes, also blocked on #767.