### PR TITLE
docs: TCK figures to 94.1% / 3,540 across README, CLAUDE.md and docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Samyama is a high-performance distributed graph database written in Rust with Redis protocol (RESP) compatibility, multi-tenancy, vector search, NLQ, and graph algorithms. Currently at Phase 4 (High Availability Foundation), version v1.7.0.
 
-Cypher conformance is **measured, not estimated**: 90.0% of the openCypher TCK's evaluated scenarios pass (3,384 of 3,761, 96.5% coverage, 2026-08-25). The `~90% OpenCypher support` this line used to claim was a self-assessment withdrawn in `#437` as unmeasured — the resemblance to today's figure is a coincidence, and only one of the two can be reproduced. Quote the pass rate **with** its coverage: a high rate over a small evaluated set is how this measurement is usually inflated, and that is exactly what the earlier 87.1% turned out to be.
+Cypher conformance is **measured, not estimated**: 94.1% of the openCypher TCK's evaluated scenarios pass (3,540 of 3,761, 96.5% coverage, 2026-08-25). The `~90% OpenCypher support` this line used to claim was a self-assessment withdrawn in `#437` as unmeasured; the measured figure has now passed it, which settles nothing, because only one of the two can be reproduced. Quote the pass rate **with** its coverage: a high rate over a small evaluated set is how this measurement is usually inflated, and that is exactly what the earlier 87.1% turned out to be.
 
 ## Build & Development Commands
 

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ into a public-health trifecta.* [Browse the catalogue →](case_studies)
 
 ## The 30-Second Tour
 
-**Cypher queries** — MATCH, CREATE, MERGE, aggregations, path finding, 30+ functions. **90.0% of the openCypher TCK's evaluated scenarios pass** (3,384 of 3,761, at 96.5% coverage of the 3,897-scenario corpus, measured 2026-08-25); on the same corpus and comparator Neo4j 5 scores 79.4%. That is conformance only — not performance or scale — and the competitor figure is a fixed baseline from one run. See [`docs/CYPHER_COMPATIBILITY.md`](docs/CYPHER_COMPATIBILITY.md) for a per-feature matrix verified by an executable probe, and [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) for the full accounting.
+**Cypher queries** — MATCH, CREATE, MERGE, aggregations, path finding, 30+ functions. **94.1% of the openCypher TCK's evaluated scenarios pass** (3,540 of 3,761, at 96.5% coverage of the 3,897-scenario corpus, measured 2026-08-25); on the same corpus and comparator Neo4j 5 scores 79.4%. That is conformance only — not performance or scale — and the competitor figure is a fixed baseline from one run. See [`docs/CYPHER_COMPATIBILITY.md`](docs/CYPHER_COMPATIBILITY.md) for a per-feature matrix verified by an executable probe, and [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) for the full accounting.
 
 ```cypher
 MATCH (a:Person)-[:KNOWS*1..3]->(b:Person)

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -140,19 +140,26 @@ cargo run --release --example tck_runner -- --features <openCypher>/tck/features
 |---|---:|
 | scenarios in the TCK | 3,897 |
 | **evaluated** by the harness | **3,761** (96.5%) |
-| pass | 3,384 |
+| pass | 3,540 |
 | skipped | 136 |
-| **pass rate, of evaluated** | **90.0%** |
+| **pass rate, of evaluated** | **94.1%** |
 | gate `CH-TCK ≥ 85%` | **met** |
-| gate *≥ best competitor* | **met** — 10.3 points ahead |
+| gate *≥ best competitor* | **met** — 14.5 points ahead |
+| wrong answers, of the 221 failures | 165 |
 
-Measured at `4118d37`; the CI floor is a **count**, currently `--min-pass 3384`,
+Measured at `3dd1a65`; the CI floor is a **count**, currently `--min-pass 3540`,
 and rises with each merge that earns it.
+
+The last row is tracked separately from the pass rate because the two failure
+classes are not equally bad: an error reaches the caller, a wrong answer does
+not. It was 242 at the start of 2026-08-25's fourth cycle. The `CH-TCK`
+envelope's own status stays `fail` while it is above zero, which is why the
+scorecard shows a met requirement inside a failing envelope.
 
 ### The corpus tripled, and the old figure was measured on a third of it
 
 The table above replaces `1,244 evaluated / 81.9%`. Nothing regressed — the
-pass *count* went from 1,019 to 3,384. The harness had been skipping every
+pass *count* went from 1,019 to 3,540. The harness had been skipping every
 `Scenario Outline`: 274 of them, expanding to ~2,280 concrete cases, and the
 harder ones, because an outline is how the TCK enumerates a feature's edge
 cases once its happy path is established (#756).
@@ -169,10 +176,17 @@ executes and renders:
 
 | Engine | 1,249-scenario set (2026-08-19) | 3,766-scenario set |
 |---|---:|---:|
-| **Samyama** `4118d37` | 81.9% | **89.7%** |
+| **Samyama** `3dd1a65` | 81.9% | **93.9%** |
 | Neo4j 5 | 98.9% | 79.4% |
 | Memgraph | 89.8% | 65.9% |
 | FalkorDB | 89.1% | 65.7% |
+
+The Samyama row reads **93.9%** where the table above reads 94.1%, and both are
+right: the cross-engine comparison scores 3,766 scenarios through the judge
+path, the direct run evaluates 3,761. The judge scores five the direct run
+skips and passes five fewer, identically across measurements. The judge figure
+is the one to compare against a competitor, because that is how the competitors
+were scored.
 
 **Every engine falls on the wider corpus, and Neo4j falls nearly twenty
 points.** That is the evidence the expansion is sound rather than malformed: a

--- a/docs/CYPHER_COMPATIBILITY.md
+++ b/docs/CYPHER_COMPATIBILITY.md
@@ -8,9 +8,9 @@
 The openCypher TCK **has now been run** (#434), so this page can give a measured
 number instead of withholding one:
 
-> **90.0% of evaluated scenarios** — 3,384 of 3,761, from 3,897 total with 136
+> **94.1% of evaluated scenarios** — 3,540 of 3,761, from 3,897 total with 136
 > skipped as unjudgeable by the harness. Measured 2026-08-25 at commit
-> `4118d37`.
+> `3dd1a65`.
 
 Two numbers, both of which matter. The pass rate says what the engine gets
 right among scenarios the harness can judge; the **96.5% coverage** says how
@@ -23,10 +23,10 @@ The harness had been skipping every `Scenario Outline` — 274 of them, expandin
 to ~2,280 concrete cases, and the harder ones, since an outline is how the TCK
 enumerates a feature's edge cases once its happy path is established (#756).
 Nothing regressed when they were included: the pass **count** went from 1,079
-to 3,384.
+to 3,540.
 
 On the same corpus and comparator, Neo4j 5 scores 79.4%, Memgraph 65.9% and
-FalkorDB 65.7% (#759). Samyama is **10.3 points ahead of the best of them** —
+FalkorDB 65.7% (#759). Samyama is **14.5 points ahead of the best of them** —
 having been 17 points behind on the old, smaller set. Every engine's number
 falls on the wider corpus, which is the evidence the expansion is sound rather
 than malformed.
@@ -42,10 +42,10 @@ was self-assessed, never checked against the TCK, and an earlier internal
 assessment of the same engine put it at 40–50%. It was withdrawn rather than
 defended.
 
-The measured number has since passed it — 90.0% against the withdrawn "~90%" —
-but the two are not comparable and the coincidence is worth naming rather than
-enjoying: one is a reproducible count over a named corpus at a named commit,
-the other was a guess. The point of withdrawing it was never the value.
+The measured number has since passed it — 94.1% against the withdrawn "~90%" —
+but the two are not comparable, and passing it settles nothing: one is a
+reproducible count over a named corpus at a named commit, the other was a
+guess. The point of withdrawing it was never the value.
 
 ```
 cargo run --release --example tck_runner -- --features <path to tck/features>


