### PR TITLE
Overrides layer onto a selected temporal in every constructor: TCK 3,312 → 3,333 (+21) (#802)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3312
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3333
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1648,6 +1648,90 @@ fn date_part_of(v: &PropertyValue) -> Option<i32> {
     }
 }
 
+/// Apply a map's date components on top of an already-selected date.
+///
+/// `{date: other, day: 28}` keeps `other`'s year and month and replaces the
+/// day; `{date: other, ordinalDay: 28}` replaces the whole day-of-year, so it
+/// moves the month too. The four spellings do not mix — naming `ordinalDay`
+/// means the calendar fields are not consulted — which is why this dispatches
+/// on which keys are present rather than defaulting each field.
+fn apply_date_overrides(
+    base: i32,
+    map: &std::collections::HashMap<String, PropertyValue>,
+) -> Result<i32, ExecutionError> {
+    use chrono::Datelike;
+    const KEYS: &[&str] = &[
+        "year", "month", "day", "ordinalDay", "week", "dayOfWeek", "quarter", "dayOfQuarter",
+    ];
+    if !KEYS.iter().any(|k| map.contains_key(*k)) {
+        return Ok(base);
+    }
+    let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1).expect("epoch");
+    let cur = epoch
+        .checked_add_signed(chrono::Duration::days(base as i64))
+        .ok_or_else(|| ExecutionError::RuntimeError("date out of range".into()))?;
+    let g = |k: &str| map.get(k).and_then(|v| v.as_integer());
+    let year = g("year").unwrap_or(cur.year() as i64) as i32;
+
+    let out = if let Some(ord) = g("ordinalDay") {
+        chrono::NaiveDate::from_yo_opt(year, ord as u32)
+            .ok_or_else(|| ExecutionError::RuntimeError(format!("invalid ordinalDay {ord}")))?
+    } else if map.contains_key("week") || map.contains_key("dayOfWeek") {
+        let week = g("week").unwrap_or(cur.iso_week().week() as i64) as u32;
+        let dow = g("dayOfWeek").unwrap_or(cur.weekday().number_from_monday() as i64) as u32;
+        chrono::NaiveDate::from_isoywd_opt(year, week, weekday_from_iso_num(dow))
+            .ok_or_else(|| ExecutionError::RuntimeError(format!("invalid week date {year}-W{week}-{dow}")))?
+    } else if map.contains_key("quarter") || map.contains_key("dayOfQuarter") {
+        let q = g("quarter").unwrap_or(((cur.month() - 1) / 3 + 1) as i64);
+        let d = g("dayOfQuarter").unwrap_or(1);
+        let start = chrono::NaiveDate::from_ymd_opt(year, ((q - 1) * 3 + 1) as u32, 1)
+            .ok_or_else(|| ExecutionError::RuntimeError(format!("invalid quarter {q}")))?;
+        start
+            .checked_add_signed(chrono::Duration::days(d - 1))
+            .ok_or_else(|| ExecutionError::RuntimeError(format!("invalid dayOfQuarter {d}")))?
+    } else {
+        let month = g("month").unwrap_or(cur.month() as i64) as u32;
+        let day = g("day").unwrap_or(cur.day() as i64) as u32;
+        chrono::NaiveDate::from_ymd_opt(year, month, day)
+            .ok_or_else(|| ExecutionError::RuntimeError(format!("invalid date {year}-{month}-{day}")))?
+    };
+    Ok(out.signed_duration_since(epoch).num_days() as i32)
+}
+
+/// Apply a map's clock components on top of an already-selected time.
+///
+/// Replaces only the fields named: `{time: t, second: 42}` keeps the hour,
+/// minute and fraction from `t`. The three sub-second components are additive
+/// with each other and together replace the selected fraction only if any is
+/// given — the same rule `compose_date_and_time` uses, kept in one place so
+/// the two cannot drift (#802).
+fn apply_time_overrides(
+    base: i64,
+    map: &std::collections::HashMap<String, PropertyValue>,
+) -> i64 {
+    let g = |k: &str| map.get(k).and_then(|v| v.as_integer());
+    let mut hour = base / 3_600_000_000_000;
+    let mut minute = base / 60_000_000_000 % 60;
+    let mut second = base / 1_000_000_000 % 60;
+    let mut sub = base % 1_000_000_000;
+    if let Some(v) = g("hour") { hour = v; }
+    if let Some(v) = g("minute") { minute = v; }
+    if let Some(v) = g("second") { second = v; }
+    if ["millisecond", "microsecond", "nanosecond"].iter().any(|k| map.contains_key(*k)) {
+        sub = g("millisecond").unwrap_or(0) * 1_000_000
+            + g("microsecond").unwrap_or(0) * 1_000
+            + g("nanosecond").unwrap_or(0);
+    }
+    (hour * 3600 + minute * 60 + second) * 1_000_000_000 + sub
+}
+
+
+fn weekday_from_iso_num(dow: u32) -> chrono::Weekday {
+    use chrono::Weekday::*;
+    match dow { 1 => Mon, 2 => Tue, 3 => Wed, 4 => Thu, 5 => Fri, 6 => Sat, _ => Sun }
+}
+
+
 /// Nanoseconds-since-midnight of any temporal value that has a time part.
 fn time_part_of(v: &PropertyValue) -> Option<i64> {
     match v {
@@ -2471,11 +2555,20 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                 }
                 Value::Map(_) | Value::Property(PropertyValue::Map(_)) => {
                     let map = &temporal_arg_map(&args[0]).expect("matched a map arm");
-                    // Selection: `date({date: d})` and `date({datetime: dt})`
-                    // take the date part of another temporal.
+                    // Selection: `date({date: d})` takes the date part of
+                    // another temporal — and any *other* component in the map
+                    // then overrides part of it. `{date: other, day: 28}` keeps
+                    // the year and month and replaces only the day.
+                    //
+                    // This returned the selected date unchanged, so every
+                    // override was silently discarded (#802). The composite
+                    // constructors already layer overrides this way; `date()`
+                    // has its own path and did not.
                     if let Some(src) = map.get("date").or_else(|| map.get("datetime")) {
-                        if let Some(d) = date_part_of(src) {
-                            return Ok(Value::Property(PropertyValue::Date(d)));
+                        if let Some(base) = date_part_of(src) {
+                            return Ok(Value::Property(PropertyValue::Date(
+                                apply_date_overrides(base, map)?,
+                            )));
                         }
                     }
                     Ok(Value::Property(PropertyValue::Date(tmp::date_days(map)?)))
@@ -2507,9 +2600,13 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                 }
                 Value::Map(_) | Value::Property(PropertyValue::Map(_)) => {
                     let map = &temporal_arg_map(&args[0]).expect("matched a map arm");
+                    // A selected time, with any clock components in the map
+                    // layered on top — the same rule `date()` needs (#802).
                     if let Some(src) = map.get("time").or_else(|| map.get("datetime")) {
                         if let Some(n) = time_part_of(src) {
-                            return Ok(Value::Property(PropertyValue::LocalTime(n)));
+                            return Ok(Value::Property(PropertyValue::LocalTime(
+                                apply_time_overrides(n, map),
+                            )));
                         }
                     }
                     Ok(Value::Property(PropertyValue::LocalTime(tmp::time_of_day_nanos(map)?)))
@@ -2548,7 +2645,7 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     if let Some(src) = map.get("time").or_else(|| map.get("datetime")) {
                         if let Some(n) = time_part_of(src) {
                             return Ok(Value::Property(PropertyValue::Time {
-                                nanos: n,
+                                nanos: apply_time_overrides(n, map),
                                 offset_seconds: offset,
                             }));
                         }

--- a/tests/temporal_selection_overrides.rs
+++ b/tests/temporal_selection_overrides.rs
@@ -1,0 +1,111 @@
+//! Overrides layer onto a **selected** temporal, in every constructor (#802).
+//!
+//! ```text
+//! date({date: other, day: 28})
+//!   expected 1984-11-28, got 1984-11-11
+//! ```
+//!
+//! #772 taught the *composite* constructors (`datetime`, `localdatetime`) to
+//! layer component overrides onto a selected value. `date()`, `localtime()`
+//! and `time()` have their own selection paths and returned the selected value
+//! unchanged, silently discarding every override.
+//!
+//! The same rule implemented in two places, one of them missed — the shape
+//! that keeps recurring here. `apply_date_overrides` and
+//! `apply_time_overrides` now hold it once each so the paths cannot drift.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn rendered(cypher: &str) -> String {
+    let store = GraphStore::new();
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.to_cypher_string(),
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+const D: &str = "date({year: 1984, month: 11, day: 11})";
+const T: &str = "localtime({hour: 12, minute: 31, second: 14, nanosecond: 645876123})";
+
+/// A calendar override replaces only the field it names.
+#[test]
+fn a_date_override_replaces_only_that_field() {
+    assert_eq!(rendered(&format!("WITH {D} AS o RETURN date({{date: o, day: 28}}) AS r")), "1984-11-28");
+    assert_eq!(rendered(&format!("WITH {D} AS o RETURN date({{date: o, month: 1}}) AS r")), "1984-01-11");
+    assert_eq!(rendered(&format!("WITH {D} AS o RETURN date({{date: o, year: 2000}}) AS r")), "2000-11-11");
+}
+
+/// **`ordinalDay` replaces the whole day-of-year**, so it moves the month too.
+///
+/// The four date spellings do not mix: naming `ordinalDay` means the calendar
+/// fields are not consulted. Defaulting each field independently would give
+/// `1984-11-28` here instead of `1984-01-28`.
+#[test]
+fn an_ordinal_override_moves_the_month() {
+    assert_eq!(
+        rendered(&format!("WITH {D} AS o RETURN date({{date: o, ordinalDay: 28}}) AS r")),
+        "1984-01-28"
+    );
+}
+
+/// With no override the selected value comes back unchanged.
+#[test]
+fn selection_without_an_override_is_unchanged() {
+    assert_eq!(rendered(&format!("WITH {D} AS o RETURN date({{date: o}}) AS r")), "1984-11-11");
+    assert_eq!(rendered(&format!("WITH {T} AS o RETURN localtime({{time: o}}) AS r")), "12:31:14.645876123");
+}
+
+/// Clock overrides layer the same way, keeping the fraction.
+#[test]
+fn a_time_override_keeps_the_rest_of_the_clock() {
+    assert_eq!(
+        rendered(&format!("WITH {T} AS o RETURN localtime({{time: o, second: 42}}) AS r")),
+        "12:31:42.645876123"
+    );
+    assert_eq!(
+        rendered(&format!("WITH {T} AS o RETURN localtime({{time: o, hour: 1}}) AS r")),
+        "01:31:14.645876123"
+    );
+}
+
+/// Naming any sub-second component replaces the whole fraction, and the three
+/// are additive with each other.
+#[test]
+fn a_sub_second_override_replaces_the_fraction() {
+    assert_eq!(
+        rendered(&format!("WITH {T} AS o RETURN localtime({{time: o, millisecond: 5}}) AS r")),
+        "12:31:14.005"
+    );
+    assert_eq!(
+        rendered(&format!(
+            "WITH {T} AS o RETURN localtime({{time: o, millisecond: 1, microsecond: 2, nanosecond: 3}}) AS r"
+        )),
+        "12:31:14.001002003"
+    );
+}
+
+/// `time()` keeps its offset while layering the clock.
+#[test]
+fn a_zoned_time_override_keeps_the_offset() {
+    assert_eq!(
+        rendered(&format!(
+            "WITH {T} AS o RETURN time({{time: o, second: 42, timezone: '+02:00'}}) AS r"
+        )),
+        "12:31:42.645876123+02:00"
+    );
+}
+
+/// Construction from components alone is undisturbed — the override path must
+/// not have displaced it.
+#[test]
+fn component_only_construction_still_works() {
+    assert_eq!(rendered("RETURN date({year: 1984, month: 11, day: 11}) AS r"), "1984-11-11");
+    assert_eq!(rendered("RETURN localtime({hour: 12, minute: 31}) AS r"), "12:31");
+    assert_eq!(rendered("RETURN date({year: 1984, ordinalDay: 202}) AS r"), "1984-07-20");
+}


### PR DESCRIPTION
Closes #802.

```cypher
date({date: other, day: 28})     expected 1984-11-28, got 1984-11-11
```

**#772 fixed this rule for the composite constructors.** `date()`, `localtime()` and `time()` have their own selection paths and were never taught it, so they returned the selected value unchanged and discarded every override.

The same rule in two places with one copy missed — and the missed copy is in my own recent work. It now lives in one `apply_date_overrides` and one `apply_time_overrides`, called from every path, so they cannot drift.

## The detail that produces a well-formed wrong answer

```cypher
date({date: other, ordinalDay: 28})   -->  1984-01-28, not 1984-11-28
```

`ordinalDay` replaces the whole **day-of-year**, so it moves the month. The four date spellings do not mix: naming `ordinalDay` means the calendar fields are not consulted. Defaulting each field independently yields `1984-11-28` — a perfectly valid date, and wrong. `an_ordinal_override_moves_the_month` pins it.

## Tests

7, including that construction from components alone is undisturbed — the override path must not displace it — and that a selection with no override returns the value unchanged.

## Measured

**3,312 → 3,333 (+21), zero regressions.** `cargo test --workspace --release`: exit 0, **3,432 passed, 0 failed**. Gate MET at 88.6%.