### PR TITLE
Complete the duration accessors and floor the negative split (#819)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3428
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3430
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -512,21 +512,60 @@ impl Value {
                 }
             }
             Value::Property(PropertyValue::Duration { months, days, seconds, nanos }) => {
+                // Duration accessors come in two families, and the difference
+                // is the whole design (#819):
+                //
+                //   * **Totals** -- `minutes` is the entire time part in
+                //     minutes (61 for PT1H1M1S), `nanoseconds` is the entire
+                //     time part in nanoseconds.
+                //   * **Remainders**, spelled `<unit>Of<Unit>` -- `minutesOfHour`
+                //     is the same value modulo the next unit up (1).
+                //
+                // `minutes` was returning the remainder and `nanoseconds` was
+                // returning only the sub-second field, so both read as the
+                // wrong family. Nine more accessors were absent and returned
+                // null, which is indistinguishable from a legitimate zero.
+                //
+                // Time and date parts never mix: a month is not a fixed number
+                // of days, so `days` cannot be derived from `months`, and the
+                // two families are computed independently.
+                const NPS: i64 = 1_000_000_000;
+                // Total sub-day time, normalized so the nanosecond remainder is
+                // **non-negative** -- `duration.between` of -86399.9s reports
+                // `seconds = -86400` with `nanosecondsOfSecond = +100000000`,
+                // not -86399 with -900000000.
+                //
+                // This is a presentation split and does not contradict the
+                // sign-consistency invariant (#806), which governs the stored
+                // components: those stay -86399/-900000000 so the duration
+                // still renders as `PT-23H-59M-59.9S`.
+                let total_nanos = *seconds as i128 * NPS as i128 + *nanos as i128;
+                let sec = total_nanos.div_euclid(NPS as i128) as i64;
+                let nos = total_nanos.rem_euclid(NPS as i128) as i64;
+                let int = |x: i64| PropertyValue::Integer(x);
                 match property {
-                    "months" => PropertyValue::Integer(*months),
-                    "days" => PropertyValue::Integer(*days),
-                    "seconds" => PropertyValue::Integer(*seconds),
-                    "nanoseconds" => PropertyValue::Integer(*nanos as i64),
-                    "hours" => PropertyValue::Integer(*seconds / 3600),
-                    "minutes" => PropertyValue::Integer((*seconds % 3600) / 60),
-                    "minutesOfHour" => PropertyValue::Integer((*seconds % 3600) / 60),
-                    "secondsOfMinute" => PropertyValue::Integer(*seconds % 60),
-                    // The sub-second accessors. `nanosecondsOfSecond` returned
-                    // null, so a scenario asserting 0 got null -- which reads
-                    // as "no such field" rather than "zero nanoseconds".
-                    "nanosecondsOfSecond" => PropertyValue::Integer(*nanos as i64),
-                    "millisecondsOfSecond" => PropertyValue::Integer(*nanos as i64 / 1_000_000),
-                    "microsecondsOfSecond" => PropertyValue::Integer(*nanos as i64 / 1_000),
+                    // Date part: totals, then remainders.
+                    "years" => int(*months / 12),
+                    "quarters" => int(*months / 3),
+                    "months" => int(*months),
+                    "weeks" => int(*days / 7),
+                    "days" => int(*days),
+                    "quartersOfYear" => int(*months / 3 % 4),
+                    "monthsOfQuarter" => int(*months % 3),
+                    "monthsOfYear" => int(*months % 12),
+                    "daysOfWeek" => int(*days % 7),
+                    // Time part: totals, then remainders.
+                    "hours" => int(sec / 3600),
+                    "minutes" => int(sec / 60),
+                    "seconds" => int(sec),
+                    "milliseconds" => int((total_nanos / 1_000_000) as i64),
+                    "microseconds" => int((total_nanos / 1_000) as i64),
+                    "nanoseconds" => int(total_nanos as i64),
+                    "minutesOfHour" => int(sec % 3600 / 60),
+                    "secondsOfMinute" => int(sec % 60),
+                    "millisecondsOfSecond" => int(nos / 1_000_000),
+                    "microsecondsOfSecond" => int(nos / 1_000),
+                    "nanosecondsOfSecond" => int(nos),
                     _ => PropertyValue::Null,
                 }
             }

