### PR TITLE
An UNWIND after a WITH reads what the WITH projected (#785)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3216
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3217
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -145,6 +145,14 @@ pub struct Query {
     /// single-UNWIND field is read in a dozen places that only ever care
     /// about the first one.
     pub extra_unwind_clauses: Vec<UnwindClause>,
+    /// `UNWIND`s that appear **after** the last `WITH`.
+    ///
+    /// Kept apart from `extra_unwind_clauses` because position is the whole
+    /// point: the planner applies the leading run before the WITH barrier, and
+    /// applying a post-WITH unwind there reads a variable the WITH has not
+    /// projected yet. `UNWIND [1,2] AS a WITH [3,4] AS b UNWIND b AS c` failed
+    /// with `VariableNotFound("b")` for exactly that reason (#785).
+    pub post_with_unwind_clauses: Vec<UnwindClause>,
     /// Whether the UNWIND *led* the statement (`UNWIND ... MATCH ...`) rather than
     /// following the match. The AST keeps a single `unwind_clause` with no position, but
     /// the two orders plan differently: a leading UNWIND must bind its variable before the
@@ -851,6 +859,7 @@ impl Query {
             clauses: Vec::new(),
             needs_clause_pipeline: false,
             extra_unwind_clauses: Vec::new(),
+            post_with_unwind_clauses: Vec::new(),
             unwind_leading: false,
             merge_clause: None,
             union_queries: Vec::new(),

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1634,6 +1634,23 @@ impl QueryPlanner {
                 }
             }
 
+            // UNWINDs written after the final WITH. They belong here, above the
+            // barrier, because they read what the WITH projected -- applying
+            // them with the leading run gave `VariableNotFound` on a variable
+            // the WITH defines one line earlier (#785).
+            if stage_idx + 1 == all_with_stages.len() {
+                for extra in &query.post_with_unwind_clauses {
+                    if let Some(op) = operator {
+                        operator = Some(Box::new(UnwindOperator::new(
+                            op,
+                            extra.expression.clone(),
+                            extra.variable.clone(),
+                        )));
+                        known_vars.insert(extra.variable.clone());
+                    }
+                }
+            }
+
             // Process post-WITH MATCH clauses for this stage
             // Pre-compute variable sets
             let match_var_sets: Vec<HashSet<String>> = stage_matches.iter().map(|mc| {

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -6847,6 +6847,7 @@ mod tests {
             match_clauses: vec![],
             where_clause: None,
             return_clause: None,
+            post_with_unwind_clauses: vec![],
             create_clause: None,
             order_by: None,
             limit: None,

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -958,7 +958,17 @@ fn parse_match_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
                     let post_matches: Vec<_> = query.match_clauses.drain(split..).collect();
                     let post_where = query.post_with_where_clause.take();
                     let prev_with = query.with_clause.take().unwrap();
-                    let prev_unwind = query.unwind_clause.take();
+                    // The UNWIND that belongs to the stage being closed is the
+                    // one written *after* its WITH, not the query's leading
+                    // one. Taking `unwind_clause` here moved the head UNWIND
+                    // into a later stage, which is the same position-losing
+                    // mistake as #785 pointing the other way; it survived only
+                    // because `unwind_leading` then suppressed the stage copy.
+                    let prev_unwind = if query.post_with_unwind_clauses.is_empty() {
+                        query.unwind_clause.take()
+                    } else {
+                        Some(query.post_with_unwind_clauses.remove(0))
+                    };
                     query.extra_with_stages.push((prev_with, prev_unwind, post_matches, post_where));
                 }
                 // Record where WITH splits pre-WITH from post-WITH match clauses
@@ -992,8 +1002,16 @@ fn parse_match_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
             Rule::unwind_clause => {
                 // The first UNWIND stays in `unwind_clause`; the rest queue up
                 // behind it, each a cross product with everything before.
+                //
+                // Unless a WITH has already been seen, in which case the UNWIND
+                // belongs *after* that WITH and must be kept apart: the planner
+                // applies the leading run before the WITH barrier, so a
+                // post-WITH unwind put there reads a variable the WITH has not
+                // projected yet (#785).
                 let u = parse_unwind_clause(inner)?;
-                if query.unwind_clause.is_none() {
+                if query.with_clause.is_some() {
+                    query.post_with_unwind_clauses.push(u);
+                } else if query.unwind_clause.is_none() {
                     query.unwind_clause = Some(u);
                 } else {
                     query.extra_unwind_clauses.push(u);

--- a/tests/unwind_after_with.rs
+++ b/tests/unwind_after_with.rs
@@ -1,0 +1,98 @@
+//! An `UNWIND` written after a `WITH` reads what that `WITH` projected (#785).
+//!
+//! ```cypher
+//! UNWIND [1,2] AS a WITH [3,4] AS b UNWIND b AS c RETURN c
+//!   -> RuntimeError: VariableNotFound("b")
+//! ```
+//!
+//! `b` is defined by the `WITH` on the same line. The parser put both unwinds
+//! in flat fields with no record of which side of the `WITH` they came from,
+//! and the planner applies that run *before* the barrier — so the second one
+//! read a variable that did not exist yet.
+//!
+//! The tell was that even the unwind's **own** variable went missing
+//! (`UNWIND [1,2] AS a WITH a AS b UNWIND [5] AS c` could not find `c`), which
+//! says the operator was not planned at all rather than planned wrongly.
+//!
+//! Row counts are asserted, not just success: a cross product that silently
+//! collapses to one row is the failure this could regress into.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+
+fn rows(cypher: &str) -> usize {
+    let store = GraphStore::new();
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"))
+        .records
+        .len()
+}
+
+/// The reported repro, and its minimal form.
+#[test]
+fn an_unwind_after_a_with_sees_the_projection() {
+    // 2 leading rows x 2 unwound = 4.
+    assert_eq!(rows("UNWIND [1,2] AS a WITH [3,4] AS b UNWIND b AS c RETURN c"), 4);
+    // The unwind's own variable was also missing, so this is the sharper case.
+    assert_eq!(rows("UNWIND [1,2] AS a WITH a AS b UNWIND [5] AS c RETURN c"), 2);
+}
+
+/// An aggregating `WITH` collapses first, and the unwind expands what survives.
+#[test]
+fn an_unwind_after_an_aggregating_with_expands_the_aggregate() {
+    // collect() gives one row holding [1,2]; unwinding it gives two.
+    assert_eq!(rows("UNWIND [1,2] AS a WITH collect(a) AS xs UNWIND xs AS y RETURN y"), 2);
+    assert_eq!(
+        rows("UNWIND [1,2,3] AS a WITH collect(a) AS xs UNWIND xs AS y RETURN y"),
+        3
+    );
+}
+
+/// Two stages, each with its own trailing unwind — **still broken**.
+///
+/// ```text
+/// UNWIND [1,2] AS a WITH [1,2] AS b UNWIND b AS c WITH c, [1,2,3] AS d UNWIND d AS e RETURN e
+///   -> VariableNotFound("b")
+/// ```
+///
+/// This fix covers one `WITH` with a trailing `UNWIND`, which is the reported
+/// repro and the shape that matters in practice. With **two** such stages the
+/// planner's `stage_unwind` still falls back to the query's *leading* unwind
+/// once `extra_with_stages` is non-empty, so the head unwind is applied twice
+/// and a stage gets the wrong one.
+///
+/// `#[ignore]`d rather than deleted or weakened: the expected row count below
+/// is what Cypher specifies, and a test asserting today's error would have to
+/// be rewritten by whoever finishes this — which is the opposite of useful.
+/// Tracked on #785.
+#[test]
+#[ignore = "multi-stage WITH+UNWIND still mis-assigns the leading unwind; see #785"]
+fn each_with_stage_keeps_its_own_unwind() {
+    assert_eq!(
+        rows("UNWIND [1,2] AS a WITH [1,2] AS b UNWIND b AS c WITH c, [1,2,3] AS d UNWIND d AS e RETURN e"),
+        24, // 2 x 2 x 3, and the leading UNWIND is not double-counted
+    );
+}
+
+/// The shapes that already worked must keep working — a leading run of
+/// unwinds is still a cross product applied before any barrier.
+#[test]
+fn the_shapes_that_worked_before_are_undisturbed() {
+    assert_eq!(rows("WITH [3,4] AS b UNWIND b AS c RETURN c"), 2);
+    assert_eq!(rows("UNWIND [1,2] AS a UNWIND [3,4] AS b RETURN b"), 4);
+    assert_eq!(rows("UNWIND [1,2,3] AS a RETURN a"), 3);
+    assert_eq!(rows("UNWIND [1,2] AS a WITH a WHERE a > 1 RETURN a"), 1);
+    // A MATCH ahead of the WITH was never affected; pinned so a later change
+    // to the leading-unwind logic cannot quietly break it.
+    assert_eq!(rows("MATCH (n) WITH [3,4] AS b UNWIND b AS c RETURN c"), 0);
+}
+
+/// Unwinding an empty list after a `WITH` produces no rows rather than an
+/// error — the same as anywhere else.
+#[test]
+fn an_empty_list_after_a_with_yields_nothing() {
+    assert_eq!(rows("UNWIND [1,2] AS a WITH [] AS b UNWIND b AS c RETURN c"), 0);
+}


### PR DESCRIPTION
Partial fix for #785 — the reported repro. **#785 stays open** for the multi-stage case; see below.

## The bug

```cypher
UNWIND [1,2] AS a WITH [3,4] AS b UNWIND b AS c RETURN c
  -> RuntimeError: VariableNotFound("b")
```

`b` is defined by the `WITH` on the same line.

The parser put both unwinds in flat fields (`unwind_clause`, `extra_unwind_clauses`) with **no record of which side of the `WITH` they came from**, and the planner applies that run *before* the barrier — so the second read a variable that did not exist yet.

The tell was that even the unwind's **own** variable went missing:

```cypher
UNWIND [1,2] AS a WITH a AS b UNWIND [5] AS c RETURN c
  -> VariableNotFound("c")
```

which says the operator was not planned at all, rather than planned against the wrong scope.

## Fix

A `post_with_unwind_clauses` field, populated when a `WITH` has already been seen, applied above the barrier where it belongs. The stage-closing path takes its unwind from that buffer rather than from the query's leading one — the tuple in `extra_with_stages` already had the `Option<UnwindClause>` slot for it.

## Measured, and a correction

**+1 TCK scenario (3,216 → 3,217), zero regressions.**

I filed #785 estimating ~25 scenarios. That was wrong: I had counted occurrences of `VariableNotFound("inputList")` in the failure detail rather than distinct scenarios. The fix earns its place on correctness — a query that errored now returns right answers, and row counts are asserted rather than mere success — but the number in the issue was not one I had checked, and it is corrected there.

## What is still broken

```cypher
UNWIND [1,2] AS a WITH [1,2] AS b UNWIND b AS c WITH c, [1,2,3] AS d UNWIND d AS e RETURN e
  -> VariableNotFound("b")
```

With **two** WITH+UNWIND stages the planner's `stage_unwind` still falls back to the query's leading unwind once `extra_with_stages` is non-empty, so a stage gets the wrong one.

`each_with_stage_keeps_its_own_unwind` is `#[ignore]`d against this, asserting the row count Cypher specifies rather than today's error — so whoever finishes it gets a passing target instead of a test to rewrite. That is the same treatment #710's expectations got.

## Tests

5, one ignored. Row counts are asserted throughout, not just success: a cross product silently collapsing to one row is the regression this could turn into.

`cargo test --workspace --release`: exit 0, **3,381 passed, 0 failed**. Gate still MET at 85.5%.