### PR TITLE
ISO-8601 parsing in every spelling, and duration signs: TCK 3,025 → 3,097 (+72) (#775)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3025
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3097
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1533,22 +1533,28 @@ fn compose_date_and_time(
 }
 
 /// Seconds/nanos of a naive date-time string, with no zone.
+///
+/// Delegates to the ISO parsers so every spelling the date and time parsers
+/// accept works here too — `20150721T21:40`, `2015-W30-2T214032.142`,
+/// `2015-202T21:40:32`. The previous list of `chrono` format strings covered
+/// four shapes out of the corpus's dozen (#775).
 fn parse_naive_date_time(s: &str) -> Result<(i64, u32), ExecutionError> {
+    use crate::query::executor::temporal as tmp;
     let t = s.trim();
-    for fmt in ["%Y-%m-%dT%H:%M:%S%.f", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M", "%Y-%m-%d"] {
-        if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(t, fmt) {
-            return Ok((dt.and_utc().timestamp(), dt.and_utc().timestamp_subsec_nanos()));
-        }
-        if fmt == "%Y-%m-%d" {
-            if let Ok(d) = chrono::NaiveDate::parse_from_str(t, fmt) {
-                let dt = d.and_hms_opt(0, 0, 0).expect("midnight is a time");
-                return Ok((dt.and_utc().timestamp(), 0));
-            }
-        }
-    }
-    Err(ExecutionError::RuntimeError(format!(
-        "cannot parse date-time: {s}"
-    )))
+    let (date_part, time_part) = match t.split_once('T') {
+        Some((d, ti)) => (d, Some(ti)),
+        None => (t, None),
+    };
+    let days = tmp::parse_iso_date(date_part)? as i64;
+    let nanos = match time_part {
+        Some(ti) if !ti.is_empty() => tmp::parse_iso_time(ti)?,
+        _ => 0,
+    };
+    let total = days * 86_400 * 1_000_000_000 + nanos;
+    Ok((
+        total.div_euclid(1_000_000_000),
+        total.rem_euclid(1_000_000_000) as u32,
+    ))
 }
 
 /// The `PropertyValue` inside a `Value`, when there is one.
@@ -2404,20 +2410,43 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
             }
             match &args[0] {
                 Value::Property(PropertyValue::String(s)) => {
-                    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
-                        return Ok(Value::Property(PropertyValue::ZonedDateTime {
-                            secs: dt.timestamp(),
-                            nanos: dt.timestamp_subsec_nanos(),
-                            offset_seconds: dt.offset().local_minus_utc(),
-                            zone: None,
-                        }));
-                    }
-                    let (secs, nanos) = parse_naive_date_time(s)?;
+                    use crate::query::executor::temporal as tmp;
+                    // `2015-07-21T21:40:32.142+02:00[Europe/Stockholm]` carries
+                    // an offset *and* a zone, and they are not redundant: the
+                    // offset is what the value had when written, the zone is
+                    // the rule it follows. Either may also appear alone.
+                    let (body, zone_name) = tmp::split_zone_suffix(s);
+                    let (clock, explicit_offset) = match body.rsplit_once('T') {
+                        Some(_) | None => {
+                            // Reuse the offset splitter, which knows not to
+                            // mistake a date dash for an offset sign.
+                            let (c, o) = tmp::parse_datetime_offset(body)?;
+                            (c, o)
+                        }
+                    };
+                    let (secs_naive, nanos) = parse_naive_date_time(clock)?;
+                    let local_days = secs_naive.div_euclid(86_400);
+                    let local_nanos = secs_naive.rem_euclid(86_400) * 1_000_000_000 + nanos as i64;
+
+                    let (offset_seconds, zone) = match zone_name {
+                        Some(z) => {
+                            let spec = tmp::parse_timezone_spec(z)?;
+                            // A zone suffix wins over a written offset for the
+                            // *rule*, but the written offset is authoritative
+                            // for the instant it recorded -- keep it when given.
+                            let off = explicit_offset
+                                .map(Ok)
+                                .unwrap_or_else(|| tmp::resolve_offset(&spec, local_days, local_nanos))?;
+                            (off, tmp::zone_name(&spec))
+                        }
+                        None => (explicit_offset.unwrap_or(0), None),
+                    };
+                    let utc = secs_naive - offset_seconds as i64;
                     Ok(Value::Property(PropertyValue::ZonedDateTime {
-                        secs,
+                        secs: utc,
                         nanos,
-                        offset_seconds: 0,
-                        zone: None,
+                        offset_seconds,
+                        zone,
                     }))
                 }
                 Value::Map(_) | Value::Property(PropertyValue::Map(_)) => {
@@ -2575,7 +2604,13 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                 (Value::Property(a), Value::Property(b)) => (a.clone(), b.clone()),
                 _ => return Err(ExecutionError::TypeError(format!("{lowered}() needs two temporal values"))),
             };
