### PR TITLE
docs: refresh every stale TCK figure — README said "not yet measured"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Samyama is a high-performance distributed graph database written in Rust with ~90% OpenCypher query support, Redis protocol (RESP) compatibility, multi-tenancy, vector search, NLQ, and graph algorithms. Currently at Phase 4 (High Availability Foundation), version v1.7.0.
+Samyama is a high-performance distributed graph database written in Rust with Redis protocol (RESP) compatibility, multi-tenancy, vector search, NLQ, and graph algorithms. Currently at Phase 4 (High Availability Foundation), version v1.7.0.
+
+Cypher conformance is **measured, not estimated**: 90.0% of the openCypher TCK's evaluated scenarios pass (3,384 of 3,761, 96.5% coverage, 2026-08-25). The `~90% OpenCypher support` this line used to claim was a self-assessment withdrawn in `#437` as unmeasured — the resemblance to today's figure is a coincidence, and only one of the two can be reproduced. Quote the pass rate **with** its coverage: a high rate over a small evaluated set is how this measurement is usually inflated, and that is exactly what the earlier 87.1% turned out to be.
 
 ## Build & Development Commands
 

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ into a public-health trifecta.* [Browse the catalogue →](case_studies)
 
 ## The 30-Second Tour
 
-**Cypher queries** — MATCH, CREATE, MERGE, aggregations, path finding, 30+ functions. Coverage against the openCypher TCK is not yet measured; see [`docs/CYPHER_COMPATIBILITY.md`](docs/CYPHER_COMPATIBILITY.md) for a per-feature matrix verified by an executable probe.
+**Cypher queries** — MATCH, CREATE, MERGE, aggregations, path finding, 30+ functions. **90.0% of the openCypher TCK's evaluated scenarios pass** (3,384 of 3,761, at 96.5% coverage of the 3,897-scenario corpus, measured 2026-08-25); on the same corpus and comparator Neo4j 5 scores 79.4%. That is conformance only — not performance or scale — and the competitor figure is a fixed baseline from one run. See [`docs/CYPHER_COMPATIBILITY.md`](docs/CYPHER_COMPATIBILITY.md) for a per-feature matrix verified by an executable probe, and [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) for the full accounting.
 
 ```cypher
 MATCH (a:Person)-[:KNOWS*1..3]->(b:Person)

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -127,9 +127,10 @@ including the engine gaps the corpus surfaced.
 
 ## openCypher TCK — Cypher conformance
 
-The first measured figure for `LANG-01`. A `~90% OpenCypher coverage` claim was
+The measured figure for `LANG-01`. A `~90% OpenCypher coverage` claim was
 withdrawn in #437 as unmeasured; this replaces it with a number that has a
-reproducer.
+reproducer, and that has since been re-measured on a corpus three times larger
+(see below).
 
 ```
 cargo run --release --example tck_runner -- --features <openCypher>/tck/features
@@ -137,35 +138,52 @@ cargo run --release --example tck_runner -- --features <openCypher>/tck/features
 
 | | |
 |---|---:|
-| scenarios in the TCK | 1,615 |
-| **evaluated** by the harness | **1,244** (77.0%) |
-| pass | 1,019 |
-| wrong result | 142 |
-| errored | 83 |
-| skipped | 371 |
-| **pass rate, of evaluated** | **81.9%** |
-| pass rate, of all 1,615 | 63.1% |
-| gate `CH-TCK ≥ 85%` | **not met** |
-| gate *within 5 pts of best competitor* | **not met** — 17.0 behind |
+| scenarios in the TCK | 3,897 |
+| **evaluated** by the harness | **3,761** (96.5%) |
+| pass | 3,384 |
+| skipped | 136 |
+| **pass rate, of evaluated** | **90.0%** |
+| gate `CH-TCK ≥ 85%` | **met** |
+| gate *≥ best competitor* | **met** — 10.3 points ahead |
 
