### PR TITLE
Extreme years survive construction: TCK 3,402 → 3,426 (+24), 91.1% (#814)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3402
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3426
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1648,6 +1648,22 @@ fn date_part_of(v: &PropertyValue) -> Option<i32> {
     }
 }
 
+/// Split a (days-since-epoch, nanoseconds-of-day) pair into the
+/// (seconds, nanos) a `LocalDateTime` or `ZonedDateTime` stores.
+///
+/// Computing `days * 86_400 * 1_000_000_000` first **overflows i64**: that
+/// product spans only about ±292 years from 1970, so `year: 1` silently became
+/// 1754 and `year: 9999` became 1815. Well-formed date-times, wrapped.
+///
+/// Seconds are the wider unit and cover ±292 *billion* years, so the days go
+/// through seconds and only the sub-day remainder is ever counted in
+/// nanoseconds (#814).
+fn day_and_nanos_to_secs(days: i32, nanos_of_day: i64) -> (i64, u32) {
+    let secs = days as i64 * 86_400 + nanos_of_day.div_euclid(1_000_000_000);
+    (secs, nanos_of_day.rem_euclid(1_000_000_000) as u32)
+}
+
+
 /// Apply a map's date components on top of an already-selected date.
 ///
 /// `{date: other, day: 28}` keeps `other`'s year and month and replaces the
@@ -2681,11 +2697,8 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     let map = &temporal_arg_map(&args[0]).expect("matched a map arm");
                     crate::query::executor::temporal::reject_unknown_map(map)?;
                     let (d, t) = compose_date_and_time(map)?;
-                    let total = d as i64 * 86_400 * 1_000_000_000 + t;
-                    Ok(Value::Property(PropertyValue::LocalDateTime {
-                        secs: total.div_euclid(1_000_000_000),
-                        nanos: total.rem_euclid(1_000_000_000) as u32,
-                    }))
+                    let (secs, nanos) = day_and_nanos_to_secs(d, t);
+                    Ok(Value::Property(PropertyValue::LocalDateTime { secs, nanos }))
                 }
                 Value::Property(PropertyValue::Null) => Ok(Value::Property(PropertyValue::Null)),
                 // A bare temporal value: take its date and time parts.
@@ -2695,11 +2708,8 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                 Value::Property(p) if date_part_of(p).is_some() => {
                     let d = date_part_of(p).unwrap_or(0);
                     let t = time_part_of(p).unwrap_or(0);
-                    let total = d as i64 * 86_400 * 1_000_000_000 + t;
-                    Ok(Value::Property(PropertyValue::LocalDateTime {
-                        secs: total.div_euclid(1_000_000_000),
-                        nanos: total.rem_euclid(1_000_000_000) as u32,
-                    }))
+                    let (secs, nanos) = day_and_nanos_to_secs(d, t);
+                    Ok(Value::Property(PropertyValue::LocalDateTime { secs, nanos }))
                 }
                 _ => Err(ExecutionError::TypeError(
                     "localdatetime() requires a string, a map, or a temporal value".to_string(),
@@ -2787,7 +2797,10 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                         None => None,
                     };
                     let (d, t) = compose_date_and_time(map)?;
-                    let local = d as i64 * 86_400 * 1_000_000_000 + t;
+                    // Seconds, not nanoseconds: the nanosecond product spans
+                    // only ±292 years from 1970 and wraps for anything outside
+                    // 1678..2262 (#814).
+                    let (local_secs, local_nanos) = day_and_nanos_to_secs(d, t);
                     // A named zone has no single offset -- Europe/Stockholm is
                     // +01:00 in October and +02:00 in July -- so it is resolved
                     // against *this* local date, not at parse time (#767).
@@ -2829,15 +2842,15 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                             _ => None,
                         });
                     // The components describe local time; store the instant.
-                    let utc = match source_offset {
-                        // A re-zoning: `local` is already the source's wall
+                    let utc_secs = match source_offset {
+                        // A re-zoning: the reading is already the source's wall
                         // clock, so undo *its* offset, not the target's.
-                        Some(src) if spec.is_some() => local - src as i64 * 1_000_000_000,
-                        _ => local - offset_seconds as i64 * 1_000_000_000,
+                        Some(src) if spec.is_some() => local_secs - src as i64,
+                        _ => local_secs - offset_seconds as i64,
                     };
                     Ok(Value::Property(PropertyValue::ZonedDateTime {
-                        secs: utc.div_euclid(1_000_000_000),
-                        nanos: utc.rem_euclid(1_000_000_000) as u32,
+                        secs: utc_secs,
+                        nanos: local_nanos,
                         offset_seconds,
                         zone,
                     }))
@@ -2857,11 +2870,10 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     };
                     let d = date_part_of(p).unwrap_or(0);
                     let t = time_part_of(p).unwrap_or(0);
-                    let local = d as i64 * 86_400 * 1_000_000_000 + t;
-                    let utc = local - off as i64 * 1_000_000_000;
+                    let (local_secs, nanos) = day_and_nanos_to_secs(d, t);
                     Ok(Value::Property(PropertyValue::ZonedDateTime {
-                        secs: utc.div_euclid(1_000_000_000),
-                        nanos: utc.rem_euclid(1_000_000_000) as u32,
+                        secs: local_secs - off as i64,
+                        nanos,
                         offset_seconds: off,
                         zone,
                     }))

