### PR TITLE
Indexing a non-list is a type error, not null: TCK 3,232 → 3,241 (+9) (#789)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3232
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3241
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -505,7 +505,57 @@ fn eval_index(collection: Value, index: Value, store: &GraphStore) -> ExecutionR
          Value::Property(PropertyValue::String(key))) => {
             Ok(Value::Property(collection.resolve_property(key, store)))
         }
-        _ => Ok(Value::Null),
+
+        // Null in, null out — an unknown collection or index has an unknown
+        // element, which is Cypher's answer and not an error.
+        (Value::Null | Value::Property(PropertyValue::Null), _)
+        | (_, Value::Null | Value::Property(PropertyValue::Null)) => Ok(Value::Null),
+
+        // Everything else is a **type error**, not null (#789).
+        //
+        // The catch-all here used to answer null for every unhandled pair, so
+        // `true[0]` and `[1,2]['x']` returned a value where Cypher raises. That
+        // is the failure mode this codebase keeps producing: a wrong answer
+        // that looks like a legitimate "no such element".
+        //
+        // The two cases are distinguished because the TCK does: indexing a
+        // *non-list* is one error, indexing a list with a *non-integer* is
+        // another, and reporting one for the other sends the reader to the
+        // wrong operand.
+        (Value::Property(p), _) if p.as_list_items().is_some() => {
+            Err(ExecutionError::TypeError(format!(
+                "a list index must be an integer, not {}",
+                type_name_of(&index)
+            )))
+        }
+        (Value::List(_), _) => Err(ExecutionError::TypeError(format!(
+            "a list index must be an integer, not {}",
+            type_name_of(&index)
+        ))),
+        (Value::Property(PropertyValue::Map(_)) | Value::Map(_), _) => {
+            Err(ExecutionError::TypeError(format!(
+                "a map key must be a string, not {}",
+                type_name_of(&index)
+            )))
+        }
+        _ => Err(ExecutionError::TypeError(format!(
+            "cannot index {}: it is not a list or a map",
+            type_name_of(&collection)
+        ))),
+    }
+}
+
+/// A value's type, for an error message that names the operand rather than
+/// saying something went wrong somewhere.
+fn type_name_of(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Property(p) => p.type_name(),
+        Value::Node(..) | Value::NodeRef(_) => "Node",
+        Value::Edge(..) | Value::EdgeRef(..) => "Relationship",
+        Value::Path { .. } => "Path",
+        Value::List(_) => "List",
+        Value::Map(_) => "Map",
     }
 }
 

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -15144,14 +15144,29 @@ mod tests {
         assert_eq!(result, Value::Null);
     }
 
+    /// Indexing a non-collection is a **type error**, not null (#789).
+    ///
+    /// This asserted `Value::Null`, which was the behaviour and is not
+    /// Cypher's: `List1 [6]` expects `TypeError: InvalidArgumentType` for
+    /// `true[0]`, `123[0]`, `4.7[0]` and `'1'[0]`. The test encoded the defect,
+    /// checked against the TCK rather than against the new code.
+    ///
+    /// The distinction it destroyed is the useful one: a list with no element
+    /// 5 is a different thing from a value that was never a list. The
+    /// neighbouring `test_eval_index_map_missing_key` still asserts null, and
+    /// still passes, because a missing key genuinely is null.
     #[test]
     fn test_eval_index_non_collection() {
-        let result = eval_index(
+        let err = eval_index(
             Value::Property(PropertyValue::Integer(1)),
             Value::Property(PropertyValue::Integer(0)),
             &GraphStore::new(),
-        ).unwrap();
-        assert_eq!(result, Value::Null);
+        )
+        .expect_err("indexing an integer is a type error");
+        assert!(
+            format!("{err:?}").contains("not a list or a map"),
+            "the message should name the problem: {err:?}"
+        );
     }
 
     #[test]

