### PR TITLE
Mixed-type duration.between compares only shared components: TCK 3,339 → 3,350 (+11) (#807)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3339
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3350
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3393,9 +3393,49 @@ fn temporal_difference_calendar(
 ) -> Result<PropertyValue, ExecutionError> {
     use chrono::Datelike;
 
-    // A pure time-of-day pair has no calendar part, so it falls through to the
-    // plain difference — which is what `PT-0.4S` and the inSeconds family need.
-    let (Some(da), Some(db)) = (date_part_of(a), date_part_of(b)) else {
+    // Only the components the two values **share** are compared. A date has no
+    // time and a time has no date, so `duration.between(date(...),
+    // localtime('16:30'))` is `PT16H30M` — the clock difference alone, with the
+    // date side contributing nothing.
+    //
+    // Treating the missing part as zero instead gave `P-5396DT-7H-30M`: the
+    // date's midnight measured against a time of day, which is a real duration
+    // between two instants that were never comparable (#807).
+    let (da, db) = (date_part_of(a), date_part_of(b));
+    if da.is_none() || db.is_none() {
+        // Compare instants only when **both** sides carry an offset; otherwise
+        // compare the local readings.
+        //
+        // `time('14:30')` vs `time('16:30+0100')` is `PT1H` — both are zoned, so
+        // the second is 15:30 UTC. But `localtime('14:30')` vs
+        // `time('16:30+0100')` is `PT2H`: the unzoned side has no instant to
+        // convert to, so the offset is not applied to the other. Normalising
+        // unconditionally gets the first right and the second wrong; not
+        // normalising at all does the reverse.
+        let has_offset = |v: &PropertyValue| matches!(v, PropertyValue::Time { .. });
+        let both_zoned = has_offset(a) && has_offset(b);
+        let clock = |v: &PropertyValue| -> Option<i64> {
+            let local = time_part_of(v)?;
+            Some(match v {
+                PropertyValue::Time { offset_seconds, .. } if both_zoned => {
+                    local - *offset_seconds as i64 * 1_000_000_000
+                }
+                _ => local,
+            })
+        };
+        let (ta, tb) = (clock(a), clock(b));
+        // One side may have a date and no time — `duration.between(date(...),
+        // localtime(...))` compares the clocks, and a date's clock is midnight.
+        let (ta, tb) = (ta.unwrap_or(0), tb.unwrap_or(0));
+        let diff = ta - tb;
+        return Ok(PropertyValue::Duration {
+            months: 0,
+            days: 0,
+            seconds: diff / 1_000_000_000,
+            nanos: (diff % 1_000_000_000) as i32,
+        });
+    }
+    let (Some(da), Some(db)) = (da, db) else {
         return temporal_difference(a, b);
     };
 

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3401,6 +3401,21 @@ fn temporal_difference_calendar(
     // Treating the missing part as zero instead gave `P-5396DT-7H-30M`: the
     // date's midnight measured against a time of day, which is a real duration
     // between two instants that were never comparable (#807).
+    // A value with **no** temporal parts at all is not a temporal value, and
+    // is rejected before any of the shared-component logic below. That is
+    // different from a date having no clock: `duration.between("a", dt)` must
+    // fail, while `duration.between(date, localtime)` must not. Defaulting a
+    // missing part to zero conflated the two and made the string case answer
+    // (#807).
+    for v in [a, b] {
+        if date_part_of(v).is_none() && time_part_of(v).is_none() {
+            return Err(ExecutionError::TypeError(format!(
+                "duration.between() needs temporal values, not {}",
+                v.type_name()
+            )));
+        }
+    }
+
     let (da, db) = (date_part_of(a), date_part_of(b));
     if da.is_none() || db.is_none() {
         // Compare instants only when **both** sides carry an offset; otherwise

--- a/tests/duration_between_calendar.rs
+++ b/tests/duration_between_calendar.rs
@@ -107,3 +107,46 @@ fn time_only_pairs_use_the_plain_difference() {
         "PT-0.4S"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Mixed-type pairs (#807): only the components the two values *share* are
+// compared.
+// ---------------------------------------------------------------------------
+
+/// A date and a time share only the clock.
+///
+/// `duration.between(date(...), localtime('16:30'))` is `PT16H30M` — the date
+/// contributes nothing, because a date has no time and a time has no date.
+/// Treating the missing part as zero gave `P-5396DT-7H-30M`: a real duration
+/// between two instants that were never comparable.
+#[test]
+fn a_date_and_a_time_compare_only_their_clocks() {
+    assert_eq!(rendered("duration.between(date('1984-10-11'), localtime('16:30'))"), "PT16H30M");
+    assert_eq!(rendered("duration.between(date('1984-10-11'), time('16:30+0100'))"), "PT16H30M");
+    assert_eq!(rendered("duration.between(localtime('14:30'), date('2015-06-24'))"), "PT-14H-30M");
+}
+
+/// **Offsets are applied only when both sides carry one.**
+///
+/// Two zoned times compare as instants: `time('16:30+0100')` is 15:30 UTC, so
+/// it is one hour after `time('14:30')`. But an *unzoned* time has no instant
+/// to convert to, so against `localtime('14:30')` the same value is compared as
+/// written — two hours.
+///
+/// Normalising unconditionally gets the first right and the second wrong;
+/// never normalising does the reverse. Both are asserted because either alone
+/// permits the other to regress.
+#[test]
+fn offsets_apply_only_when_both_sides_are_zoned() {
+    assert_eq!(rendered("duration.between(time('14:30'), time('16:30+0100'))"), "PT1H");
+    assert_eq!(rendered("duration.between(localtime('14:30'), time('16:30+0100'))"), "PT2H");
+}
+
+/// A local date-time against a zoned time also compares local readings.
+#[test]
+fn a_localdatetime_against_a_zoned_time_uses_local_readings() {
+    assert_eq!(
+        rendered("duration.between(localdatetime('2015-07-21T21:40:32.142'), time('16:30+0100'))"),
+        "PT-5H-10M-32.142S"
+    );
+}


### PR DESCRIPTION
Closes #807.

```cypher
duration.between(date('1984-10-11'), localtime('16:30'))
  expected PT16H30M, got P-5396DT-7H-30M
```

Only the components the two values **share** are compared. Treating a missing part as zero measures the date's midnight against a time of day — a real duration between instants that were never comparable.

## The middle attempt was the trap

| | |
|---|---|
| compare shared components | +7, **1 regression** |
| normalise offsets always | fixed it, **cost 2 others**, broke date/time pairs |
| normalise **only when both sides are zoned** | **+11, zero regressions** |

```cypher
duration.between(time('14:30'), time('16:30+0100'))       -- PT1H, both zoned: instants
duration.between(localtime('14:30'), time('16:30+0100'))  -- PT2H, one unzoned: as written
```

An unzoned time has no instant to convert to, so the other side's offset must not be applied to it. Normalising unconditionally gets the first right and the second wrong; never normalising does the reverse. **Both are asserted** — either alone lets the other regress silently, and either alone looks like progress on the failure in front of you.

This is why the manifest diff runs against the merge base rather than the previous attempt.

## A loosening the suite caught

The shared-component logic defaulted a missing part to zero, so `duration.between("a", datetime)` **answered** instead of raising. `test_eval_function_duration_between_type_error` — pre-existing — caught it.

The collapsed distinction: a **date** has no clock (legitimate, compare what is shared); a **string** has no temporal parts at all (not a temporal value, reject). Same family as the null-versus-type-error work earlier in this run.

## Measured

**3,339 → 3,350 (+11), zero regressions.** `cargo test --workspace --release`: exit 0, **3,443 passed, 0 failed**. Gate MET at 89.1%.