--- a/tests/temporal_extreme_years.rs
+++ b/tests/temporal_extreme_years.rs
@@ -1,0 +1,108 @@
+//! Extreme years survive construction (#814).
+//!
+//! ```text
+//! localdatetime({year: 1, month: 1, day: 1, hour: 1, ...})
+//!   expected 0001-01-01T01:01:01.000000001
+//!   got      1754-08-30T23:44:42.128654849
+//! ```
+//!
+//! The composite constructors computed `days * 86_400 * 1_000_000_000` before
+//! splitting it. **That product spans only about ±292 years from 1970**, so
+//! every value outside roughly 1678..2262 wrapped silently — and came back as a
+//! perfectly well-formed date-time in the wrong century.
+//!
+//! It surfaced as a *sorting* failure. `WithOrderBy1` sorts local date-times
+//! and got the order wrong, which reads as a comparison bug; the comparison was
+//! fine and the values were corrupt before they reached it. 24 scenarios across
+//! WithOrderBy1 and WithOrderBy2 were failing on this.
+//!
+//! Seconds are the wider unit — ±292 *billion* years — so the days now go
+//! through seconds and only the sub-day remainder is counted in nanoseconds.
+//! `date()` was always correct because it never left days.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn rendered(expr: &str) -> String {
+    let store = GraphStore::new();
+    let cypher = format!("RETURN {expr} AS r");
+    let q = parse_query(&cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.to_cypher_string(),
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+/// Both ends of the TCK's range, which straddle the i64-nanosecond limit.
+#[test]
+fn extreme_years_survive_construction() {
+    assert_eq!(
+        rendered("localdatetime({year:1,month:1,day:1,hour:1,minute:1,second:1,nanosecond:1})"),
+        "0001-01-01T01:01:01.000000001"
+    );
+    assert_eq!(
+        rendered("localdatetime({year:9999,month:9,day:9,hour:9,minute:59,second:59,nanosecond:999999999})"),
+        "9999-09-09T09:59:59.999999999"
+    );
+    assert_eq!(
+        rendered("datetime({year:1,month:1,day:1,hour:1,timezone:'+01:00'})"),
+        "0001-01-01T01:00+01:00"
+    );
+    assert_eq!(rendered("datetime({year:9999,month:9,day:9,hour:9,timezone:'Z'})"), "9999-09-09T09:00Z");
+}
+
+/// Ordinary years are undisturbed — the fix must not shift the common case.
+#[test]
+fn ordinary_years_are_unchanged() {
+    assert_eq!(
+        rendered("localdatetime({year:1984,month:10,day:11,hour:12,minute:30,second:14,nanosecond:12})"),
+        "1984-10-11T12:30:14.000000012"
+    );
+    assert_eq!(
+        rendered("datetime({year:2015,month:7,day:21,hour:21,minute:40,timezone:'+01:00'})"),
+        "2015-07-21T21:40+01:00"
+    );
+    assert_eq!(rendered("localdatetime({year:1970,month:1,day:1})"), "1970-01-01T00:00");
+}
+
+/// **Sorting was where this showed up, and it is worth pinning there too.**
+///
+/// The order looked wrong; the comparison was correct and the values were
+/// corrupt before reaching it. A test that only checked construction would not
+/// have connected the two.
+#[test]
+fn extreme_years_sort_correctly() {
+    use samyama::query::executor::MutQueryExecutor;
+    let mut store = GraphStore::new();
+    let setup = "CREATE (:A {d: localdatetime({year:1984,month:10,day:11,hour:12,minute:30})}), \
+                        (:A {d: localdatetime({year:1,month:1,day:1,hour:1,minute:1})}), \
+                        (:A {d: localdatetime({year:9999,month:9,day:9,hour:9,minute:59})}), \
+                        (:A {d: localdatetime({year:1980,month:12,day:11,hour:12,minute:31})})";
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&parse_query(setup).expect("setup parses"))
+        .expect("setup runs");
+
+    let q = parse_query("MATCH (a:A) RETURN a.d AS d ORDER BY a.d").expect("parses");
+    let batch = QueryExecutor::new(&store).execute(&q).expect("runs");
+    let got: Vec<String> = batch
+        .records
+        .iter()
+        .filter_map(|r| match r.get("d") {
+            Some(Value::Property(p)) => Some(p.to_cypher_string()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        got,
+        vec![
+            "0001-01-01T01:01",
+            "1980-12-11T12:31",
+            "1984-10-11T12:30",
+            "9999-09-09T09:59",
+        ]
+    );
+}


### PR DESCRIPTION
Closes #814.

```
localdatetime({year: 1, ...})     →  1754-08-30T23:44:42.128654849
localdatetime({year: 9999, ...})  →  1815-12-07T15:56:08.066277375
```

`days * 86_400 * 1_000_000_000` **overflows i64**. The product spans only ±292 years from 1970, so anything outside roughly **1678..2262** wraps and comes back as a well-formed date-time in the wrong century.

Seconds span ±292 *billion* years, so the days now go through seconds and only the sub-day remainder is counted in nanoseconds. `date()` was always correct — it never leaves days.

## It presented as a sorting bug

The failing scenarios were named `Sort local date times in ascending order`, which reads as a comparison defect. The comparison was fine and the values were corrupt before reaching it.

Two things worth keeping:

* the failure name pointed at the wrong subsystem entirely;
* **the corruption is invisible to any test using dates near the present** — which is every date anyone writes casually. The TCK found it only because it deliberately probes year 1 and year 9999.

`extreme_years_sort_correctly` therefore pins construction **and** sorting together; a construction-only test would not have connected them.

## Measured

**3,402 → 3,426 (+24), zero regressions** — 14 `WithOrderBy1`, 10 `WithOrderBy2`. Silently-wrong scenarios 286 → 244.

`cargo test --workspace --release`: exit 0, **3,452 passed, 0 failed**. Pass rate 91.1%.