### PR TITLE
A value-bound variable cannot be a pattern: TCK 3,257 → 3,273 (+16) (#795)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3257
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3273
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -1074,6 +1074,40 @@ fn validate_property_access_targets(query: &Query) -> Result<(), ValidationError
     Ok(())
 }
 
+
+/// Whether a projection binds this name to something that **cannot** be a node,
+/// relationship or path — so using it as a pattern is a type conflict.
+///
+/// ```text
+/// WITH 123 AS n MATCH (n) RETURN n     -> SyntaxError: VariableTypeConflict
+/// ```
+///
+/// Was lists and maps only, which covered `WITH [n] AS users MATCH (users)`
+/// (#654) and missed every scalar — 16 TCK scenarios across Match1 [11]/[13]
+/// and Match6 [25], covering `true`, `123`, `123.4`, `'foo'` and `null` as
+/// node, relationship and path variables.
+///
+/// Literals only, and deliberately: `WITH n.prop AS x MATCH (x)` cannot be
+/// judged from the text, and `validate.rs` opens by naming over-rejection as
+/// the worse failure. Two copies of this test existed and both were narrow;
+/// they now share one function, because the next widening should not have to
+/// find both.
+fn not_an_entity(e: &Expression) -> bool {
+    matches!(
+        e,
+        Expression::ListExpr(_)
+            | Expression::MapExpr(_)
+            | Expression::Literal(
+                crate::graph::PropertyValue::Array(_)
+                    | crate::graph::PropertyValue::Map(_)
+                    | crate::graph::PropertyValue::Integer(_)
+                    | crate::graph::PropertyValue::Float(_)
+                    | crate::graph::PropertyValue::String(_)
+                    | crate::graph::PropertyValue::Boolean(_)
+            )
+    )
+}
+
 pub fn validate(query: &Query) -> Result<(), ValidationError> {
     validate_property_access_targets(query)?;
 
@@ -1325,13 +1359,7 @@ pub fn validate(query: &Query) -> Result<(), ValidationError> {
                 Clause::With(wc) => {
                     for item in &wc.items {
                         let Some(alias) = item.alias.as_ref() else { continue };
-                        let is_collection = matches!(
-                            &item.expression,
-                            Expression::ListExpr(_)
-                                | Expression::MapExpr(_)
-                                | Expression::Literal(crate::graph::PropertyValue::Array(_))
-                                | Expression::Literal(crate::graph::PropertyValue::Map(_))
-                        );
+                        let is_collection = not_an_entity(&item.expression);
                         // Re-aliasing something else to the same name clears it.
                         if is_collection {
                             collections.insert(alias.clone());
@@ -1350,6 +1378,10 @@ pub fn validate(query: &Query) -> Result<(), ValidationError> {
                             }
                             Ok(())
                         };
+                        // The *path* variable too: `WITH 123 AS p MATCH p = ()-[]-()`
+                        // is the same conflict and was walked past, because
+                        // this loop only visited the nodes and edges (#795).
+                        check(&path.path_variable)?;
                         check(&path.start.variable)?;
                         for seg in &path.segments {
                             check(&seg.node.variable)?;
@@ -1371,13 +1403,7 @@ pub fn validate(query: &Query) -> Result<(), ValidationError> {
                         collections: &mut HashSet<String>| {
             for item in &wc.items {
                 let Some(alias) = item.alias.as_ref() else { continue };
-                let is_collection = matches!(
-                    &item.expression,
-                    Expression::ListExpr(_)
-                        | Expression::MapExpr(_)
-                        | Expression::Literal(crate::graph::PropertyValue::Array(_))
-                        | Expression::Literal(crate::graph::PropertyValue::Map(_))
-                );
+                let is_collection = not_an_entity(&item.expression);
                 if is_collection {
                     collections.insert(alias.clone());
                 } else {
@@ -1398,6 +1424,7 @@ pub fn validate(query: &Query) -> Result<(), ValidationError> {
                         }
                         Ok(())
                     };
+                    check(&path.path_variable)?;
                     check(&path.start.variable)?;
                     for seg in &path.segments {
                         check(&seg.node.variable)?;

--- a/tests/value_as_pattern.rs
+++ b/tests/value_as_pattern.rs
@@ -1,0 +1,93 @@
+//! A variable bound to a value cannot then be a pattern (#795).
+//!
+//! ```text
+//! WITH 123 AS n MATCH (n) RETURN n     -> SyntaxError: VariableTypeConflict
+//! ```
+//!
+//! The check existed but was narrow in two independent ways, and each hid the
+//! other:
+//!
+//! * it recognised only **lists and maps** — the shape #654 needed — so every
+//!   scalar walked past;
+//! * it visited only **node and edge** variables in a pattern, never the path
+//!   variable, so `WITH 123 AS p MATCH p = ()-[]-()` was never examined.
+//!
+//! Widening one alone gets 8 of the 16 scenarios and looks like progress.
+//!
+//! Both checks also existed in **two copies**, for the two AST shapes. They now
+//! share one predicate, so the next widening does not have to find both.
+
+use samyama::query::parser::parse_query;
+
+fn rejected(q: &str) -> bool {
+    parse_query(q).is_err()
+}
+fn accepted(q: &str) -> bool {
+    parse_query(q).is_ok()
+}
+
+/// Every scalar the TCK lists, as a node variable.
+#[test]
+fn a_scalar_cannot_be_a_node_pattern() {
+    for lit in ["true", "123", "123.4", "'foo'"] {
+        assert!(
+            rejected(&format!("WITH {lit} AS n MATCH (n) RETURN n")),
+            "{lit} as a node should be refused"
+        );
+    }
+}
+
+/// ...as a relationship variable.
+#[test]
+fn a_scalar_cannot_be_a_relationship_pattern() {
+    for lit in ["true", "123", "123.4", "'foo'"] {
+        assert!(
+            rejected(&format!("WITH {lit} AS r MATCH ()-[r]-() RETURN r")),
+            "{lit} as a relationship should be refused"
+        );
+    }
+}
+
+/// ...and as a **path** variable, which the walk skipped entirely.
+#[test]
+fn a_scalar_cannot_be_a_path_pattern() {
+    for lit in ["true", "123", "123.4", "'foo'"] {
+        assert!(
+            rejected(&format!("WITH {lit} AS p MATCH p = ()-[]-() RETURN p")),
+            "{lit} as a path should be refused"
+        );
+    }
+}
+
+/// Lists and maps are still refused — the case the check was originally
+/// written for (#654) must not be lost while widening it.
+#[test]
+fn the_original_collection_case_still_holds() {
+    assert!(rejected("WITH [1] AS users MATCH (users)-->(m) RETURN m"));
+    assert!(rejected("WITH {a: 1} AS m MATCH (m) RETURN m"));
+}
+
+/// **A name re-bound to something that could be an entity is fine.**
+#[test]
+fn a_rebound_name_is_free_again() {
+    assert!(accepted("MATCH (x) WITH 1 AS n WITH x AS n MATCH (n)-->(m) RETURN m"));
+}
+
+/// Ordinary queries are undisturbed. This is where a widened type check does
+/// damage, so it carries the most cases.
+#[test]
+fn ordinary_patterns_are_undisturbed() {
+    for q in [
+        "MATCH (n) RETURN n",
+        "MATCH (a)-[r]->(b) RETURN a, r, b",
+        "MATCH p = (a)-[*1..3]->(b) RETURN p",
+        "MATCH (n) WITH n MATCH (n)-->(m) RETURN m",
+        "MATCH (n) WITH n AS x MATCH (x)-->(m) RETURN m",
+        "MATCH p = (a)-->(b) WITH p MATCH (c) RETURN p, c",
+        // A property is not knowable from the text and must pass through.
+        "MATCH (n) WITH n.friend AS f MATCH (f)-->(m) RETURN m",
+        "UNWIND [1, 2] AS i MATCH (n) RETURN n, i",
+    ] {
+        assert!(accepted(q), "must still be accepted: {q}");
+    }
+}


### PR DESCRIPTION
Closes #795.

```cypher
WITH 123 AS n MATCH (n) RETURN n     -- expected SyntaxError: VariableTypeConflict
```

## Two narrownesses, each hiding the other

The check existed (#654) and was narrow in two independent ways:

| | |
|---|---|
| recognised only **lists and maps** | every scalar walked past |
| visited only **node and edge** variables | `WITH 123 AS p MATCH p = ()-[]-()` never examined |

Widening either alone fixes **8 of 16** and reads as success — and worse, leaves the topic *looking* covered, because the tests that exist then pass. `a_scalar_cannot_be_a_path_pattern` exists specifically so the second half cannot be forgotten again.

## Two copies, now one

Both checks existed twice — once per AST shape — and both copies were narrow identically. They share one `not_an_entity` predicate now, so the next widening does not have to find both.

That two-representation split has accounted for eight fixes this session. It is the most reliable way for a change here to measure zero.

## Bounded to literals

Only a projection binding a name to a **literal** is judged. `WITH n.friend AS f MATCH (f)-->(m)` cannot be decided from the text and passes through. Eight accept-side shapes are pinned, including var-length paths and pass-through projections.

## Measured

**3,257 → 3,273 (+16), zero regressions.** `cargo test --workspace --release`: exit 0, **3,411 passed, 0 failed**. Gate MET at 87.0%.