-            let diff = temporal_difference(&a, &b)?;
+            // `duration.inX(lhs, rhs)` is **rhs - lhs**, the same orientation
+            // as `duration.between`: the duration you would add to `lhs` to
+            // reach `rhs`. This had the operands the other way round, so every
+            // result carried the wrong sign -- and half the TCK rows expect a
+            // negative answer, so it looked correct on exactly the half that
+            // happened to be positive (#775).
+            let diff = temporal_difference(&b, &a)?;
             let (days, seconds, nanos) = match diff {
                 PropertyValue::Duration { days, seconds, nanos, .. } => (days, seconds, nanos),
                 _ => (0, 0, 0),
@@ -2948,12 +2983,17 @@ fn temporal_difference(
         _ => return Err(ExecutionError::TypeError("not temporal values".to_string())),
     };
     let diff = na - nb;
-    let secs_total = diff.div_euclid(1_000_000_000) as i64;
+    // Truncating division, not Euclidean. `div_euclid`/`rem_euclid` floor
+    // toward negative infinity, so a difference of -0.4s split into
+    // (seconds, nanos) becomes (-1, +600_000_000) and renders as `PT-1.6S`
+    // instead of `PT-0.4S`. The components of a duration must share a sign;
+    // `/` and `%` truncate toward zero and do (#775).
+    let secs_total = (diff / 1_000_000_000) as i64;
     Ok(PropertyValue::Duration {
         months: 0,
         days: secs_total / 86_400,
         seconds: secs_total % 86_400,
-        nanos: diff.rem_euclid(1_000_000_000) as i32,
+        nanos: (diff % 1_000_000_000) as i32,
     })
 }
 

--- a/src/query/executor/temporal.rs
+++ b/src/query/executor/temporal.rs
@@ -223,50 +223,31 @@ pub fn parse_timezone(tz: &str) -> Result<(i32, Option<String>), ExecutionError>
     Ok((resolve_offset(&spec, 0, 0)?, zone_name(&spec)))
 }
 
-/// `PropertyValue::Date` from an ISO string: `2015-07-21`, `20150721`,
-/// `2015-W30-2`, `2015-201`.
+/// `PropertyValue::Date` from an ISO string, in any spelling.
 pub fn parse_date(s: &str) -> Result<PropertyValue, ExecutionError> {
-    use chrono::NaiveDate;
-    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).expect("epoch is a date");
-    let t = s.trim();
-    let parsed = NaiveDate::parse_from_str(t, "%Y-%m-%d")
-        .or_else(|_| NaiveDate::parse_from_str(t, "%Y%m%d"))
-        .or_else(|_| NaiveDate::parse_from_str(t, "%Y-%j"))
-        .map_err(|_| err(format!("cannot parse date: {s}")))?;
-    Ok(PropertyValue::Date(
-        parsed.signed_duration_since(epoch).num_days() as i32,
-    ))
+    Ok(PropertyValue::Date(parse_iso_date(s)?))
 }
 
 /// Nanoseconds since midnight, and an offset if the string carried one.
 pub fn parse_time_parts(s: &str) -> Result<(i64, Option<i32>), ExecutionError> {
-    let t = s.trim();
-    // Split the offset off the end before parsing the clock, so `-05:00` is
-    // not mistaken for part of the time.
-    let (clock, offset) = split_offset(t)?;
-    let nt = chrono::NaiveTime::parse_from_str(clock, "%H:%M:%S%.f")
-        .or_else(|_| chrono::NaiveTime::parse_from_str(clock, "%H:%M:%S"))
-        .or_else(|_| chrono::NaiveTime::parse_from_str(clock, "%H:%M"))
-        .or_else(|_| chrono::NaiveTime::parse_from_str(clock, "%H"))
-        .map_err(|_| err(format!("cannot parse time: {s}")))?;
-    let nanos = nt
-        .signed_duration_since(chrono::NaiveTime::MIN)
-        .num_nanoseconds()
-        .ok_or_else(|| err(format!("time out of range: {s}")))?;
-    Ok((nanos, offset))
+    let (clock, offset) = split_offset(s.trim())?;
+    Ok((parse_iso_time(clock)?, offset))
 }
 
 /// Separate a trailing UTC offset from the clock part.
