### PR TITLE
Duration multiply/divide and sub-second components: TCK 3,217 → 3,232 (+15) (#787)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3217
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3232
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -366,6 +366,18 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
             _ => return Err(ExecutionError::TypeError("Sub requires numeric operands".to_string())),
         },
         BinaryOp::Mul => match (&left_prop, &right_prop) {
+            // duration * number, either way round (#787).
+            (PropertyValue::Duration { months, days, seconds, nanos }, n)
+            | (n, PropertyValue::Duration { months, days, seconds, nanos })
+                if matches!(n, PropertyValue::Integer(_) | PropertyValue::Float(_)) =>
+            {
+                let f = match n {
+                    PropertyValue::Integer(i) => *i as f64,
+                    PropertyValue::Float(f) => *f,
+                    _ => unreachable!("guarded above"),
+                };
+                scale_duration(*months, *days, *seconds, *nanos, f)?
+            }
             (PropertyValue::Integer(l), PropertyValue::Integer(r)) => PropertyValue::Integer(l * r),
             (PropertyValue::Float(l), PropertyValue::Float(r)) => PropertyValue::Float(l * r),
             (PropertyValue::Integer(l), PropertyValue::Float(r)) => PropertyValue::Float(*l as f64 * r),
@@ -374,6 +386,22 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
             _ => return Err(ExecutionError::TypeError("Mul requires numeric operands".to_string())),
         },
         BinaryOp::Div => match (&left_prop, &right_prop) {
+            // duration / number. Not commutative, so only this order.
+            (PropertyValue::Duration { months, days, seconds, nanos }, n)
+                if matches!(n, PropertyValue::Integer(_) | PropertyValue::Float(_)) =>
+            {
+                let f = match n {
+                    PropertyValue::Integer(i) => *i as f64,
+                    PropertyValue::Float(f) => *f,
+                    _ => unreachable!("guarded above"),
+                };
+                if f == 0.0 {
+                    return Err(ExecutionError::RuntimeError(
+                        "cannot divide a duration by zero".to_string(),
+                    ));
+                }
+                scale_duration(*months, *days, *seconds, *nanos, 1.0 / f)?
+            }
             (PropertyValue::Integer(_), PropertyValue::Integer(0)) => return Err(ExecutionError::RuntimeError("Division by zero".to_string())),
             (PropertyValue::Integer(l), PropertyValue::Integer(r)) => PropertyValue::Integer(l / r),
             (PropertyValue::Float(l), PropertyValue::Float(r)) => PropertyValue::Float(l / r),
@@ -2609,13 +2637,23 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     let minutes = map.get("minutes").and_then(|v| v.as_integer()).unwrap_or(0);
                     let seconds = map.get("seconds").and_then(|v| v.as_integer()).unwrap_or(0);
                     let years = map.get("years").and_then(|v| v.as_integer()).unwrap_or(0);
+                    // The sub-second components, which were hardcoded to zero:
+                    // `duration({nanoseconds: 1})` silently lost the 1, so the
+                    // value was already wrong before any arithmetic touched it
+                    // (#787). Additive with each other, as everywhere else.
+                    let millis = map.get("milliseconds").and_then(|v| v.as_integer()).unwrap_or(0);
+                    let micros = map.get("microseconds").and_then(|v| v.as_integer()).unwrap_or(0);
+                    let nanos_in = map.get("nanoseconds").and_then(|v| v.as_integer()).unwrap_or(0);
+                    let weeks = map.get("weeks").and_then(|v| v.as_integer()).unwrap_or(0);
                     let total_months = years * 12 + months;
-                    let total_seconds = hours * 3600 + minutes * 60 + seconds;
+                    let sub_nanos = millis * 1_000_000 + micros * 1_000 + nanos_in;
+                    let total_seconds = hours * 3600 + minutes * 60 + seconds
+                        + sub_nanos.div_euclid(1_000_000_000);
                     Ok(Value::Property(PropertyValue::Duration {
                         months: total_months,
-                        days,
+                        days: days + weeks * 7,
                         seconds: total_seconds,
-                        nanos: 0,
+                        nanos: sub_nanos.rem_euclid(1_000_000_000) as i32,
                     }))
                 }
                 _ => Err(ExecutionError::TypeError("duration() requires string or map argument".to_string())),