### PR DESCRIPTION
Nine merges this cycle took the direct-run rate from **90.0% (3,384) to 94.1% (3,540)** at `3dd1a65`, and the judge-path rate from 89.7% to **93.9%** — 14.5 points ahead of Neo4j on the same corpus and comparator.

Every stale figure moves together, because a page quoting the old rate beside one quoting the new reads as a discrepancy rather than as a date.

## Three things added, not just renumbered

**`BENCHMARKS.md` now says why its two tables disagree.** The suite table reads 94.1% over 3,761; the cross-engine table reads 93.9% over 3,766. The judge scores five scenarios the direct run skips and passes five fewer — identically in this measurement and the last, so it is a property of the two paths, not drift. The judge figure is the one to compare against a competitor, since that is how the competitors were scored. Left unexplained the pair looks like an error in one of them.

**The wrong-answer count is now in the table** — 165 of the 221 failures, down from 242 at the start of this cycle. It is tracked apart from the pass rate because an error reaches the caller and a wrong answer does not, and it is why the `CH-TCK` envelope stays `fail` while the requirement inside it reads met.

**The "~90%" paragraph no longer treats passing the withdrawn claim as the point.** It has been passed, at 94.1% against ~90% — and that settles nothing, because one is a reproducible count over a named corpus at a named commit and the other was a guess.

## Checked, not assumed

`cypher_matrix_probe` was re-run: unchanged at **77 of 78 supported**, so that section needed no edit.

Companion commit in the benchmarks repo: `819a606` (`CROSS-ENGINE-2026-08-25c.md`, `SCORECARD.json`/`.md` regenerated, `ch_tck.py` baseline line).