--- a/tests/duration_accessors.rs
+++ b/tests/duration_accessors.rs
@@ -1,0 +1,137 @@
+//! All twenty duration accessors, both families (#819).
+//!
+//! Accessors split into **totals** (`minutes` = the entire time part in
+//! minutes) and **remainders** (`minutesOfHour` = the same quantity modulo the
+//! next unit up). Every bug here was a confusion between the two, or an
+//! accessor that simply did not exist — and a missing accessor returns null,
+//! which is indistinguishable from a legitimate zero.
+//!
+//! The table below is the TCK's own (`Temporal5` scenario 7), transcribed
+//! whole rather than sampled, so a future accessor change has to face all
+//! twenty at once instead of the two someone happened to think of.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn accessors(dur: &str, fields: &[&str]) -> Vec<i64> {
+    let store = GraphStore::new();
+    let projection: Vec<String> = fields
+        .iter()
+        .enumerate()
+        .map(|(i, f)| format!("d.{f} AS c{i}"))
+        .collect();
+    let cypher = format!("WITH {dur} AS d RETURN {}", projection.join(", "));
+    let q = parse_query(&cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    let rec = batch.records.first().expect("one row");
+    fields
+        .iter()
+        .enumerate()
+        .map(|(i, f)| match rec.get(&format!("c{i}")) {
+            Some(Value::Property(PropertyValue::Integer(n))) => *n,
+            // Null is the failure this test exists for: it is what an absent
+            // accessor returns, and it reads exactly like a zero.
+            other => panic!("d.{f} on {dur} gave {other:?}, not an integer"),
+        })
+        .collect()
+}
+
+fn check(dur: &str, expected: &[(&str, i64)]) {
+    let fields: Vec<&str> = expected.iter().map(|(f, _)| *f).collect();
+    let got = accessors(dur, &fields);
+    let mismatched: Vec<String> = expected
+        .iter()
+        .zip(&got)
+        .filter(|((_, want), have)| *want != **have)
+        .map(|((f, want), have)| format!("  d.{f}: want {want}, got {have}"))
+        .collect();
+    assert!(mismatched.is_empty(), "{dur}\n{}", mismatched.join("\n"));
+}
+
+/// The TCK's table, entire.
+#[test]
+fn every_accessor_on_a_positive_duration() {
+    check(
+        "duration({years: 1, months: 4, days: 10, hours: 1, minutes: 1, seconds: 1, nanoseconds: 111111111})",
+        &[
+            // Date part: totals...
+            ("years", 1),
+            ("quarters", 5),
+            ("months", 16),
+            ("weeks", 1),
+            ("days", 10),
+            // ...then remainders.
+            ("quartersOfYear", 1),
+            ("monthsOfQuarter", 1),
+            ("monthsOfYear", 4),
+            ("daysOfWeek", 3),
+            // Time part: totals...
+            ("hours", 1),
+            ("minutes", 61),
+            ("seconds", 3661),
+            ("milliseconds", 3661111),
+            ("microseconds", 3661111111),
+            ("nanoseconds", 3661111111111),
+            // ...then remainders.
+            ("minutesOfHour", 1),
+            ("secondsOfMinute", 1),
+            ("millisecondsOfSecond", 111),
+            ("microsecondsOfSecond", 111111),
+            ("nanosecondsOfSecond", 111111111),
+        ],
+    );
+}
+
+/// `minutes` is a total and `minutesOfHour` a remainder; they agreed only
+/// because `minutes` was computing the remainder. Two hours makes them differ.
+#[test]
+fn totals_and_remainders_are_not_the_same_accessor() {
+    check(
+        "duration({hours: 2, minutes: 5, seconds: 7})",
+        &[
+            ("hours", 2),
+            ("minutes", 125),
+            ("minutesOfHour", 5),
+            ("seconds", 7507),
+            ("secondsOfMinute", 7),
+        ],
+    );
+    check(
+        "duration({years: 2, months: 5})",
+        &[("years", 2), ("months", 29), ("monthsOfYear", 5), ("quarters", 9), ("quartersOfYear", 1)],
+    );
+}
+
+/// The nanosecond remainder is **always non-negative**, with seconds floored to
+/// compensate — the value below is -86399.9s and reports `-86400 / +100000000`.
+///
+/// The stored components stay sign-consistent (#806) so the duration still
+/// renders as `PT-23H-59M-59.9S`; this is a presentation split derived from the
+/// total, which is why a Euclidean division is correct here and wrong there.
+#[test]
+fn a_negative_duration_floors_its_second_and_keeps_nanos_non_negative() {
+    let dur = "duration.between(localdatetime('2018-01-02T10:00:00.1'), localdatetime('2018-01-01T10:00:00.2'))";
+    check(dur, &[("days", 0), ("seconds", -86400), ("nanosecondsOfSecond", 100000000)]);
+
+    // Exactly-divisible negatives have no remainder to borrow and must not
+    // gain a spurious one.
+    let exact = "duration.between(localdatetime('2018-01-02T10:00'), localdatetime('2018-01-01T12:00'))";
+    check(exact, &[("seconds", -79200), ("nanosecondsOfSecond", 0)]);
+}
+
+/// A duration with only a date part still answers its time accessors with zero
+/// rather than null, and the reverse.
+#[test]
+fn absent_parts_read_as_zero_not_null() {
+    check(
+        "duration({days: 3})",
+        &[("days", 3), ("weeks", 0), ("months", 0), ("seconds", 0), ("nanosecondsOfSecond", 0)],
+    );
+    check(
+        "duration({seconds: 3})",
+        &[("days", 0), ("months", 0), ("seconds", 3), ("hours", 0), ("minutes", 0)],
+    );
+}


