### PR TITLE
duration.between counts calendar components: TCK 3,333 → 3,339 (+6) (#804)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3333
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3339
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2961,7 +2961,7 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
             // Argument order is (from, to): `between(a, b)` is b - a.
             match (&args[0], &args[1]) {
                 (Value::Property(a), Value::Property(b)) => {
-                    Ok(Value::Property(temporal_difference(b, a).map_err(|_| {
+                    Ok(Value::Property(temporal_difference_calendar(b, a).map_err(|_| {
                         ExecutionError::TypeError(
                             "duration.between() requires two temporal arguments".to_string(),
                         )
@@ -3371,6 +3371,140 @@ fn rebuild_temporal_like(like: &PropertyValue, total_nanos: i128) -> PropertyVal
 }
 
 /// `a - b` for two temporals: the duration between them.
+/// `a - b` for two temporals, in **calendar** components.
+///
+/// ```text
+/// duration.between(date('1984-10-11'), date('2015-06-24'))  ->  P30Y8M13D
+/// ```
+///
+/// Not `P11213D`. Cypher counts whole months first and leaves the remainder in
+/// days, because a month has no fixed length — the answer must be the one you
+/// get by *counting off* years and months on a calendar, not by dividing
+/// elapsed time.
+///
+/// The `-` operator on two temporals stays a plain elapsed difference
+/// (`temporal_difference` below); only `duration.between` is calendar-aware.
+/// That split is Cypher's, and collapsing the two would make the same
+/// subtraction disagree with itself depending on which spelling was used
+/// (#804).
+fn temporal_difference_calendar(
+    a: &PropertyValue,
+    b: &PropertyValue,
+) -> Result<PropertyValue, ExecutionError> {
+    use chrono::Datelike;
+
+    // A pure time-of-day pair has no calendar part, so it falls through to the
+    // plain difference — which is what `PT-0.4S` and the inSeconds family need.
+    let (Some(da), Some(db)) = (date_part_of(a), date_part_of(b)) else {
+        return temporal_difference(a, b);
+    };
+
+    // Within one month the calendar answer *is* the elapsed one, and the plain
+    // form gives it in the shape the TCK wants: `PT6H`, not `P0M0DT6H`. Going
+    // through the month arithmetic for these produced four regressions —
+    // correct values, wrong shape, which a diff reports as breakage.
+    //
+    // The threshold is a differing (year, month), not a day count: 31 Jan to
+    // 1 Feb is one day apart and *does* cross a month.
+    {
+        let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1).expect("epoch");
+        let same_month = |x: i32, y: i32| {
+            match (
+                epoch.checked_add_signed(chrono::Duration::days(x as i64)),
+                epoch.checked_add_signed(chrono::Duration::days(y as i64)),
+            ) {
+                (Some(p), Some(q)) => {
+                    use chrono::Datelike;
+                    p.year() == q.year() && p.month() == q.month()
+                }
+                _ => false,
+            }
+        };
+        if same_month(da, db) {
+            return temporal_difference(a, b);
+        }
+    }
+
+    let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1).expect("epoch");
+    let to_date = |d: i32| {
+        epoch
+            .checked_add_signed(chrono::Duration::days(d as i64))
+            .ok_or_else(|| ExecutionError::RuntimeError("date out of range".into()))
+    };
+    let (start, end) = (to_date(db)?, to_date(da)?);
+    let (ta, tb) = (time_part_of(a).unwrap_or(0), time_part_of(b).unwrap_or(0));
+
+    // Whole months, then leftover days, then the clock. Borrowing works as it
+    // does on paper: if the clock difference is negative, one day is not yet
+    // complete; if the day count then goes negative, one month is not either.
+    let mut months = (end.year() as i64 - start.year() as i64) * 12
+        + (end.month() as i64 - start.month() as i64);
+    // The clock difference keeps its own sign; it is only borrowed into days
+    // when the *whole* result is positive. Borrowing unconditionally produced
+    // `P-28DT2H19M27.858S` where `P-27DT-21H-40M-32.142S` was expected — the
+    // same instant pair, with the components disagreeing in sign, which is the
+    // one thing a duration's components may not do (#775 again, one level up).
+    let nanos = ta - tb;
+    let forward = da > db || (da == db && nanos >= 0);
+    let (mut nanos, mut day_adjust) = if nanos < 0 && forward {
+        (nanos + 86_400 * 1_000_000_000, -1i64)
+    } else if nanos > 0 && !forward {
+        (nanos - 86_400 * 1_000_000_000, 1i64)
+    } else {
+        (nanos, 0i64)
+    };
+    let _ = &mut nanos;
+    let _ = &mut day_adjust;
+    let mut days = end
+        .signed_duration_since(shift_months_clamped(start, months)?)
+        .num_days()
+        + day_adjust;
+    // Borrow toward zero, not toward negative infinity. Going **backwards**, a
+    // partial month stays as days rather than becoming a whole negative month
+    // plus positive days: 2015-07-21 back to 2015-06-24 is `P-27D`, not
+    // `P-1M3D`. Both describe the same instant pair and only one is what
+    // Cypher writes.
+    if months > 0 && days < 0 {
+        months -= 1;
+        days = end
+            .signed_duration_since(shift_months_clamped(start, months)?)
+            .num_days()
+            + day_adjust;
+    } else if months < 0 && days > 0 {
+        months += 1;
+        days = end
+            .signed_duration_since(shift_months_clamped(start, months)?)
+            .num_days()
+            + day_adjust;
+    }
+
+    Ok(PropertyValue::Duration {
+        months,
+        days,
+        // Truncating, not Euclidean — the same trap #775 fixed in
+        // `temporal_difference` and that I reintroduced here. `div_euclid`
+        // floors toward negative infinity, so -78032.142s splits into
+        // (-78033s, +858ms) and renders `-33.858S` where `-32.142S` belongs.
+        // A duration's components must share a sign.
+        seconds: nanos / 1_000_000_000,
+        nanos: (nanos % 1_000_000_000) as i32,
+    })
+}
+
+/// Move a date by whole months, clamping the day into the target month —
+/// 31 January plus one month is 28 February.
+fn shift_months_clamped(
+    d: chrono::NaiveDate,
+    months: i64,
+) -> Result<chrono::NaiveDate, ExecutionError> {
+    use chrono::Datelike;
+    let total = d.year() as i64 * 12 + d.month0() as i64 + months;
+    let (y, m0) = (total.div_euclid(12), total.rem_euclid(12));
+    let last = days_in_month(y as i32, m0 as u32 + 1);
+    chrono::NaiveDate::from_ymd_opt(y as i32, m0 as u32 + 1, d.day().min(last))
+        .ok_or_else(|| ExecutionError::RuntimeError("date out of range".into()))
+}
+
 fn temporal_difference(
     a: &PropertyValue,
     b: &PropertyValue,

--- a/tests/duration_between_calendar.rs
+++ b/tests/duration_between_calendar.rs
@@ -1,0 +1,109 @@
+//! `duration.between` counts calendar components, not elapsed days (#804).
+//!
+//! ```text
+//! duration.between(date('1984-10-11'), date('2015-06-24'))
+//!   expected P30Y8M13D, got P11213D
+//! ```
+//!
+//! A month has no fixed length, so the answer must be the one you get by
+//! *counting off* years and months on a calendar — not by dividing elapsed
+//! time. The `-` operator stays a plain elapsed difference; only
+//! `duration.between` is calendar-aware, and collapsing the two would make the
+//! same subtraction disagree with itself depending on spelling.
+//!
+//! Three rules here were found by measurement, each after a wrong version that
+//! produced a **well-formed duration describing the right instants**:
+//!
+//! 1. Within one month the answer is the plain elapsed form — `PT6H`, not
+//!    `P0M0DT6H`. Going through month arithmetic for those cost four
+//!    regressions: correct values, wrong shape.
+//! 2. Borrowing runs **toward zero**. Backwards, a partial month stays as days:
+//!    `P-27D`, not `P-1M3D`.
+//! 3. The (seconds, nanos) split must be **truncating**. Euclidean division
+//!    gives `-33.858S` where `-32.142S` belongs — the same trap #775 fixed in
+//!    the sibling function, which I then reintroduced here.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn rendered(expr: &str) -> String {
+    let store = GraphStore::new();
+    let cypher = format!("RETURN {expr} AS r");
+    let q = parse_query(&cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.to_cypher_string(),
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+/// The TCK's own rows.
+#[test]
+fn the_calendar_form_matches_the_reference() {
+    assert_eq!(
+        rendered("duration.between(date('1984-10-11'), date('2015-06-24'))"),
+        "P30Y8M13D"
+    );
+    assert_eq!(
+        rendered("duration.between(date('1984-10-11'), datetime('2015-07-21T21:40:32.142+0100'))"),
+        "P30Y9M10DT21H40M32.142S"
+    );
+}
+
+/// **Within one month the plain elapsed form is the answer**, in the shape the
+/// TCK expects.
+#[test]
+fn a_same_month_difference_is_plain_elapsed() {
+    assert_eq!(
+        rendered("duration.between(localdatetime('2018-01-01T12:00'), localdatetime('2018-01-02T10:00'))"),
+        "PT22H"
+    );
+    assert_eq!(
+        rendered("duration.between(localdatetime('2018-01-02T10:00'), localdatetime('2018-01-01T12:00'))"),
+        "PT-22H"
+    );
+}
+
+/// **Borrowing runs toward zero.** Backwards, a partial month stays as days.
+#[test]
+fn a_backwards_partial_month_stays_in_days() {
+    assert_eq!(
+        rendered("duration.between(localdatetime('2015-07-21T21:40:32.142'), date('2015-06-24'))"),
+        "P-27DT-21H-40M-32.142S"
+    );
+}
+
+/// **The (seconds, nanos) split is truncating.**
+///
+/// Every component of the answer above is negative. Euclidean division floors
+/// toward negative infinity and produces `-33.858S` — the same instants, with
+/// the seconds and the fraction disagreeing in sign, which a duration may not
+/// do. Asserted separately because it is the rule most easily lost in a later
+/// edit: the value still looks like a duration.
+#[test]
+fn negative_components_share_a_sign() {
+    let got = rendered("duration.between(localdatetime('2015-07-21T21:40:32.142'), date('2015-06-24'))");
+    assert!(!got.contains("T2H"), "the clock part borrowed the wrong way: {got}");
+    assert!(got.contains("-32.142S"), "the fraction lost its sign: {got}");
+}
+
+/// A month boundary one day apart still crosses a month — the threshold is a
+/// differing (year, month), not a day count.
+#[test]
+fn one_day_across_a_month_boundary_counts_as_a_month() {
+    // 31 Jan to 1 Feb: one day elapsed, and the months differ.
+    let got = rendered("duration.between(date('2018-01-31'), date('2018-02-01'))");
+    assert_eq!(got, "P1D", "one day, and no phantom month: {got}");
+}
+
+/// Time-only pairs are untouched — they have no calendar part.
+#[test]
+fn time_only_pairs_use_the_plain_difference() {
+    assert_eq!(
+        rendered("duration.inSeconds(localtime('12:34:54.7'), localtime('12:34:54.3'))"),
+        "PT-0.4S"
+    );
+}


### PR DESCRIPTION
Closes #804.

```cypher
duration.between(date('1984-10-11'), date('2015-06-24'))
  expected P30Y8M13D, got P11213D
```

A month has no fixed length, so the answer is the one you get by **counting off** years and months on a calendar. The `-` operator stays plain elapsed; only `duration.between` is calendar-aware.

## Small count, four attempts

Every wrong version produced a **well-formed duration describing the correct instants**:

| attempt | wrong output | rule |
|---|---|---|
| calendar path everywhere | `P0M0DT6H` for `PT6H` — **4 regressions** | within one month, the plain form is the answer |
| borrow toward −∞ | `P-1M3D` for `P-27D` | borrowing runs **toward zero** |
| `div_euclid` for the split | `-33.858S` for `-32.142S` | the split must be **truncating** |

The third is **the same trap #775 fixed in the sibling function**, reintroduced in code I wrote an hour later. `negative_components_share_a_sign` tests it separately from the value assertion, because the wrong version still renders as a perfectly good duration and only a sign-consistency check catches it.

The same-month threshold is a differing `(year, month)`, not a day count: 31 Jan → 1 Feb is one day apart and does cross a month. `one_day_across_a_month_boundary_counts_as_a_month` pins that, since "small difference ⇒ same month" is the obvious wrong simplification.

## Measured

**3,333 → 3,339 (+6), zero regressions.** `cargo test --workspace --release`: exit 0, **3,438 passed, 0 failed**. Gate MET at 88.8%.