### PR TITLE
Accept fractional duration components (#829)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3504
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3514
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2929,29 +2929,82 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     parse_iso_duration(s)
                 }
                 Value::Property(PropertyValue::Map(map)) => {
-                    let months = map.get("months").and_then(|v| v.as_integer()).unwrap_or(0);
-                    let days = map.get("days").and_then(|v| v.as_integer()).unwrap_or(0);
-                    let hours = map.get("hours").and_then(|v| v.as_integer()).unwrap_or(0);
-                    let minutes = map.get("minutes").and_then(|v| v.as_integer()).unwrap_or(0);
-                    let seconds = map.get("seconds").and_then(|v| v.as_integer()).unwrap_or(0);
-                    let years = map.get("years").and_then(|v| v.as_integer()).unwrap_or(0);
-                    // The sub-second components, which were hardcoded to zero:
-                    // `duration({nanoseconds: 1})` silently lost the 1, so the
-                    // value was already wrong before any arithmetic touched it
-                    // (#787). Additive with each other, as everywhere else.
-                    let millis = map.get("milliseconds").and_then(|v| v.as_integer()).unwrap_or(0);
-                    let micros = map.get("microseconds").and_then(|v| v.as_integer()).unwrap_or(0);
-                    let nanos_in = map.get("nanoseconds").and_then(|v| v.as_integer()).unwrap_or(0);
-                    let weeks = map.get("weeks").and_then(|v| v.as_integer()).unwrap_or(0);
-                    let total_months = years * 12 + months;
-                    let sub_nanos = millis * 1_000_000 + micros * 1_000 + nanos_in;
-                    let total_seconds = hours * 3600 + minutes * 60 + seconds
-                        + sub_nanos.div_euclid(1_000_000_000);
+                    // Every component may be **fractional**, and the fraction
+                    // carries into the next smaller unit (#829):
+                    //
+                    //     duration({months: 0.75})   ->  P22DT19H51M49.5S
+                    //     duration({weeks: 2.5})     ->  P17DT12H
+                    //     duration({months: 5, days: 1.5})  ->  P5M1DT12H
+                    //
+                    // `as_integer()` returns `None` for a float, so each of
+                    // these silently became zero: `duration({months: 0.75})`
+                    // was `PT0S`, a well-formed duration nothing downstream
+                    // could question. (#787 was the same shape, one component
+                    // over.)
+                    let num = |key: &str| -> f64 {
+                        map.get(key)
+                            .and_then(|v| v.as_integer().map(|i| i as f64).or_else(|| v.as_float()))
+                            .unwrap_or(0.0)
+                    };
+                    // A mean Gregorian month is 365.2425/12 days, which is
+                    // **exactly 2,629,746 seconds**. Carrying in seconds rather
+                    // than in days keeps the arithmetic on integers-as-floats:
+                    // 0.75 months is 1,972,309.5s exactly, where 0.75 x
+                    // 30.436875 days is not exactly representable and lands a
+                    // hundred nanoseconds short of the expected 49.5S.
+                    const SECS_PER_MEAN_MONTH: f64 = 2_629_746.0;
+
+                    let months_f = num("years") * 12.0 + num("months");
+                    let months = months_f.trunc();
+                    // A month's fraction becomes whole days first, then time --
+                    // 0.75 months is 22 days *and* 19:51:49.5, not 22.83 days.
+                    let month_carry_secs = (months_f - months) * SECS_PER_MEAN_MONTH;
+                    let carry_days = (month_carry_secs / 86_400.0).trunc();
+                    let month_rem_secs = month_carry_secs - carry_days * 86_400.0;
+
+                    let days_f = num("days") + num("weeks") * 7.0 + carry_days;
+                    let days = days_f.trunc();
+
+                    let secs_f = num("hours") * 3600.0
+                        + num("minutes") * 60.0
+                        + num("seconds")
+                        + (days_f - days) * 86_400.0
+                        + month_rem_secs;
+                    let secs = secs_f.trunc();
+
+                    // Sub-second components are additive with each other and
+                    // with whatever fell out of the seconds (#787).
+                    let nanos_f = num("milliseconds") * 1_000_000.0
+                        + num("microseconds") * 1_000.0
+                        + num("nanoseconds")
+                        + (secs_f - secs) * 1_000_000_000.0;
+                    // Ties to even: `.round()` goes half away from zero, which
+                    // biases an exact `...000.5` upward every time.
+                    let nanos_total = nanos_f.round_ties_even() as i64;
+
+                    // Combine seconds and nanoseconds into one total **before**
+                    // splitting, then split truncating toward zero. Neither
+                    // split alone is right, and each looks right on the cases
+                    // the other gets wrong:
+                    //
+                    //   {seconds: 2, milliseconds: -1}  is PT1.999S
+                    //     truncating in place: (2s, -1ms)   mixed signs
+                    //     Euclidean:           (1s, +999ms) correct
+                    //
+                    //   {nanoseconds: -1}               is PT-0.000000001S
+                    //     truncating in place: (0s, -1ns)   correct
+                    //     Euclidean:           (-1s, +999999999ns) mixed signs
+                    //
+                    // The invariant (#806) is that the components share the
+                    // sign of the **total**, so the total is what has to be
+                    // formed first. i128 because seconds can be large and the
+                    // nanosecond product overflows i64 past ~292 years (#814).
+                    let total_nanos = secs as i128 * 1_000_000_000 + nanos_total as i128;
                     Ok(Value::Property(PropertyValue::Duration {
-                        months: total_months,
-                        days: days + weeks * 7,
-                        seconds: total_seconds,
-                        nanos: sub_nanos.rem_euclid(1_000_000_000) as i32,
+                        months: months as i64,
+                        days: days as i64,
+                        seconds: (total_nanos / 1_000_000_000) as i64,
+                        nanos: (total_nanos % 1_000_000_000) as i32,
                     }))
                 }
                 _ => Err(ExecutionError::TypeError("duration() requires string or map argument".to_string())),

