### PR TITLE
Store a non-literal list property on every write path (#831)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3514
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3526
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3499,6 +3499,35 @@ fn zone_aligned_instants(a: &PropertyValue, b: &PropertyValue) -> Option<(i128, 
     ))
 }
 
+/// A `Value` as something a property can hold, or `None` if it cannot.
+///
+/// The distinction that matters is `Value::List` versus
+/// `PropertyValue::Array`. `eval_expression` produces the latter only when
+/// every element was already a literal, so `{xs: [date('1984-10-11')]}` --
+/// or `[1 + 1]`, or `[abs(-1)]` -- arrives as a `Value::List`.
+///
+/// Five write paths each tested for `Value::Property` separately and each got
+/// this wrong in its own way: two raised "refers to a variable that is not
+/// bound here" about a query with no variables in it, one raised "must be a
+/// scalar" about a list, and the relationship path **silently stored nothing**
+/// -- `CREATE ()-[:R {xs: [date(...)]}]->()` succeeded with `xs` null (#831).
+///
+/// `Value::Null` is deliberately not handled here: the paths disagree about
+/// whether an unbound variable is an error or a null property, and that
+/// disagreement is theirs to keep.
+fn storable_property(v: &Value) -> Option<PropertyValue> {
+    match v {
+        Value::Property(p) => Some(p.clone()),
+        Value::List(items) => items
+            .iter()
+            .map(storable_property)
+            .collect::<Option<Vec<_>>>()
+            .map(PropertyValue::Array),
+        // A property can hold neither an entity nor a map.
+        _ => None,
+    }
+}
+
 fn temporal_epoch_nanos(v: &PropertyValue) -> Option<i128> {
     match v {
         PropertyValue::Date(d) => Some(*d as i128 * 86_400 * 1_000_000_000),
@@ -9612,11 +9641,11 @@ impl PhysicalOperator for CreateNodeOperator {
                 if let Some(exprs) = property_exprs {
                     let empty = Record::new();
                     for (key, expr) in exprs {
-                        match eval_expression(expr, &empty, store) {
-                            Ok(Value::Property(p)) => {
+                        match eval_expression(expr, &empty, store).ok().as_ref().and_then(storable_property) {
+                            Some(p) => {
                                 evaluated.insert(key.clone(), p);
                             }
-                            _ => {
+                            None => {
                                 let _ = store.delete_node(tenant_id, node_id);
                                 return Err(ExecutionError::RuntimeError(format!(
                                     "CREATE property `{key}` refers to a variable that is not bound here; bind it first with MATCH, WITH or UNWIND"
@@ -10539,7 +10568,7 @@ impl PhysicalOperator for CreateNodesAndEdgesOperator {
 
         // Phase 1: Create all edges
         if self.phase == 1 {
-            for (source_var, target_var, edge_type, properties, edge_var, _exprs) in
+            for (source_var, target_var, edge_type, properties, edge_var, exprs) in
                 &self.edges_to_create
             {
                 let source_id = self.var_to_node_id.get(source_var)
@@ -10547,12 +10576,37 @@ impl PhysicalOperator for CreateNodesAndEdgesOperator {
                 let target_id = self.var_to_node_id.get(target_var)
                     .ok_or_else(|| ExecutionError::VariableNotFound(target_var.clone()))?;
 
+                // Non-literal property values, evaluated before the edge is
+                // created so the immutable borrow ends first.
+                //
+                // This operator discarded them (`_exprs`), and the literal map
+                // carries a `Null` placeholder for each -- so
+                // `CREATE ()-[:R {xs: [date('1984-10-11')]}]->()` reported
+                // success and stored `xs = null`. Silent data loss on the write
+                // path, which no read can distinguish from a property that was
+                // never set (#831).
+                let mut evaluated: Vec<(String, PropertyValue)> = Vec::new();
+                if let Some(exprs) = exprs {
+                    let empty = Record::new();
+                    for (key, expr) in exprs {
+                        if let Some(pv) =
+                            storable_property(&eval_expression(expr, &empty, store)?)
+                        {
+                            evaluated.push((key.clone(), pv));
+                        }
+                    }
+                }
+
                 let edge_id = store.create_edge(*source_id, *target_id, edge_type.clone())
                     .map_err(|e| ExecutionError::GraphError(e.to_string()))?;
 
-                // Set properties on edge via DS-07c sparse map
+                // Set properties on edge via DS-07c sparse map. The evaluated
+                // expressions go last so they overwrite the placeholders.
                 for (key, value) in properties {
                     store.set_edge_property_sparse(edge_id, key.clone(), value.clone());
+                }
+                for (key, value) in evaluated {
+                    store.set_edge_property_sparse(edge_id, key, value);
                 }
 
                 // Always track created edges for persistence (even without variable names)
@@ -10694,13 +10748,15 @@ impl PhysicalOperator for MatchCreateEdgeOperator {
                         for (key, expr) in exprs {
                             let value = eval_expression(expr, &record, store)?;
                             let pv = match value {
-                                Value::Property(p) => p,
                                 Value::Null => PropertyValue::Null,
-                                other => {
-                                    return Err(ExecutionError::TypeError(format!(
-                                        "property `{key}` must be a scalar, got {other:?}"
-                                    )))
-                                }
+                                other => match storable_property(&other) {
+                                    Some(p) => p,
+                                    None => {
+                                        return Err(ExecutionError::TypeError(format!(
+                                            "property `{key}` must be a scalar, got {other:?}"
+                                        )))
+                                    }
+                                },
                             };
                             evaluated.insert(key.clone(), pv);
                         }
@@ -10750,7 +10806,9 @@ impl PhysicalOperator for MatchCreateEdgeOperator {
                     // defect the node side had in #467.
                     if let Some(exprs) = property_exprs {
                         for (key, expr) in exprs {
-                            if let Value::Property(pv) = eval_expression(expr, &record, store)? {
+                            if let Some(pv) =
+                                storable_property(&eval_expression(expr, &record, store)?)
+                            {
                                 store.set_edge_property_sparse(edge_id, key.clone(), pv);
                             }
                         }
@@ -10764,7 +10822,9 @@ impl PhysicalOperator for MatchCreateEdgeOperator {
                     // defect the node side had in #467.
                     if let Some(exprs) = property_exprs {
                         for (key, expr) in exprs {
-                            if let Value::Property(pv) = eval_expression(expr, &record, store)? {
+                            if let Some(pv) =
+                                storable_property(&eval_expression(expr, &record, store)?)
+                            {
                                 store.set_edge_property_sparse(edge_id, key.clone(), pv);
                             }
                         }
@@ -12441,17 +12501,19 @@ impl MergeOperator {
         let mut out = literals.cloned().unwrap_or_default();
         for (key, expr) in exprs.into_iter().flatten() {
             match eval_expression(expr, record, store)? {
-                Value::Property(pv) => {
-                    out.insert(key.clone(), pv);
-                }
                 Value::Null => {
                     out.insert(key.clone(), PropertyValue::Null);
                 }
-                other => {
-                    return Err(ExecutionError::TypeError(format!(
-                        "MERGE property `{key}` must be a scalar value, got {other:?}"
-                    )));
-                }
+                other => match storable_property(&other) {
+                    Some(pv) => {
+                        out.insert(key.clone(), pv);
+                    }
+                    None => {
+                        return Err(ExecutionError::TypeError(format!(
+                            "MERGE property `{key}` must be a scalar value, got {other:?}"
+                        )));
+                    }
+                },
             }
         }
         Ok(Some(out))
@@ -12899,14 +12961,16 @@ impl PhysicalOperator for ForeachOperator {
                             for (k, expr) in prop_exprs {
                                 let val = eval_expression(expr, &inner_record, store)?;
                                 let prop_val = match val {
-                                    Value::Property(p) => p,
                                     Value::Null => PropertyValue::Null,
-                                    other => {
-                                        return Err(ExecutionError::TypeError(format!(
-                                            "FOREACH CREATE: property `{k}` evaluated to {other:?}, \
+                                    other => match storable_property(&other) {
+                                        Some(p) => p,
+                                        None => {
+                                            return Err(ExecutionError::TypeError(format!(
+                                                "FOREACH CREATE: property `{k}` evaluated to {other:?}, \
 which cannot be stored as a property value"
-                                        )))
-                                    }
+                                            )))
+                                        }
+                                    },
                                 };
                                 let _ = store.set_node_property(tenant_id, node_id, k.to_string(), prop_val);
                             }

--- a/tests/list_property_write_paths.rs
+++ b/tests/list_property_write_paths.rs
@@ -1,0 +1,112 @@
+//! A list property whose elements are not literals, on every write path (#831).
+//!
+//! `eval_expression` produces `PropertyValue::Array` only when every element
+//! was already a literal. A function call or an arithmetic expression comes
+//! back as `Value::List` instead, and six write paths each tested for
+//! `Value::Property` separately — refusing it with three different messages,
+//! skipping it silently, or storing `null`.
+//!
+//! Two things make this worth a table rather than a single case:
+//!
+//! * **`SET` was already correct**, so the value round-trips fine once it is
+//!   in. That makes the defect look like a constructor problem instead of a
+//!   write-path one.
+//! * **`CREATE ()-[:R {xs: [...]}]->()` reported success and stored `null`.**
+//!   No read can tell that from a property that was never set.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn exec(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+}
+
+/// The single property value the store now holds for `xs`.
+fn stored(store: &GraphStore, read: &str) -> PropertyValue {
+    let q = parse_query(read).expect("read parses");
+    let batch = QueryExecutor::new(store).execute(&q).expect("read runs");
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.clone(),
+        other => panic!("{read}\n  got {other:?}"),
+    }
+}
+
+const LIST: &str = "[date({year: 1984, month: 10, day: 12})]";
+
+fn expected() -> PropertyValue {
+    PropertyValue::Array(vec![PropertyValue::Date(5398)])
+}
+
+/// Every way of writing a node property.
+#[test]
+fn every_node_write_path_stores_the_list() {
+    for write in [
+        format!("CREATE ({{xs: {LIST}}})"),
+        format!("MERGE ({{xs: {LIST}}})"),
+        format!("WITH {LIST} AS v CREATE ({{xs: v}})"),
+        format!("UNWIND [1] AS i CREATE ({{xs: {LIST}}})"),
+        format!("FOREACH (i IN [1] | CREATE ({{xs: {LIST}}}))"),
+    ] {
+        let mut store = GraphStore::new();
+        exec(&mut store, &write);
+        assert_eq!(stored(&store, "MATCH (n) RETURN n.xs AS r"), expected(), "{write}");
+    }
+
+    // SET was already correct and must stay so.
+    let mut store = GraphStore::new();
+    exec(&mut store, "CREATE ({id: 1})");
+    exec(&mut store, &format!("MATCH (n) SET n.xs = {LIST}"));
+    assert_eq!(stored(&store, "MATCH (n) RETURN n.xs AS r"), expected());
+}
+
+/// **The silent one.** This path reported success and stored `null`.
+#[test]
+fn a_relationship_property_is_not_silently_dropped() {
+    let mut store = GraphStore::new();
+    exec(&mut store, &format!("CREATE ()-[:R {{xs: {LIST}}}]->()"));
+    assert_eq!(
+        stored(&store, "MATCH ()-[e]->() RETURN e.xs AS r"),
+        expected(),
+        "the relationship's list property was stored as null"
+    );
+}
+
+/// It was never about temporal values: any non-literal element does it.
+#[test]
+fn any_non_literal_element_is_affected() {
+    for (list, want) in [
+        ("[1 + 1]", PropertyValue::Array(vec![PropertyValue::Integer(2)])),
+        ("[abs(-1)]", PropertyValue::Array(vec![PropertyValue::Integer(1)])),
+        (
+            "[toUpper('a'), 'b']",
+            PropertyValue::Array(vec![
+                PropertyValue::String("A".into()),
+                PropertyValue::String("b".into()),
+            ]),
+        ),
+    ] {
+        let mut store = GraphStore::new();
+        exec(&mut store, &format!("CREATE ({{xs: {list}}})"));
+        assert_eq!(stored(&store, "MATCH (n) RETURN n.xs AS r"), want, "{list}");
+    }
+}
+
+/// Lists that were already all-literal went down a different branch and must
+/// keep working unchanged.
+#[test]
+fn all_literal_lists_are_undisturbed() {
+    let mut store = GraphStore::new();
+    exec(&mut store, "CREATE ({xs: [1, 2, 3]})");
+    assert_eq!(
+        stored(&store, "MATCH (n) RETURN n.xs AS r"),
+        PropertyValue::Array(vec![
+            PropertyValue::Integer(1),
+            PropertyValue::Integer(2),
+            PropertyValue::Integer(3)
+        ])
+    );
+}


### PR DESCRIPTION
Closes #831.

```cypher
CREATE ({xs: [date({year: 1984, month: 10, day: 12})]})
-- RuntimeError: CREATE property `xs` refers to a variable that is not bound here
```

There is no variable in that query. It isn't about temporal values either — `[1 + 1]`, `[abs(-1)]` and `[toUpper('a')]` fail identically. The rule is: **a list literal any of whose elements is not itself a literal**.

`eval_expression` produces `PropertyValue::Array` only when every element was already a literal; anything else comes back as `Value::List`. Six write paths each tested for `Value::Property` separately, and each got it wrong in its own way:

| path | behaviour |
|---|---|
| `CREATE` node, no input row | "refers to a variable that is not bound here" |
| `CREATE` node, with input row | "property must be a scalar" |
| `CREATE` relationship (2 sites) | property silently skipped |
| `CREATE` relationship, no input row | `_exprs` discarded entirely; **stored as `null`** |
| `MERGE` | "must be a scalar value, got List" |
| `FOREACH CREATE` | "cannot be stored as a property value" |
| `SET` | **correct** |

**`SET` being correct is what hid this.** The value round-trips fine once it is in, so the defect reads as a constructor problem rather than a write-path one.

## The serious case is not an error

`CREATE ()-[:R {xs: [date('1984-10-11')]}]->()` **reported success and stored `xs = null`.** The literal map carries a `Null` placeholder for each non-literal property and that operator never evaluated the expressions — so no read can distinguish the result from a property that was never set. Silent data loss on the write path.

## Fix

One `storable_property(&Value) -> Option<PropertyValue>` used by all of them, recursing into lists. Each site keeps its own policy for `Value::Null`, because the paths genuinely disagree about whether an unbound variable is an error or a null property, and that disagreement is theirs to keep.

Six sites for one rule is the shape #777 and #800 had. Patching whichever site the failing scenario named would have left five.

## Verification

- TCK **3,514 → 3,526** — the whole of `Temporal4`'s array-storage scenarios — regression diff against the merge base **empty**.
- `tests/list_property_write_paths.rs` walks all six paths plus `SET`, and pins the relationship case against `null` specifically.
- `--min-pass` ratcheted 3514 → 3526.