### PR TITLE
Bind IN tighter than the comparison operators (#833)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3526
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3535
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -80,7 +80,16 @@ static PRATT_PARSER: LazyLock<PrattParser<Rule>> = LazyLock::new(|| {
         // NOT sits between AND and the comparisons: `NOT a STARTS WITH b` negates the
         // comparison, while `NOT a AND b` still groups as `(NOT a) AND b`.
         .op(Op::prefix(Rule::not_op))
-        .op(Op::infix(Rule::in_op, Assoc::Left) | Op::infix(Rule::comparison_op, Assoc::Left))
+        .op(Op::infix(Rule::comparison_op, Assoc::Left))
+        // `IN` binds **tighter than every comparison operator**, so
+        // `a < b IN c` is `a < (b IN c)` and not `(a < b) IN c` (#833).
+        //
+        // Sharing a level with the comparisons made it group left, and the two
+        // readings agree whenever the list holds what the comparison would have
+        // produced -- which is most hand-written queries and every example
+        // anyone reaches for. The TCK settles it by enumerating all three
+        // truth values against six lists at once.
+        .op(Op::infix(Rule::in_op, Assoc::Left))
         .op(Op::infix(Rule::add_sub_op, Assoc::Left))
         .op(Op::infix(Rule::mul_div_mod_op, Assoc::Left))
         // Exponentiation binds tightest and associates to the *right*:

--- a/tests/in_operator_precedence.rs
+++ b/tests/in_operator_precedence.rs
@@ -1,0 +1,97 @@
+//! `IN` binds tighter than every comparison operator (#833).
+//!
+//! ```text
+//! true < false IN [false]
+//!   is  true < (false IN [false])   ->  true < true   ->  false
+//!   not (true < false) IN [false]   ->  false IN [false]  ->  true
+//! ```
+//!
+//! `in_op` shared a Pratt level with `comparison_op`, so the two grouped left
+//! to right. The readings agree whenever the list happens to hold what the
+//! comparison would have produced — which is most hand-written queries and
+//! every example anyone reaches for.
+//!
+//! So each case below asserts the bare form against the **right**-grouped form
+//! *and* checks that the left grouping would have given something else. A case
+//! where both groupings agree proves nothing, and this file would be quietly
+//! vacuous without that second half.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// `Some(bool)` for a definite answer, `None` for null.
+fn truth(expr: &str) -> Option<bool> {
+    let store = GraphStore::new();
+    let cypher = format!("RETURN {expr} AS r");
+    let q = parse_query(&cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(samyama::graph::PropertyValue::Boolean(b))) => Some(*b),
+        _ => None,
+    }
+}
+
+/// `lhs op rhs IN list` must equal `lhs op (rhs IN list)`.
+fn groups_right(lhs: &str, op: &str, rhs: &str, list: &str) {
+    let bare = truth(&format!("{lhs} {op} {rhs} IN {list}"));
+    let right = truth(&format!("{lhs} {op} ({rhs} IN {list})"));
+    let left = truth(&format!("({lhs} {op} {rhs}) IN {list}"));
+    assert_eq!(bare, right, "{lhs} {op} {rhs} IN {list} did not group as `{lhs} {op} ({rhs} IN {list})`");
+    assert_ne!(
+        right, left,
+        "{lhs} {op} {rhs} IN {list}: both groupings agree, so this case cannot detect the bug"
+    );
+}
+
+/// Every comparison operator, each on a case where the two groupings differ.
+#[test]
+fn in_binds_tighter_than_every_comparison() {
+    groups_right("true", "<", "false", "[false]");
+    groups_right("1", "<", "2", "[true]");
+    groups_right("1", "=", "2", "[false]");
+    groups_right("3", ">=", "2", "[false]");
+    groups_right("1", "<=", "2", "[true, false]");
+    groups_right("2", ">", "1", "[false]");
+    groups_right("1", "<>", "2", "[false]");
+}
+
+/// The TCK's own formulation: over every combination of truth values and lists,
+/// the bare form always equals the right grouping, and *somewhere* differs from
+/// the left one. The second conjunct is what makes it a test.
+#[test]
+fn the_tck_enumeration() {
+    let store = GraphStore::new();
+    let cypher = "
+        UNWIND [true, false, null] AS a
+        UNWIND [true, false, null] AS b
+        UNWIND [[], [true], [false], [null], [true, false], [true, false, null]] AS c
+        WITH collect((a < b IN c) = (a < (b IN c))) AS eq,
+             collect((a < b IN c) <> ((a < b) IN c)) AS neq
+        RETURN all(x IN eq WHERE x) AND any(x IN neq WHERE x) AS result";
+    let q = parse_query(cypher).expect("parses");
+    let batch = QueryExecutor::new(&store).execute(&q).expect("runs");
+    assert_eq!(
+        batch.records.first().and_then(|r| r.get("result")),
+        Some(&Value::Property(samyama::graph::PropertyValue::Boolean(true)))
+    );
+}
+
+/// Arithmetic still binds tighter than `IN`, which the new level must not
+/// disturb: `1 + 1 IN [2]` is `(1 + 1) IN [2]`, true.
+#[test]
+fn arithmetic_still_binds_tighter_than_in() {
+    assert_eq!(truth("1 + 1 IN [2]"), Some(true));
+    assert_eq!(truth("2 * 3 IN [6]"), Some(true));
+    assert_eq!(truth("2 ^ 3 IN [8.0]"), Some(true));
+}
+
+/// And `AND`/`OR`/`NOT` still bind looser.
+#[test]
+fn boolean_operators_still_bind_looser() {
+    assert_eq!(truth("1 IN [1] AND 2 IN [2]"), Some(true));
+    assert_eq!(truth("1 IN [9] OR 2 IN [2]"), Some(true));
+    assert_eq!(truth("NOT 1 IN [9]"), Some(true));
+}


### PR DESCRIPTION
Closes #833.

```
true < false IN [false]
  expected false   --  true < (false IN [false])  ->  true < true
  got      true    --       (true < false) IN [false]  ->  false IN [false]
```

`in_op` shared a Pratt level with `comparison_op`, so the two grouped left to right. openCypher gives `IN` **tighter** binding than every comparison operator; it now has its own level, between the comparisons and the additive operators.

## Why it survived

The two readings agree whenever the list happens to hold what the comparison would have produced — most hand-written queries, and every example anyone reaches for.

So each case in `tests/in_operator_precedence.rs` asserts the bare form against the **right**-grouped form *and* that the left grouping gives something different. A case where both groupings agree proves nothing, and the file would be quietly vacuous without that second half. The TCK's own formulation is included too: all three truth values on both sides against six lists in one query, asserting the right grouping always matches and the left one differs somewhere.

Arithmetic still binds tighter and the boolean operators still bind looser; both are pinned.

## Verification

- TCK **3,526 → 3,535**, regression diff against the merge base **empty**. `Precedence1` goes from 7 failures to **0**.
- `--min-pass` ratcheted 3526 → 3535.

`Precedence2`'s remaining failures are exponentiation *associativity*, a separate rule — filed and fixed separately.