### PR TITLE
Three-valued equality for values containing null: TCK 3,207 → 3,216 (+9) (#783)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3207
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3216
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -107,6 +107,63 @@ fn node_id_of(v: &Value) -> Option<NodeId> {
     }
 }
 
+
+/// Cypher equality with three-valued logic, for values that may contain null.
+///
+/// `None` means *unknown*. The rule is not "any null makes it null": a
+/// definitive difference wins over an unknown one, because two lists that
+/// differ in length or in a known element are unequal whatever the nulls say.
+///
+/// ```text
+/// [1]        = [null]      -> null    (might be equal, cannot tell)
+/// [1, null]  = [1, 2]      -> null
+/// [1, null]  = [2, 3]      -> false   (the first pair settles it)
+/// [1]        = [1, null]   -> false   (lengths differ)
+/// [null]     = [null]      -> null
+/// ```
+///
+/// Scalar nulls are handled by the caller's existing three-valued guard; this
+/// is only reached for values that are not themselves null, which is why a
+/// bare `Null` here can only appear *inside* a list or map.
+fn cypher_equals(a: &PropertyValue, b: &PropertyValue) -> Option<bool> {
+    use PropertyValue::*;
+    match (a, b) {
+        (Null, _) | (_, Null) => None,
+        (Array(x), Array(y)) => {
+            // A length difference is definitive -- no element comparison can
+            // rescue it, so this is `false` and not `null`.
+            if x.len() != y.len() {
+                return Some(false);
+            }
+            let mut unknown = false;
+            for (xi, yi) in x.iter().zip(y.iter()) {
+                match cypher_equals(xi, yi) {
+                    Some(false) => return Some(false),
+                    None => unknown = true,
+                    Some(true) => {}
+                }
+            }
+            if unknown { None } else { Some(true) }
+        }
+        (Map(x), Map(y)) => {
+            // Differing key sets are definitive, for the same reason.
+            if x.len() != y.len() || !x.keys().all(|k| y.contains_key(k)) {
+                return Some(false);
+            }
+            let mut unknown = false;
+            for (k, xv) in x {
+                match cypher_equals(xv, &y[k]) {
+                    Some(false) => return Some(false),
+                    None => unknown = true,
+                    Some(true) => {}
+                }
+            }
+            if unknown { None } else { Some(true) }
+        }
+        _ => Some(a == b),
+    }
+}
+
 /// Shared binary operator evaluation used by Project, Aggregate, and Sort operators
 fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<Value> {
     // Node/edge identity comparison (Cypher: n1 = n2, n1 <> n2)
@@ -143,8 +200,18 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
     }
 
     let result = match op {
-        BinaryOp::Eq => PropertyValue::Boolean(left_prop == right_prop),
-        BinaryOp::Ne => PropertyValue::Boolean(left_prop != right_prop),
+        // Three-valued, because a null *inside* a list makes the comparison
+        // unknown rather than false. The guard above only catches a null
+        // operand; `[1] = [null]` has no null operand and was answering
+        // `false` (#783).
+        BinaryOp::Eq => match cypher_equals(&left_prop, &right_prop) {
+            Some(v) => PropertyValue::Boolean(v),
+            None => PropertyValue::Null,
+        },
+        BinaryOp::Ne => match cypher_equals(&left_prop, &right_prop) {
+            Some(v) => PropertyValue::Boolean(!v),
+            None => PropertyValue::Null,
+        },
         BinaryOp::Pow => match (&left_prop, &right_prop) {
             (PropertyValue::Null, _) | (_, PropertyValue::Null) => PropertyValue::Null,
             _ => {

--- a/tests/list_equality_three_valued.rs
+++ b/tests/list_equality_three_valued.rs
@@ -1,0 +1,107 @@
+//! Comparing values that *contain* null is three-valued (#783).
+//!
+//! The engine already treated a null **operand** as unknown. A null *inside* a
+//! list is different and was answering `false`:
+//!
+//! ```text
+//! RETURN [1] = [null]     expected null, got false
+//! ```
+//!
+//! The rule is not "any null makes it null". A definitive difference wins over
+//! an unknown one, because two lists that differ in length or in a known
+//! element are unequal whatever the nulls say. Getting that backwards turns
+//! `[1, null] = [2, 3]` from `false` into `null`, which is just as wrong and
+//! much harder to notice.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn eval(cypher: &str) -> PropertyValue {
+    let store = GraphStore::new();
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.clone(),
+        Some(Value::Null) | None => PropertyValue::Null,
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+fn is_null(cypher: &str) -> bool {
+    matches!(eval(cypher), PropertyValue::Null)
+}
+fn is(cypher: &str, want: bool) -> bool {
+    eval(cypher) == PropertyValue::Boolean(want)
+}
+
+/// A null inside a list makes the comparison unknown.
+#[test]
+fn a_null_element_makes_the_comparison_unknown() {
+    assert!(is_null("RETURN [1] = [null] AS r"));
+    assert!(is_null("RETURN [null] = [1] AS r"));
+    assert!(is_null("RETURN [null] = [null] AS r"));
+    assert!(is_null("RETURN [1, null] = [1, 2] AS r"));
+    assert!(is_null("RETURN [[1], [null]] = [[1], [2]] AS r"));
+}
+
+/// **A definitive difference beats an unknown one.**
+///
+/// This is the half that is easy to get wrong in the other direction. If any
+/// pair of elements is known to differ, the lists are unequal whatever the
+/// nulls elsewhere say — returning null here would be just as wrong and far
+/// harder to spot, because null is the answer you expect when nulls appear.
+#[test]
+fn a_known_difference_settles_it_despite_nulls() {
+    assert!(is("RETURN [1, null] = [2, 3] AS r", false));
+    assert!(is("RETURN [null, 1] = [null, 2] AS r", false));
+}
+
+/// A length difference is definitive: no element can rescue it.
+#[test]
+fn a_length_difference_is_false_not_null() {
+    assert!(is("RETURN [1] = [1, null] AS r", false));
+    assert!(is("RETURN [null] = [] AS r", false));
+    assert!(is("RETURN [null, null] = [null] AS r", false));
+}
+
+/// Lists with no nulls are unaffected.
+#[test]
+fn ordinary_list_comparison_is_undisturbed() {
+    assert!(is("RETURN [1, 2] = [1, 2] AS r", true));
+    assert!(is("RETURN [1, 2] = [2, 1] AS r", false));
+    assert!(is("RETURN [] = [] AS r", true));
+    assert!(is("RETURN ['a'] = ['a'] AS r", true));
+    assert!(is("RETURN [[1, 2]] = [[1, 2]] AS r", true));
+}
+
+/// `<>` is the negation, and negating unknown is still unknown.
+#[test]
+fn inequality_negates_a_known_answer_and_propagates_an_unknown_one() {
+    assert!(is("RETURN [1, 2] <> [1, 2] AS r", false));
+    assert!(is("RETURN [1, 2] <> [2, 1] AS r", true));
+    assert!(is_null("RETURN [1] <> [null] AS r"));
+}
+
+/// Maps follow the same rule, keys included.
+#[test]
+fn maps_compare_the_same_way() {
+    assert!(is_null("RETURN {a: 1, b: null} = {a: 1, b: 2} AS r"));
+    assert!(is("RETURN {a: 1, b: null} = {a: 2, b: 3} AS r", false));
+    // A differing key set is definitive.
+    assert!(is("RETURN {a: null} = {b: null} AS r", false));
+    assert!(is("RETURN {a: 1} = {a: 1} AS r", true));
+}
+
+/// Scalar nulls still behave as before — this change must not disturb the
+/// existing three-valued guard.
+#[test]
+fn scalar_null_comparison_is_unchanged() {
+    assert!(is_null("RETURN null = 1 AS r"));
+    assert!(is_null("RETURN 1 = null AS r"));
+    assert!(is_null("RETURN null = null AS r"));
+    assert!(is("RETURN 1 = 1 AS r", true));
+    assert!(is("RETURN 1 = 2 AS r", false));
+}


### PR DESCRIPTION
Closes #783.

```cypher
RETURN [1] = [null]     -- expected null, got false
```

Cypher's three-valued logic was applied to a null **operand** but not to a null *inside* a list, which fell through to derived `PartialEq`.

## The rule, and the direction that is easy to invert

**Not** "any null makes it null" — a definitive difference beats an unknown one:

| | |
|---|---|
| `[1, null] = [1, 2]` | `null` — cannot tell |
| `[1, null] = [2, 3]` | `false` — the first pair settles it |
| `[1] = [1, null]` | `false` — lengths differ |
| `[null] = [null]` | `null` |

Getting this backwards produces `null` where `false` belongs, which is **equally wrong and much harder to notice**, because null is the answer you expect once nulls appear. Two tests exist only to pin that direction: `a_known_difference_settles_it_despite_nulls` and `a_length_difference_is_false_not_null`.

Maps follow the same rule; a differing key set is definitive.

## Tests

7, and most guard against over-reaching rather than under-reaching: ordinary list comparison undisturbed, scalar null comparison unchanged, `<>` negating a known answer while propagating an unknown one.

## Measured

**3,207 → 3,216 (+9), zero regressions.** `cargo test --workspace --release`: exit 0, **3,377 passed, 0 failed**. Gate still MET.