--- a/tests/duration_fractional_components.rs
+++ b/tests/duration_fractional_components.rs
@@ -1,0 +1,103 @@
+//! `duration()` accepts fractional components, which carry down (#829).
+//!
+//! Read with `as_integer()`, a float component returned `None` and
+//! `unwrap_or(0)` turned it into zero — so `duration({months: 0.75})` was
+//! `PT0S`, a **well-formed duration nothing downstream can question**. Same
+//! shape as #787, one component over.
+//!
+//! Two details make this more than a division, and each is pinned below:
+//!
+//! * A month's fraction becomes **whole days first, then time**: 0.75 months is
+//!   22 days *and* 19:51:49.5, not 22.83 days.
+//! * A mean Gregorian month is 365.2425/12 days, which is **exactly 2,629,746
+//!   seconds**. Carried in seconds the arithmetic is exact; carried in days
+//!   (`0.75 × 30.436875`) it is not representable in binary and lands a hundred
+//!   nanoseconds short of `49.5S`.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn rendered(map: &str) -> String {
+    let store = GraphStore::new();
+    let cypher = format!("RETURN duration({map}) AS r");
+    let q = parse_query(&cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.to_cypher_string(),
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+fn check(rows: &[(&str, &str)]) {
+    let wrong: Vec<String> = rows
+        .iter()
+        .filter_map(|(map, want)| {
+            let got = rendered(map);
+            (got != *want).then(|| format!("  duration({map})\n    want {want}\n    got  {got}"))
+        })
+        .collect();
+    assert!(wrong.is_empty(), "\n{}", wrong.join("\n"));
+}
+
+/// The TCK's table (`Temporal1` scenario 12), transcribed whole — the integer
+/// rows included, since they are what a carry rule can most easily break.
+#[test]
+fn the_tck_construction_table() {
+    check(&[
+        ("{days: 14, hours: 16, minutes: 12}", "P14DT16H12M"),
+        ("{months: 5, days: 1.5}", "P5M1DT12H"),
+        ("{months: 0.75}", "P22DT19H51M49.5S"),
+        ("{weeks: 2.5}", "P17DT12H"),
+        (
+            "{years: 12, months: 5, days: 14, hours: 16, minutes: 12, seconds: 70}",
+            "P12Y5M14DT16H13M10S",
+        ),
+        ("{days: 14, seconds: 70, milliseconds: 1}", "P14DT1M10.001S"),
+        ("{days: 14, seconds: 70, microseconds: 1}", "P14DT1M10.000001S"),
+        ("{days: 14, seconds: 70, nanoseconds: 1}", "P14DT1M10.000000001S"),
+        ("{minutes: 1.5, seconds: 1}", "PT1M31S"),
+    ]);
+}
+
+/// **The exact-halves case.** `49.5S` is the digit that distinguishes carrying
+/// in seconds from carrying in days: the days constant is not representable in
+/// binary and gives `49.4999999S`.
+#[test]
+fn a_months_fraction_carries_exactly() {
+    check(&[
+        ("{months: 0.75}", "P22DT19H51M49.5S"),
+        ("{months: 0.5}", "P15DT5H14M33S"),
+        ("{months: 1.5}", "P1M15DT5H14M33S"),
+    ]);
+}
+
+/// Each unit's fraction lands in the next unit down, not two down and not in
+/// the same one.
+#[test]
+fn every_unit_carries_into_the_next() {
+    check(&[
+        ("{years: 1.5}", "P1Y6M"),
+        ("{weeks: 1.5}", "P10DT12H"),
+        ("{days: 0.5}", "PT12H"),
+        ("{hours: 1.5}", "PT1H30M"),
+        ("{minutes: 0.5}", "PT30S"),
+        ("{seconds: 0.5}", "PT0.5S"),
+    ]);
+}
+
+/// Negative and mixed-sign components keep sign-consistent parts, which needs
+/// the seconds and nanoseconds summed **before** they are split — see
+/// `duration_sign_invariant.rs` for why neither split works alone.
+#[test]
+fn negative_and_mixed_sign_components() {
+    check(&[
+        ("{nanoseconds: -1}", "PT-0.000000001S"),
+        ("{seconds: 2, milliseconds: -1}", "PT1.999S"),
+        ("{seconds: -2, milliseconds: 1}", "PT-1.999S"),
+        ("{days: -1.5}", "P-1DT-12H"),
+        ("{weeks: -2.5}", "P-17DT-12H"),
+    ]);
+}

--- a/tests/duration_sign_invariant.rs
+++ b/tests/duration_sign_invariant.rs
@@ -84,6 +84,25 @@ fn every_duration_path_is_sign_consistent() {
         "localdatetime('2018-01-01T12:00') - localdatetime('2018-01-02T10:00')",
         // and durations of each other
         "duration({days: 1}) - duration({days: 3, hours: 4})",
+        // **The constructor**, which this list did not reach until a mixed-sign
+        // duration escaped from it (#829). Every entry above is arithmetic, so
+        // the whole class of "built wrong in the first place" was uncovered --
+        // and the two cases below want *opposite* splits, which is what makes
+        // the constructor its own path rather than a caller of the others:
+        //
+        //   {seconds: 2, milliseconds: -1}  is +1.999s -> (1s, +999000000ns)
+        //   {nanoseconds: -1}               is -1ns    -> (0s, -1ns)
+        //
+        // A split chosen to satisfy either one alone violates the invariant on
+        // the other.
+        "duration({seconds: 2, milliseconds: -1})",
+        "duration({nanoseconds: -1})",
+        "duration({seconds: -2, milliseconds: 1})",
+        "duration({minutes: -1, seconds: 1})",
+        "duration({months: -0.75})",
+        "duration({days: -1.5})",
+        "duration({weeks: -2.5})",
+        "duration({hours: 1, minutes: -30, seconds: -1, nanoseconds: -1})",
     ];
     for e in exprs {
         assert_sign_consistent(e);


### PR DESCRIPTION
Closes #829.

Every component was read with `as_integer()`, which returns `None` for a float, so `unwrap_or(0)` turned it into zero.

```
duration({months: 0.75})              got PT0S   want P22DT19H51M49.5S
duration({weeks: 2.5})                got PT0S   want P17DT12H
duration({months: 5, days: 1.5})      got P5M    want P5M1DT12H
duration({minutes: 1.5, seconds: 1})  got PT1S   want PT1M31S
```

A **well-formed duration that renders perfectly** — nothing downstream can question `PT0S`. Same shape as #787, one component over.

## Two details beyond "divide and carry"

**A month's fraction becomes whole days first, then time.** `duration({months: 0.75})` is 22 days *and* 19:51:49.5 — not 22.83 days.

**A mean Gregorian month is 365.2425/12 days, which is exactly 2,629,746 seconds.** Carried in seconds the arithmetic is exact (0.75 months is 1,972,309.5 s on the nose). Carried in days, `0.75 × 30.436875` is not representable in binary and lands a hundred nanoseconds short of the expected `49.5S`. It is the same constant #793 derived for scaling; the *unit it is written in* is what matters here.

Rounding is ties-to-even — `.round()` goes half away from zero and biases an exact `...000.5` upward every time.

## The split has to come after the sum

Both plausible splits are wrong, and each looks right on what the other gets wrong:

```
{seconds: 2, milliseconds: -1}   is PT1.999S
  truncating in place   (2s, -1ms)              mixed signs
  Euclidean             (1s, +999000000ns)      correct

{nanoseconds: -1}                is PT-0.000000001S
  truncating in place   (0s, -1ns)              correct
  Euclidean             (-1s, +999999999ns)     mixed signs
```

#806's invariant is that components share the sign of the **total**, so the total must be formed first. My first attempt truncated in place and produced two `Temporal6` regressions.

**#806's own test did not catch that.** Every expression in its list is *arithmetic* — the constructor was an uncovered path, and "built wrong in the first place" a whole class it could not see. Constructor cases are now in that list, and I verified they fail against the reverted code rather than assuming they would.

## Verification

- TCK **3,504 → 3,514**, regression diff against the merge base **empty**.
- `--min-pass` ratcheted 3504 → 3514.