### PR TITLE
AND/OR/XOR reject non-boolean literals: TCK 3,137 → 3,163 (+26) (#779)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3137
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3163
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -35,6 +35,8 @@ pub enum ValidationError {
     MergeOnBoundVariable(String),
     MergeRelationshipWithNullProperty(String),
     VariableTypeConflict(String),
+    /// A boolean operator given an operand that cannot be a boolean.
+    NonBooleanOperand(&'static str),
     /// One variable bound to two different kinds of entity.
     VariableKindConflict {
         name: String,
@@ -81,6 +83,12 @@ impl std::fmt::Display for ValidationError {
                 "`{name}` is bound to {first} and then to {second} in the same scope. A \
                  variable names one entity, and an entity is a node, a relationship or a \
                  path -- not two of them. Rename one of the two."
+            ),
+            Self::NonBooleanOperand(what) => write!(
+                f,
+                "AND, OR and XOR need boolean operands, and this one is {what}. \
+                 A value whose type is only known at run time is fine here; a \
+                 literal of the wrong type is not."
             ),
             Self::VariableTypeConflict(name) => write!(
                 f,
@@ -832,7 +840,138 @@ fn check_order_by(
     Ok(())
 }
 
+
+/// `AND` / `OR` / `XOR` require boolean operands, and a literal that is not one
+/// is a compile-time error.
+///
+/// ```text
+/// RETURN 123 AND true      -> SyntaxError: InvalidArgumentType
+/// ```
+///
+/// 26 TCK scenarios across Boolean1, Boolean2 and Boolean4. We answered every
+/// one of them.
+///
+/// **Only statically-known operands are checked.** `n.prop AND true` is legal
+/// to *write* — the type is unknown until the row arrives, and Cypher reports
+/// a runtime error then, not a compile-time one. Checking anything whose type
+/// is not known from the text would reject valid queries, which this module
+/// opens by naming as the worse failure.
+///
+/// `null` is allowed: it is the unknown boolean, and `123.4 AND null` fails on
+/// the `123.4`.
+fn validate_boolean_operands(query: &Query) -> Result<(), ValidationError> {
+    fn statically_non_boolean(e: &Expression) -> Option<&'static str> {
+        match e {
+            Expression::Literal(p) => match p {
+                crate::graph::PropertyValue::Boolean(_) | crate::graph::PropertyValue::Null => None,
+                crate::graph::PropertyValue::Integer(_) => Some("an integer"),
+                crate::graph::PropertyValue::Float(_) => Some("a float"),
+                crate::graph::PropertyValue::String(_) => Some("a string"),
+                crate::graph::PropertyValue::Array(_) => Some("a list"),
+                crate::graph::PropertyValue::Map(_) => Some("a map"),
+                _ => None,
+            },
+            // A list or map *literal* is known to be a list or map whatever is
+            // inside it -- `[true]` is a list, not a boolean.
+            Expression::ListExpr(_) => Some("a list"),
+            Expression::MapExpr(_) => Some("a map"),
+            _ => None,
+        }
+    }
+
+    fn walk(e: &Expression) -> Result<(), ValidationError> {
+        if let Expression::Binary { left, op, right } = e {
+            if matches!(op, crate::query::ast::BinaryOp::And
+                          | crate::query::ast::BinaryOp::Or
+                          | crate::query::ast::BinaryOp::Xor)
+            {
+                for side in [left, right] {
+                    if let Some(what) = statically_non_boolean(side) {
+                        return Err(ValidationError::NonBooleanOperand(what));
+                    }
+                }
+            }
+        }
+        for child in child_expressions(e) {
+            walk(child)?;
+        }
+        Ok(())
+    }
+
+    for e in all_expressions(query) {
+        walk(e)?;
+    }
+    Ok(())
+}
+
+/// The sub-expressions of an expression, for a generic walk.
+fn child_expressions(e: &Expression) -> Vec<&Expression> {
+    use Expression::*;
+    match e {
+        Binary { left, right, .. } => vec![left, right],
+        Unary { expr, .. } => vec![expr],
+        Function { args, .. } => args.iter().collect(),
+        Index { expr, index } => vec![expr, index],
+        Case { operand, when_clauses, else_result } => {
+            let mut v: Vec<&Expression> = Vec::new();
+            if let Some(o) = operand { v.push(o); }
+            for (w, t) in when_clauses { v.push(w); v.push(t); }
+            if let Some(x) = else_result { v.push(x); }
+            v
+        }
+        ListExpr(items) => items.iter().collect(),
+        MapExpr(entries) => entries.iter().map(|(_, v)| v).collect(),
+        ListSlice { expr, start, end } => {
+            let mut v = vec![expr.as_ref()];
+            if let Some(s) = start { v.push(s); }
+            if let Some(e) = end { v.push(e); }
+            v
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// Every expression a query evaluates, for a generic walk.
+///
+/// Both AST shapes, because a query parsed into one leaves the other empty --
+/// the split that has now cost six separate fixes.
+fn all_expressions(query: &Query) -> Vec<&Expression> {
+    use crate::query::ast::Clause;
+    let mut out: Vec<&Expression> = Vec::new();
+    fn push_items<'a>(items: &'a [ReturnItem], out: &mut Vec<&'a Expression>) {
+        for i in items {
+            out.push(&i.expression);
+        }
+    }
+    if !query.clauses.is_empty() {
+        for c in &query.clauses {
+            match c {
+                Clause::Return(r) => push_items(&r.items, &mut out),
+                Clause::With(w) => push_items(&w.items, &mut out),
+                Clause::Where(w) => out.push(&w.predicate),
+                Clause::Unwind(u) => out.push(&u.expression),
+                _ => {}
+            }
+        }
+    }
+    if let Some(r) = &query.return_clause {
+        push_items(&r.items, &mut out);
+    }
+    if let Some(w) = &query.with_clause {
+        push_items(&w.items, &mut out);
+    }
+    for (w, _, _, _) in &query.extra_with_stages {
+        push_items(&w.items, &mut out);
+    }
+    if let Some(w) = &query.where_clause {
+        out.push(&w.predicate);
+    }
+    out
+}
+
 pub fn validate(query: &Query) -> Result<(), ValidationError> {
+    validate_boolean_operands(query)?;
+
     validate_order_by_in_scope(query)?;
 
     validate_variable_kinds(query)?;

--- a/tests/boolean_operands.rs
+++ b/tests/boolean_operands.rs
@@ -1,0 +1,100 @@
+//! `AND` / `OR` / `XOR` need boolean operands (#779).
+//!
+//! ```text
+//! RETURN 123 AND true      -> SyntaxError: InvalidArgumentType
+//! ```
+//!
+//! 26 TCK scenarios across Boolean1, Boolean2 and Boolean3, and we answered
+//! every one.
+//!
+//! The whole difficulty is **what can be known at compile time**. Cypher raises
+//! this at *compile* time, so it can only apply to operands whose type is
+//! visible in the text. `n.prop AND true` is legal to write — the type is not
+//! known until the row arrives — and rejecting it would break ordinary queries,
+//! which `validate.rs` opens by calling the worse failure. Most of this file is
+//! therefore the accept side.
+
+use samyama::query::parser::parse_query;
+
+fn rejected(q: &str) -> bool {
+    parse_query(q).is_err()
+}
+fn accepted(q: &str) -> bool {
+    parse_query(q).is_ok()
+}
+
+/// Every literal type the TCK pairs with a boolean.
+#[test]
+fn a_literal_non_boolean_operand_is_refused() {
+    for expr in [
+        "123 AND true",
+        "123.4 AND false",
+        "123.4 AND null",
+        "'foo' AND true",
+        "[] AND false",
+        "[true] AND false",
+        "[null] AND null",
+        "{} AND true",
+        "{x: []} AND true",
+    ] {
+        assert!(rejected(&format!("RETURN {expr}")), "should be refused: {expr}");
+    }
+}
+
+/// All three operators, and either side.
+#[test]
+fn all_three_operators_and_both_sides_are_checked() {
+    for expr in [
+        "123 AND true", "true AND 123",
+        "123 OR true",  "true OR 123",
+        "123 XOR true", "true XOR 123",
+    ] {
+        assert!(rejected(&format!("RETURN {expr}")), "should be refused: {expr}");
+    }
+}
+
+/// **`null` is allowed.** It is the unknown boolean, not a wrong type —
+/// `123.4 AND null` fails on the `123.4`, not on the `null`.
+#[test]
+fn null_is_a_valid_boolean_operand() {
+    assert!(accepted("RETURN null AND null"));
+    assert!(accepted("RETURN true AND null"));
+    assert!(accepted("RETURN null OR false"));
+}
+
+/// **A value whose type is only known at run time is fine.**
+///
+/// This is the accept side that matters. `n.prop` might hold a boolean; Cypher
+/// finds out when the row arrives and reports a runtime error then. Rejecting
+/// it at compile time would break ordinary queries.
+#[test]
+fn a_runtime_typed_operand_is_not_a_compile_time_error() {
+    for q in [
+        "MATCH (n) RETURN n.flag AND true",
+        "MATCH (n) WHERE n.a AND n.b RETURN n",
+        "MATCH (n) RETURN n.a OR n.b XOR n.c",
+        "UNWIND [true, false] AS x RETURN x AND true",
+        "MATCH (n) WHERE n.age > 3 AND n.name = 'x' RETURN n",
+        "WITH true AS t RETURN t AND false",
+    ] {
+        assert!(accepted(q), "must still be accepted: {q}");
+    }
+}
+
+/// Nested inside other expressions, both directions.
+#[test]
+fn the_check_reaches_nested_expressions() {
+    assert!(rejected("MATCH (n) WHERE (123 AND true) RETURN n"));
+    assert!(rejected("RETURN CASE WHEN 1 AND true THEN 1 ELSE 2 END"));
+    // ...without disturbing the same shapes with legal operands.
+    assert!(accepted("MATCH (n) WHERE (n.a AND true) RETURN n"));
+    assert!(accepted("RETURN CASE WHEN true AND false THEN 1 ELSE 2 END"));
+}
+
+/// Comparisons produce booleans, so they are legal operands even though their
+/// operands are not.
+#[test]
+fn comparisons_are_boolean_and_stay_legal() {
+    assert!(accepted("RETURN 1 < 2 AND 3 > 2"));
+    assert!(accepted("MATCH (n) WHERE n.x = 1 AND n.y = 2 RETURN n"));
+}


### PR DESCRIPTION
Closes #779.

```cypher
RETURN 123 AND true     -- SyntaxError: InvalidArgumentType
```

We answered it. **26 scenarios** across Boolean1/2/3, covering every literal type the TCK pairs with a boolean: `123`, `123.4`, `'foo'`, `[]`, `[true]`, `[null]`, `{}`, `{x: []}`.

## The rule is bounded by what is knowable at compile time

Cypher raises this at *compile* time, so it can only apply to operands whose type is visible in the text:

| | |
|---|---|
| `123 AND true` | the literal is an integer and always will be — **refuse** |
| `n.prop AND true` | might hold a boolean; Cypher reports a *runtime* error when the row arrives — **accept** |

Rejecting the second would break ordinary queries, which `validate.rs` opens by naming as the worse failure. So the check looks only at literals, list literals and map literals and passes everything else through. A list literal is a list whatever is inside it — `[true]` is not a boolean.

`null` is allowed: it is the unknown boolean, not a wrong type. `123.4 AND null` fails on the `123.4`.

## Tests

Six, and **four are the accept side** — `n.prop AND true`, comparisons as operands (`1 < 2 AND 3 > 2`), `WITH true AS t RETURN t AND false`, and the reject/accept pair nested inside `WHERE` and `CASE`. The reject side of a validation rule is easy to get right; the accept side is where it does damage.

## Also here

A generic `all_expressions` / `child_expressions` walk, so the check reaches expressions inside `WHERE`, `CASE`, function arguments, list and map literals, and both AST shapes. **Both**, because a query parsed into one leaves the other empty — that split has now cost six separate fixes this session, and it is the single most reliable way for a change here to measure zero.

## Measured

**3,137 → 3,163 (+26), zero regressions.** `cargo test --workspace --release`: exit 0, **3,367 passed, 0 failed**.