### PR TITLE
A pattern predicate may not introduce variables: TCK 3,273 → 3,287 (+14) (#798)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3273
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3287
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -498,6 +498,15 @@ pub enum Expression {
         pattern: Pattern,
         /// Optional WHERE predicate
         where_clause: Option<Box<WhereClause>>,
+        /// True when this came from a **bare pattern predicate** —
+        /// `WHERE (n)-[r]->(a)` — rather than from `EXISTS { ... }`.
+        ///
+        /// The two desugar to the same node because they evaluate identically,
+        /// but one rule separates them: a bare predicate may **not** introduce
+        /// variables, while `EXISTS` may. Without this flag the check cannot
+        /// tell them apart, and applying it to both rejects every
+        /// `EXISTS { MATCH (n)-->(m) ... }` — which is what happened (#798).
+        bare_pattern: bool,
     },
     /// List comprehension: [x IN list WHERE cond | expr]
     ListComprehension {

--- a/src/query/executor/logical_optimizer.rs
+++ b/src/query/executor/logical_optimizer.rs
@@ -343,7 +343,7 @@ fn collect_vars_recursive(expr: &crate::query::ast::Expression, vars: &mut HashS
             collect_vars_recursive(inner, vars);
             collect_vars_recursive(index, vars);
         }
-        Expression::ExistsSubquery { pattern, where_clause } => {
+        Expression::ExistsSubquery { pattern, where_clause, .. } => {
             // Variables the subquery shares with the outer query are genuine
             // dependencies of this predicate — the filter must not be pushed
             // below the operator that binds them, or the subquery is evaluated

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -714,7 +714,7 @@ fn eval_expression(expr: &Expression, record: &Record, store: &GraphStore) -> Ex
             let en = match end { Some(e) => Some(eval_expression(e, record, store)?), None => None };
             eval_list_slice(collection, s, en)
         }
-        Expression::ExistsSubquery { pattern, where_clause } => {
+        Expression::ExistsSubquery { pattern, where_clause, .. } => {
             eval_exists_subquery(pattern, where_clause.as_deref(), record, store)
         }
         Expression::ListComprehension { variable, list_expr, filter, map_expr } => {
@@ -4348,7 +4348,7 @@ impl FilterOperator {
                 let en = match end { Some(e) => Some(self.evaluate_expression(e, record, store)?), None => None };
                 eval_list_slice(collection, s, en)
             }
-            Expression::ExistsSubquery { pattern, where_clause } => {
+            Expression::ExistsSubquery { pattern, where_clause, .. } => {
                 eval_exists_subquery(pattern, where_clause.as_deref(), record, store)
             }
             Expression::ListComprehension { variable, list_expr, filter, map_expr } => {
@@ -6240,7 +6240,7 @@ impl ProjectOperator {
                 let en = match end { Some(e) => Some(self.evaluate_expression(e, record, store)?), None => None };
                 eval_list_slice(collection, s, en)
             }
-            Expression::ExistsSubquery { pattern, where_clause } => {
+            Expression::ExistsSubquery { pattern, where_clause, .. } => {
                 eval_exists_subquery(pattern, where_clause.as_deref(), record, store)
             }
             Expression::ListComprehension { variable, list_expr, filter, map_expr } => {
@@ -6819,7 +6819,7 @@ impl AggregateOperator {
                 let en = match end { Some(e) => Some(Self::evaluate_expression(e, record, store)?), None => None };
                 eval_list_slice(collection, s, en)
             }
-            Expression::ExistsSubquery { pattern, where_clause } => {
+            Expression::ExistsSubquery { pattern, where_clause, .. } => {
                 eval_exists_subquery(pattern, where_clause.as_deref(), record, store)
             }
             Expression::ListComprehension { variable, list_expr, filter, map_expr } => {
@@ -8010,7 +8010,7 @@ impl SortOperator {
                 let en = match end { Some(e) => Some(Self::evaluate_expression(e, record, store)?), None => None };
                 eval_list_slice(collection, s, en)
             }
-            Expression::ExistsSubquery { pattern, where_clause } => {
+            Expression::ExistsSubquery { pattern, where_clause, .. } => {
                 eval_exists_subquery(pattern, where_clause.as_deref(), record, store)
             }
             Expression::ListComprehension { variable, list_expr, filter, map_expr } => {
@@ -12746,7 +12746,7 @@ impl WithBarrierOperator {
                 let en = match end { Some(e) => Some(Self::evaluate_expression(e, record, store)?), None => None };
                 eval_list_slice(collection, s, en)
             }
-            Expression::ExistsSubquery { pattern, where_clause } => {
+            Expression::ExistsSubquery { pattern, where_clause, .. } => {
                 eval_exists_subquery(pattern, where_clause.as_deref(), record, store)
             }
             Expression::ListComprehension { variable, list_expr, filter, map_expr } => {

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -3817,7 +3817,7 @@ impl QueryPlanner {
             Expression::Function { args, .. } => {
                 for arg in args { Self::collect_expression_variables(arg, vars); }
             }
-            Expression::ExistsSubquery { pattern, where_clause } => {
+            Expression::ExistsSubquery { pattern, where_clause, .. } => {
                 // An EXISTS subquery's pattern routinely references variables bound
                 // by the enclosing query — `NOT EXISTS { MATCH (a)-[:KNOWS]-(b) }`
                 // where both `a` and `b` come from the outer MATCH. Those are real

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -2268,6 +2268,7 @@ fn parse_primary(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
                 return Ok(Expression::ExistsSubquery {
                     pattern: Pattern { paths: vec![parse_path(inner)?] },
                     where_clause: None,
+                    bare_pattern: true,
                 });
             }
             Rule::reduce_expression => {
@@ -2418,6 +2419,9 @@ fn parse_exists_subquery(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expre
     Ok(Expression::ExistsSubquery {
         pattern: pattern.ok_or_else(|| ParseError::SemanticError("EXISTS missing pattern".to_string()))?,
         where_clause: where_clause.map(Box::new),
+        // `EXISTS { ... }` may introduce variables; a bare pattern predicate
+        // may not (#798).
+        bare_pattern: false,
     })
 }
 
@@ -2975,7 +2979,7 @@ mod tests {
         let result = parse_query(query);
         assert!(result.is_ok(), "Failed to parse EXISTS with WHERE: {:?}", result.err());
         let ast = result.unwrap();
-        if let Expression::ExistsSubquery { pattern, where_clause } = &ast.where_clause.unwrap().predicate {
+        if let Expression::ExistsSubquery { pattern, where_clause, .. } = &ast.where_clause.unwrap().predicate {
             assert!(!pattern.paths.is_empty());
             assert!(where_clause.is_some());
         } else {
@@ -3716,7 +3720,7 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse EXISTS subquery: {:?}", result.err());
         let ast = result.unwrap();
         let wc = ast.where_clause.unwrap();
-        if let Expression::ExistsSubquery { pattern, where_clause } = &wc.predicate {
+        if let Expression::ExistsSubquery { pattern, where_clause, .. } = &wc.predicate {
             assert!(!pattern.paths.is_empty());
             assert!(where_clause.is_none());
         } else {

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -39,6 +39,8 @@ pub enum ValidationError {
     NonBooleanOperand(&'static str),
     /// Property access on a value that cannot carry properties.
     PropertyAccessOnNonMap { name: String, what: &'static str },
+    /// A pattern predicate naming a variable nothing has bound.
+    UnboundPatternVariable(String),
     /// One variable bound to two different kinds of entity.
     VariableKindConflict {
         name: String,
@@ -85,6 +87,12 @@ impl std::fmt::Display for ValidationError {
                 "`{name}` is bound to {first} and then to {second} in the same scope. A \
                  variable names one entity, and an entity is a node, a relationship or a \
                  path -- not two of them. Rename one of the two."
+            ),
+            Self::UnboundPatternVariable(name) => write!(
+                f,
+                "`{name}` is introduced by a pattern used as a predicate, which tests \
+                 whether a pattern exists rather than binding anything. Bind `{name}` \
+                 in a MATCH first, or use EXISTS {{ ... }}, which may introduce names."
             ),
             Self::PropertyAccessOnNonMap { name, what } => write!(
                 f,
@@ -1108,7 +1116,104 @@ fn not_an_entity(e: &Expression) -> bool {
     )
 }
 
+
+/// A pattern predicate in `WHERE` may not **introduce** variables (#798).
+///
+/// ```text
+/// MATCH (n) WHERE (n)-[r]->(a) RETURN n
+///   -> SyntaxError: UndefinedVariable      -- r and a are bound nowhere
+/// ```
+///
+/// The pattern is a *test*, not a match: it asks whether an edge exists, and
+/// `r` and `a` have no meaning outside it. openCypher requires them to be
+/// already bound; `EXISTS { ... }` is the form that may introduce names.
+///
+/// 15 scenarios in `Pattern1` [10]. We answered every one, silently binding
+/// variables that go nowhere.
+///
+/// Anonymous positions are fine — `(n)-[]->()` introduces nothing — which is
+/// why the check is on *named* variables rather than on pattern complexity.
+fn validate_pattern_predicate_vars(query: &Query) -> Result<(), ValidationError> {
+    use crate::query::ast::Clause;
+
+    /// Names a pattern binds, ignoring anonymous positions.
+    fn pattern_named(pattern: &crate::query::ast::Pattern) -> HashSet<String> {
+        let mut out = HashSet::new();
+        pattern_vars(pattern, &mut out);
+        out
+    }
+
+    /// Walk an expression for pattern predicates, checking each against scope.
+    fn walk(
+        e: &Expression,
+        bound: &HashSet<String>,
+    ) -> Result<(), ValidationError> {
+        if let Expression::ExistsSubquery { pattern, .. } = e {
+            for name in pattern_named(pattern) {
+                if !bound.contains(&name) {
+                    return Err(ValidationError::UnboundPatternVariable(name));
+                }
+            }
+        }
+        for child in child_expressions(e) {
+            walk(child, bound)?;
+        }
+        Ok(())
+    }
+
+    // What the reading clauses have bound by the time the WHERE runs.
+    let mut bound: HashSet<String> = HashSet::new();
+
+    if !query.clauses.is_empty() {
+        for clause in &query.clauses {
+            match clause {
+                Clause::Match(mc) => pattern_vars(&mc.pattern, &mut bound),
+                Clause::Create(cc) => pattern_vars(&cc.pattern, &mut bound),
+                Clause::Merge(mc) => pattern_vars(&mc.pattern, &mut bound),
+                Clause::Unwind(u) => { bound.insert(u.variable.clone()); }
+                Clause::With(w) => bound = projected_names(&w.items),
+                Clause::Where(w) => walk(&w.predicate, &bound)?,
+                _ => {}
+            }
+        }
+        return Ok(());
+    }
+
+    let upto = query.with_split_index.unwrap_or(query.match_clauses.len());
+    for mc in query.match_clauses.iter().take(upto) {
+        pattern_vars(&mc.pattern, &mut bound);
+    }
+    if let Some(u) = &query.unwind_clause {
+        bound.insert(u.variable.clone());
+    }
+    for u in &query.extra_unwind_clauses {
+        bound.insert(u.variable.clone());
+    }
+    if let Some(w) = &query.where_clause {
+        walk(&w.predicate, &bound)?;
+    }
+    // Post-WITH stages get the projection's scope plus their own matches.
+    for (wc, uw, matches, wh) in &query.extra_with_stages {
+        bound = projected_names(&wc.items);
+        if let Some(u) = uw { bound.insert(u.variable.clone()); }
+        for mc in matches { pattern_vars(&mc.pattern, &mut bound); }
+        if let Some(w) = wh { walk(&w.predicate, &bound)?; }
+    }
+    if let Some(wc) = &query.with_clause {
+        bound = projected_names(&wc.items);
+        for mc in query.match_clauses.iter().skip(upto) {
+            pattern_vars(&mc.pattern, &mut bound);
+        }
+        if let Some(w) = &query.post_with_where_clause {
+            walk(&w.predicate, &bound)?;
+        }
+    }
+    Ok(())
+}
+
 pub fn validate(query: &Query) -> Result<(), ValidationError> {
+    validate_pattern_predicate_vars(query)?;
+
     validate_property_access_targets(query)?;
 
     validate_boolean_operands(query)?;

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -1148,7 +1148,11 @@ fn validate_pattern_predicate_vars(query: &Query) -> Result<(), ValidationError>
         e: &Expression,
         bound: &HashSet<String>,
     ) -> Result<(), ValidationError> {
-        if let Expression::ExistsSubquery { pattern, .. } = e {
+        // Only a *bare* pattern predicate is restricted. `EXISTS { ... }`
+        // desugars to the same node and may introduce names -- that is the
+        // whole difference between the two spellings, and checking both
+        // rejects every `EXISTS { MATCH (n)-->(m) }` (#798).
+        if let Expression::ExistsSubquery { pattern, bare_pattern: true, .. } = e {
             for name in pattern_named(pattern) {
                 if !bound.contains(&name) {
                     return Err(ValidationError::UnboundPatternVariable(name));

--- a/tests/pattern_predicate_scope.rs
+++ b/tests/pattern_predicate_scope.rs
@@ -79,19 +79,23 @@ fn already_bound_variables_are_fine() {
 /// documented way to express this.
 #[test]
 fn exists_subqueries_may_introduce_variables() {
+    // Asserted, not merely warned about. The first version of this test only
+    // checked *which* error came back if one did, so it passed while the rule
+    // rejected every EXISTS in the codebase -- the workspace suite caught it
+    // instead, via `test_parse_exists_subquery_with_where`. A test that
+    // tolerates failure cannot report one.
+    // The `EXISTS { MATCH ... RETURN ... }` form does not parse at all yet —
+    // a pre-existing grammar gap, tracked by the TCK as ExistentialSubquery2,
+    // and nothing to do with this rule. Only the forms that *do* parse are
+    // asserted here, so this test reports on what it actually governs.
     for q in [
-        "MATCH (n) WHERE EXISTS { (n)-[r]->(a) } RETURN n",
-        "MATCH (n) WHERE EXISTS { MATCH (n)-->(m) RETURN m } RETURN n",
+        "MATCH (n:Person) WHERE EXISTS { MATCH (n)-[:KNOWS]->(m:Person) WHERE m.age > 30 } RETURN n",
     ] {
-        // Some of these may not parse for unrelated reasons; what must not
-        // happen is a rejection *by this rule*.
-        if let Err(e) = parse_query(q) {
-            let msg = format!("{e:?}");
-            assert!(
-                !msg.contains("used as a predicate"),
-                "EXISTS must be allowed to introduce names: {q}\n  {msg}"
-            );
-        }
+        assert!(
+            accepted(q),
+            "EXISTS may introduce names and must be accepted: {q}\n  {:?}",
+            parse_query(q).err()
+        );
     }
 }
 

--- a/tests/pattern_predicate_scope.rs
+++ b/tests/pattern_predicate_scope.rs
@@ -1,0 +1,111 @@
+//! A pattern predicate may not introduce variables (#798).
+//!
+//! ```text
+//! MATCH (n) WHERE (n)-[r]->(a) RETURN n
+//!   -> SyntaxError: UndefinedVariable       -- r and a are bound nowhere
+//! ```
+//!
+//! The pattern is a **test**, not a match: it asks whether such an edge
+//! exists, and `r` and `a` have no meaning outside it. We answered these,
+//! silently binding variables that go nowhere.
+//!
+//! `EXISTS { ... }` is the form that *may* introduce names, so the rule must
+//! not touch it — and pattern predicates are common enough in real queries
+//! that over-rejecting here would be worse than the bug. Most of this file is
+//! the accept side.
+
+use samyama::query::parser::parse_query;
+
+fn rejected(q: &str) -> bool {
+    parse_query(q).is_err()
+}
+fn accepted(q: &str) -> bool {
+    parse_query(q).is_ok()
+}
+
+/// Every shape the TCK lists, in both directions.
+#[test]
+fn a_pattern_predicate_may_not_introduce_a_variable() {
+    for pat in [
+        // `(a)` alone is deliberately absent: it parses as a *parenthesised
+        // variable*, not a pattern predicate — the grammar's
+        // `pattern_predicate` requires at least one edge — so refusing it is a
+        // different rule (an undefined variable in WHERE) and a wider change
+        // than this one. One TCK row is therefore still failing here, and
+        // saying so beats quietly widening the rule to make a number look
+        // complete. Tracked on #798.
+        "(n)-[r]->(a)",
+        "(a)-[r]->(n)",
+        "(n)<-[r {}]-(a)",
+        "(n)-[r {}]-(a)",
+        "(n)-[r]->()",
+        "()-[r]->(n)",
+        "(n)<-[r]-()",
+        "(n)-[r]-()",
+    ] {
+        assert!(
+            rejected(&format!("MATCH (n) WHERE {pat} RETURN n")),
+            "`{pat}` introduces a variable and should be refused"
+        );
+    }
+}
+
+/// **Anonymous positions introduce nothing.**
+///
+/// `(n)-[]->()` is the ordinary way to write "n has an outgoing edge", and it
+/// must keep working. The rule is about *named* variables, not about pattern
+/// complexity — checking the latter would break the most common form of the
+/// feature.
+#[test]
+fn anonymous_positions_are_fine() {
+    for pat in ["(n)-->()", "(n)-[]->()", "()-->(n)", "(n)-[]-()", "(n)-[:T]->()"] {
+        assert!(
+            accepted(&format!("MATCH (n) WHERE {pat} RETURN n")),
+            "`{pat}` introduces nothing and must be accepted"
+        );
+    }
+}
+
+/// A variable already bound by the MATCH is fine on both sides.
+#[test]
+fn already_bound_variables_are_fine() {
+    assert!(accepted("MATCH (n), (m) WHERE (n)-->(m) RETURN n"));
+    assert!(accepted("MATCH (n)-[r]->(m) WHERE (n)-[r]->(m) RETURN n"));
+    assert!(accepted("MATCH (a), (b), (c) WHERE (a)-->(b) AND (b)-->(c) RETURN a"));
+}
+
+/// **`EXISTS { ... }` may introduce names.** That is the whole difference
+/// between the two forms, and a rule that conflated them would break the
+/// documented way to express this.
+#[test]
+fn exists_subqueries_may_introduce_variables() {
+    for q in [
+        "MATCH (n) WHERE EXISTS { (n)-[r]->(a) } RETURN n",
+        "MATCH (n) WHERE EXISTS { MATCH (n)-->(m) RETURN m } RETURN n",
+    ] {
+        // Some of these may not parse for unrelated reasons; what must not
+        // happen is a rejection *by this rule*.
+        if let Err(e) = parse_query(q) {
+            let msg = format!("{e:?}");
+            assert!(
+                !msg.contains("used as a predicate"),
+                "EXISTS must be allowed to introduce names: {q}\n  {msg}"
+            );
+        }
+    }
+}
+
+/// A name bound by `UNWIND` counts as bound.
+#[test]
+fn unwind_bindings_count() {
+    assert!(accepted("UNWIND [1] AS i MATCH (n) WHERE (n)-->() RETURN n, i"));
+}
+
+/// The message names the variable and points at the fix.
+#[test]
+fn the_message_names_the_variable() {
+    let e = parse_query("MATCH (n) WHERE (n)-[r]->(a) RETURN n").expect_err("refused");
+    let msg = format!("{e:?}");
+    assert!(msg.contains('r') || msg.contains('a'), "{msg}");
+    assert!(msg.contains("EXISTS"), "the message should offer the alternative: {msg}");
+}


### PR DESCRIPTION
Partial fix for #798 — 14 of 15. **#798 stays open** for the last row; see below.

```cypher
MATCH (n) WHERE (n)-[r]->(a) RETURN n     -- expected SyntaxError: UndefinedVariable
```

A pattern used as a predicate is a **test**; `r` and `a` are bound nowhere and have no meaning outside it.

## The trap

A bare pattern predicate and a real `EXISTS { ... }` **desugar to the same AST node** — the parser comment says so, and it is right for *evaluation*. It is wrong for *validation*: one may introduce variables and the other may not.

My first version enforced the rule on both and **rejected every `EXISTS` in the codebase**. `ExistsSubquery` now carries `bare_pattern`; adding the field made the compiler surface all ten match sites, which is the argument for a field over a heuristic.

## My own test should have caught that

`exists_subqueries_may_introduce_variables` was written as *"if it fails, check the reason"*:

```rust
if let Err(e) = parse_query(q) { assert!(!msg.contains("used as a predicate")); }
```

**A test that tolerates failure cannot report one.** It passed while the rule broke every `EXISTS`; the workspace suite caught it via a pre-existing parser test. It now asserts acceptance outright — and the file's own header says so, because I wrote it *specifically* to guard the accept side and still got it wrong.

## The accept side is most of the file

Pattern predicates are common, so this rule is easy to make harmful:

- **anonymous positions** — `(n)-[]->()` introduces nothing and is the ordinary way to write "n has an outgoing edge". Checking pattern *complexity* rather than *named variables* would have broken the most common form of the feature.
- already-bound names on either side
- `EXISTS { ... }`, which may introduce names

## Two scope limits, stated rather than papered over

* `WHERE (a)` parses as a **parenthesised variable**, not a pattern predicate. Refusing it is a different rule, so **one TCK row still fails** and #798 stays open. Widening the check to claim 15/15 would be tuning the rule to the score.
* `EXISTS { MATCH ... RETURN ... }` does not parse at all — pre-existing, tracked by the TCK as `ExistentialSubquery2`.

## Measured

**3,273 → 3,287 (+14), zero regressions.** `cargo test --workspace --release`: exit 0, **3,420 passed, 0 failed**. Gate MET at 87.4%.