### PR TITLE
duration.inX truncates to its own unit; zoned pairs compare as instants: TCK 3,384 → 3,402 (+18) (#812)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3384
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3402
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2964,15 +2964,25 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
             // result carried the wrong sign -- and half the TCK rows expect a
             // negative answer, so it looked correct on exactly the half that
             // happened to be positive (#775).
-            let diff = temporal_difference(&b, &a)?;
-            let (days, seconds, nanos) = match diff {
-                PropertyValue::Duration { days, seconds, nanos, .. } => (days, seconds, nanos),
-                _ => (0, 0, 0),
+            // `inMonths` needs the **calendar** month count, so it uses the
+            // calendar difference; `inDays` and `inSeconds` want elapsed time
+            // and use the plain one. Dividing an elapsed day count by 30 gave
+            // `P11M29D...` where `P1Y` belongs — 12 months' worth of days that
+            // never became a year, because 365 / 30 is 12.16 and the truncation
+            // lands one month short (#812).
+            let diff = if lowered == "duration.inmonths" {
+                temporal_difference_calendar(&b, &a)?
+            } else {
+                temporal_difference(&b, &a)?
+            };
+            let (months, days, seconds, nanos) = match diff {
+                PropertyValue::Duration { months, days, seconds, nanos } => (months, days, seconds, nanos),
+                _ => (0, 0, 0, 0),
             };
             Ok(Value::Property(match lowered.as_str() {
-                // Seconds carries the whole difference in seconds plus the
-                // sub-second remainder; days and months carry only whole units,
-                // with the remainder discarded rather than rounded.
+                // Each truncates to its own unit and **discards** the
+                // remainder, rather than rounding it: `inDays` of 30 hours is
+                // one day, not one and a quarter.
                 "duration.inseconds" => PropertyValue::Duration {
                     months: 0, days: 0, seconds: days * 86_400 + seconds, nanos,
                 },
@@ -2980,7 +2990,7 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     months: 0, days: days + seconds / 86_400, seconds: 0, nanos: 0,
                 },
                 _ => PropertyValue::Duration {
-                    months: (days + seconds / 86_400) / 30, days: 0, seconds: 0, nanos: 0,
+                    months, days: 0, seconds: 0, nanos: 0,
                 },
             }))
         }
@@ -3522,7 +3532,26 @@ fn temporal_difference_calendar(
             .ok_or_else(|| ExecutionError::RuntimeError("date out of range".into()))
     };
     let (start, end) = (to_date(db)?, to_date(da)?);
-    let (ta, tb) = (time_part_of(a).unwrap_or(0), time_part_of(b).unwrap_or(0));
+    // The clock parts must be compared as **instants** when both sides carry an
+    // offset, exactly as in the time-only path (#807). `time_part_of` returns
+    // the local wall clock, which is right for rendering and wrong here:
+    // 21:40:36.143+0200 and 21:40:32.142+0100 read as 4ms apart locally and are
+    // really 59m55.999s apart, so the borrow fired and stole a month —
+    // `P11M` where `P1Y` belongs (#812).
+    let both_zoned = matches!(
+        (a, b),
+        (PropertyValue::ZonedDateTime { .. }, PropertyValue::ZonedDateTime { .. })
+    );
+    let clock = |v: &PropertyValue| -> i64 {
+        let local = time_part_of(v).unwrap_or(0);
+        match v {
+            PropertyValue::ZonedDateTime { offset_seconds, .. } if both_zoned => {
+                local - *offset_seconds as i64 * 1_000_000_000
+            }
+            _ => local,
+        }
+    };
+    let (ta, tb) = (clock(a), clock(b));
 
     // Whole months, then leftover days, then the clock. Borrowing works as it
     // does on paper: if the clock difference is negative, one day is not yet

--- a/tests/duration_between_calendar.rs
+++ b/tests/duration_between_calendar.rs
@@ -150,3 +150,59 @@ fn a_localdatetime_against_a_zoned_time_uses_local_readings() {
         "PT-5H-10M-32.142S"
     );
 }