### PR DESCRIPTION
Closes #819.

Duration accessors come in two families, and every defect here was a confusion between them:

* **Totals** — `minutes` is the entire time part in minutes (61 for `PT1H1M1S`); `nanoseconds` is the entire time part in nanoseconds.
* **Remainders**, spelled `<unit>Of<Unit>` — `minutesOfHour` is the same quantity modulo the next unit up (1).

## Three defects

1. **`minutes` returned the remainder** — `(seconds % 3600) / 60`, byte-for-byte identical to `minutesOfHour`.
2. **`nanoseconds` returned only the sub-second field** instead of the whole time part.
3. **Nine accessors were absent**: `years`, `quarters`, `weeks`, `milliseconds`, `microseconds`, `quartersOfYear`, `monthsOfQuarter`, `monthsOfYear`, `daysOfWeek`. A missing accessor returns null, which is indistinguishable from a legitimate zero — so a scenario asserting `0` fails without saying why.

Date and time parts are computed independently, since a month is not a fixed number of days.

## The negative split

`duration.between` of −86399.9s must report `seconds = -86400` with `nanosecondsOfSecond = +100000000` — the nanosecond remainder is always non-negative.

**This does not contradict #806.** That invariant governs the *stored* components, which stay sign-consistent so the value still renders as `PT-23H-59M-59.9S`. The floor here is a presentation split computed from the stored total. `rem_euclid` is banned on the storage path, not everywhere — and since the obvious reading of #806 is the stronger one, the comment in the code says so explicitly.

## Verification

- TCK **3,428 → 3,430**, regression diff against the merge base **empty**.
- `tests/duration_accessors.rs` transcribes the TCK's twenty-column table whole rather than sampling it, so a future change has to face all twenty at once.
- `--min-pass` ratcheted 3428 → 3430.