### PR TITLE
Give every WITH stage its own UNWIND (#785)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3479
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3504
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1504,16 +1504,14 @@ impl QueryPlanner {
         // it was seeded further down: the rest of the planner -- filters,
         // aggregation, ORDER BY, SKIP/LIMIT -- then applies unchanged.
         //
-        // Which slot holds it depends on how many WITH stages follow, which is
-        // a parser detail rather than a semantic one: with a single WITH the
-        // leading UNWIND is `query.unwind_clause`, and with two or more it is
-        // the *first* extra stage's unwind. Both mean the same query.
+        // The leading UNWIND is always `query.unwind_clause`. It used to be
+        // read from `extra_with_stages[0].1` when there were two or more
+        // stages, because the parser moved it there -- but that slot also
+        // holds a stage's *own* trailing unwind, and nothing distinguished the
+        // two. With both present the stage's unwind was hoisted to the head
+        // and read a variable its WITH had not projected yet (#785).
         let leading_unwind: Option<&UnwindClause> = if query.unwind_leading {
-            if query.extra_with_stages.is_empty() {
-                query.unwind_clause.as_ref()
-            } else {
-                query.extra_with_stages[0].1.as_ref()
-            }
+            query.unwind_clause.as_ref()
         } else {
             None
         };
@@ -1586,15 +1584,22 @@ impl QueryPlanner {
         let mut all_with_stages: Vec<(&WithClause, Option<&UnwindClause>, Vec<&MatchClause>, Option<&WhereClause>)> = Vec::new();
 
         for (idx, (wc, uw, mcs, wh)) in query.extra_with_stages.iter().enumerate() {
-            // Stage 0 holds the leading UNWIND when there is more than one WITH;
-            // it was applied before the barriers, above.
-            let stage_unwind = if idx == 0 && leading_unwind.is_some() { None } else { uw.as_ref() };
-            all_with_stages.push((wc, stage_unwind, mcs.iter().collect(), wh.as_ref()));
+            // Every stage keeps its own trailing UNWIND. Stage 0 used to be
+            // suppressed whenever the query had a leading UNWIND, to undo the
+            // parser storing that leading unwind here; now that it does not,
+            // suppressing stage 0 would simply drop a real clause (#785).
+            let _ = idx;
+            all_with_stages.push((wc, uw.as_ref(), mcs.iter().collect(), wh.as_ref()));
         }
         if let Some(wc) = &query.with_clause {
             // A *leading* UNWIND was applied before the barriers, above. Only a
             // trailing one belongs to this stage.
-            let stage_unwind = if query.unwind_leading && query.extra_with_stages.is_empty() {
+            // A *leading* UNWIND was applied at the head, whatever the stage
+            // count. The `extra_with_stages.is_empty()` guard existed only
+            // because the parser emptied `unwind_clause` when there were more
+            // stages; with that gone, keeping the guard re-applies the head
+            // unwind a second time (#785).
+            let stage_unwind = if query.unwind_leading {
                 None
             } else {
                 query.unwind_clause.as_ref()

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -959,13 +959,25 @@ fn parse_match_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
                     let post_where = query.post_with_where_clause.take();
                     let prev_with = query.with_clause.take().unwrap();
                     // The UNWIND that belongs to the stage being closed is the
-                    // one written *after* its WITH, not the query's leading
-                    // one. Taking `unwind_clause` here moved the head UNWIND
-                    // into a later stage, which is the same position-losing
-                    // mistake as #785 pointing the other way; it survived only
-                    // because `unwind_leading` then suppressed the stage copy.
+                    // one written *after* its WITH. The query's leading UNWIND
+                    // belongs at the head and stays in `unwind_clause`.
+                    //
+                    // Taking `unwind_clause` here made this slot mean two
+                    // different things -- the stage's own unwind when it had
+                    // one, the query's leading unwind when it did not -- and
+                    // the planner cannot tell them apart. It read
+                    // `extra_with_stages[0].1` as the leading unwind and so
+                    // hoisted `UNWIND b AS c` to the head of
+                    //
+                    //   UNWIND [1,2] AS a WITH [1,2] AS b UNWIND b AS c ...
+                    //
+                    // where `b` does not exist yet: `VariableNotFound("b")`.
+                    // A second hack in the planner suppressed stage 0's unwind
+                    // to compensate, and the two cancelled out for every shape
+                    // with no unwind on the first stage -- which is why one
+                    // WITH+UNWIND worked and two did not (#785).
                     let prev_unwind = if query.post_with_unwind_clauses.is_empty() {
-                        query.unwind_clause.take()
+                        None
                     } else {
                         Some(query.post_with_unwind_clauses.remove(0))
                     };

--- a/tests/unwind_after_with.rs
+++ b/tests/unwind_after_with.rs
@@ -58,22 +58,30 @@ fn an_unwind_after_an_aggregating_with_expands_the_aggregate() {
 ///   -> VariableNotFound("b")
 /// ```
 ///
-/// This fix covers one `WITH` with a trailing `UNWIND`, which is the reported
-/// repro and the shape that matters in practice. With **two** such stages the
-/// planner's `stage_unwind` still falls back to the query's *leading* unwind
-/// once `extra_with_stages` is non-empty, so the head unwind is applied twice
-/// and a stage gets the wrong one.
+/// Two stages each carrying their own `UNWIND` now work, and the leading one
+/// is applied exactly once.
 ///
-/// `#[ignore]`d rather than deleted or weakened: the expected row count below
-/// is what Cypher specifies, and a test asserting today's error would have to
-/// be rewritten by whoever finishes this — which is the opposite of useful.
-/// Tracked on #785.
+/// This test was `#[ignore]`d while #785 was open, and **its expected value was
+/// wrong**: it asserted 24 while the comment beside it computed `2 x 2 x 3`,
+/// which is 12. A `WITH` is a projection, not an aggregation, so it does not
+/// multiply rows — the count is one factor per `UNWIND` and nothing else. Had
+/// the fix been judged against 24 it would have looked incomplete when it was
+/// finished, which is the failure mode of an expectation nobody re-derived.
 #[test]
-#[ignore = "multi-stage WITH+UNWIND still mis-assigns the leading unwind; see #785"]
 fn each_with_stage_keeps_its_own_unwind() {
     assert_eq!(
         rows("UNWIND [1,2] AS a WITH [1,2] AS b UNWIND b AS c WITH c, [1,2,3] AS d UNWIND d AS e RETURN e"),
-        24, // 2 x 2 x 3, and the leading UNWIND is not double-counted
+        12, // 2 (a) x 2 (b) x 3 (d); the leading UNWIND is not double-counted
+    );
+    // Three stages, to show the fix is not "one more than before".
+    assert_eq!(
+        rows("UNWIND [1,2] AS a WITH [1,2] AS b UNWIND b AS c WITH c, [1,2,3] AS d UNWIND d AS e WITH e, [1,2] AS f UNWIND f AS g RETURN g"),
+        24, // x 2
+    );
+    // A stage with no UNWIND between two that have one must not shift them.
+    assert_eq!(
+        rows("UNWIND [1,2] AS a WITH [1,2] AS b UNWIND b AS c WITH c AS k WITH k, [1,2,3] AS d UNWIND d AS e RETURN e"),
+        12,
     );
 }
 


### PR DESCRIPTION
Closes #785.

`UNWIND … WITH … UNWIND …` raised `VariableNotFound` on a variable the `WITH` defined one line earlier — but only from the **second** such stage onward. Two compensating hacks cancelled each other out for every shape with no unwind on the first stage, which is exactly why one `WITH`+`UNWIND` worked and two did not.

## What was happening

The parser stored the query's **leading** `UNWIND` in the first extra stage's unwind slot whenever that stage had none of its own. The slot therefore meant two different things and nothing distinguished them. The planner read `extra_with_stages[0].1` as the leading unwind — so when the stage *did* have one, it hoisted that unwind to the head of the query:

```cypher
UNWIND [1,2] AS a WITH [1,2] AS b UNWIND b AS c WITH c, [1,2,3] AS d UNWIND d AS e RETURN e
-- VariableNotFound("b")
```

A second hack suppressed stage 0's unwind to undo the first, and the last stage fell back to `query.unwind_clause` once `extra_with_stages` was non-empty, re-applying the head unwind.

Both are removed rather than adjusted: `unwind_clause` is the leading unwind and nothing else, each stage keeps its own trailing unwind, and the leading one is applied once at the head.

## The ignored test's expectation was wrong

The `#[ignore]`d test left behind for this asserted **24** rows while the comment beside it computed `2 x 2 x 3` — which is 12. A `WITH` is a projection, not an aggregation; it does not multiply rows. Judged against 24, the finished fix would have looked incomplete.

Corrected to 12, and joined by a three-stage case and one with a bare `WITH` between two unwinding stages, so "works for two" cannot pass for "works in general".

## Verification

- TCK **3,479 → 3,504**, regression diff against the merge base **empty**. That is exactly the 25 scenarios that were erroring on `VariableNotFound("inputList")` across `Quantifier9`–`Quantifier12`.
- Fourteen shapes probed before and after, including every one that already worked; only the broken one changed.
- `--min-pass` ratcheted 3479 → 3504.

This closes the last of the four issues deliberately left open at the end of the previous cycle.