@@ -2925,6 +2963,84 @@ fn extract_float(val: &Value) -> ExecutionResult<f64> {
 }
 
 /// Add duration components to a DateTime (millis timestamp)
+
+/// `duration * number` and `duration / number`.
+///
+/// Scaling a duration is not scaling three independent numbers. The TCK pins
+/// the rule:
+///
+/// ```text
+/// P12Y5M14DT16H13M10.000000001S * 0.5  ->  P6Y2M22DT13H21M8S
+/// ```
+///
+/// 149 months halved is 74.5, and the half **carries into days at 30 days per
+/// month** — 14 days becomes 22. Hours do *not* carry into days: the input's
+/// 16h doubles to `32H` and stays there, because a day is not always 24 hours
+/// once zones are involved and Cypher declines to assume it is.
+///
+/// So months and the days-and-below part scale separately, with one carry
+/// between them and none below.
+fn scale_duration(
+    months: i64,
+    days: i64,
+    seconds: i64,
+    nanos: i32,
+    factor: f64,
+) -> Result<PropertyValue, ExecutionError> {
+    if !factor.is_finite() {
+        return Err(ExecutionError::RuntimeError(
+            "cannot scale a duration by a non-finite number".to_string(),
+        ));
+    }
+    // The mean Gregorian month: 365.2425 / 12. **Not 30.**
+    //
+    // Derived from the TCK rather than assumed. `P12Y5M14DT16H13M10S * 0.5`
+    // is `P6Y2M22DT13H21M8S`, and reaching 13:21:08 from a half-month carry
+    // requires 30.4369 days per month; 30 gives 08:06:35, which is a
+    // plausible-looking wrong answer.
+    const DAYS_PER_MONTH: f64 = 365.2425 / 12.0;
+
+    let scaled_months = months as f64 * factor;
+    let whole_months = scaled_months.trunc();
+    let carry_days = (scaled_months - whole_months) * DAYS_PER_MONTH;
+
+    // Days and the sub-day part scale separately: a day is not always 24 hours
+    // once zones are involved, so Cypher does not carry hours into days.
+    // Doubling 14D16H gives `28DT32H`, not `29DT8H` -- normalising looks
+    // tidier and is wrong.
+    let scaled_days = days as f64 * factor + carry_days;
+    let whole_days = scaled_days.trunc();
+    let day_remainder_nanos = (scaled_days - whole_days) * 86_400.0 * 1e9;
+
+    // The sub-second part in integers where it can be. A float round-trip of
+    // (seconds * 1e9 + nanos) loses the last nanosecond at these magnitudes --
+    // it rendered `8.000000001S` where the TCK expects `8S`.
+    let sub_day_exact = (seconds as i128) * 1_000_000_000 + nanos as i128;
+    // Each part is rounded **before** they are added, not after. Adding first
+    // then rounding turns 29195000000000.5 + 18873000000000.027 into one extra
+    // nanosecond, and the TCK's halving case expects exactly `8S`. Two roundings
+    // of well-conditioned quantities beat one rounding of their sum here,
+    // because the .5 and the .027 are independent artefacts.
+    let scaled_sub = if factor == factor.trunc() && factor.abs() < 1e15 {
+        // An integral factor multiplies exactly, with no float involved.
+        sub_day_exact * (factor as i128)
+    } else {
+        // Ties to **even**, not away from zero. `58390000000001 * 0.5` is
+        // exactly `...000.5`, and `.round()` takes it up to `...001` where the
+        // TCK expects `8S` with no fraction. Half-away-from-zero also biases
+        // every exact tie upward, which accumulates; banker's rounding does
+        // not, and is what the reference agrees with.
+        (sub_day_exact as f64 * factor).round_ties_even() as i128
+    };
+    let sub_day = scaled_sub + day_remainder_nanos.round_ties_even() as i128;
+
+    Ok(PropertyValue::Duration {
+        months: whole_months as i64,
+        days: whole_days as i64,
+        seconds: (sub_day / 1_000_000_000) as i64,
+        nanos: (sub_day % 1_000_000_000) as i32,
+    })
+}
 
 /// Nanoseconds since the epoch that a temporal value denotes, and a way back.
 ///

