### PR TITLE
Named time zones: TCK 2,981 → 3,025 (+44) (#767)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 2981
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3025
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,6 +2309,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3009,6 +3037,7 @@ dependencies = [
  "bincode",
  "bytes",
  "chrono",
+ "chrono-tz",
  "criterion",
  "flate2",
  "futures",
@@ -3293,6 +3322,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skiplist"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,14 @@ tracing-subscriber = "0.3"
 rocksdb = { version = "0.22", default-features = false, features = ["lz4", "zstd"] }
 bincode = "1.3"
 chrono = "0.4"
+# The IANA tz database, for named time zones (`Europe/Stockholm`) in temporal
+# values (#767). MIT/Apache-2.0; the embedded database is public domain.
+#
+# The whole database, deliberately. `chrono-tz` can subset with
+# `filter-by-regex`, but subsetting to the zones the TCK happens to use would
+# be tuning the engine to the benchmark -- the standing rule against benchmark
+# identifiers in engine source is the same principle.
+chrono-tz = "0.10"
 sha2 = "0.10"
 
 # High Availability (Phase 4)

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2444,12 +2444,22 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                             zone: None,
                         }));
                     }
-                    let (offset_seconds, zone) = match map.get("timezone").and_then(|v| v.as_string()) {
-                        Some(tz) => tmp::parse_timezone(&tz)?,
-                        None => (0, None),
+                    let spec = match map.get("timezone").and_then(|v| v.as_string()) {
+                        Some(tz) => Some(tmp::parse_timezone_spec(&tz)?),
+                        None => None,
                     };
                     let (d, t) = compose_date_and_time(map)?;
                     let local = d as i64 * 86_400 * 1_000_000_000 + t;
+                    // A named zone has no single offset -- Europe/Stockholm is
+                    // +01:00 in October and +02:00 in July -- so it is resolved
+                    // against *this* local date, not at parse time (#767).
+                    let (offset_seconds, zone) = match &spec {
+                        Some(sp) => (
+                            tmp::resolve_offset(sp, d as i64, t)?,
+                            tmp::zone_name(sp),
+                        ),
+                        None => (0, None),
+                    };
                     // The components describe local time; store the instant.
                     let utc = local - offset_seconds as i64 * 1_000_000_000;
                     Ok(Value::Property(PropertyValue::ZonedDateTime {

--- a/src/query/executor/temporal.rs
+++ b/src/query/executor/temporal.rs
@@ -136,36 +136,91 @@ fn weekday_from_iso(dow: u32) -> chrono::Weekday {
     }
 }
 
-/// A UTC offset in seconds from `Z`, `+01:00`, `+0100`, `+01`, or an IANA name.
+/// What a `timezone:` field named: a fixed offset, or an IANA zone.
 ///
-/// Returns the offset and the IANA name when one was given, because Cypher
-/// keeps both: an offset alone cannot survive a DST boundary and a name alone
-/// cannot express `+05:30` attached to nothing.
-pub fn parse_timezone(tz: &str) -> Result<(i32, Option<String>), ExecutionError> {
+/// They are different things and cannot be collapsed. A **fixed offset** is a
+/// constant. A **named zone** has no single offset — `Europe/Stockholm` is
+/// +01:00 in October and +02:00 in July — so its offset is only knowable once
+/// the local date is known, which is why resolution is a separate step from
+/// parsing (#767).
+#[derive(Debug, Clone, PartialEq)]
+pub enum TzSpec {
+    Offset(i32),
+    Named(chrono_tz::Tz),
+}
+
+/// Parse `Z`, `+01:00`, `+0100`, `+01`, `+02:05:59`, or `Europe/Stockholm`.
+pub fn parse_timezone_spec(tz: &str) -> Result<TzSpec, ExecutionError> {
     let t = tz.trim();
     if t.eq_ignore_ascii_case("z") || t.eq_ignore_ascii_case("utc") {
-        return Ok((0, None));
+        return Ok(TzSpec::Offset(0));
     }
     if t.starts_with('+') || t.starts_with('-') {
         let sign = if t.starts_with('-') { -1 } else { 1 };
         let rest = &t[1..];
-        let (h, m) = match rest.split_once(':') {
-            Some((h, m)) => (h, m),
-            None if rest.len() == 4 => (&rest[..2], &rest[2..]),
-            None => (rest, "0"),
+        let parts: Vec<&str> = rest.split(':').collect();
+        let (h, m, sec) = match parts.as_slice() {
+            [h] if h.len() == 4 => (&h[..2], &h[2..], "0"),
+            [h] => (*h, "0", "0"),
+            [h, m] => (*h, *m, "0"),
+            // `+02:05:59` — an offset with seconds, which the TCK uses.
+            [h, m, sec] => (*h, *m, *sec),
+            _ => return Err(err(format!("bad timezone offset: {tz}"))),
         };
-        let h: i32 = h.parse().map_err(|_| err(format!("bad timezone offset: {tz}")))?;
-        let m: i32 = m.parse().map_err(|_| err(format!("bad timezone offset: {tz}")))?;
-        return Ok((sign * (h * 3600 + m * 60), None));
+        let p = |x: &str| x.parse::<i32>().map_err(|_| err(format!("bad timezone offset: {tz}")));
+        return Ok(TzSpec::Offset(sign * (p(h)? * 3600 + p(m)? * 60 + p(sec)?)));
     }
-    // A named zone. Resolving it to an offset needs a tz database, which the
-    // engine does not carry yet; the name is preserved so nothing is lost, and
-    // the offset is reported as unknown rather than guessed as UTC — guessing
-    // would silently shift every value by the real offset.
-    Err(err(format!(
-        "named time zone `{tz}` needs a tz database, which is not built in yet; \
-         use an offset such as +01:00"
-    )))
+    t.parse::<chrono_tz::Tz>()
+        .map(TzSpec::Named)
+        .map_err(|_| err(format!("unknown time zone: {tz}")))
+}
+
+/// The UTC offset this spec has at a given **local** wall-clock instant.
+///
+/// A local time can be ambiguous (the hour repeated when clocks go back) or
+/// non-existent (the hour skipped when they go forward). Cypher resolves both
+/// toward the earlier offset, which is what `LocalResult::earliest` gives;
+/// picking arbitrarily would make one hour a year silently wrong.
+pub fn resolve_offset(spec: &TzSpec, local_days: i64, local_nanos: i64) -> Result<i32, ExecutionError> {
+    match spec {
+        TzSpec::Offset(o) => Ok(*o),
+        TzSpec::Named(tz) => {
+            use chrono::TimeZone;
+            let naive = chrono::DateTime::from_timestamp(
+                local_days * 86_400 + local_nanos.div_euclid(NANOS_PER_SEC),
+                local_nanos.rem_euclid(NANOS_PER_SEC) as u32,
+            )
+            .ok_or_else(|| err("date-time out of range"))?
+            .naive_utc();
+            let resolved = tz
+                .from_local_datetime(&naive)
+                .earliest()
+                .or_else(|| tz.from_local_datetime(&naive).latest())
+                .ok_or_else(|| err(format!("{tz} has no offset for {naive}")))?;
+            use chrono::Offset as _;
+            Ok(resolved.offset().fix().local_minus_utc())
+        }
+    }
+}
+
+/// The IANA name, when the spec has one.
+pub fn zone_name(spec: &TzSpec) -> Option<String> {
+    match spec {
+        TzSpec::Named(tz) => Some(tz.name().to_string()),
+        TzSpec::Offset(_) => None,
+    }
+}
+
+/// Back-compatible shim for callers with no date in hand.
+///
+/// A named zone still needs a date to have an offset, so this resolves it
+/// against 1970-01-01 — correct for a fixed offset, and an approximation for a
+/// named zone that the date-bearing constructors do not use. Kept narrow on
+/// purpose: `time()` is the only caller, because a time of day genuinely has
+/// no date to resolve against.
+pub fn parse_timezone(tz: &str) -> Result<(i32, Option<String>), ExecutionError> {
+    let spec = parse_timezone_spec(tz)?;
+    Ok((resolve_offset(&spec, 0, 0)?, zone_name(&spec)))
 }
 
 /// `PropertyValue::Date` from an ISO string: `2015-07-21`, `20150721`,

--- a/tests/temporal_representation.rs
+++ b/tests/temporal_representation.rs
@@ -284,18 +284,40 @@ fn timezone_offsets_parse_in_every_spelling() {
     }
 }
 
-/// A named zone is refused with a message that says why, rather than being
-/// read as UTC.
+/// A named zone resolves against the IANA database, and **its offset depends
+/// on the date**.
 ///
-/// Treating it as UTC would shift every value by the real offset and return a
-/// plausible-looking wrong instant. Tracked as #767; this test pins the
-/// refusal so nobody "fixes" it by defaulting to zero.
+/// This asserted the *refusal* until #767: with no tz database, erroring was
+/// better than reading `Europe/Stockholm` as UTC and shifting every value by
+/// the real offset. Now it resolves, and the property worth pinning is the
+/// date dependence — Stockholm is +01:00 in October and +02:00 in July. An
+/// implementation that resolved a zone to one offset and cached it would pass
+/// half of these and be wrong for half the year.
 #[test]
-fn a_named_zone_is_refused_rather_than_assumed_to_be_utc() {
-    let e = tmp::parse_timezone("Europe/Stockholm").expect_err("should refuse");
-    let msg = format!("{e}");
-    assert!(msg.contains("Europe/Stockholm"), "message should name the zone: {msg}");
-    assert!(msg.contains("tz database"), "message should say what is missing: {msg}");
+fn a_named_zone_resolves_and_its_offset_depends_on_the_date() {
+    use samyama::query::executor::temporal::{parse_timezone_spec, resolve_offset, zone_name};
+
+    let spec = parse_timezone_spec("Europe/Stockholm").expect("a known zone");
+    assert_eq!(zone_name(&spec).as_deref(), Some("Europe/Stockholm"));
+
+    // 1984-10-11 is CET (+01:00); 1984-07-20 is CEST (+02:00).
+    assert_eq!(P::Date(5397).to_cypher_string(), "1984-10-11", "sanity: reference date");
+    assert_eq!(resolve_offset(&spec, 5397, 0).unwrap(), 3600);
+    assert_eq!(P::Date(5314).to_cypher_string(), "1984-07-20", "sanity: reference date");
+    assert_eq!(resolve_offset(&spec, 5314, 0).unwrap(), 7200);
+
+    // A zone with no DST, so both dates agree — the control for the above.
+    let hst = parse_timezone_spec("Pacific/Honolulu").expect("a known zone");
+    assert_eq!(resolve_offset(&hst, 5397, 0).unwrap(), -36_000);
+    assert_eq!(resolve_offset(&hst, 5314, 0).unwrap(), -36_000);
+}
+
+/// An unknown zone is still an error, and names itself.
+#[test]
+fn an_unknown_zone_is_refused() {
+    use samyama::query::executor::temporal::parse_timezone_spec;
+    let e = parse_timezone_spec("Middle/Earth").expect_err("not a zone");
+    assert!(format!("{e}").contains("Middle/Earth"), "{e}");
 }
 
 /// Strings parse into the right type with full precision.


### PR DESCRIPTION
Closes #767.

## The dependency call

Adds `chrono-tz` (MIT/Apache-2.0; the embedded IANA database is public domain), and takes **the whole database**.

`chrono-tz` can subset with `filter-by-regex`, and subsetting to `Europe/Stockholm` and `Pacific/Honolulu` — the only two zones the TCK uses — would have passed the same scenarios for a fraction of the binary. That is tuning the engine to the benchmark, which is the same principle as the standing rule against benchmark identifiers in engine source. Ship the whole database or none of it.

Binary: 27 MB.

## The design point

**A named zone has no single offset.** `Europe/Stockholm` is +01:00 in October and +02:00 in July, and the TCK checks both:

```
{year: 1984, month: 10, day: 11, timezone: 'Europe/Stockholm'}  ->  ...+01:00[Europe/Stockholm]
{year: 1984, ordinalDay: 202,    timezone: 'Europe/Stockholm'}  ->  ...+02:00[Europe/Stockholm]
```

So resolution cannot happen at parse time. Parsing yields a `TzSpec` — `Offset(i32)` or `Named(Tz)` — and the constructor resolves it once the local date is known. An implementation that resolved a zone to one offset and cached it would pass half these scenarios and be wrong for half the year.

`a_named_zone_resolves_and_its_offset_depends_on_the_date` pins both dates, plus `Pacific/Honolulu` as a **no-DST control** — without that, a broken date-dependence could still look right on one sample.

Ambiguous local times (the hour repeated when clocks go back) and non-existent ones (the hour skipped going forward) resolve toward the earlier offset, which is Cypher's rule. Picking arbitrarily makes one hour a year silently wrong.

## Measured

**2,981 → 3,025 (+44)**: Temporal1 +30, Temporal3 +13, Temporal6 +1.

## A cost I disclosed in #768, now recovered

#768 refused named zones rather than reading them as UTC, and I flagged that this broke `Temporal5`'s **setup**, moving it from evaluated to `setup did not run` and dropping coverage 3,761 → 3,760.

Coverage is back to **3,761** and `setup did not run` back to 5.

The manifest diff reports one "regression": `Temporal5 [6] Should provide accessors for date time`. That is the same scenario — its setup now runs, so it moved from *skipped* to *evaluated-and-failing*. It was never passing. Coverage improved; a scenario did not break. Recorded plainly because a diff cannot tell those apart and would otherwise book it as damage.

## Test updated rather than deleted

`a_named_zone_is_refused_rather_than_assumed_to_be_utc` existed to stop anyone "fixing" the gap by defaulting to zero. Now that the capability exists it asserts correct resolution instead, with the reason written into the test rather than silently swapped.

`cargo test --workspace --release`: exit 0, **3,348 passed, 0 failed**.