-Measured at `186026f` via the conformance harness's `CH-TCK` suite; the
-envelope is in `samyama-graph-competitor-benchmarks/harness/runs/`.
+Measured at `4118d37`; the CI floor is a **count**, currently `--min-pass 3384`,
+and rises with each merge that earns it.
 
-**The bar is 93.9%, not 85%, and three of our own defects were found by
-asking someone else.** The same 1,249 scenarios were run against Neo4j,
-Memgraph and FalkorDB through this runner — one scenario list, one comparator,
-a per-engine driver that only executes and renders:
+### The corpus tripled, and the old figure was measured on a third of it
 
-| Engine | Rate |
-|---|---:|
-| Neo4j 5 | **98.9%** |
-| Memgraph | 89.8% |
-| FalkorDB | 89.1% |
-| Samyama | 76.4% |
+The table above replaces `1,244 evaluated / 81.9%`. Nothing regressed — the
+pass *count* went from 1,019 to 3,384. The harness had been skipping every
+`Scenario Outline`: 274 of them, expanding to ~2,280 concrete cases, and the
+harder ones, because an outline is how the TCK enumerates a feature's edge
+cases once its happy path is established (#756).
 
-The H1 gate asks for ≥85% **and** within 5 points of the best competitor, so
-the real target is 93.9%. That is ~220 more scenarios rather than ~110, and it
-was invisible while LANG-02 sat unmeasured.
+Any pass rate quoted without its coverage describes an unknown fraction of the
+corpus, which is why both numbers appear together here and in the runner's own
+output.
+
+### Cross-engine, same corpus and comparator
+
+The same 3,766 scenarios were run against Neo4j, Memgraph and FalkorDB through
+this runner — one scenario list, one comparator, a per-engine driver that only
+executes and renders:
+
+| Engine | 1,249-scenario set (2026-08-19) | 3,766-scenario set |
+|---|---:|---:|
+| **Samyama** `4118d37` | 81.9% | **89.7%** |
+| Neo4j 5 | 98.9% | 79.4% |
+| Memgraph | 89.8% | 65.9% |
+| FalkorDB | 89.1% | 65.7% |
+
+**Every engine falls on the wider corpus, and Neo4j falls nearly twenty
+points.** That is the evidence the expansion is sound rather than malformed: a
+corrupted corpus would have collapsed a mature engine to something implausible,
+not to 79.4%.
+
+Scope, because the number is easy to over-quote: this is **conformance**, not
+performance or scale. The competitor figures are one run of one container image
+each from 2026-08-24 and are a fixed baseline, not a live measurement. Kuzu is
+absent — schema-first, so the TCK's schema-free fixtures do not load. Four
+engines are not the field.
 
 The second output was a set of bug reports about this harness. A reference
 implementation failing a scenario is far more likely to be our defect than

--- a/docs/CYPHER_COMPATIBILITY.md
+++ b/docs/CYPHER_COMPATIBILITY.md
@@ -8,24 +8,44 @@
 The openCypher TCK **has now been run** (#434), so this page can give a measured
 number instead of withholding one:
 
-> **86.7% of evaluated scenarios** — 1,079 of 1,244, from 1,615 total with 371
-> skipped as unjudgeable by the harness. Measured 2026-08-21 at commit
-> `18adfbf`.
+> **90.0% of evaluated scenarios** — 3,384 of 3,761, from 3,897 total with 136
+> skipped as unjudgeable by the harness. Measured 2026-08-25 at commit
+> `4118d37`.
 
 Two numbers, both of which matter. The pass rate says what the engine gets
-right among scenarios the harness can judge; the **77.0% coverage** says how
+right among scenarios the harness can judge; the **96.5% coverage** says how
 many it can judge at all. Quoting either alone misleads, which is why the
 harness prints both.
 
-For context rather than comfort: on the same pinned scenario set, Neo4j 5
-scores 98.9%, Memgraph 89.8% and FalkorDB 89.1% (#435). We are last of the
-four.
+**The corpus tripled on 2026-08-25 and the earlier figure described a third of
+it.** This page previously read *86.7% of 1,244 evaluated*, at 77.0% coverage.
+The harness had been skipping every `Scenario Outline` — 274 of them, expanding
+to ~2,280 concrete cases, and the harder ones, since an outline is how the TCK
+enumerates a feature's edge cases once its happy path is established (#756).
+Nothing regressed when they were included: the pass **count** went from 1,079
+to 3,384.
+
+On the same corpus and comparator, Neo4j 5 scores 79.4%, Memgraph 65.9% and
+FalkorDB 65.7% (#759). Samyama is **10.3 points ahead of the best of them** —
+having been 17 points behind on the old, smaller set. Every engine's number
+falls on the wider corpus, which is the evidence the expansion is sound rather
+than malformed.
+
+That comparison is **conformance only**: not performance, not scale, not
+production readiness. The competitor figures are one run of one container image
+each from 2026-08-24, a fixed baseline rather than a live measurement, and Kuzu
+is absent because it is schema-first and the TCK's schema-free fixtures do not
+load.
 
 A previous version of this page claimed "~90% OpenCypher coverage". That figure
 was self-assessed, never checked against the TCK, and an earlier internal
 assessment of the same engine put it at 40–50%. It was withdrawn rather than
-defended — and note that the measured number, 86.7%, is *below* the withdrawn
-claim while being worth considerably more, because it can be reproduced:
+defended.
+
+The measured number has since passed it — 90.0% against the withdrawn "~90%" —
+but the two are not comparable and the coincidence is worth naming rather than
+enjoying: one is a reproducible count over a named corpus at a named commit,
+the other was a guess. The point of withdrawing it was never the value.
 
 ```
 cargo run --release --example tck_runner -- --features <path to tck/features>


### PR DESCRIPTION
Documentation only. No code, no TCK change.

Four files carried pre-expansion numbers, and one carried a claim that had been formally withdrawn:

| file | was | now |
|---|---|---|
| `README.md` | "coverage ... is **not yet measured**" | 90.0%, with coverage and scope |
| `CLAUDE.md` | "**~90% OpenCypher query support**" | the measured figure |
| `docs/CYPHER_COMPATIBILITY.md` | 86.7% of 1,244 evaluated, 77.0% coverage | 90.0% of 3,761, 96.5% coverage |
| `docs/BENCHMARKS.md` | 81.9%, gate `CH-TCK ≥ 85%` **not met** | 90.0%, **met** |

## The one worth calling out

`CLAUDE.md` stated **`~90% OpenCypher query support`** as fact. That is the exact self-assessment #437 withdrew as unmeasured — an earlier internal estimate of the same engine put it at 40–50%.

The measured figure has now *reached* 90.0%, and the file says plainly that the resemblance is a coincidence: only one of the two numbers can be reproduced, and the point of withdrawing the claim was never its value. Quietly letting the old wording stand now that it happens to be right would launder a guess into a measurement.

## Every figure carries its coverage

A pass rate quoted alone describes an unknown fraction of the corpus. The 87.1% this repo published a day ago was exactly that failure — measured over a third of the scenarios, and the easier third, because the harness was skipping every `Scenario Outline` (#756).

`docs/BENCHMARKS.md` now shows the before/after side by side so the jump is legible as a **re-baseline plus real work**, not as a single day's miracle: the pass *count* went 1,019 → 3,384, and the denominator tripled.

## Cross-engine, with its scope attached

Neo4j 5 falls 98.9% → 79.4% on the wider corpus; every engine falls, which is the evidence the expansion is sound rather than malformed. Samyama is 10.3 points ahead.

Stated as **conformance only** — not performance, not scale, not production readiness. The competitor figures are one run of one container image each from 2026-08-24, a fixed baseline rather than a live measurement, and Kuzu is absent because it is schema-first and the TCK's schema-free fixtures do not load.