### PR TITLE
Read a local temporal in the other operand's zone (#821)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3430
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3460
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3320,6 +3320,95 @@ fn scale_duration(
 /// that decision in one place is the point: the shift used to be written inline
 /// per operator, which is how `+` and `-` came to disagree about whether months
 /// were calendar months.
+/// The zone a value carries, if it carries one.
+///
+/// A `ZonedDateTime` may name a *region* whose offset depends on the moment it
+/// is applied to — `Europe/Stockholm` is +02:00 in summer and +01:00 in winter
+/// — so the name is kept rather than collapsed to the stored offset. A `Time`
+/// only ever carries a fixed offset.
+///
+/// The legacy `DateTime` is deliberately absent: it exists for snapshot
+/// compatibility and is already read as UTC everywhere.
+fn zone_of(v: &PropertyValue) -> Option<crate::query::executor::temporal::TzSpec> {
+    use crate::query::executor::temporal::{parse_timezone_spec, TzSpec};
+    match v {
+        PropertyValue::ZonedDateTime { zone, offset_seconds, .. } => Some(
+            zone.as_deref()
+                .and_then(|z| parse_timezone_spec(z).ok())
+                .unwrap_or(TzSpec::Offset(*offset_seconds)),
+        ),
+        PropertyValue::Time { offset_seconds, .. } => Some(TzSpec::Offset(*offset_seconds)),
+        _ => None,
+    }
+}
+
+/// Both values as instants, with an unzoned value read **in the other's zone**.
+///
+/// Cypher does not compare a local temporal against a zoned one by treating the
+/// local one as UTC. The local one is placed in the zoned one's zone, and only
+/// then are the two instants compared:
+///
+/// ```text
+/// duration.between(localdatetime('2015-07-21T21:40:32.142'),
+///                  datetime('2015-07-21T21:40:32.142+0100'))   ->  PT0S
+/// ```
+///
+/// Reading the left side as UTC gives `PT1H`. Every wrong answer in this class
+/// was off by exactly one offset, which is why it looked like a sign or
+/// rounding bug rather than a missing rule.
+///
+/// Two consequences that are easy to miss:
+///
+///   * **A value with no date borrows the other's.** `duration.between` of a
+///     `time` and a `datetime` compares them on the datetime's day — otherwise
+///     the time-of-day sits at the epoch and the answer is decades.
+///   * **DST is resolved at the local side's own wall clock**, not the zoned
+///     side's. On 2017-10-29 Stockholm falls back at 03:00, so a local
+///     midnight is still +02:00 while 04:00 is already +01:00:
+///
+/// ```text
+/// duration.between(localdatetime({year: 2017, month: 10, day: 29, hour: 0}),
+///                  datetime({year: 2017, month: 10, day: 29, hour: 4,
+///                            timezone: 'Europe/Stockholm'}))    ->  PT5H
+/// ```
+///
+/// `PT5H`, not the `PT4H` the wall clocks suggest. That one hour is the whole
+/// reason this cannot be done by subtracting local readings (#821).
+///
+/// Returns `None` when neither side is zoned, leaving the existing local-only
+/// paths untouched.
+fn zone_aligned_instants(a: &PropertyValue, b: &PropertyValue) -> Option<(i128, i128)> {
+    use crate::query::executor::temporal::resolve_offset;
+    let (za, zb) = (zone_of(a), zone_of(b));
+    if za.is_none() && zb.is_none() {
+        return None;
+    }
+    let (da, db) = (date_part_of(a), date_part_of(b));
+    // A date-less value borrows the other's day. When neither has one — two
+    // `time`s — the day is arbitrary and cancels.
+    let (day_a, day_b) = (da.or(db).unwrap_or(0), db.or(da).unwrap_or(0));
+    // A clock-less value is midnight, which is what a bare `date` means.
+    let (ta, tb) = (time_part_of(a).unwrap_or(0), time_part_of(b).unwrap_or(0));
+    let instant = |own: &Option<_>, other: &Option<_>, day: i32, nanos_of_day: i64| {
+        // Own zone first; the other's only when there is none of one's own.
+        let spec: Option<crate::query::executor::temporal::TzSpec> =
+            own.clone().or_else(|| other.clone());
+        let offset = match &spec {
+            Some(s) => resolve_offset(s, day as i64, nanos_of_day).ok()?,
+            None => 0,
+        };
+        // Seconds carry the day, so a far-off year cannot overflow the way a
+        // nanosecond product does (#814).
+        let secs = day as i128 * 86_400 + nanos_of_day.div_euclid(1_000_000_000) as i128
+            - offset as i128;
+        Some(secs * 1_000_000_000 + nanos_of_day.rem_euclid(1_000_000_000) as i128)
+    };
+    Some((
+        instant(&za, &zb, day_a, ta)?,
+        instant(&zb, &za, day_b, tb)?,
+    ))
+}
+
 fn temporal_epoch_nanos(v: &PropertyValue) -> Option<i128> {
     match v {
         PropertyValue::Date(d) => Some(*d as i128 * 86_400 * 1_000_000_000),
@@ -3501,6 +3590,22 @@ fn temporal_difference_calendar(
         // convert to, so the offset is not applied to the other. Normalising
         // unconditionally gets the first right and the second wrong; not
         // normalising at all does the reverse.
+        // Both sides have a clock and at least one carries a zone: the two are
+        // real instants on a shared day, and only that treatment gets the
+        // daylight-saving rows right (#821). A side with no clock at all — a
+        // bare `date` against a `localtime` — keeps the shared-component rule
+        // below instead, since there is no instant to compare.
+        if time_part_of(a).is_some() && time_part_of(b).is_some() {
+            if let Some((na, nb)) = zone_aligned_instants(a, b) {
+                let diff = na - nb;
+                return Ok(PropertyValue::Duration {
+                    months: 0,
+                    days: 0,
+                    seconds: (diff / 1_000_000_000) as i64,
+                    nanos: (diff % 1_000_000_000) as i32,
+                });
+            }
+        }
         let has_offset = |v: &PropertyValue| matches!(v, PropertyValue::Time { .. });
         let both_zoned = has_offset(a) && has_offset(b);
         let clock = |v: &PropertyValue| -> Option<i64> {
@@ -3657,9 +3762,14 @@ fn temporal_difference(
     a: &PropertyValue,
     b: &PropertyValue,
 ) -> Result<PropertyValue, ExecutionError> {
-    let (na, nb) = match (temporal_epoch_nanos(a), temporal_epoch_nanos(b)) {
-        (Some(x), Some(y)) => (x, y),
-        _ => return Err(ExecutionError::TypeError("not temporal values".to_string())),
+    // When either side carries a zone the other is read in it, rather than as
+    // UTC (#821).
+    let (na, nb) = match zone_aligned_instants(a, b) {
+        Some(pair) => pair,
+        None => match (temporal_epoch_nanos(a), temporal_epoch_nanos(b)) {
+            (Some(x), Some(y)) => (x, y),
+            _ => return Err(ExecutionError::TypeError("not temporal values".to_string())),
+        },
     };
     let diff = na - nb;
     // Truncating division, not Euclidean. `div_euclid`/`rem_euclid` floor

--- a/tests/zone_aligned_comparison.rs
+++ b/tests/zone_aligned_comparison.rs
@@ -1,0 +1,137 @@
+//! A local temporal is read **in the other operand's zone**, not as UTC (#821).
+//!
+//! ```text
+//! duration.between(localdatetime('2015-07-21T21:40:32.142'),
+//!                  datetime('2015-07-21T21:40:32.142+0100'))
+//!   expected PT0S, got PT-1H
+//! ```
+//!
+//! Every wrong answer in this class was off by exactly one offset, which is why
+//! it read as a sign or rounding bug rather than a missing rule.
+//!
+//! The rule has two halves that a single example cannot distinguish, so both are
+//! pinned here:
+//!
+//! 1. **A date-less value borrows the other's day.** Otherwise a `time`
+//!    compared against a `datetime` sits at the epoch and the answer is decades.
+//! 2. **Daylight saving resolves at the *local* side's own wall clock.** This is
+//!    the half that rules out the plausible-but-wrong reading of the same
+//!    examples — see [`daylight_saving_is_resolved_at_each_side_s_own_clock`].
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn duration(expr: &str) -> String {
+    let store = GraphStore::new();
+    let cypher = format!("RETURN {expr} AS r");
+    let q = parse_query(&cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.to_cypher_string(),
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+fn between(a: &str, b: &str) -> String {
+    duration(&format!("duration.between({a}, {b})"))
+}
+
+/// The daylight-saving rows use `duration.inSeconds`, which puts the whole
+/// elapsed time in the seconds field. `duration.between` would split 25 hours
+/// into `P1DT1H`, so the two spellings are not interchangeable here and the
+/// tests below use the one the TCK uses.
+fn in_seconds(a: &str, b: &str) -> String {
+    duration(&format!("duration.inSeconds({a}, {b})"))
+}
+
+/// The plain case: the same wall clock in a zone one hour east is the same
+/// instant, so the difference is zero and not an hour.
+#[test]
+fn a_local_datetime_is_read_in_the_zoned_operands_offset() {
+    assert_eq!(
+        between(
+            "localdatetime('2015-07-21T21:40:32.142')",
+            "datetime('2015-07-21T21:40:32.142+0100')"
+        ),
+        "PT0S"
+    );
+}
+
+/// **This is the test that rules out "subtract the wall clocks".**
+///
+/// Europe/Stockholm falls back at 03:00 on 2017-10-29, so on that date local
+/// midnight is still +02:00 while 04:00 is already +01:00. The two operands are
+/// in *different offsets of the same zone*, and the honest answer is five
+/// hours, not the four the clock faces show.
+///
+/// Every variant below borrows something different — a `localdatetime` brings
+/// its own date, a `date` brings a date and no clock, a `localtime` brings a
+/// clock and no date — and all three must reach the same instant.
+#[test]
+fn daylight_saving_is_resolved_at_each_side_s_own_clock() {
+    let stockholm_4am =
+        "datetime({year: 2017, month: 10, day: 29, hour: 4, timezone: 'Europe/Stockholm'})";
+
+    for local in [
+        "localdatetime({year: 2017, month: 10, day: 29, hour: 0})",
+        "date({year: 2017, month: 10, day: 29})",
+        "localtime({hour: 0})",
+    ] {
+        assert_eq!(in_seconds(local, stockholm_4am), "PT5H", "{local}");
+    }
+
+    // And in the other direction, with the zoned side at the earlier instant.
+    let stockholm_midnight =
+        "datetime({year: 2017, month: 10, day: 29, hour: 0, timezone: 'Europe/Stockholm'})";
+    assert_eq!(
+        in_seconds(stockholm_midnight, "localdatetime({year: 2017, month: 10, day: 29, hour: 4})"),
+        "PT5H"
+    );
+    assert_eq!(in_seconds(stockholm_midnight, "localtime({hour: 4})"), "PT5H");
+    // Crossing midnight into a day that is 25 hours long.
+    assert_eq!(
+        in_seconds(stockholm_midnight, "date({year: 2017, month: 10, day: 30})"),
+        "PT25H"
+    );
+}
+
+/// A `time` has no date and must borrow the other's, or the two are measured
+/// forty-five years apart.
+#[test]
+fn a_date_less_value_borrows_the_others_day() {
+    assert_eq!(
+        between("time('14:30')", "datetime('2015-07-21T21:40:32.142+0100')"),
+        "PT6H10M32.142S"
+    );
+    assert_eq!(
+        between("time('14:30')", "localdatetime('2016-07-21T21:45:22.142')"),
+        "PT7H15M22.142S"
+    );
+}
+
+/// **The offset applies only to sides that carry one**, which is the rule #807
+/// established and which this change must not undo.
+///
+/// `time('14:30')` against `time('16:30+0100')` is `PT1H` — both are zoned, so
+/// the second is 15:30 UTC. `localtime('14:30')` against the same value is
+/// `PT2H`: the unzoned side is read *in* +01:00, which cancels.
+#[test]
+fn zoned_and_unzoned_times_still_differ() {
+    assert_eq!(between("time('14:30')", "time('16:30+0100')"), "PT1H");
+    assert_eq!(between("localtime('14:30')", "time('16:30+0100')"), "PT2H");
+}
+
+/// Comparisons with no zone anywhere keep the shared-component rule: a date has
+/// no clock and a time has no date, so only what they share is compared.
+#[test]
+fn local_only_comparisons_are_untouched() {
+    assert_eq!(between("date({year: 1984, month: 10, day: 11})", "localtime('16:30')"), "PT16H30M");
+    assert_eq!(between("localtime('14:30')", "localtime('16:30')"), "PT2H");
+    assert_eq!(
+        between("localdatetime('2018-01-01T12:00')", "localdatetime('2018-01-02T10:00')"),
+        "PT22H"
+    );
+}


### PR DESCRIPTION
Closes #821.

Comparing a local temporal against a zoned one read the local side as **UTC**. Cypher reads it **in the zoned side's zone**, then compares instants.

```
duration.between(localdatetime('2015-07-21T21:40:32.142'), datetime('2015-07-21T21:40:32.142+0100'))
  expected PT0S    got PT-1H
```

Being off by exactly one offset every time is what made this look like a sign or rounding bug instead of a missing rule.

## Two halves, both pinned

**A date-less value borrows the other's day.** Otherwise a `time` compared against a `datetime` sits at the epoch and the answer is decades.

**Daylight saving resolves at the local side's own wall clock.** On 2017-10-29 Europe/Stockholm falls back at 03:00, so local midnight is still +02:00 while 04:00 is already +01:00 — the two operands are in *different offsets of the same zone*:

```
duration.inSeconds(localdatetime({year: 2017, month: 10, day: 29, hour: 0}),
                   datetime({year: 2017, month: 10, day: 29, hour: 4, timezone: 'Europe/Stockholm'}))
  ->  PT5H
```

`PT5H`, not the `PT4H` the clock faces show. That hour is the only thing separating this rule from "subtract the wall clocks", which fits every non-DST row equally well — so I verified the rule against **six independent TCK rows** in both directions and for all three local types before writing any code.

## Scope

Local-only comparisons are untouched. #807's shared-component rule still governs where neither side carries a zone (`duration.between(date(...), localtime('16:30'))` is `PT16H30M`), and where one side has no clock at all there is no instant to compare. `tests/zone_aligned_comparison.rs::local_only_comparisons_are_untouched` pins that.

## Verification

- TCK **3,430 → 3,460**, regression diff against the merge base **empty**.
- `--min-pass` ratcheted 3430 → 3460.

## Found while testing, filed separately

Writing the tests turned up two things this PR does **not** fix, both outside the TCK rows:

- `duration.between` splits elapsed time into 24-hour days, returning `P1DT1H` across the fall-back day where `P1D` round-trips exactly.
- `datetime + duration` keeps the original offset instead of re-resolving the named zone, producing `2017-10-30T00:00+02:00[Europe/Stockholm]` — an offset that disagrees with its own zone name.

My first version of the DST test asserted `duration.between(...) = PT25H` and failed at `P1DT1H`. The TCK row uses `duration.inSeconds`; the test was wrong, the code was right, and chasing the difference is what surfaced both observations above.