### PR TITLE
Property access on a non-map is a type error: TCK 3,241 → 3,253 (+12) (#791)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3241
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3253
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -37,6 +37,8 @@ pub enum ValidationError {
     VariableTypeConflict(String),
     /// A boolean operator given an operand that cannot be a boolean.
     NonBooleanOperand(&'static str),
+    /// Property access on a value that cannot carry properties.
+    PropertyAccessOnNonMap { name: String, what: &'static str },
     /// One variable bound to two different kinds of entity.
     VariableKindConflict {
         name: String,
@@ -83,6 +85,11 @@ impl std::fmt::Display for ValidationError {
                 "`{name}` is bound to {first} and then to {second} in the same scope. A \
                  variable names one entity, and an entity is a node, a relationship or a \
                  path -- not two of them. Rename one of the two."
+            ),
+            Self::PropertyAccessOnNonMap { name, what } => write!(
+                f,
+                "`{name}` is {what}, so it has no properties to read. Only a map, \
+                 a node or a relationship does."
             ),
             Self::NonBooleanOperand(what) => write!(
                 f,
@@ -969,7 +976,107 @@ fn all_expressions(query: &Query) -> Vec<&Expression> {
     out
 }
 
+
+/// Property access on something that cannot have properties (#791).
+///
+/// ```text
+/// WITH 123 AS nonMap RETURN nonMap.num     -> TypeError: InvalidArgumentType
+/// ```
+///
+/// The TCK asks for this **at compile time**, which bounds what can be
+/// checked: only a variable whose value is a literal of a non-map type, taken
+/// from the projection that introduced it. `n.name` where `n` is a node, or a
+/// map, or anything read from the graph, is untouched — the type is not known
+/// from the text, and rejecting it would break every ordinary query.
+///
+/// So this fires on `WITH <literal> AS x ... x.prop` and nothing else. Narrow
+/// on purpose: `validate.rs` opens by naming over-rejection as the worse
+/// failure, and property access is the single most common expression in Cypher.
+fn validate_property_access_targets(query: &Query) -> Result<(), ValidationError> {
+    use crate::query::ast::Clause;
+
+    /// Literal types that cannot carry properties. A map can; a node,
+    /// relationship or anything read at run time is not visible here.
+    fn non_map_literal(e: &Expression) -> Option<&'static str> {
+        match e {
+            Expression::Literal(p) => match p {
+                crate::graph::PropertyValue::Integer(_) => Some("an integer"),
+                crate::graph::PropertyValue::Float(_) => Some("a float"),
+                crate::graph::PropertyValue::String(_) => Some("a string"),
+                crate::graph::PropertyValue::Boolean(_) => Some("a boolean"),
+                crate::graph::PropertyValue::Array(_) => Some("a list"),
+                _ => None,
+            },
+            Expression::ListExpr(_) => Some("a list"),
+            _ => None,
+        }
+    }
+
+    // Names a projection binds to a literal of a non-map type.
+    let mut bad: std::collections::HashMap<String, &'static str> =
+        std::collections::HashMap::new();
+    let mut note = |items: &[ReturnItem], bad: &mut std::collections::HashMap<String, &'static str>| {
+        for item in items {
+            let Some(alias) = &item.alias else { continue };
+            match non_map_literal(&item.expression) {
+                Some(what) => { bad.insert(alias.clone(), what); }
+                // Re-binding the name to anything else clears it.
+                None => { bad.remove(alias); }
+            }
+        }
+    };
+
+    let mut check = |e: &Expression, bad: &std::collections::HashMap<String, &'static str>|
+        -> Result<(), ValidationError> {
+        if let Expression::Property { variable, .. } = e {
+            if let Some(what) = bad.get(variable) {
+                return Err(ValidationError::PropertyAccessOnNonMap {
+                    name: variable.clone(),
+                    what,
+                });
+            }
+        }
+        Ok(())
+    };
+
+    if !query.clauses.is_empty() {
+        for clause in &query.clauses {
+            match clause {
+                Clause::With(w) => {
+                    for item in &w.items { check(&item.expression, &bad)?; }
+                    note(&w.items, &mut bad);
+                }
+                Clause::Return(r) => {
+                    for item in &r.items { check(&item.expression, &bad)?; }
+                }
+                Clause::Where(w) => check(&w.predicate, &bad)?,
+                _ => {}
+            }
+        }
+        return Ok(());
+    }
+
+    // The by-kind shape: earlier WITHs first, then the last, then RETURN.
+    for (wc, _, _, _) in &query.extra_with_stages {
+        for item in &wc.items { check(&item.expression, &bad)?; }
+        note(&wc.items, &mut bad);
+    }
+    if let Some(wc) = &query.with_clause {
+        for item in &wc.items { check(&item.expression, &bad)?; }
+        note(&wc.items, &mut bad);
+    }
+    if let Some(w) = &query.where_clause {
+        check(&w.predicate, &bad)?;
+    }
+    if let Some(rc) = &query.return_clause {
+        for item in &rc.items { check(&item.expression, &bad)?; }
+    }
+    Ok(())
+}
+
 pub fn validate(query: &Query) -> Result<(), ValidationError> {
+    validate_property_access_targets(query)?;
+
     validate_boolean_operands(query)?;
 
     validate_order_by_in_scope(query)?;

--- a/tests/property_access_targets.rs
+++ b/tests/property_access_targets.rs
@@ -1,0 +1,93 @@
+//! Property access on something that cannot carry properties (#791).
+//!
+//! ```text
+//! WITH 123 AS nonMap RETURN nonMap.num     -> TypeError: InvalidArgumentType
+//! ```
+//!
+//! We answered `null`, which is the recurring failure in this codebase: a
+//! wrong answer indistinguishable from a legitimate absent property.
+//!
+//! The TCK asks for this **at compile time**, and that bound is what makes the
+//! rule safe. Only a variable a projection binds to a *literal* of a non-map
+//! type can be checked; `n.name` where `n` comes from the graph is untouched,
+//! because the type is not knowable from the text.
+//!
+//! Property access is the most common expression in Cypher, so over-rejecting
+//! here would be severe. Most of this file is the accept side.
+
+use samyama::query::parser::parse_query;
+
+fn rejected(q: &str) -> bool {
+    parse_query(q).is_err()
+}
+fn accepted(q: &str) -> bool {
+    parse_query(q).is_ok()
+}
+
+/// Every non-map literal type.
+#[test]
+fn property_access_on_a_non_map_literal_is_refused() {
+    for lit in ["123", "42.45", "true", "'string'", "[1, 2]"] {
+        assert!(
+            rejected(&format!("WITH {lit} AS nonMap RETURN nonMap.num")),
+            "{lit}.num should be refused"
+        );
+    }
+}
+
+/// A map literal *can* carry properties.
+#[test]
+fn a_map_literal_is_fine() {
+    assert!(accepted("WITH {num: 1} AS m RETURN m.num"));
+    assert!(accepted("WITH {} AS m RETURN m.num"));
+}
+
+/// **Anything read at run time is untouched.**
+///
+/// This is the accept side that matters. `n` might be a node, a map, or
+/// anything else; the type is not knowable from the text, and Cypher reports a
+/// runtime error if it turns out wrong. Rejecting these would break essentially
+/// every query.
+#[test]
+fn run_time_typed_values_are_not_compile_time_errors() {
+    for q in [
+        "MATCH (n) RETURN n.name",
+        "MATCH (n) WHERE n.age > 3 RETURN n",
+        "MATCH (a)-[r]->(b) RETURN r.weight",
+        "MATCH (n) WITH n AS m RETURN m.name",
+        "UNWIND [{a: 1}, {a: 2}] AS m RETURN m.a",
+        "MATCH (n) WITH n.data AS d RETURN d.inner",
+        "WITH $param AS p RETURN p.field",
+    ] {
+        assert!(accepted(q), "must still be accepted: {q}");
+    }
+}
+
+/// **Re-binding the name clears the judgement.**
+///
+/// `WITH 1 AS x` then `WITH {a: 2} AS x` leaves `x` a map. Carrying the first
+/// binding forward would reject a valid query — the failure mode this rule is
+/// most likely to have.
+#[test]
+fn rebinding_a_name_clears_it() {
+    assert!(accepted("WITH 1 AS x WITH {a: 2} AS x RETURN x.a"));
+    assert!(accepted("MATCH (n) WITH 1 AS x WITH n AS x RETURN x.name"));
+    // ...and the reverse still catches it.
+    assert!(rejected("WITH {a: 1} AS x WITH 2 AS x RETURN x.a"));
+}
+
+/// The name survives an intermediate projection that passes it through.
+#[test]
+fn the_judgement_follows_the_name_through_a_projection() {
+    assert!(rejected("WITH 123 AS x WITH x RETURN x.num"));
+}
+
+/// The message names the variable and its type, rather than reporting that
+/// something somewhere was wrong.
+#[test]
+fn the_message_names_the_variable() {
+    let e = parse_query("WITH 123 AS nonMap RETURN nonMap.num").expect_err("refused");
+    let msg = format!("{e:?}");
+    assert!(msg.contains("nonMap"), "{msg}");
+    assert!(msg.contains("integer"), "{msg}");
+}


### PR DESCRIPTION
Closes #791.

```cypher
WITH 123 AS nonMap RETURN nonMap.num     -- expected TypeError, got null
```

Same shape as #789: a wrong answer indistinguishable from a legitimate one. Nothing separates "the map has no key `num`" from "that was never a map".

## What I checked before editing

This scenario sits in the same failure bucket as `toInteger`/`toFloat`/`toBoolean` on invalid types, and I opened the task expecting to fix both. Probing first:

```
RETURN toInteger([])                    -> TypeError   already correct
RETURN [x IN [1, []] | toInteger(x)]    -> TypeError   already correct
RETURN toFloat({})                      -> TypeError   already correct
RETURN toBoolean([])                    -> TypeError   already correct
```

**The conversion functions already raise.** Editing first would have meant "fixing" working code and booking a gain to it that belongs elsewhere. Only property access was broken, and that is all this PR touches.

## The rule, bounded by "compile time"

The TCK asks for this at compile time, so only a variable a projection binds to a **literal** of a non-map type is checkable:

| | |
|---|---|
| `WITH 123 AS x ... x.num` | integer literal, always will be — **refuse** |
| `MATCH (n) RETURN n.name` | may be a node or a map; not knowable from the text — **accept** |

Property access is the most common expression in Cypher, so over-rejection here would be severe. Seven accept-side shapes are pinned, including `$param.field` and `n.data.inner`.

The subtle one is re-binding:

```cypher
WITH 1 AS x WITH {a: 2} AS x RETURN x.a     -- valid; x is a map now
```

Carrying the first binding forward rejects a valid query. `rebinding_a_name_clears_it` pins both directions.

## Measured

**3,241 → 3,253 (+12), zero regressions.** `cargo test --workspace --release`: exit 0, **3,401 passed, 0 failed**. Gate MET at 86.5%.