### PR TITLE
Make exponentiation left-associative (#835)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3535
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3540
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -92,9 +92,16 @@ static PRATT_PARSER: LazyLock<PrattParser<Rule>> = LazyLock::new(|| {
         .op(Op::infix(Rule::in_op, Assoc::Left))
         .op(Op::infix(Rule::add_sub_op, Assoc::Left))
         .op(Op::infix(Rule::mul_div_mod_op, Assoc::Left))
-        // Exponentiation binds tightest and associates to the *right*:
-        // `2 ^ 3 ^ 2` is 2^(3^2), not (2^3)^2.
-        .op(Op::infix(Rule::pow_op, Assoc::Right))
+        // Exponentiation binds tightest and associates to the **left**:
+        // `2 ^ 3 ^ 2` is (2^3)^2 = 64, not 2^(3^2) = 512.
+        //
+        // This is where Cypher parts company with mathematical convention, and
+        // the convention is what was implemented. openCypher's grammar makes
+        // `PowerOfExpression` left-recursive, and two `Precedence2` scenarios
+        // pin it independently: `4 ^ 5 ^ 3` is 1073741824 (4^15) and
+        // `4 ^ 1 ^ 3` is 64, both of which only the left grouping produces
+        // (#835).
+        .op(Op::infix(Rule::pow_op, Assoc::Left))
 });
 
 /// Parser errors

--- a/tests/cypher_sweep_gaps.rs
+++ b/tests/cypher_sweep_gaps.rs
@@ -138,13 +138,20 @@ fn the_power_operator_works() {
 }
 
 #[test]
-fn the_power_operator_binds_tightest_and_associates_right() {
+fn the_power_operator_binds_tightest_and_associates_left() {
     // `2 + 3 ^ 2` is 11, not 25 — it binds tighter than `+`.
     assert_eq!(one("RETURN 2 + 3 ^ 2 AS r"), PropertyValue::Float(11.0));
     // `2 * 3 ^ 2` is 18, not 36 — tighter than `*` too.
     assert_eq!(one("RETURN 2 * 3 ^ 2 AS r"), PropertyValue::Float(18.0));
-    // `2 ^ 3 ^ 2` is 2^(3^2) = 512, not (2^3)^2 = 64.
-    assert_eq!(one("RETURN 2 ^ 3 ^ 2 AS r"), PropertyValue::Float(512.0));
+    // `2 ^ 3 ^ 2` is **(2^3)^2 = 64**, not 2^(3^2) = 512.
+    //
+    // This assertion had it the other way round, with a comment stating the
+    // mathematical convention as though it were the rule. Cypher does not
+    // follow it: openCypher's `PowerOfExpression` is left-recursive, and
+    // `Precedence2` scenarios 2 and 3 both pin the left grouping. The test was
+    // corrected against the reference rather than the code against the test
+    // (#835).
+    assert_eq!(one("RETURN 2 ^ 3 ^ 2 AS r"), PropertyValue::Float(64.0));
 }
 
 #[test]

--- a/tests/exponentiation_associativity.rs
+++ b/tests/exponentiation_associativity.rs
@@ -1,0 +1,71 @@
+//! `^` associates to the **left** in Cypher (#835).
+//!
+//! ```text
+//! 2 ^ 3 ^ 2  is  (2^3)^2 = 64,  not  2^(3^2) = 512
+//! ```
+//!
+//! This is where Cypher parts company with mathematical convention, and the
+//! convention is what was implemented — with a comment in the Pratt table and
+//! an assertion in `cypher_sweep_gaps.rs` both stating it as though it were the
+//! rule. openCypher's grammar makes `PowerOfExpression` left-recursive, and two
+//! `Precedence2` scenarios pin it independently.
+//!
+//! The *precedence* was already right: `4 ^ 3 * 2 ^ 3` is `(4^3) * (2^3)`. Only
+//! the associativity was wrong, which is why those scenarios failed on one
+//! column out of three.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn num(expr: &str) -> f64 {
+    let store = GraphStore::new();
+    let cypher = format!("RETURN {expr} AS r");
+    let q = parse_query(&cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(PropertyValue::Float(f))) => *f,
+        Some(Value::Property(PropertyValue::Integer(i))) => *i as f64,
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+/// A chain of `^` groups left, and the two groupings differ in every case here.
+#[test]
+fn exponentiation_groups_left() {
+    for (expr, left, right) in [
+        ("2 ^ 3 ^ 2", 64.0, 512.0),
+        ("4 ^ 6 ^ 3", 68719476736.0, f64::INFINITY),
+        ("4 ^ 5 ^ 3", 1073741824.0, f64::INFINITY),
+        ("4 ^ 1 ^ 3", 64.0, 4.0),
+        ("2 ^ 2 ^ 2 ^ 2", 256.0, 65536.0),
+    ] {
+        let got = num(expr);
+        assert_eq!(got, left, "{expr} should group left");
+        assert_ne!(got, right, "{expr}: the two groupings agree, so this case proves nothing");
+    }
+}
+
+/// The TCK's own scenarios, whose `a` and `b` columns already passed — included
+/// so a later change to associativity cannot silently take precedence with it.
+#[test]
+fn precedence_over_multiplicative_and_additive_is_unchanged() {
+    for (mult, right) in [("*", 512.0), ("/", 8.0), ("%", 0.0)] {
+        assert_eq!(num(&format!("4 ^ 3 {mult} 2 ^ 3")), right, "{mult}");
+        assert_eq!(num(&format!("(4 ^ 3) {mult} (2 ^ 3)")), right, "{mult} parenthesised");
+    }
+    for (add, right) in [("+", 72.0), ("-", 56.0)] {
+        assert_eq!(num(&format!("4 ^ 3 {add} 2 ^ 3")), right, "{add}");
+        assert_eq!(num(&format!("(4 ^ 3) {add} (2 ^ 3)")), right, "{add} parenthesised");
+    }
+}
+
+/// Unary minus binds tighter than `^`: `-3 ^ 2` is `(-3)^2 = 9`.
+#[test]
+fn unary_minus_still_binds_tighter() {
+    assert_eq!(num("-3 ^ 2"), 9.0);
+    assert_eq!(num("(-3) ^ 2"), 9.0);
+    assert_eq!(num("-(3 ^ 2)"), -9.0);
+}


### PR DESCRIPTION
Closes #835.

```
RETURN 4 ^ 6 ^ 3
  expected 68719476736.0   -- (4^6)^3 = 4^18
  got      1.109e130       --  4^(6^3) = 4^216
```

The Pratt table declared `pow_op` as `Assoc::Right`, with a comment stating the **mathematical** convention as though it were the rule. Cypher does not follow it — openCypher's grammar makes `PowerOfExpression` left-recursive, and two `Precedence2` scenarios pin it independently:

| expression | expected | left | right |
|---|---|---|---|
| `4 ^ 5 ^ 3` | 1073741824.0 | 4^15 ✓ | 4^125 |
| `4 ^ 1 ^ 3` | 64.0 | 4^3 ✓ | 4^1 |

The **precedence was already correct** — `4 ^ 3 * 2 ^ 3` is `(4^3) * (2^3)`. Only associativity was wrong, which is why those scenarios failed on one column out of three and read as an arithmetic bug rather than a grammar one.

## A test asserted the opposite

```rust
// `2 ^ 3 ^ 2` is 2^(3^2) = 512, not (2^3)^2 = 64.
assert_eq!(one("RETURN 2 ^ 3 ^ 2 AS r"), PropertyValue::Float(512.0));
```

Corrected against the reference rather than the code against the test — along with its name, which read `..._associates_right`. Same shape as #607: a plausible comment restating an assumption nobody checked.

The new test asserts each chain groups left **and** that the right grouping would differ, so no case in it can be vacuous.

## Verification

- TCK **3,535 → 3,540**, regression diff against the merge base **empty**. `Precedence2` goes from 5 failures to **0**.
- `--min-pass` ratcheted 3535 → 3540.