--- a/tests/duration_arithmetic.rs
+++ b/tests/duration_arithmetic.rs
@@ -1,0 +1,137 @@
+//! Scaling a duration by a number (#787).
+//!
+//! `duration * n` and `duration / n` were unimplemented (`Mul requires numeric
+//! operands`), and `duration()` silently discarded its sub-second components
+//! — `duration({nanoseconds: 1})` lost the 1 at construction, so the value was
+//! already wrong before any arithmetic touched it.
+//!
+//! Three rules here were **derived from the TCK's expected values**, not
+//! assumed, and each has a plausible-looking wrong alternative:
+//!
+//! 1. A fractional month carries into days at the **mean Gregorian month**,
+//!    365.2425/12 = 30.4369 days — not 30. Using 30 gives `08:06:35` where
+//!    `13:21:08` is expected.
+//! 2. Hours do **not** carry into days: doubling `14D16H` gives `28DT32H`, not
+//!    `29DT8H`. A day is not always 24 hours once zones are involved.
+//!    Normalising looks tidier and is wrong.
+//! 3. Rounding is **ties-to-even**. `58390000000001 * 0.5` is exactly
+//!    `...000.5`; Rust's `.round()` takes it away from zero to `...001` where
+//!    the TCK expects a whole `8S`.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn rendered(cypher: &str) -> String {
+    let store = GraphStore::new();
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.to_cypher_string(),
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+const D: &str = "duration({years: 12, months: 5, days: 14, hours: 16, minutes: 12, seconds: 70, nanoseconds: 1})";
+
+/// The TCK's own table, verbatim. Every row of `Temporal8 [7]`.
+#[test]
+fn the_tck_multiply_and_divide_table() {
+    for (expr, want) in [
+        ("* 1", "P12Y5M14DT16H13M10.000000001S"),
+        ("* 2", "P24Y10M28DT32H26M20.000000002S"),
+        ("* 0.5", "P6Y2M22DT13H21M8S"),
+        ("/ 1", "P12Y5M14DT16H13M10.000000001S"),
+        ("/ 2", "P6Y2M22DT13H21M8S"),
+        ("/ 0.5", "P24Y10M28DT32H26M20.000000002S"),
+    ] {
+        assert_eq!(rendered(&format!("RETURN {D} {expr} AS r")), want, "{D} {expr}");
+    }
+}
+
+/// `duration()` keeps its sub-second components, additively.
+///
+/// They were hardcoded to zero, so the `nanoseconds: 1` above was lost at
+/// construction — the `* 1` row of the table above is really a test of *this*.
+#[test]
+fn duration_keeps_its_sub_second_components() {
+    assert_eq!(rendered("RETURN duration({nanoseconds: 1}) AS r"), "PT0.000000001S");
+    assert_eq!(rendered("RETURN duration({milliseconds: 645}) AS r"), "PT0.645S");
+    // Additive with each other, as everywhere else in the temporal surface.
+    assert_eq!(
+        rendered("RETURN duration({milliseconds: 123, microseconds: 456, nanoseconds: 789}) AS r"),
+        "PT0.123456789S"
+    );
+    // And they carry into seconds when they overflow.
+    assert_eq!(rendered("RETURN duration({milliseconds: 1500}) AS r"), "PT1.5S");
+}
+
+/// `weeks` is seven days.
+#[test]
+fn weeks_are_days() {
+    assert_eq!(rendered("RETURN duration({weeks: 2}) AS r"), "P14D");
+    assert_eq!(rendered("RETURN duration({weeks: 1, days: 3}) AS r"), "P10D");
+}
+
+/// **Hours do not carry into days.**
+///
+/// A day is not always 24 hours once zones are involved, so Cypher does not
+/// normalise. `28DT32H` is the answer; `29DT8H` is the tidy-looking wrong one.
+#[test]
+fn hours_do_not_normalise_into_days() {
+    assert_eq!(rendered("RETURN duration({days: 14, hours: 16}) * 2 AS r"), "P28DT32H");
+    assert_eq!(rendered("RETURN duration({hours: 30}) AS r"), "PT30H");
+}
+
+/// **A fractional month carries at 30.4369 days, not 30.**
+///
+/// Halving 12Y5M leaves half a month to convert. At 30 days/month the result
+/// is `13:21:08` short by nearly five hours — a wrong answer that renders
+/// perfectly well.
+#[test]
+fn a_fractional_month_uses_the_mean_gregorian_month() {
+    // Half of 30.436875 days is 15.2184375 = 15d 5h 14m 33s exactly.
+    //
+    // At 30 days/month it would be 15d 0h 0m 0s, so the two rules are 5h 14m
+    // apart on a single month — the same discrepancy the TCK table exposes at
+    // 12Y5M, just visible without the arithmetic in between. My first
+    // expectation here said 24s; the code said 33s and the code was right.
+    assert_eq!(rendered("RETURN duration({months: 1}) * 0.5 AS r"), "P15DT5H14M33S");
+}
+
+/// Scaling by zero and by a negative number.
+#[test]
+fn zero_and_negative_factors() {
+    assert_eq!(rendered("RETURN duration({days: 3}) * 0 AS r"), "PT0S");
+    assert_eq!(rendered("RETURN duration({days: 3}) * -1 AS r"), "P-3D");
+    assert_eq!(rendered("RETURN duration({days: 3, hours: 4}) * -2 AS r"), "P-6DT-8H");
+}
+
+/// Dividing by zero is an error, not an infinite duration.
+#[test]
+fn division_by_zero_is_refused() {
+    let store = GraphStore::new();
+    let q = parse_query("RETURN duration({days: 1}) / 0 AS r").expect("parses");
+    let e = QueryExecutor::new(&store).execute(&q).expect_err("should refuse");
+    assert!(format!("{e:?}").contains("zero"), "{e:?}");
+}
+
+/// Adding and subtracting two durations is componentwise, and unaffected.
+#[test]
+fn duration_addition_is_undisturbed() {
+    let store = GraphStore::new();
+    let q = parse_query(
+        "RETURN duration({days: 1, hours: 2}) + duration({days: 3, hours: 4}) AS r",
+    )
+    .expect("parses");
+    let batch = QueryExecutor::new(&store).execute(&q).expect("runs");
+    match batch.records[0].get("r") {
+        Some(Value::Property(PropertyValue::Duration { days, seconds, .. })) => {
+            assert_eq!(*days, 4);
+            assert_eq!(*seconds, 6 * 3600);
+        }
+        other => panic!("expected a Duration, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Closes #787.

## Two defects

**`duration * n` and `duration / n` did not exist** — `TypeError("Mul requires numeric operands")`.

**`duration()` discarded its sub-second components.** `nanos: 0` was hardcoded and `milliseconds`/`microseconds`/`nanoseconds`/`weeks` were never read, so `duration({nanoseconds: 1})` lost the 1 **at construction**. The value was wrong before any arithmetic touched it — which is why the TCK's `* 1` row is really a test of the constructor.

## Three rules derived from the TCK, not assumed

I implemented each of these wrongly first, and **every wrong version produced a well-formed duration that renders perfectly**. That is what makes them worth writing down.

| rule | the plausible wrong version | what it gives |
|---|---|---|
| fractional month → days at **30.436875** (365.2425/12) | 30 | `08:06:35` instead of `13:21:08` |
| hours **do not** carry into days | normalise `28D32H` → `29D8H` | tidier, wrong — a day is not always 24h with zones |
| **ties-to-even** rounding | `f64::round()` | `...000.5` → `...001` where a whole `8S` is expected |

The mean-Gregorian-month figure came from solving *backwards* from the expected output — "what days-per-month produces 13:21:08?" — not from reasoning forwards. Forward reasoning from "a month is about 30 days" produces a wrong answer that looks right.

Worth noting for anyone doing numeric work here: **Rust's `.round()` rounds half away from zero**, which biases every exact tie upward and accumulates. `round_ties_even` is the one that matches the reference.

## Tests

8. `the_tck_multiply_and_divide_table` is the TCK's own table verbatim; the rest pin each derived rule separately, so a regression says *which* rule broke rather than just that a duration is wrong.

**One correction:** my hand-computed expectation in `a_fractional_month_uses_the_mean_gregorian_month` said `P15DT5H14M24S`. The code said `33S` and the code was right — I had miscalculated. The test now carries the correct value and a note saying which side was wrong.

## Measured

**3,217 → 3,232 (+15), zero regressions.** `cargo test --workspace --release`: exit 0, **3,389 passed, 0 failed**. Gate MET at 85.9%.