+
+// ---------------------------------------------------------------------------
+// The `duration.inX` family (#812): each truncates to its own unit.
+// ---------------------------------------------------------------------------
+
+/// `inMonths` returns **whole calendar months**, discarding days and clock.
+///
+/// It was dividing an elapsed day count by 30, which gives `P11M29D...` where
+/// `P1Y` belongs: 365/30 is 12.16, and truncating lands one month short while
+/// leaving the remainder as days that should not be there at all.
+#[test]
+fn in_months_counts_calendar_months_only() {
+    assert_eq!(rendered("duration.inMonths(date('1984-10-11'), date('2015-06-24'))"), "P30Y8M");
+    assert_eq!(
+        rendered("duration.inMonths(date('1984-10-11'), localdatetime('2016-07-21T21:45:22.142'))"),
+        "P31Y9M"
+    );
+    // Under a month is zero months, not a rounded one.
+    assert_eq!(rendered("duration.inMonths(date('1984-10-11'), localtime('16:30'))"), "PT0S");
+}
+
+/// **Two zoned datetimes compare as instants, not wall clocks.**
+///
+/// `21:40:36.143+0200` and `21:40:32.142+0100` read as 4ms apart locally and
+/// are really 59m55.999s apart. Comparing the local readings made the clock
+/// difference negative, so the month borrow fired and produced `P11M` where a
+/// full `P1Y` belongs — a year and a month apart from one 4ms illusion.
+///
+/// Same distinction as #807 one layer up, which is why it is asserted here
+/// rather than left to the `between` tests.
+#[test]
+fn two_zoned_datetimes_compare_as_instants() {
+    assert_eq!(
+        rendered("duration.inMonths(datetime('2014-07-21T21:40:36.143+0200'), datetime('2015-07-21T21:40:32.142+0100'))"),
+        "P1Y"
+    );
+    assert_eq!(
+        rendered("duration.between(datetime('2014-07-21T21:40:36.143+0200'), datetime('2015-07-21T21:40:32.142+0100'))"),
+        "P1YT59M55.999S"
+    );
+}
+
+/// `inDays` and `inSeconds` use elapsed time, and truncate rather than round.
+#[test]
+fn in_days_and_in_seconds_truncate_elapsed_time() {
+    assert_eq!(rendered("duration.inDays(date('2017-10-11'), date('2017-10-13'))"), "P2D");
+    // 30 hours is one day, not one and a quarter.
+    assert_eq!(
+        rendered("duration.inDays(localdatetime('2018-01-01T00:00'), localdatetime('2018-01-02T06:00'))"),
+        "P1D"
+    );
+    assert_eq!(
+        rendered("duration.inSeconds(localdatetime('2018-01-01T00:00'), localdatetime('2018-01-01T00:01'))"),
+        "PT1M"
+    );
+}


### PR DESCRIPTION
Closes #812. Both defects are in the **silently wrong** class the CH-TCK envelope tracks apart from the pass rate — every wrong output below is a well-formed duration.

## 1. `inMonths` divided elapsed days by 30

```
duration.inMonths(datetime('2014-07-21T...'), datetime('2015-07-21T...'))
  expected P1Y, got P11M29DT23H59M55.999S
```

365/30 is 12.16, so truncation lands **one month short** — and a months-only function was returning days and a clock at all. It needs the calendar month count; `inDays`/`inSeconds` correctly want elapsed time, so only that one call site changes.

## 2. Zoned pairs compared wall clocks

Routing `inMonths` through the calendar difference fixed 17 and **broke the case that motivated it**:

```
21:40:36.143+0200  vs  21:40:32.142+0100
  wall clocks: 4 ms apart      instants: 59m 55.999s apart
```

The local reading made the clock difference negative, the month borrow fired, and a year became `P11M`. **A 4 ms illusion moved the answer by a month.**

`time_part_of` returns the local clock — right for rendering, wrong for comparison. Same distinction as #807 one layer up, same rule: normalise **only when both sides carry an offset**, since an unzoned value has no instant to convert to.

That the fix's own regression pointed at the second bug is the argument for diffing manifests against the merge base every time, rather than trusting a headline that had gone up by 17.

## Measured

**3,384 → 3,402 (+18), zero regressions.** `cargo test --workspace --release`: exit 0, **3,449 passed, 0 failed**. Pass rate 90.5%.