+///
+/// Care is needed with `-`: in `2015-07-21T21:40:32-04` the offset dash is the
+/// last one, but in `2015-07-21` every dash belongs to the date. The rule used
+/// here is that an offset dash must come after a `T` when one is present, and
+/// otherwise after the time has started.
 fn split_offset(t: &str) -> Result<(&str, Option<i32>), ExecutionError> {
     if let Some(stripped) = t.strip_suffix('Z').or_else(|| t.strip_suffix('z')) {
         return Ok((stripped, Some(0)));
     }
-    // Scan from the right for a sign that begins an offset, not a date dash.
-    if let Some(pos) = t.rfind(['+', '-']) {
-        // A '-' inside the first 8 characters of a date-time belongs to the
-        // date, not to an offset.
-        let looks_like_offset = t[pos..].contains(':') || t[pos..].len() <= 5;
-        if looks_like_offset && pos > 0 {
+    let search_from = t.rfind('T').map(|i| i + 1).unwrap_or(0);
+    if let Some(rel) = t[search_from..].rfind(['+', '-']) {
+        let pos = search_from + rel;
+        if pos > 0 {
             let (clock, off) = t.split_at(pos);
             let (secs, _) = parse_timezone(off)?;
             return Ok((clock, Some(secs)));
@@ -470,4 +451,141 @@ fn build(
         }
         other => return Err(err(format!("cannot truncate to {other}"))),
     })
+}
+
+
+/// Split a trailing `[Area/City]` zone suffix off an ISO string.
+///
+/// `2015-07-21T21:40:32.142+02:00[Europe/Stockholm]` carries **both** an offset
+/// and a zone, and they are not redundant: the offset is what the value had
+/// when it was written, the zone is the rule it follows. Cypher keeps both, so
+/// the parser must not discard either.
+pub fn split_zone_suffix(s: &str) -> (&str, Option<&str>) {
+    let t = s.trim();
+    if let Some(open) = t.rfind('[') {
+        if t.ends_with(']') {
+            return (&t[..open], Some(&t[open + 1..t.len() - 1]));
+        }
+    }
+    (t, None)
+}
+
+/// A date in any ISO-8601 spelling the TCK uses, as days since the epoch.
+///
+/// Six forms, and the compact ones are not decoration — `20150721`,
+/// `2015W302` and `2015202` all appear:
+///
+/// ```text
+/// 2015-07-21   20150721     calendar, extended and compact
+/// 2015-W30-2   2015W302     ISO week date
+/// 2015-202     2015202      ordinal day
+/// ```
+///
+/// Years may also be signed and wider than four digits (`-999999999-01-01`),
+/// which is why the year is scanned rather than taken as a fixed slice.
+pub fn parse_iso_date(s: &str) -> Result<i32, ExecutionError> {
+    use chrono::{Datelike, NaiveDate};
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).expect("epoch");
+    let t = s.trim();
+    if t.is_empty() {
+        return Err(err("empty date"));
+    }
+
+    // Signed, variable-width year.
+    let (sign, rest) = match t.strip_prefix('-') {
+        Some(r) => (-1i64, r),
+        None => (1i64, t.strip_prefix('+').unwrap_or(t)),
+    };
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if digits.len() < 4 {
+        return Err(err(format!("cannot parse date: {s}")));
+    }
+    // A compact form packs everything into one digit run; an extended form
+    // stops at four.
+    let (year_str, tail) = if digits.len() >= 8 && !rest[digits.len()..].starts_with('-') {
+        (&digits[..4], &rest[4..])
+    } else {
+        (&digits[..digits.len().min(if rest.len() > digits.len() { digits.len() } else { 4 })], &rest[digits.len().min(if rest.len() > digits.len() { digits.len() } else { 4 })..])
+    };
+    let year = sign * year_str.parse::<i64>().map_err(|_| err(format!("bad year in {s}")))?;
+    let year = i32::try_from(year).map_err(|_| err(format!("year out of range in {s}")))?;
+    let tail = tail.trim_start_matches('-');
+
+    let date = if tail.is_empty() {
+        NaiveDate::from_ymd_opt(year, 1, 1)
+    } else if let Some(w) = tail.strip_prefix('W').or_else(|| tail.strip_prefix('w')) {
+        let w = w.replace('-', "");
+        let week: u32 = w[..2].parse().map_err(|_| err(format!("bad week in {s}")))?;
+        let dow: u32 = if w.len() > 2 { w[2..3].parse().unwrap_or(1) } else { 1 };
+        NaiveDate::from_isoywd_opt(year, week, weekday_from_iso(dow))
+    } else {
+        let d = tail.replace('-', "");
+        match d.len() {
+            // Ordinal day: three digits.
+            3 => NaiveDate::from_yo_opt(year, d.parse().map_err(|_| err("bad ordinal"))?),
+            // Month only.
+            2 => NaiveDate::from_ymd_opt(year, d.parse().map_err(|_| err("bad month"))?, 1),
+            4 => NaiveDate::from_ymd_opt(
+                year,
+                d[..2].parse().map_err(|_| err("bad month"))?,
+                d[2..].parse().map_err(|_| err("bad day"))?,
+            ),
+            _ => return Err(err(format!("cannot parse date: {s}"))),
+        }
+    };
+    let date = date.ok_or_else(|| err(format!("invalid date: {s}")))?;
+    Ok(date.signed_duration_since(epoch).num_days() as i32)
+}
+
+/// A time of day in any ISO-8601 spelling, as nanoseconds since midnight.
+///
+/// `21:40:32.142`, `214032.142`, `2140`, `21`. The fraction may use a comma,
+/// which ISO-8601 permits and the TCK uses.
+pub fn parse_iso_time(s: &str) -> Result<i64, ExecutionError> {
+    let t = s.trim().replace(',', ".");
+    if t.is_empty() {
+        return Err(err("empty time"));
+    }
+    let (clock, frac) = match t.split_once('.') {
+        Some((c, f)) => (c.to_string(), f.to_string()),
+        None => (t.clone(), String::new()),
+    };
+    let c = clock.replace(':', "");
+    if !c.chars().all(|ch| ch.is_ascii_digit()) || c.is_empty() {
+        return Err(err(format!("cannot parse time: {s}")));
+    }
+    let take = |a: usize, b: usize| -> i64 {
+        c.get(a..b).and_then(|x| x.parse().ok()).unwrap_or(0)
+    };
+    let (h, m, sec) = match c.len() {
+        1 | 2 => (take(0, c.len()), 0, 0),
+        3 | 4 => (take(0, 2), take(2, c.len()), 0),
+        5 | 6 => (take(0, 2), take(2, 4), take(4, c.len())),
+        _ => return Err(err(format!("cannot parse time: {s}"))),
+    };
+    if h > 24 || m > 59 || sec > 59 {
+        return Err(err(format!("time out of range: {s}")));
+    }
+    // Pad or trim the fraction to exactly nine digits.
+    let nanos: i64 = if frac.is_empty() {
+        0
+    } else {
+        let mut f = frac.chars().filter(|c| c.is_ascii_digit()).collect::<String>();
+        f.truncate(9);
+        while f.len() < 9 {
+            f.push('0');
+        }
+        f.parse().unwrap_or(0)
+    };
+    Ok((h * 3600 + m * 60 + sec) * NANOS_PER_SEC + nanos)
+}
+
+
+/// Split a date-time string into its clock part and a written UTC offset.
+///
+/// Public because the `datetime()` string form needs the same dash rule the
+/// time parser uses: in `2015-07-21T21:40:32-04` the offset dash is the last
+/// one *after the `T`*, while in `2015-07-21` every dash belongs to the date.
+pub fn parse_datetime_offset(t: &str) -> Result<(&str, Option<i32>), ExecutionError> {
+    split_offset(t)
 }

--- a/tests/temporal_iso_parsing.rs
+++ b/tests/temporal_iso_parsing.rs
@@ -1,0 +1,166 @@
+//! ISO-8601 in every spelling the corpus uses, and duration signs (#775).
+//!
+//! Two unrelated defects, both found by reading failure *detail* rather than
+//! counts.
+//!
+//! **Parsing.** The string constructors used a short list of `chrono` format
+//! strings — four shapes out of the dozen openCypher permits. Compact forms
+//! (`20150721T21:40`), week dates (`2015-W30-2T214032.142`), ordinal dates
+//! (`2015-202T21:40:32`) and bracketed zones
+//! (`...+02:00[Europe/Stockholm]`) were all parse errors.
+//!
+//! **Duration signs.** `duration.inSeconds` had its operands reversed, and the
+//! (seconds, nanos) split used Euclidean division so the two components could
+//! disagree in sign. Together those produced `PT-1.6S` where `PT0.4S` was
+//! expected — and looked *correct* on exactly the half of the corpus whose
+//! answers happen to be positive.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::temporal as tmp;
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn rendered(cypher: &str) -> String {
+    let store = GraphStore::new();
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.to_cypher_string(),
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+/// Every date spelling, extended and compact.
+#[test]
+fn dates_parse_in_every_iso_spelling() {
+    for (input, want) in [
+        ("2015-07-21", "2015-07-21"),
+        ("20150721", "2015-07-21"),
+        ("2015-W30-2", "2015-07-21"),
+        ("2015W302", "2015-07-21"),
+        ("2015-202", "2015-07-21"),
+        ("2015202", "2015-07-21"),
+    ] {
+        assert_eq!(
+            PropertyValue::Date(tmp::parse_iso_date(input).unwrap_or_else(|e| panic!("{input}: {e}")))
+                .to_cypher_string(),
+            want,
+            "date({input})"
+        );
+    }
+}
+
+/// Every time spelling, including a comma fraction, which ISO-8601 allows.
+#[test]
+fn times_parse_in_every_iso_spelling() {
+    for (input, want) in [
+        ("21:40:32.142", "21:40:32.142"),
+        ("214032.142", "21:40:32.142"),
+        ("21:40:32", "21:40:32"),
+        ("214032", "21:40:32"),
+        ("21:40", "21:40"),
+        ("2140", "21:40"),
+        ("21", "21:00"),
+        ("21:40:32,142", "21:40:32.142"),
+    ] {
+        assert_eq!(
+            PropertyValue::LocalTime(tmp::parse_iso_time(input).unwrap_or_else(|e| panic!("{input}: {e}")))
+                .to_cypher_string(),
+            want,
+            "time({input})"
+        );
+    }
+}
+
+/// A bracketed zone suffix, with and without a written offset.
+///
+/// They are not redundant: the offset is what the value had when written, the
+/// zone is the rule it follows. Dropping either loses information Cypher keeps.
+#[test]
+fn a_bracketed_zone_suffix_is_understood() {
+    assert_eq!(
+        rendered("RETURN datetime('2015-07-21T21:40:32.142+02:00[Europe/Stockholm]') AS r"),
+        "2015-07-21T21:40:32.142+02:00[Europe/Stockholm]"
+    );
+    // No written offset: resolved from the zone at that date (CEST, +02:00).
+    assert_eq!(
+        rendered("RETURN datetime('2015-07-21T21:40:32.142[Europe/Stockholm]') AS r"),
+        "2015-07-21T21:40:32.142+02:00[Europe/Stockholm]"
+    );
+    // A different date in the same zone gives a different offset (CET).
+    assert_eq!(
+        rendered("RETURN datetime('2015-01-21T21:40:32[Europe/Stockholm]') AS r"),
+        "2015-01-21T21:40:32+01:00[Europe/Stockholm]"
+    );
+}
+
+/// A `-` inside a date is not an offset sign.
+///
+/// `2015-07-21T21:40:32-04` ends with an offset; `2015-07-21` does not. The
+/// rule is that an offset sign must come after the `T`.
+#[test]
+fn a_date_dash_is_not_mistaken_for_an_offset() {
+    assert_eq!(rendered("RETURN date('2015-07-21') AS r"), "2015-07-21");
+    assert_eq!(
+        rendered("RETURN datetime('2015-07-21T21:40:32-04:00') AS r"),
+        "2015-07-21T21:40:32-04:00"
+    );
+    assert_eq!(
+        rendered("RETURN datetime('2015-07-21T21:40:32+0100') AS r"),
+        "2015-07-21T21:40:32+01:00"
+    );
+}
+
+/// Mixed date and time spellings compose.
+#[test]
+fn compact_and_extended_forms_compose() {
+    for (input, want) in [
+        ("20150721T21:40", "2015-07-21T21:40"),
+        ("2015-W30-2T214032.142", "2015-07-21T21:40:32.142"),
+        ("2015-202T21:40:32", "2015-07-21T21:40:32"),
+    ] {
+        assert_eq!(rendered(&format!("RETURN localdatetime('{input}') AS r")), want, "{input}");
+    }
+}
+
+/// **A duration's components must share a sign.**
+///
+/// Euclidean division splits -0.4s into (-1s, +600ms) and renders `PT-1.6S`.
+/// Every row here comes from the TCK, and the negative ones are the point: the
+/// bug was invisible on positive answers, which is half the corpus.
+#[test]
+fn duration_components_share_a_sign() {
+    let cases = [
+        ("12:34:54.7", "12:34:54.3", "PT-0.4S"),
+        ("12:34:54.3", "12:34:54.7", "PT0.4S"),
+        ("12:34:54.7", "12:34:55.3", "PT0.6S"),
+        ("12:34:54.7", "12:44:55.3", "PT10M0.6S"),
+        ("12:44:54.7", "12:34:55.3", "PT-9M-59.4S"),
+        ("12:34:56", "12:34:55.7", "PT-0.3S"),
+        ("12:34:56.3", "12:34:54.7", "PT-1.6S"),
+        ("12:34:54.7", "12:34:56.3", "PT1.6S"),
+    ];
+    for (lhs, rhs, want) in cases {
+        assert_eq!(
+            rendered(&format!("RETURN duration.inSeconds(localtime('{lhs}'), localtime('{rhs}')) AS r")),
+            want,
+            "duration.inSeconds({lhs}, {rhs})"
+        );
+    }
+}
+
+/// `duration.inX(lhs, rhs)` is **rhs - lhs** — the duration you would add to
+/// `lhs` to reach `rhs`, the same orientation as `duration.between`.
+#[test]
+fn the_operand_order_is_from_then_to() {
+    assert_eq!(
+        rendered("RETURN duration.inDays(date('2017-10-11'), date('2017-10-13')) AS r"),
+        "P2D"
+    );
+    assert_eq!(
+        rendered("RETURN duration.inDays(date('2017-10-13'), date('2017-10-11')) AS r"),
+        "P-2D"
+    );
+}


### PR DESCRIPTION
Closes #775.

## Two defects that hide each other

```cypher
RETURN duration.inSeconds(localtime('12:34:54.3'), localtime('12:34:54.7'))
  expected  PT0.4S
  got       PT-1.6S
```

**Operands reversed.** `duration.inX(lhs, rhs)` is `rhs - lhs` — the duration you would add to `lhs` to reach `rhs`, the same orientation as `duration.between`. It computed `lhs - rhs`.

**Euclidean split.** `div_euclid`/`rem_euclid` floor toward negative infinity, so `-0.4s` becomes `(-1s, +600_000_000ns)` — components with opposite signs — rendering `PT-1.6S`. A duration's components must share a sign, and `/`/`%` truncate toward zero.

Each is invisible on about half the inputs, and together they are invisible on every row whose expected answer is positive. **Reversing the operands alone fixes row 1 and appears to be progress; fixing the split alone fixes row 2 and appears to be progress.** A suite exercising only positive durations would call this feature correct — which is why `duration_components_share_a_sign` pins all eight TCK rows, negatives included.

## ISO-8601 parsing

Same failure detail, unrelated cause. The string constructors used a list of `chrono` format strings covering four shapes out of the dozen openCypher permits:

```
2015-07-21T21:40:32.142+0100                       compact offset
2015-07-21T21:40:32.142+02:00[Europe/Stockholm]    offset AND zone
2015-07-21T21:40:32.142-04[America/New_York]       hour-only offset AND zone
2015-202T21:40:32                                  ordinal date
2015-W30-2T214032.142                              week date, compact time
20150721T21:40                                     compact date, extended time
-999999999-01-01                                   signed, wide year
```

All parse errors. Replaced with real date and time parsers covering the extended and compact spellings of calendar, week and ordinal dates, plus comma fractions.

Two things worth recording:

* **A `-` inside a date is not an offset sign.** `2015-07-21T21:40:32-04` ends with an offset; `2015-07-21` does not. The rule used is that an offset sign must follow the `T` when there is one — `a_date_dash_is_not_mistaken_for_an_offset` pins both directions.
* **A bracketed zone and a written offset are both kept.** The offset is what the value had when written, the zone is the rule it follows, and neither implies the other. With no written offset the zone is resolved at that date, so the same string in January and July gives +01:00 and +02:00.

## Measured

**3,025 → 3,097 (+72), zero regressions** by manifest diff. +46 parsing (Temporal2 +35, Temporal10 +11), +26 signs. Pass rate 80.4% → **82.3%**.

`cargo test --workspace --release`: exit 0, **3,355 passed, 0 failed**.