### PR TITLE
Re-zoning a selected temporal converts the instant: TCK 3,350 → 3,384 (+34), 90.0% (#809)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3350
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3384
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2796,10 +2796,45 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                             tmp::resolve_offset(sp, d as i64, t)?,
                             tmp::zone_name(sp),
                         ),
-                        None => (0, None),
+                        // No target zone given: a **zoned source keeps its
+                        // own**. Defaulting to UTC re-labelled the value —
+                        // `datetime({datetime: s})` turned `12:00+02:00` into
+                        // `12:00Z`, the same wall clock two hours earlier.
+                        // Found by a test written for the re-zoning case, which
+                        // is the neighbouring behaviour (#809).
+                        None => match map.get("datetime").or_else(|| map.get("time")) {
+                            Some(PropertyValue::ZonedDateTime { offset_seconds, zone, .. }) => {
+                                (*offset_seconds, zone.clone())
+                            }
+                            Some(PropertyValue::Time { offset_seconds, .. }) => (*offset_seconds, None),
+                            _ => (0, None),
+                        },
                     };
+                    // Selecting a **zoned** source into a different zone
+                    // converts the instant rather than copying the wall clock:
+                    // 12:00 in Europe/Stockholm (+01:00) is 11:00 UTC, which is
+                    // 01:00 in Pacific/Honolulu (-10:00) — not 12:00.
+                    //
+                    // The components are read as local time in the *target*
+                    // zone only when the source had no zone of its own. With a
+                    // zoned source the same reading is an instant, and treating
+                    // it as local time shifts every value by the difference
+                    // between the two offsets (#809).
+                    let source_offset = map
+                        .get("datetime")
+                        .or_else(|| map.get("time"))
+                        .and_then(|v| match v {
+                            PropertyValue::ZonedDateTime { offset_seconds, .. }
+                            | PropertyValue::Time { offset_seconds, .. } => Some(*offset_seconds),
+                            _ => None,
+                        });
                     // The components describe local time; store the instant.
-                    let utc = local - offset_seconds as i64 * 1_000_000_000;
+                    let utc = match source_offset {
+                        // A re-zoning: `local` is already the source's wall
+                        // clock, so undo *its* offset, not the target's.
+                        Some(src) if spec.is_some() => local - src as i64 * 1_000_000_000,
+                        _ => local - offset_seconds as i64 * 1_000_000_000,
+                    };
                     Ok(Value::Property(PropertyValue::ZonedDateTime {
                         secs: utc.div_euclid(1_000_000_000),
                         nanos: utc.rem_euclid(1_000_000_000) as u32,

--- a/tests/temporal_selection_overrides.rs
+++ b/tests/temporal_selection_overrides.rs
@@ -109,3 +109,55 @@ fn component_only_construction_still_works() {
     assert_eq!(rendered("RETURN localtime({hour: 12, minute: 31}) AS r"), "12:31");
     assert_eq!(rendered("RETURN date({year: 1984, ordinalDay: 202}) AS r"), "1984-07-20");
 }
+
+// ---------------------------------------------------------------------------
+// Re-zoning a selected value (#809).
+// ---------------------------------------------------------------------------
+
+/// Selecting a **zoned** source into a different zone converts the instant.
+///
+/// 12:00 in Europe/Stockholm (+01:00 in October) is 11:00 UTC, which is 01:00
+/// in Pacific/Honolulu (−10:00). Copying the wall clock gives 12:00 — the same
+/// numbers in a different zone, describing a moment eleven hours away.
+#[test]
+fn re_zoning_a_zoned_source_converts_the_instant() {
+    let src = "datetime({year: 1984, month: 10, day: 28, hour: 12, timezone: 'Europe/Stockholm'})";
+    assert_eq!(
+        rendered(&format!(
+            "WITH {src} AS s RETURN datetime({{datetime: s, timezone: 'Pacific/Honolulu'}}) AS r"
+        )),
+        "1984-10-28T01:00-10:00[Pacific/Honolulu]"
+    );
+}
+
+/// **An unzoned source is read as local time in the target zone.**
+///
+/// This is the other half, and the two are easy to conflate: with no source
+/// zone there is no instant to convert *from*, so the components mean what
+/// they say in the zone being applied. Converting here instead would shift
+/// every plain construction by the target offset.
+#[test]
+fn an_unzoned_source_is_local_time_in_the_target_zone() {
+    let src = "localdatetime({year: 1984, month: 10, day: 28, hour: 12})";
+    assert_eq!(
+        rendered(&format!(
+            "WITH {src} AS s RETURN datetime({{datetime: s, timezone: 'Pacific/Honolulu'}}) AS r"
+        )),
+        "1984-10-28T12:00-10:00[Pacific/Honolulu]"
+    );
+    // And plain component construction is unaffected.
+    assert_eq!(
+        rendered("RETURN datetime({year: 1984, month: 10, day: 28, hour: 12, timezone: '+02:00'}) AS r"),
+        "1984-10-28T12:00+02:00"
+    );
+}
+
+/// Selecting with no target zone keeps the source's own.
+#[test]
+fn selecting_without_a_target_zone_keeps_the_source_zone() {
+    let src = "datetime({year: 1984, month: 10, day: 28, hour: 12, timezone: '+02:00'})";
+    assert_eq!(
+        rendered(&format!("WITH {src} AS s RETURN datetime({{datetime: s}}) AS r")),
+        "1984-10-28T12:00+02:00"
+    );
+}


### PR DESCRIPTION
Closes #809.

```cypher
WITH datetime({..., hour: 12, timezone: 'Europe/Stockholm'}) AS s
RETURN datetime({datetime: s, timezone: 'Pacific/Honolulu'})
  expected 1984-10-28T01:00-10:00[Pacific/Honolulu]
  got      1984-10-28T12:00-10:00[Pacific/Honolulu]
```

12:00 in Stockholm (+01:00) is 11:00 UTC, which is 01:00 in Honolulu (−10:00). We kept the wall clock and relabelled the zone.

## The distinction

| source | the components mean |
|---|---|
| **zoned** | an instant — convert into the target zone |
| **unzoned** | local time *in* the target zone — no instant to convert from |

Converting unconditionally shifts every plain construction by the target offset; never converting gives the bug. `re_zoning_a_zoned_source_converts_the_instant` and `an_unzoned_source_is_local_time_in_the_target_zone` pin both, because either alone permits the other to regress.

## A second bug, found by the test for the first

Selecting with **no** target zone was dropping the source's offset:

```cypher
RETURN datetime({datetime: s})    -- s is 12:00+02:00
  expected 1984-10-28T12:00+02:00, got 1984-10-28T12:00Z
```

The same wall clock relabelled two hours earlier. That took the change from **+17 to +34** — the half I was not looking for was worth as much as the half I was.

I wrote `selecting_without_a_target_zone_keeps_the_source_zone` expecting it to pass. It is the clearest case this session of an accept-side test earning its keep: most of them confirm nothing is broken, and occasionally one finds what the failing-case list did not name.

## Measured

**3,350 → 3,384 (+34), zero regressions.** `cargo test --workspace --release`: exit 0, **3,446 passed, 0 failed**. Pass rate **90.0%**, gate MET.