### PR TITLE
Carry the source offset through time() selection (#838)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3540
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3553
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1736,7 +1736,19 @@ fn apply_date_overrides(
             .ok_or_else(|| ExecutionError::RuntimeError(format!("invalid week date {year}-W{week}-{dow}")))?
     } else if map.contains_key("quarter") || map.contains_key("dayOfQuarter") {
         let q = g("quarter").unwrap_or(((cur.month() - 1) / 3 + 1) as i64);
-        let d = g("dayOfQuarter").unwrap_or(1);
+        // The day within the quarter defaults to the **current** one, exactly
+        // as `week`/`dayOfWeek` above default from `cur`. Defaulting to 1 made
+        // `{date: <1984-11-11>, quarter: 3}` answer 1984-07-01 instead of
+        // 1984-08-11: an override that names one component silently reset two
+        // others, and the result is a perfectly ordinary date (#838).
+        let cur_quarter_start = chrono::NaiveDate::from_ymd_opt(
+            cur.year(),
+            ((cur.month() - 1) / 3) * 3 + 1,
+            1,
+        )
+        .ok_or_else(|| ExecutionError::RuntimeError("date out of range".into()))?;
+        let cur_day_of_quarter = cur.signed_duration_since(cur_quarter_start).num_days() + 1;
+        let d = g("dayOfQuarter").unwrap_or(cur_day_of_quarter);
         let start = chrono::NaiveDate::from_ymd_opt(year, ((q - 1) * 3 + 1) as u32, 1)
             .ok_or_else(|| ExecutionError::RuntimeError(format!("invalid quarter {q}")))?;
         start
@@ -2691,26 +2703,65 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                 }
                 Value::Map(_) | Value::Property(PropertyValue::Map(_)) => {
                     let map = &temporal_arg_map(&args[0]).expect("matched a map arm");
-                    let offset = match map.get("timezone").and_then(|v| v.as_string()) {
-                        Some(tz) => tmp::parse_timezone(&tz)?.0,
-                        None => 0,
+                    let named = match map.get("timezone").and_then(|v| v.as_string()) {
+                        Some(tz) => Some(tmp::parse_timezone(&tz)?.0),
+                        None => None,
                     };
                     if let Some(src) = map.get("time").or_else(|| map.get("datetime")) {
                         if let Some(n) = time_part_of(src) {
+                            // Selecting a time from a zoned value **inherits its
+                            // offset**. Defaulting to 0 relabelled 12:00+01:00 as
+                            // 12:00Z -- a different instant, rendered as a
+                            // perfectly good time (#838).
+                            let src_offset = offset_seconds_of(src);
+                            let from = src_offset.unwrap_or(0);
+                            // A `timezone` given alongside a **zoned** source
+                            // converts the instant rather than renaming the
+                            // offset: `{time: <12:00+01:00>, timezone: '+05:00'}`
+                            // is 16:00+05:00, the same moment read elsewhere.
+                            // Overrides apply after the conversion, so
+                            // `second: 42` on that gives 16:00:42+05:00.
+                            //
+                            // A **local** source has no instant to convert
+                            // from, so the timezone labels its clock and leaves
+                            // it where it is:
+                            // `{time: localtime('12:31'), timezone: '+05:00'}`
+                            // is 12:31+05:00, not 16:31. Converting
+                            // unconditionally gets the zoned rows right and
+                            // these four wrong -- the same asymmetry as #821,
+                            // one constructor over.
+                            let to = named.unwrap_or(from);
+                            let shifted = if src_offset.is_some() {
+                                (n + (to - from) as i64 * 1_000_000_000)
+                                    .rem_euclid(86_400 * 1_000_000_000)
+                            } else {
+                                n
+                            };
                             return Ok(Value::Property(PropertyValue::Time {
-                                nanos: apply_time_overrides(n, map),
-                                offset_seconds: offset,
+                                nanos: apply_time_overrides(shifted, map),
+                                offset_seconds: to,
                             }));
                         }
                     }
+                    // Built from components, `timezone` names the offset the
+                    // clock is *in*; there is no source instant to convert.
                     Ok(Value::Property(PropertyValue::Time {
                         nanos: tmp::time_of_day_nanos(map)?,
-                        offset_seconds: offset,
+                        offset_seconds: named.unwrap_or(0),
                     }))
                 }
                 Value::Property(PropertyValue::Null) => Ok(Value::Property(PropertyValue::Null)),
-                other => match value_as_property(other).and_then(|p| time_part_of(&p)) {
-                    Some(n) => Ok(Value::Property(PropertyValue::Time { nanos: n, offset_seconds: 0 })),
+                other => match value_as_property(other) {
+                    // `time(<zoned value>)` keeps the value's own offset (#838).
+                    Some(p) => match time_part_of(&p) {
+                        Some(n) => Ok(Value::Property(PropertyValue::Time {
+                            nanos: n,
+                            offset_seconds: offset_seconds_of(&p).unwrap_or(0),
+                        })),
+                        None => Err(ExecutionError::TypeError(
+                            "time() requires a string, a map, or a temporal value".to_string(),
+                        )),
+                    },
                     None => Err(ExecutionError::TypeError(
                         "time() requires a string, a map, or a temporal value".to_string(),
                     )),
@@ -3419,6 +3470,20 @@ fn scale_duration(
 ///
 /// The legacy `DateTime` is deliberately absent: it exists for snapshot
 /// compatibility and is already read as UTC everywhere.
+/// The UTC offset a value carries, if it carries one.
+///
+/// A `LocalTime` or `LocalDateTime` has none; a `Date` has none. Only the two
+/// zoned types answer, and the caller decides what "none" means -- inheriting
+/// zero and inheriting nothing are different (#838).
+fn offset_seconds_of(v: &PropertyValue) -> Option<i32> {
+    match v {
+        PropertyValue::Time { offset_seconds, .. }
+        | PropertyValue::ZonedDateTime { offset_seconds, .. } => Some(*offset_seconds),
+        PropertyValue::DateTime(_) => Some(0),
+        _ => None,
+    }
+}
+
 fn zone_of(v: &PropertyValue) -> Option<crate::query::executor::temporal::TzSpec> {
     use crate::query::executor::temporal::{parse_timezone_spec, TzSpec};
     match v {

--- a/tests/temporal_selection_offsets.rs
+++ b/tests/temporal_selection_offsets.rs
@@ -1,0 +1,143 @@
+//! Selecting a time carries the source's offset, and a `timezone` converts
+//! only when there is an instant to convert (#838).
+//!
+//! Three defects, each producing a perfectly ordinary-looking value:
+//!
+//! * `time(<zoned>)` returned `12:00Z` for `12:00+01:00` — a **different
+//!   instant**, rendered as a good time.
+//! * `{time: <zoned>, timezone: X}` relabelled the offset instead of
+//!   converting the moment.
+//! * `{date: d, quarter: 3}` reset the day to the 1st, so naming one component
+//!   silently changed two others.
+//!
+//! The asymmetry in the middle one is the part worth pinning: a **local**
+//! source has no instant to convert from, so its clock stays put and only
+//! gains a label. Converting unconditionally fixes the zoned rows and breaks
+//! the local ones — the same shape as #821, one constructor over.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn rendered(expr: &str) -> String {
+    let store = GraphStore::new();
+    let cypher = format!("RETURN {expr} AS r");
+    let q = parse_query(&cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.to_cypher_string(),
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+fn check(rows: &[(String, &str)]) {
+    let wrong: Vec<String> = rows
+        .iter()
+        .filter_map(|(expr, want)| {
+            let got = rendered(expr);
+            (got != *want).then(|| format!("  {expr}\n    want {want}\n    got  {got}"))
+        })
+        .collect();
+    assert!(wrong.is_empty(), "\n{}", wrong.join("\n"));
+}
+
+const ZONED_DT: &str =
+    "datetime({year: 1984, month: 10, day: 11, hour: 12, timezone: 'Europe/Stockholm'})";
+const ZONED_TIME: &str =
+    "time({hour: 12, minute: 31, second: 14, microsecond: 645876, timezone: '+01:00'})";
+
+/// A zoned source keeps its offset, and a `timezone` moves the clock with it.
+#[test]
+fn a_zoned_source_is_converted() {
+    check(&[
+        (format!("time({ZONED_DT})"), "12:00+01:00"),
+        (format!("time({{time: {ZONED_DT}}})"), "12:00+01:00"),
+        (format!("time({{time: {ZONED_DT}, second: 42}})"), "12:00:42+01:00"),
+        (format!("time({{time: {ZONED_DT}, timezone: '+05:00'}})"), "16:00+05:00"),
+        (
+            format!("time({{time: {ZONED_DT}, second: 42, timezone: '+05:00'}})"),
+            "16:00:42+05:00",
+        ),
+        (format!("time({ZONED_TIME})"), "12:31:14.645876+01:00"),
+        (format!("time({{time: {ZONED_TIME}}})"), "12:31:14.645876+01:00"),
+        (format!("time({{time: {ZONED_TIME}, second: 42}})"), "12:31:42.645876+01:00"),
+        (
+            format!("time({{time: {ZONED_TIME}, timezone: '+05:00'}})"),
+            "16:31:14.645876+05:00",
+        ),
+        (
+            format!("time({{time: {ZONED_TIME}, second: 42, timezone: '+05:00'}})"),
+            "16:31:42.645876+05:00",
+        ),
+    ]);
+}
+
+/// **A local source is labelled, not moved.** There is no instant to convert
+/// from, so `12:31` in `+05:00` is `12:31+05:00` and not `16:31`.
+#[test]
+fn a_local_source_is_only_labelled() {
+    let local_t = "localtime({hour: 12, minute: 31, second: 14, nanosecond: 645876123})";
+    let local_dt =
+        "localdatetime({year: 1984, month: 3, day: 7, hour: 12, minute: 31, second: 14, millisecond: 645})";
+    check(&[
+        (format!("time({{time: {local_t}, timezone: '+05:00'}})"), "12:31:14.645876123+05:00"),
+        (
+            format!("time({{time: {local_t}, second: 42, timezone: '+05:00'}})"),
+            "12:31:42.645876123+05:00",
+        ),
+        (format!("time({{time: {local_dt}, timezone: '+05:00'}})"), "12:31:14.645+05:00"),
+        (
+            format!("time({{time: {local_dt}, second: 42, timezone: '+05:00'}})"),
+            "12:31:42.645+05:00",
+        ),
+    ]);
+}
+
+/// Built from components there is no source at all, so `timezone` names the
+/// offset the clock is already in.
+#[test]
+fn components_are_not_converted_either() {
+    check(&[
+        ("time({hour: 12, timezone: '+05:00'})".into(), "12:00+05:00"),
+        ("time({hour: 12})".into(), "12:00Z"),
+    ]);
+}
+
+/// Overriding the quarter keeps the day within it: 11 November is day 42 of Q4,
+/// and day 42 of Q3 is 11 August.
+#[test]
+fn a_quarter_override_keeps_the_day_within_the_quarter() {
+    check(&[
+        (
+            "date({date: date({year: 1984, month: 11, day: 11}), quarter: 3})".into(),
+            "1984-08-11",
+        ),
+        (
+            "date({date: date({year: 1984, month: 11, day: 11}), quarter: 1})".into(),
+            "1984-02-11",
+        ),
+        // An explicit dayOfQuarter still wins.
+        (
+            "date({date: date({year: 1984, month: 11, day: 11}), quarter: 3, dayOfQuarter: 1})".into(),
+            "1984-07-01",
+        ),
+    ]);
+}
+
+/// `datetime()` was already correct here (#809) and must stay so — this fix
+/// touched `time()` only.
+#[test]
+fn datetime_selection_is_undisturbed() {
+    check(&[
+        (
+            format!("datetime({{datetime: {ZONED_DT}, timezone: '+05:00'}})"),
+            "1984-10-11T16:00+05:00",
+        ),
+        (
+            format!("datetime({{datetime: {ZONED_DT}}})"),
+            "1984-10-11T12:00+01:00[Europe/Stockholm]",
+        ),
+    ]);
+}


### PR DESCRIPTION
Closes #838. Three defects in temporal *selection*, each producing a perfectly ordinary-looking value.

## `time()` dropped the source's offset

```
time(datetime({year: 1984, month: 10, day: 11, hour: 12, timezone: 'Europe/Stockholm'}))
  expected 12:00+01:00     got 12:00Z
```

`offset_seconds: 0` was hardcoded on both the bare-value and the map-selection paths. `12:00Z` is a **different instant** rendered as a good time.

## A `timezone` alongside a source converts, rather than relabels

```
time({time: <12:00+01:00>, timezone: '+05:00'})   ->  16:00+05:00
```

The same moment read elsewhere. Overrides apply *after* the conversion, so `{..., second: 42, timezone: '+05:00'}` is `16:00:42+05:00`.

**Only for a source that carries an offset.** A local source has no instant to convert from, so the timezone labels its clock and leaves it where it is:

```
time({time: localtime('12:31:14'), timezone: '+05:00'})  ->  12:31:14+05:00
```

Converting unconditionally fixes the zoned rows and breaks these four — which is exactly what my first attempt did, and the regression diff named them. Same asymmetry as #821, one constructor over.

`datetime()` was already correct here (#809), so this is one path and not a family — probed rather than assumed, and pinned by `datetime_selection_is_undisturbed`.

## A `quarter` override reset the day

```
date({date: date({year: 1984, month: 11, day: 11}), quarter: 3})
  expected 1984-08-11      got 1984-07-01
```

`dayOfQuarter` defaulted to `1` instead of the source's current value — unlike the `week`/`dayOfWeek` branch immediately above it, which defaults from the source date. Naming one component silently reset two others, and 1984-07-01 is an ordinary date nothing questions.

## Verification

- TCK **3,540 → 3,553**, regression diff against the merge base **empty**. `Temporal3` goes from 15 failures to 2.
- `--min-pass` ratcheted 3540 → 3553.