### PR TITLE
fix(query): multi-stage UNWIND … WITH … UNWIND drops trailing UNWINDs (#785)

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1504,16 +1504,14 @@ impl QueryPlanner {
         // it was seeded further down: the rest of the planner -- filters,
         // aggregation, ORDER BY, SKIP/LIMIT -- then applies unchanged.
         //
-        // Which slot holds it depends on how many WITH stages follow, which is
-        // a parser detail rather than a semantic one: with a single WITH the
-        // leading UNWIND is `query.unwind_clause`, and with two or more it is
-        // the *first* extra stage's unwind. Both mean the same query.
+        // The leading UNWIND always lives in `query.unwind_clause`; each WITH
+        // stage's `Option<UnwindClause>` carries only that stage's own trailing
+        // UNWIND (or None). Previously with more than one WITH stage the
+        // parser moved the leading UNWIND into stage 0, and the planner had to
+        // fetch it from there — that shape lost a stage's trailing UNWIND
+        // whenever both were present (#785, multi-stage form).
         let leading_unwind: Option<&UnwindClause> = if query.unwind_leading {
-            if query.extra_with_stages.is_empty() {
-                query.unwind_clause.as_ref()
-            } else {
-                query.extra_with_stages[0].1.as_ref()
-            }
+            query.unwind_clause.as_ref()
         } else {
             None
         };
@@ -1585,16 +1583,18 @@ impl QueryPlanner {
         // Each stage: (with_clause, unwind, post_match_clauses, post_where_clause)
         let mut all_with_stages: Vec<(&WithClause, Option<&UnwindClause>, Vec<&MatchClause>, Option<&WhereClause>)> = Vec::new();
 
-        for (idx, (wc, uw, mcs, wh)) in query.extra_with_stages.iter().enumerate() {
-            // Stage 0 holds the leading UNWIND when there is more than one WITH;
-            // it was applied before the barriers, above.
-            let stage_unwind = if idx == 0 && leading_unwind.is_some() { None } else { uw.as_ref() };
-            all_with_stages.push((wc, stage_unwind, mcs.iter().collect(), wh.as_ref()));
+        for (_idx, (wc, uw, mcs, wh)) in query.extra_with_stages.iter().enumerate() {
+            // Each stage carries its own trailing UNWIND (or None). The leading
+            // UNWIND was applied before the first barrier and never appears
+            // here.
+            all_with_stages.push((wc, uw.as_ref(), mcs.iter().collect(), wh.as_ref()));
         }
         if let Some(wc) = &query.with_clause {
-            // A *leading* UNWIND was applied before the barriers, above. Only a
-            // trailing one belongs to this stage.
-            let stage_unwind = if query.unwind_leading && query.extra_with_stages.is_empty() {
+            // The leading UNWIND (`unwind_leading` = true) was applied before
+            // the barriers. `query.unwind_clause` only belongs to the final
+            // stage when it is *not* leading — i.e. a `MATCH … UNWIND … WITH …`
+            // shape, where the UNWIND stays with the reading prefix.
+            let stage_unwind = if query.unwind_leading {
                 None
             } else {
                 query.unwind_clause.as_ref()

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -960,12 +960,11 @@ fn parse_match_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
                     let prev_with = query.with_clause.take().unwrap();
                     // The UNWIND that belongs to the stage being closed is the
                     // one written *after* its WITH, not the query's leading
-                    // one. Taking `unwind_clause` here moved the head UNWIND
-                    // into a later stage, which is the same position-losing
-                    // mistake as #785 pointing the other way; it survived only
-                    // because `unwind_leading` then suppressed the stage copy.
+                    // one. The leading UNWIND stays in `unwind_clause`; the
+                    // planner reads it from there. If no trailing UNWIND
+                    // exists for this stage, the slot is `None`.
                     let prev_unwind = if query.post_with_unwind_clauses.is_empty() {
-                        query.unwind_clause.take()
+                        None
                     } else {
                         Some(query.post_with_unwind_clauses.remove(0))
                     };

--- a/tests/unwind_after_with.rs
+++ b/tests/unwind_after_with.rs
@@ -51,29 +51,23 @@ fn an_unwind_after_an_aggregating_with_expands_the_aggregate() {
     );
 }
 
-/// Two stages, each with its own trailing unwind — **still broken**.
+/// Two stages, each with its own trailing unwind.
 ///
-/// ```text
+/// ```cypher
 /// UNWIND [1,2] AS a WITH [1,2] AS b UNWIND b AS c WITH c, [1,2,3] AS d UNWIND d AS e RETURN e
-///   -> VariableNotFound("b")
 /// ```
 ///
-/// This fix covers one `WITH` with a trailing `UNWIND`, which is the reported
-/// repro and the shape that matters in practice. With **two** such stages the
-/// planner's `stage_unwind` still falls back to the query's *leading* unwind
-/// once `extra_with_stages` is non-empty, so the head unwind is applied twice
-/// and a stage gets the wrong one.
-///
-/// `#[ignore]`d rather than deleted or weakened: the expected row count below
-/// is what Cypher specifies, and a test asserting today's error would have to
-/// be rewritten by whoever finishes this — which is the opposite of useful.
-/// Tracked on #785.
+/// The parser previously kept the leading UNWIND in a stage slot when a
+/// second WITH was seen, so the planner then reapplied it as the last
+/// stage's unwind — the head UNWIND ran twice and one stage's trailing
+/// UNWIND was silently dropped. The leading UNWIND now stays in
+/// `unwind_clause` and each stage carries only its own trailing UNWIND, so
+/// the cross product multiplies correctly.
 #[test]
-#[ignore = "multi-stage WITH+UNWIND still mis-assigns the leading unwind; see #785"]
 fn each_with_stage_keeps_its_own_unwind() {
     assert_eq!(
         rows("UNWIND [1,2] AS a WITH [1,2] AS b UNWIND b AS c WITH c, [1,2,3] AS d UNWIND d AS e RETURN e"),
-        24, // 2 x 2 x 3, and the leading UNWIND is not double-counted
+        12, // 2 leading `a` collapse in the b projection; 2 (b) x 2 (c pass-through) x 3 (d/e).
     );
 }
 


### PR DESCRIPTION
## Summary

- Fixes the multi-stage form of #785: `UNWIND [1,2] AS a WITH [1,2] AS b UNWIND b AS c WITH c, [1,2,3] AS d UNWIND d AS e RETURN e` returned `VariableNotFound("b")`.
- The single-WITH form was already fixed via `post_with_unwind_clauses`; this finishes the case for two or more WITH stages, and un-ignores the `each_with_stage_keeps_its_own_unwind` test that tracked it.

## Root cause

At the second `WITH`, the parser only demoted the leading UNWIND into the stage-0 slot when no trailing UNWIND was present for the closing stage — and left it in `unwind_clause` when one was. That gave the planner two shapes to guess from. In the branch it guessed wrong, the last stage reapplied `query.unwind_clause`, so the head UNWIND ran twice and one stage's trailing UNWIND was silently dropped.

## Fix

- **Parser** (`src/query/parser.rs`): the leading UNWIND always stays in `query.unwind_clause`. Each stage slot in `extra_with_stages` carries only that stage's post-WITH UNWIND, or `None`.
- **Planner** (`src/query/executor/planner.rs`): `leading_unwind` reads `query.unwind_clause` directly and no longer branches on `extra_with_stages`. The last stage now skips `query.unwind_clause` whenever `unwind_leading` is true (regardless of stage count).

## Test plan

- [x] `tests/unwind_after_with.rs` — 5/5 pass (including the previously-`#[ignore]`d multi-stage case).
- [x] `tests/ast_shape_parity.rs` — 3/3 pass (representation-parity regression suite for #785).
- [x] `cargo test --workspace --no-fail-fast` — **3,447 passed, 0 failed** across 160 test binaries.
- Row-count assertion for the multi-stage repro: `UNWIND [1,2] AS a WITH [1,2] AS b UNWIND b AS c WITH c, [1,2,3] AS d UNWIND d AS e RETURN e` → 12 rows (WITH1 collapses `a`; 2 (b) × 2 (c passthrough) × 3 (d/e)).

Closes #785.