### PR TITLE
now() is fixed once per statement: TCK 3,253 → 3,257 (+4) (#793)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3253
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3257
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -310,6 +310,10 @@ impl<'a> QueryExecutor<'a> {
     }
 
     pub fn execute(&self, query: &Query) -> ExecutionResult<RecordBatch> {
+        // "now" is fixed for the whole statement, so two `datetime()` calls in
+        // one query return the same instant (#793). The guard clears it on the
+        // way out, including on an early return.
+        let _clock = crate::query::executor::operator::statement_clock::begin();
         // Substitute parameters if any
         let query = if !self.params.is_empty() || !query.params.is_empty() {
             let mut q = query.clone();
@@ -518,6 +522,8 @@ impl<'a> MutQueryExecutor<'a> {
     /// Execute a query (read or write) and return results
     /// For CREATE queries, nodes/edges are created in the graph store
     pub fn execute(&mut self, query: &Query) -> ExecutionResult<RecordBatch> {
+        // See the read-only executor above: one clock per statement (#793).
+        let _clock = crate::query::executor::operator::statement_clock::begin();
         // Substitute parameters if any
         let query = if !self.params.is_empty() || !query.params.is_empty() {
             let mut q = query.clone();

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -164,6 +164,52 @@ fn cypher_equals(a: &PropertyValue, b: &PropertyValue) -> Option<bool> {
     }
 }
 
+/// The instant "now" means for the duration of one statement.
+///
+/// Cypher fixes the clock **once per query**, not once per call. Without that,
+/// `duration.inSeconds(datetime(), datetime())` returns `PT0.00000016S` -- the
+/// two calls land microseconds apart -- where the TCK requires exactly `PT0S`.
+///
+/// It is not only a test artefact. `WHERE n.created < datetime() AND
+/// n.expires > datetime()` should test one instant against both bounds, and a
+/// row arriving between the two reads is judged against a moving target.
+///
+/// A thread-local rather than a parameter because `eval_function` is reached
+/// from many operators and threading a clock through all of them would be a
+/// large change for a small need. Set by `QueryExecutor::execute` at the start
+/// of a statement and cleared by the guard on the way out, including on an
+/// early return, so a stale value cannot leak into the next statement (#793).
+pub(crate) mod statement_clock {
+    use std::cell::Cell;
+
+    thread_local! {
+        static NOW: Cell<Option<i64>> = const { Cell::new(None) };
+    }
+
+    /// Fix "now" for this statement. The returned guard clears it on drop.
+    pub fn begin() -> Guard {
+        NOW.with(|c| c.set(Some(chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0))));
+        Guard
+    }
+
+    /// The statement's instant, or the wall clock when no statement is active
+    /// -- a direct `eval_function` call from a test, for instance.
+    pub fn now() -> chrono::DateTime<chrono::Utc> {
+        match NOW.with(|c| c.get()) {
+            Some(n) => chrono::DateTime::from_timestamp_nanos(n),
+            None => chrono::Utc::now(),
+        }
+    }
+
+    pub struct Guard;
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            NOW.with(|c| c.set(None));
+        }
+    }
+}
+
+
 /// Shared binary operator evaluation used by Project, Aggregate, and Sort operators
 fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<Value> {
     // Node/edge identity comparison (Cypher: n1 = n2, n1 <> n2)
@@ -2158,7 +2204,7 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
             Ok(Value::Property(PropertyValue::Float(val)))
         }
         "timestamp" => {
-            let ts = chrono::Utc::now().timestamp_millis();
+            let ts = statement_clock::now().timestamp_millis();
             Ok(Value::Property(PropertyValue::Integer(ts)))
         }
         // Type/meta functions
@@ -2395,7 +2441,7 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
         "date" => {
             use crate::query::executor::temporal as tmp;
             if args.is_empty() {
-                let days = (chrono::Utc::now().timestamp() / 86_400) as i32;
+                let days = (statement_clock::now().timestamp() / 86_400) as i32;
                 return Ok(Value::Property(PropertyValue::Date(days)));
             }
             match &args[0] {
@@ -2428,7 +2474,7 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
         "localtime" => {
             use crate::query::executor::temporal as tmp;
             if args.is_empty() {
-                let now = chrono::Utc::now();
+                let now = statement_clock::now();
                 let nanos = now.timestamp().rem_euclid(86_400) * 1_000_000_000
                     + now.timestamp_subsec_nanos() as i64;
                 return Ok(Value::Property(PropertyValue::LocalTime(nanos)));
@@ -2459,7 +2505,7 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
         "time" => {
             use crate::query::executor::temporal as tmp;
             if args.is_empty() {
-                let now = chrono::Utc::now();
+                let now = statement_clock::now();
                 let nanos = now.timestamp().rem_euclid(86_400) * 1_000_000_000
                     + now.timestamp_subsec_nanos() as i64;
                 return Ok(Value::Property(PropertyValue::Time { nanos, offset_seconds: 0 }));
@@ -2502,7 +2548,7 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
         }
         "localdatetime" => {
             if args.is_empty() {
-                let now = chrono::Utc::now();
+                let now = statement_clock::now();
                 return Ok(Value::Property(PropertyValue::LocalDateTime {
                     secs: now.timestamp(),
                     nanos: now.timestamp_subsec_nanos(),
@@ -2545,7 +2591,7 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
         "datetime" => {
             use crate::query::executor::temporal as tmp;
             if args.is_empty() {
-                let now = chrono::Utc::now();
+                let now = statement_clock::now();
                 return Ok(Value::Property(PropertyValue::ZonedDateTime {
                     secs: now.timestamp(),
                     nanos: now.timestamp_subsec_nanos(),

--- a/tests/statement_clock.rs
+++ b/tests/statement_clock.rs
@@ -1,0 +1,82 @@
+//! "Now" is fixed once per statement, not once per call (#793).
+//!
+//! ```text
+//! RETURN duration.inSeconds(datetime(), datetime())
+//!   expected PT0S, got PT0.00000016S
+//! ```
+//!
+//! Each `datetime()` read the wall clock independently, so two calls in one
+//! query landed microseconds apart.
+//!
+//! Not merely a test artefact. `WHERE n.created < datetime() AND n.expires >
+//! datetime()` should test one instant against both bounds; with a moving
+//! clock a row arriving between the two reads is judged against a target that
+//! shifted underneath it. The bug is small in magnitude and unbounded in
+//! consequence.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn eval(cypher: &str) -> PropertyValue {
+    let store = GraphStore::new();
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.clone(),
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+/// Two calls to the same constructor in one statement give the same instant.
+#[test]
+fn two_calls_in_one_statement_agree() {
+    for f in ["localtime()", "time()", "datetime()", "localdatetime()", "date()"] {
+        assert_eq!(
+            eval(&format!("RETURN duration.inSeconds({f}, {f}) AS r")).to_cypher_string(),
+            "PT0S",
+            "duration between two {f} calls"
+        );
+    }
+}
+
+/// ...and compare equal, which is the same property stated where a user would
+/// meet it.
+#[test]
+fn the_clock_is_stable_across_an_expression() {
+    assert_eq!(eval("RETURN datetime() = datetime() AS r"), PropertyValue::Boolean(true));
+    assert_eq!(eval("RETURN date() = date() AS r"), PropertyValue::Boolean(true));
+    // Different constructors read the same underlying instant, so the date
+    // part of `datetime()` is `date()`.
+    assert_eq!(eval("RETURN date(datetime()) = date() AS r"), PropertyValue::Boolean(true));
+}
+
+/// **The clock is fixed per statement, not frozen.**
+///
+/// This is the half that a naive "cache now() forever" implementation gets
+/// wrong, and it would not show up in any TCK scenario — every one of them is
+/// a single statement.
+#[test]
+fn separate_statements_see_time_move() {
+    let a = eval("RETURN datetime() AS r");
+    std::thread::sleep(std::time::Duration::from_millis(30));
+    let b = eval("RETURN datetime() AS r");
+    assert_ne!(a, b, "a later statement must see a later instant");
+}
+
+/// A statement that errors must still release the clock, or every later
+/// statement on the thread inherits a stale "now".
+#[test]
+fn a_failed_statement_does_not_leak_its_clock() {
+    let store = GraphStore::new();
+    if let Ok(q) = parse_query("RETURN 1/0 AS r") {
+        let _ = QueryExecutor::new(&store).execute(&q);
+    }
+    std::thread::sleep(std::time::Duration::from_millis(30));
+    let after = eval("RETURN datetime() AS r");
+    std::thread::sleep(std::time::Duration::from_millis(30));
+    let later = eval("RETURN datetime() AS r");
+    assert_ne!(after, later, "the clock must still advance after a failed statement");
+}


### PR DESCRIPTION
Closes #793.

```cypher
RETURN duration.inSeconds(datetime(), datetime())
  expected PT0S, got PT0.00000016S
```

Six call sites each read `chrono::Utc::now()` independently, so two constructor calls in one query landed microseconds apart. Cypher fixes the clock once per statement.

## The count understates the bug

Only 4 scenarios, but:

```cypher
WHERE n.created < datetime() AND n.expires > datetime()
```

should test **one** instant against both bounds. With a per-call clock a row arriving between the two reads is judged against a target that moved underneath it. Microseconds wide, so it never shows up in testing and never reproduces on demand — it just occasionally returns a row that should not be there.

## The half no TCK scenario covers

The clock must be **fixed per statement, not frozen**. Every TCK scenario is one statement, so caching `now()` for the process passes all four and breaks every subsequent query in a long-lived server. Two tests exist only for that:

- `separate_statements_see_time_move`
- `a_failed_statement_does_not_leak_its_clock` — a statement that errors must still release the clock, or later statements on the thread inherit a stale instant

A thread-local set by both `execute` entry points and cleared by a drop guard, so an early return cannot leak it. `now()` falls back to the wall clock when no statement is active, keeping direct `eval_function` calls in unit tests working.

## Measured

**3,253 → 3,257 (+4), zero regressions.** `cargo test --workspace --release`: exit 0, **3,405 passed, 0 failed**. Gate MET at 86.6%.