### PR TITLE
ORDER BY may not name an out-of-scope variable: TCK 3,097 → 3,137 (+40) (#777)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3097
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3137
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -656,7 +656,185 @@ fn validate_variable_kinds(query: &Query) -> Result<(), ValidationError> {
     Ok(())
 }
 
+
+/// Variables a pattern binds.
+fn pattern_vars(pattern: &crate::query::ast::Pattern, out: &mut HashSet<String>) {
+    for path in &pattern.paths {
+        if let Some(v) = &path.path_variable { out.insert(v.clone()); }
+        if let Some(v) = &path.start.variable { out.insert(v.clone()); }
+        for seg in &path.segments {
+            if let Some(v) = &seg.edge.variable { out.insert(v.clone()); }
+            if let Some(v) = &seg.node.variable { out.insert(v.clone()); }
+        }
+    }
+}
+
+/// The names a projection makes available downstream.
+fn projected_names(items: &[ReturnItem]) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for item in items {
+        if let Some(a) = &item.alias {
+            out.insert(a.clone());
+        } else if let Expression::Variable(v) = &item.expression {
+            out.insert(v.clone());
+        }
+    }
+    out
+}
+
+/// Every variable an expression reads.
+fn expression_vars(e: &Expression, out: &mut HashSet<String>) {
+    use Expression::*;
+    match e {
+        Variable(v) => { out.insert(v.clone()); }
+        Property { variable, .. } => { out.insert(variable.clone()); }
+        Binary { left, right, .. } => { expression_vars(left, out); expression_vars(right, out); }
+        Unary { expr, .. } => expression_vars(expr, out),
+        Function { args, .. } => for a in args { expression_vars(a, out) },
+        Index { expr, index } => { expression_vars(expr, out); expression_vars(index, out); }
+        Case { operand, when_clauses, else_result } => {
+            if let Some(o) = operand { expression_vars(o, out); }
+            for (w, t) in when_clauses { expression_vars(w, out); expression_vars(t, out); }
+            if let Some(e) = else_result { expression_vars(e, out); }
+        }
+        _ => {}
+    }
+}
+
+/// `ORDER BY` may not name a variable that is not in scope.
+///
+/// ```text
+/// MATCH (a:A), (b:B), (c:C)
+/// WITH a, b
+/// WITH a ORDER BY c        <-- c was dropped two clauses ago
+/// RETURN a
+/// ```
+///
+/// 40 TCK scenarios across WithOrderBy1 and WithOrderBy3 assert a
+/// `SyntaxError` here and we answered them, sorting by a column that does not
+/// exist.
+///
+/// **Deliberately conservative**, because this module opens by saying scope
+/// analysis is absent precisely so that valid queries are not rejected. Two
+/// choices keep it safe:
+///
+/// * the allowed set is the projection **plus the scope that preceded it**, not
+///   the projection alone. `MATCH (n) RETURN n.name ORDER BY n.age` is legal —
+///   `n` is in scope even though the projected column is `n.name` — and a
+///   stricter rule would reject it.
+/// * anything the walk cannot account for leaves the scope *empty*, and an
+///   empty scope checks nothing. A query shape this does not model is passed
+///   through rather than guessed at.
+fn validate_order_by_in_scope(query: &Query) -> Result<(), ValidationError> {
+    use crate::query::ast::Clause;
+    let mut scope: HashSet<String> = HashSet::new();
+    let mut seen_any_binding = false;
+
+    // The by-kind shape. A multi-WITH query parses into `with_clause` plus
+    // `extra_with_stages` and leaves `clauses` empty, so declining it here
+    // would leave the rule checking nothing at all -- which is exactly what
+    // the first version of this did, and it measured +0. The two-representation
+    // split has now cost four separate fixes; assume neither shape.
+    if query.clauses.is_empty() {
+        // The by-kind shape, and its WITH order is **not** the obvious one:
+        // `extra_with_stages` holds the *earlier* WITHs in order and
+        // `with_clause` holds the **last** one. Walking `with_clause` first --
+        // which is what it looks like it should be -- checks the final ORDER BY
+        // against the scope of the first clause and silently finds nothing.
+        // Verified against a three-WITH query rather than assumed.
+        let upto = query.with_split_index.unwrap_or(query.match_clauses.len());
+        for mc in query.match_clauses.iter().take(upto) {
+            pattern_vars(&mc.pattern, &mut scope);
+            seen_any_binding = true;
+        }
+        for (wc, _, matches, _) in &query.extra_with_stages {
+            let projected = projected_names(&wc.items);
+            if let Some(ob) = &wc.order_by {
+                check_order_by(ob, &projected, &scope, seen_any_binding)?;
+            }
+            scope = projected;
+            // A WITH projection *is* exact scope knowledge -- more exact than a
+            // pattern, in fact -- so it satisfies the guard. Requiring a
+            // pattern binding first silently skipped every query of the form
+            // `WITH 1 AS a ... ORDER BY c`, which is 30 of the 40 scenarios
+            // this rule exists for.
+            seen_any_binding = true;
+            for mc in matches {
+                pattern_vars(&mc.pattern, &mut scope);
+            }
+        }
+        if let Some(wc) = &query.with_clause {
+            let projected = projected_names(&wc.items);
+            if let Some(ob) = &wc.order_by {
+                check_order_by(ob, &projected, &scope, seen_any_binding)?;
+            }
+            scope = projected;
+            for mc in query.match_clauses.iter().skip(upto) {
+                pattern_vars(&mc.pattern, &mut scope);
+            }
+        }
+        if let Some(rc) = &query.return_clause {
+            let projected = projected_names(&rc.items);
+            if let Some(ob) = &query.order_by {
+                check_order_by(ob, &projected, &scope, seen_any_binding)?;
+            }
+        }
+        return Ok(());
+    }
+
+    for clause in &query.clauses {
+        match clause {
+            Clause::Match(mc) => { pattern_vars(&mc.pattern, &mut scope); seen_any_binding = true; }
+            Clause::Create(cc) => { pattern_vars(&cc.pattern, &mut scope); seen_any_binding = true; }
+            Clause::Merge(mc) => { pattern_vars(&mc.pattern, &mut scope); seen_any_binding = true; }
+            Clause::Unwind(u) => { scope.insert(u.variable.clone()); seen_any_binding = true; }
+            Clause::With(wc) => {
+                let projected = projected_names(&wc.items);
+                if let Some(ob) = &wc.order_by {
+                    check_order_by(ob, &projected, &scope, seen_any_binding)?;
+                }
+                scope = projected;
+                seen_any_binding = true;
+            }
+            Clause::Return(rc) => {
+                let projected = projected_names(&rc.items);
+                if let Some(ob) = &query.order_by {
+                    check_order_by(ob, &projected, &scope, seen_any_binding)?;
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn check_order_by(
+    ob: &OrderByClause,
+    projected: &HashSet<String>,
+    scope: &HashSet<String>,
+    seen_any_binding: bool,
+) -> Result<(), ValidationError> {
+    // Nothing was bound anywhere the walk could see, so there is no scope to
+    // check against. Saying "undefined" here would reject `RETURN 1 ORDER BY 1`
+    // and anything else this walk does not model.
+    if !seen_any_binding {
+        return Ok(());
+    }
+    for item in &ob.items {
+        let mut used = HashSet::new();
+        expression_vars(&item.expression, &mut used);
+        for v in used {
+            if !projected.contains(&v) && !scope.contains(&v) {
+                return Err(ValidationError::OrderByUndefinedVariable(v));
+            }
+        }
+    }
+    Ok(())
+}
+
 pub fn validate(query: &Query) -> Result<(), ValidationError> {
+    validate_order_by_in_scope(query)?;
+
     validate_variable_kinds(query)?;
 
     // ---- ORDER BY scope after an aggregating or DISTINCT projection.

--- a/tests/order_by_scope.rs
+++ b/tests/order_by_scope.rs
@@ -1,0 +1,102 @@
+//! `ORDER BY` may not name a variable that is out of scope (#777).
+//!
+//! ```text
+//! MATCH (a:A), (b:B), (c:C)
+//! WITH a, b
+//! WITH a ORDER BY c        <-- c was dropped two clauses ago
+//! RETURN a
+//! ```
+//!
+//! 40 TCK scenarios assert a `SyntaxError` here and we answered them, sorting
+//! by a column that does not exist.
+//!
+//! `validate.rs` opens by saying scope analysis is deliberately absent, because
+//! getting it slightly wrong rejects **valid** queries — a far worse failure
+//! than accepting an invalid one. So most of this file is the accept side. Two
+//! choices keep the rule safe:
+//!
+//! * the allowed set is the projection **plus the scope that preceded it**, so
+//!   `MATCH (n) RETURN n.name ORDER BY n.age` stays legal;
+//! * a shape the walk cannot account for leaves the scope empty and checks
+//!   nothing.
+//!
+//! Both directions were wrong in the first implementation, and each mistake
+//! measured as progress on its own — see the notes on the individual tests.
+
+use samyama::query::parser::parse_query;
+
+fn rejected(q: &str) -> bool {
+    parse_query(q).is_err()
+}
+fn accepted(q: &str) -> bool {
+    parse_query(q).is_ok()
+}
+
+/// The TCK's shape: a variable dropped by an earlier projection.
+#[test]
+fn sorting_by_a_dropped_variable_is_refused() {
+    assert!(rejected(
+        "MATCH (a:A), (b:B), (c:C) WITH a, b WITH a ORDER BY c RETURN a"
+    ));
+    // No pattern at all — the projection is the only scope there is.
+    assert!(rejected(
+        "WITH 1 AS a, 'b' AS b, 3 AS c, true AS d WITH a, b WITH a ORDER BY c RETURN a"
+    ));
+    // In any position among several sort keys.
+    assert!(rejected(
+        "WITH 1 AS a, 3 AS c WITH a WITH a ORDER BY a, c RETURN a"
+    ));
+}
+
+/// A variable that was never bound anywhere.
+#[test]
+fn sorting_by_a_never_defined_variable_is_refused() {
+    assert!(rejected("MATCH (a:A) WITH a ORDER BY zzz RETURN a"));
+}
+
+/// **A property of an in-scope variable is fine even when the projected column
+/// is something else.**
+///
+/// `RETURN n.name ORDER BY n.age` is legal Cypher: the projected column is
+/// `n.name`, but `n` is in scope. A rule that allowed only projected *columns*
+/// would reject this, and that is the single most likely way to get this wrong.
+#[test]
+fn sorting_by_a_property_of_an_in_scope_variable_is_allowed() {
+    assert!(accepted("MATCH (n) RETURN n.name ORDER BY n.age"));
+    assert!(accepted("MATCH (n) WITH n RETURN n.name ORDER BY n.age"));
+    assert!(accepted("MATCH (n) RETURN n ORDER BY n.name DESC"));
+}
+
+/// Ordinary shapes that must keep working.
+#[test]
+fn the_accept_side_is_undisturbed() {
+    for q in [
+        "MATCH (n) RETURN n ORDER BY n.name",
+        "MATCH (n) WITH n AS m RETURN m ORDER BY m.name",
+        "MATCH (a)-[r]->(b) WITH a, r, b ORDER BY r.weight RETURN a, b",
+        "UNWIND [3,1,2] AS x RETURN x ORDER BY x",
+        "UNWIND [3,1,2] AS x WITH x AS y RETURN y ORDER BY y",
+        "MATCH (n) RETURN count(n) AS c ORDER BY c",
+        "MATCH (n) RETURN n.name AS nm ORDER BY nm",
+        // Renaming through two projections — a shape that broke the first
+        // implementation because it walked the WITH stages in the wrong order.
+        "UNWIND [1,2] AS x WITH x AS y WITH y AS x RETURN x ORDER BY x",
+        "MATCH (a) RETURN a AS a, a AS b ORDER BY a",
+    ] {
+        assert!(accepted(q), "must still be accepted: {q}");
+    }
+}
+
+/// A literal sort key names no variable and cannot be undefined.
+#[test]
+fn a_constant_sort_key_is_not_a_variable() {
+    assert!(accepted("RETURN 1 AS r ORDER BY 1"));
+    assert!(accepted("MATCH (n) RETURN n ORDER BY 1"));
+}
+
+/// Sorting by an expression over in-scope variables.
+#[test]
+fn expressions_over_in_scope_variables_are_allowed() {
+    assert!(accepted("WITH 1 AS a WITH a ORDER BY a * a DESC RETURN a"));
+    assert!(accepted("WITH 1 AS a WITH a ORDER BY -1 * a ASC, a DESC RETURN a"));
+}


### PR DESCRIPTION
Closes #777.

```cypher
MATCH (a:A), (b:B), (c:C)
WITH a, b
WITH a ORDER BY c        -- c was dropped two clauses ago
RETURN a
```

openCypher raises `SyntaxError: UndefinedVariable`; we answered it, sorting by a column that does not exist. **40 scenarios**, in two shapes — one with a `MATCH`, one built entirely from projections.

## Measured

**3,097 → 3,137 (+40), zero regressions.**

## The accept side is where the risk is

`validate.rs` opens by saying scope analysis is deliberately absent because getting it slightly wrong rejects **valid** queries — a worse failure than accepting an invalid one. Most of `tests/order_by_scope.rs` is therefore the accept side, nine shapes that must keep working. The one that matters most:

```cypher
MATCH (n) RETURN n.name ORDER BY n.age
```

Legal: the projected column is `n.name`, and `n` is in scope. A rule allowing only projected *columns* rejects it, and that is the likeliest way to get this wrong. So the allowed set is the projection **plus the preceding scope**, and any shape the walk cannot account for leaves the scope empty and checks nothing.

## Three attempts, and the failures are the useful part

Each of these measured as progress on its own, and two are properties of the AST rather than of Cypher.

**+0.** The first version declined the by-kind AST shape as unmodellable — and that is precisely the shape a multi-`WITH` query uses (`clauses` empty, `with_clause` + `extra_with_stages` populated). Declining a representation checks nothing; the two-representation split has now cost five separate fixes.

**+3, and two over-rejections.** `extra_with_stages` holds the *earlier* WITHs and `with_clause` holds the **last** — inverted from how it reads. Walking `with_clause` first checks the final `ORDER BY` against the first clause's scope, which found almost nothing and broke `Return4 [11]` and `With4 [6]`. Correcting the order fixed the over-rejections too: they were the same bug from the other side. Verified against a three-`WITH` query rather than assumed, and the ordering is now written down in the code.

**+10.** A guard requiring a pattern binding before checking anything suppressed every projection-only query — 30 of the 40. A `WITH` projection is *more* exact about scope than a pattern, not less.

`cargo test --workspace --release`: exit 0, **3,361 passed, 0 failed**.