### PR TITLE
Make all/any/none/single three-valued (#826)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3460
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3479
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1193,24 +1193,61 @@ fn eval_predicate_function(
         _ => return Ok(Value::Property(PropertyValue::Boolean(false))),
     };
 
+    // Quantifiers are **three-valued**: a predicate that evaluates to null on
+    // some element makes the answer null unless the elements that *did* decide
+    // already settle it (#826).
+    //
+    // Counting nulls as "not true" -- which is what tracking only `true_count`
+    // does -- collapses the third value into `false`, and `false` is a
+    // perfectly usable answer that the caller will branch on:
+    //
+    //     any(x IN [0, null] WHERE x = 2)     null, was false
+    //     all(x IN [2, null] WHERE x = 2)     null, was false
+    //     single(x IN [2, null] WHERE x = 2)  null, was true
+    //
+    // The last one is the worst of the three: it flips to the *opposite*
+    // certainty rather than to a weaker one.
     let mut true_count = 0usize;
+    let mut false_count = 0usize;
+    let mut unknown = false;
     for item in &items {
         let mut inner_record = record.clone_with_capacity(1);
         inner_record.bind(variable.to_string(), item.clone());
-        let result = eval_expression(predicate, &inner_record, store)?;
-        if matches!(result, Value::Property(PropertyValue::Boolean(true))) {
-            true_count += 1;
+        match eval_expression(predicate, &inner_record, store)? {
+            Value::Property(PropertyValue::Boolean(true)) => true_count += 1,
+            Value::Property(PropertyValue::Boolean(false)) => false_count += 1,
+            Value::Property(PropertyValue::Null) | Value::Null => unknown = true,
+            // A predicate that is neither boolean nor null keeps its existing
+            // treatment. Cypher would raise here; making that change without a
+            // scenario to check it against would be guessing.
+            _ => false_count += 1,
         }
     }
 
-    let result = match name {
-        "all" => true_count == items.len(),
-        "any" => true_count > 0,
-        "none" => true_count == 0,
-        "single" => true_count == 1,
-        _ => false,
+    // Each quantifier has one outcome it can be *certain* of from a single
+    // element. Reaching it beats an unknown; failing to reach it does not,
+    // because the unknown elements could have supplied it.
+    let decided = match name {
+        "all" => (false_count > 0).then_some(false),
+        "any" => (true_count > 0).then_some(true),
+        "none" => (true_count > 0).then_some(false),
+        // `single` is the one that can be settled by *either* certainty:
+        // two trues rule it out no matter what the unknowns hold.
+        "single" => (true_count > 1).then_some(false),
+        _ => Some(false),
     };
-    Ok(Value::Property(PropertyValue::Boolean(result)))
+    let result = match decided {
+        Some(v) => PropertyValue::Boolean(v),
+        None if unknown => PropertyValue::Null,
+        None => PropertyValue::Boolean(match name {
+            "all" => true,
+            "any" => false,
+            "none" => true,
+            "single" => true_count == 1,
+            _ => false,
+        }),
+    };
+    Ok(Value::Property(result))
 }
 
 /// Evaluate reduce(acc = init, x IN list | expr)

--- a/tests/quantifier_three_valued.rs
+++ b/tests/quantifier_three_valued.rs
@@ -1,0 +1,119 @@
+//! `all`/`any`/`none`/`single` are three-valued (#826).
+//!
+//! Tracking only a true-count makes a null predicate result indistinguishable
+//! from a `false` one, so the third truth value never reaches the caller — who
+//! gets a **boolean they will branch on**, not an error and not a null they
+//! might check.
+//!
+//! `single` is the worst of the four: it does not weaken to a wrong-but-cautious
+//! answer, it flips to the *opposite certainty*. `single(x IN [2, null] WHERE
+//! x = 2)` returned `true`, asserting exactly one match, when there might be two.
+//!
+//! The tables below are `Quantifier1`–`Quantifier4` scenario 10, transcribed
+//! whole. The four quantifiers disagree on the same input — `[0, null]` with
+//! `x = 2` is null, false, null and null respectively — so a test covering one
+//! of them says nothing about the others.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// `Some(bool)` for a definite answer, `None` for null.
+fn quantify(q: &str, list: &str, pred: &str) -> Option<bool> {
+    let store = GraphStore::new();
+    let cypher = format!("RETURN {q}(x IN {list} WHERE {pred}) AS r");
+    let parsed = parse_query(&cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&parsed)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(PropertyValue::Boolean(b))) => Some(*b),
+        Some(Value::Property(PropertyValue::Null)) | Some(Value::Null) | None => None,
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+/// One TCK table. `None` in the expectation means the scenario says `null`.
+fn check(q: &str, rows: &[(&str, &str, Option<bool>)]) {
+    let wrong: Vec<String> = rows
+        .iter()
+        .filter_map(|(list, pred, want)| {
+            let got = quantify(q, list, pred);
+            (got != *want).then(|| {
+                let show = |v: &Option<bool>| match v {
+                    Some(b) => b.to_string(),
+                    None => "null".to_string(),
+                };
+                format!("  {q}(x IN {list} WHERE {pred}) -> {}, want {}", show(&got), show(want))
+            })
+        })
+        .collect();
+    assert!(wrong.is_empty(), "\n{}", wrong.join("\n"));
+}
+
+const LISTS: [(&str, &str); 8] = [
+    ("[null]", "x = 2"),
+    ("[null, null]", "x = 2"),
+    ("[0, null]", "x = 2"),
+    ("[2, null]", "x = 2"),
+    ("[null, 2]", "x = 2"),
+    ("[34, 0, null, 5, 900]", "x < 10"),
+    ("[34, 10, null, 15, 900]", "x < 10"),
+    ("[4, 0, null, -15, 9]", "x < 10"),
+];
+
+fn table(q: &str, expected: [Option<bool>; 8]) {
+    let rows: Vec<(&str, &str, Option<bool>)> = LISTS
+        .iter()
+        .zip(expected)
+        .map(|((l, p), want)| (*l, *p, want))
+        .collect();
+    check(q, &rows);
+}
+
+/// A single `false` settles it; otherwise a null leaves it undecided.
+#[test]
+fn all_is_three_valued() {
+    use Some as S;
+    table("all", [None, None, S(false), None, None, S(false), S(false), None]);
+}
+
+/// A single `true` settles it.
+#[test]
+fn any_is_three_valued() {
+    use Some as S;
+    table("any", [None, None, None, S(true), S(true), S(true), None, S(true)]);
+}
+
+/// A single `true` settles it — to `false`.
+#[test]
+fn none_is_three_valued() {
+    use Some as S;
+    table("none", [None, None, None, S(false), S(false), S(false), None, S(false)]);
+}
+
+/// **Two** trues settle it, which no other quantifier does: they rule out
+/// "exactly one" regardless of what the unknown elements hold. One true does
+/// not, because an unknown could be a second.
+#[test]
+fn single_is_settled_by_a_count_not_by_one_element() {
+    use Some as S;
+    table("single", [None, None, None, None, None, S(false), None, S(false)]);
+}
+
+/// Without nulls the four keep their ordinary two-valued answers, including on
+/// the empty list, where they differ from each other.
+#[test]
+fn null_free_lists_are_unaffected() {
+    for (q, empty, some, one) in [
+        ("all", true, false, true),
+        ("any", false, true, true),
+        ("none", true, false, false),
+        ("single", false, false, true),
+    ] {
+        assert_eq!(quantify(q, "[]", "x = 2"), Some(empty), "{q} on []");
+        // Two matches: `single` must say false where `all` and `any` say true.
+        assert_eq!(quantify(q, "[2, 2, 3]", "x = 2"), Some(some), "{q} on [2, 2, 3]");
+        assert_eq!(quantify(q, "[2]", "x = 2"), Some(one), "{q} on [2]");
+    }
+}


### PR DESCRIPTION
Closes #826.

`eval_predicate_function` tracked only a true-count, so a null predicate result was indistinguishable from `false` and the third truth value never reached the caller.

```
any(x IN [0, null] WHERE x = 2)             expected null   got false
all(x IN [2, null] WHERE x = 2)             expected null   got false
none(x IN [34, 10, null] WHERE x < 10)      expected null   got true
single(x IN [2, null] WHERE x = 2)          expected null   got true
```

The result is a **boolean the caller will branch on** — not an error, not a null they might check. And `single` doesn't merely weaken: it flips to the *opposite certainty*, asserting exactly one match where there might be two.

## The rule

Each quantifier has one outcome it can be certain of from a single element. Reaching it beats an unknown; failing to reach it does not, because the unknown elements could have supplied it.

| | certain | otherwise, if any null | otherwise |
|---|---|---|---|
| `all` | a `false` → **false** | null | true |
| `any` | a `true` → **true** | null | false |
| `none` | a `true` → **false** | null | true |
| `single` | **two** trues → **false** | null | exactly one true |

`single` is the only one settled by a *count* rather than a single element — which is why `single(x IN [34, 0, null, 5, 900] WHERE x < 10)` is `false`, not null: 0 and 5 already make two.

I read the `Quantifier1`–`Quantifier4` scenario 10 tables in full before writing the rule rather than inferring it from the failures. The four disagree on the same input (`[0, null]` with `x = 2` is null, false, null, null), so a rule derived from one of them says nothing about the others — and `tests/quantifier_three_valued.rs` transcribes all four tables whole for the same reason.

## Deliberately unchanged

- A predicate returning something neither boolean nor null keeps its current treatment. Cypher would raise; there is no scenario here to check that against.
- `all(x IN null WHERE ...)` still answers `false`. The TCK has no row for a null *list*.

## Verification

- TCK **3,460 → 3,479**, regression diff against the merge base **empty**.
- `--min-pass` ratcheted 3460 → 3479.