--- a/tests/index_type_errors.rs
+++ b/tests/index_type_errors.rs
@@ -1,0 +1,114 @@
+//! Indexing something that is not a list or map is a type error (#789).
+//!
+//! `eval_index` ended in `_ => Ok(Value::Null)`, so every unhandled pair
+//! answered null:
+//!
+//! ```text
+//! WITH true AS list, 0 AS idx RETURN list[idx]     -- expected TypeError, got null
+//! ```
+//!
+//! That is the failure this codebase keeps producing — a wrong answer that
+//! looks like a legitimate "no such element". Nothing distinguishes "the list
+//! has no element 5" from "that was never a list".
+//!
+//! The risk in fixing it runs the other way: an over-eager error breaks
+//! queries that legitimately index past the end, or index a null. Most of this
+//! file is therefore about what must **not** raise.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn run(cypher: &str) -> Result<Value, String> {
+    let store = GraphStore::new();
+    let q = parse_query(cypher).map_err(|e| format!("parse: {e:?}"))?;
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .map_err(|e| format!("exec: {e:?}"))?;
+    Ok(batch
+        .records
+        .first()
+        .and_then(|r| r.get("r"))
+        .cloned()
+        .unwrap_or(Value::Null))
+}
+
+fn raises(cypher: &str) -> bool {
+    run(cypher).is_err()
+}
+fn is_null(cypher: &str) -> bool {
+    matches!(run(cypher), Ok(Value::Null))
+}
+
+/// Indexing a non-list, every type the TCK lists.
+#[test]
+fn indexing_a_non_list_raises() {
+    for expr in ["true", "123", "4.7", "'1'"] {
+        assert!(
+            raises(&format!("WITH {expr} AS list, 0 AS idx RETURN list[idx] AS r")),
+            "indexing {expr} should raise"
+        );
+    }
+}
+
+/// Indexing a list with a non-integer.
+#[test]
+fn a_non_integer_index_raises() {
+    for idx in ["true", "4.7", "'x'", "[1]", "{a: 1}"] {
+        assert!(
+            raises(&format!("WITH [1, 2, 3] AS list, {idx} AS idx RETURN list[idx] AS r")),
+            "index {idx} should raise"
+        );
+    }
+}
+
+/// **Out of range is null, not an error.**
+///
+/// A list that has no element 5 is a different thing from a value that was
+/// never a list. This is the distinction the old catch-all destroyed, and the
+/// one most easily destroyed again from the other side.
+#[test]
+fn an_out_of_range_index_is_still_null() {
+    assert!(is_null("WITH [1, 2, 3] AS list RETURN list[10] AS r"));
+    assert!(is_null("WITH [1, 2, 3] AS list RETURN list[-10] AS r"));
+    assert!(is_null("WITH [] AS list RETURN list[0] AS r"));
+    assert!(is_null("WITH {a: 1} AS m RETURN m['nope'] AS r"));
+}
+
+/// **Null in, null out.** An unknown collection has an unknown element.
+#[test]
+fn indexing_null_is_null_not_an_error() {
+    assert!(is_null("WITH null AS list RETURN list[0] AS r"));
+    assert!(is_null("WITH [1, 2] AS list RETURN list[null] AS r"));
+    assert!(is_null("WITH null AS list RETURN list[null] AS r"));
+}
+
+/// Ordinary indexing is undisturbed, including the cases earlier fixes added.
+#[test]
+fn ordinary_indexing_still_works() {
+    let cases = [
+        ("WITH [1, 2, 3] AS list RETURN list[0] AS r", 1i64),
+        ("WITH [1, 2, 3] AS list RETURN list[2] AS r", 3),
+        ("WITH [1, 2, 3] AS list RETURN list[-1] AS r", 3),
+    ];
+    for (q, want) in cases {
+        match run(q) {
+            Ok(Value::Property(samyama::graph::PropertyValue::Integer(i))) => assert_eq!(i, want, "{q}"),
+            other => panic!("{q}\n  got {other:?}"),
+        }
+    }
+    // A map by string key, and an all-float literal that parses as a Vector.
+    assert!(run("WITH {a: 7} AS m RETURN m['a'] AS r").is_ok());
+    assert!(run("WITH [1.0, 2.0] AS v RETURN v[0] AS r").is_ok());
+}
+
+/// The message names the operand that is wrong, so the reader is sent to the
+/// right half of the expression.
+#[test]
+fn the_error_says_which_operand_is_wrong() {
+    let e = run("WITH 123 AS list, 0 AS idx RETURN list[idx] AS r").unwrap_err();
+    assert!(e.contains("not a list or a map"), "{e}");
+
+    let e = run("WITH [1, 2] AS list, 'x' AS idx RETURN list[idx] AS r").unwrap_err();
+    assert!(e.contains("index must be an integer"), "{e}");
+}


### PR DESCRIPTION
Closes #789.

`eval_index` ended in `_ => Ok(Value::Null)`, so `true[0]` and `[1,2]['x']` returned a value where Cypher raises.

## The distinction the catch-all destroyed

| | | |
|---|---|---|
| `[1,2,3][10]` | null | the list has no element 10 — **correct** |
| `true[0]` | null | `true` was never a list — **wrong, and indistinguishable** |

A caller reading null could not tell "no such element" from "that was never a collection". Same shape as the temporal `Debug` rendering and `duration()`'s dropped nanoseconds: a wrong answer that looks exactly like a legitimate one.

## The risk runs the other way

Turning a silent null into an error is the most dangerous kind of change in this file, because an over-eager version breaks queries that legitimately index past the end or index a null. Four of the six tests are therefore about what must **not** raise:

- out of range stays null — `[1,2,3][10]`, `[1,2,3][-10]`, `[][0]`, `{a:1}['nope']`
- null in, null out, in either operand
- ordinary indexing undisturbed, including the `Vector` (#605) and entity-property (#673) cases earlier fixes added

The errors name which operand is wrong — *"not a list or a map"* vs *"index must be an integer"* — because the TCK distinguishes them.

## A test that encoded the defect

`test_eval_index_non_collection` asserted `1[0] == Value::Null`. Checked against the TCK, not against the new code: `List1 [6]` expects `TypeError` for `true[0]`, `123[0]`, `4.7[0]`, `'1'[0]`. The test was wrong; corrected with a note recording which side lost.

`test_eval_index_map_missing_key` still asserts null and **still passes** — the check that this did not over-reach. Had both flipped, the fix would be wrong.

## Measured

**3,232 → 3,241 (+9), zero regressions.** `cargo test --workspace --release`: exit 0, **3,395 passed, 0 failed**. Gate MET at 86.2%.