### PR TITLE
A comprehension over entity lists: TCK 3,287 → 3,312 (+25) (#800)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3287
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3312
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1117,15 +1117,36 @@ fn eval_list_comprehension(
     // `as_list_items` rather than an `Array` match: an all-float list literal
     // parses as a `Vector`, and returning the empty list for it made a
     // comprehension over one silently produce nothing (#605).
-    let items = match list_val {
-        Value::Property(ref p) if p.as_list_items().is_some() => p.as_list_items().unwrap(),
-        _ => return Ok(Value::Property(PropertyValue::Array(vec![]))),
+    // A list holding **entities** is a `Value::List`, not a `PropertyValue`
+    // list — a PropertyValue list cannot hold a node or relationship. So
+    // `[x IN [r, 1] | type(x)]` fell to the catch-all and returned `[]`:
+    // an empty list where a TypeError belongs, and indistinguishable from a
+    // comprehension that legitimately filtered everything out (#799).
+    let items: Vec<Value> = match list_val {
+        Value::Property(ref p) if p.as_list_items().is_some() => p
+            .as_list_items()
+            .unwrap()
+            .into_iter()
+            .map(Value::Property)
+            .collect(),
+        Value::List(items) => items,
+        // Null in, null out. Anything else is not a list at all, and saying so
+        // beats returning an empty one.
+        Value::Null | Value::Property(PropertyValue::Null) => {
+            return Ok(Value::Property(PropertyValue::Null))
+        }
+        other => {
+            return Err(ExecutionError::TypeError(format!(
+                "a list comprehension needs a list, not {}",
+                type_name_of(&other)
+            )))
+        }
     };
 
     let mut result = Vec::new();
     for item in items {
         let mut inner_record = record.clone();
-        inner_record.bind(variable.to_string(), Value::Property(item));
+        inner_record.bind(variable.to_string(), item);
 
         // Apply filter
         if let Some(f) = filter {

--- a/tests/comprehension_entity_lists.rs
+++ b/tests/comprehension_entity_lists.rs
@@ -1,0 +1,106 @@
+//! A list comprehension over a list holding **entities** (#800).
+//!
+//! ```text
+//! MATCH (n)-[r]->() RETURN [x IN [r, 1] | type(x)]
+//!   expected TypeError, got []
+//! ```
+//!
+//! A `PropertyValue` list cannot hold a node or a relationship, so `[r, 1]` is
+//! a `Value::List`. `eval_list_comprehension` matched only the `PropertyValue`
+//! form and fell to `_ => Ok(Array(vec![]))`.
+//!
+//! The empty list is the dangerous part. It is indistinguishable from a
+//! comprehension that legitimately filtered everything out, so the type error
+//! inside never surfaced — and neither did any *other* error raised by the map
+//! expression. That is why fixing this moved **25** scenarios across eight
+//! features when the failure that led here named only `type()`: every function
+//! reached through a comprehension over entities was having its errors
+//! swallowed.
+//!
+//! Same shape as #789 and #791: a value that is wrong and looks exactly like a
+//! legitimate one.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn store_with_edge() -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (a:A)-[:T]->(b:B)").expect("setup parses");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup runs");
+    store
+}
+
+fn run(cypher: &str) -> Result<Value, String> {
+    let store = store_with_edge();
+    let q = parse_query(cypher).map_err(|e| format!("parse: {e:?}"))?;
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .map_err(|e| format!("exec: {e:?}"))?;
+    Ok(batch
+        .records
+        .first()
+        .and_then(|r| r.get("r"))
+        .cloned()
+        .unwrap_or(Value::Null))
+}
+
+/// An error inside the map expression **surfaces** instead of becoming `[]`.
+#[test]
+fn an_error_in_the_map_expression_is_not_swallowed() {
+    let e = run("MATCH (n)-[r]->() RETURN [x IN [r, 1] | type(x)] AS r")
+        .expect_err("type() on an integer must raise");
+    assert!(e.contains("type()"), "{e}");
+}
+
+/// A comprehension over entities **works** — the fix is not "reject entity
+/// lists", it is "iterate them properly".
+#[test]
+fn a_comprehension_over_entities_evaluates() {
+    match run("MATCH (n)-[r]->() RETURN [x IN [r] | type(x)] AS r") {
+        Ok(Value::Property(p)) => assert_eq!(p.to_cypher_string(), "[\"T\"]"),
+        other => panic!("got {other:?}"),
+    }
+    // Nodes too.
+    assert!(run("MATCH (n) RETURN [x IN [n] | labels(x)] AS r").is_ok());
+}
+
+/// Ordinary comprehensions are undisturbed.
+#[test]
+fn ordinary_comprehensions_still_work() {
+    for q in [
+        "MATCH (n) RETURN [x IN [1,2,3] | x * 2] AS r",
+        "MATCH (n) RETURN [x IN [1,2,3] WHERE x > 1 | x] AS r",
+        "MATCH (n) RETURN [x IN [] | x] AS r",
+        "MATCH (n) RETURN [x IN ['a','b'] | toUpper(x)] AS r",
+        // An all-float literal parses as a Vector (#605) and must keep working.
+        "MATCH (n) RETURN [x IN [1.0, 2.0] | x] AS r",
+    ] {
+        assert!(run(q).is_ok(), "{q}");
+    }
+}
+
+/// Null in, null out — not an empty list, and not an error.
+///
+/// A null arrives as `Value::Property(PropertyValue::Null)`, not `Value::Null`;
+/// both spellings exist and matching only the latter made this test fail
+/// against correct behaviour. Accepting either is what the assertion means.
+#[test]
+fn a_null_list_gives_null() {
+    let got = run("MATCH (n) RETURN [x IN null | x] AS r").expect("null is not an error");
+    assert!(
+        matches!(got, Value::Null | Value::Property(samyama::graph::PropertyValue::Null)),
+        "expected null, got {got:?}"
+    );
+}
+
+/// **Something that is not a list at all is an error**, where it used to be an
+/// empty list. This is the half that turns a silent wrong answer into a
+/// report.
+#[test]
+fn a_non_list_is_refused() {
+    let e = run("MATCH (n) RETURN [x IN 123 | x] AS r").expect_err("123 is not a list");
+    assert!(e.contains("needs a list"), "{e}");
+}


### PR DESCRIPTION
Closes #800.

```cypher
MATCH (n)-[r]->() RETURN [x IN [r, 1] | type(x)]
  expected TypeError, got []
```

A `PropertyValue` list cannot hold a relationship, so `[r, 1]` is a `Value::List`. The comprehension matched only the `PropertyValue` form and fell to `_ => Ok(Array(vec![]))`.

## The empty list is the damage

`[]` is indistinguishable from a comprehension that legitimately filtered everything out — so the type error never surfaced, **and neither did any other error the map expression raised.** The comprehension was a silent error sink for every entity-bearing list.

Which is why this moved **25 scenarios across eight features** when the failure that led here named only `type()`:

```
5 WithOrderBy1   5 Graph4   3 TypeConversion4   3 TypeConversion3
3 TypeConversion2   3 TypeConversion1   2 List12   1 Pattern2
```

## What was not broken, and a method note

I opened this expecting to fix `size()` and `type()` on invalid arguments. **Both already raise correctly.** My first probe said otherwise because it ran against an **empty store** — every query "answered" with zero rows, meaning the function never executed. A probe over an empty graph tests the planner, not the evaluator.

Had I edited on that evidence I would have "fixed" working code and booked this gain to it.

## Fix

Accept `Value::List` as well, propagate null, and **error** on a non-list where it used to return `[]`. Five tests, including that ordinary comprehensions, `Vector` literals (#605) and filtered forms are undisturbed.

One correction: my null test asserted `Value::Null` when a null arrives as `Value::Property(PropertyValue::Null)`. Both spellings exist; the code was right and the test was wrong.

## Measured

**3,287 → 3,312 (+25), zero regressions.** `cargo test --workspace --release`: exit 0, **3,425 passed, 0 failed**. Gate MET at 88.1%.