### PR TITLE
A WITH's WHERE sees the variables the projection drops (#840)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3553
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3561
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -222,6 +222,25 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
         }
     }
 
+    // Ordering an entity against anything is **null**, not an error.
+    //
+    // Cypher's rule is that comparing across types yields null except between
+    // numbers, and a node, relationship or path is just another type that does
+    // not order. Raising instead took down the whole query: `Comparison2`
+    // builds a list of one value per type and compares every pair, so a single
+    // `TypeError` on `node < ''` lost all 90 rows including the numeric pair
+    // the scenario is actually about (#840).
+    //
+    // Only the ordering operators. `=` and `<>` on two entities are identity
+    // and are handled above; arithmetic on an entity stays an error, because
+    // there `null` really would hide a mistake.
+    if matches!(op, BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge)
+        && (!matches!(left, Value::Property(_) | Value::Null)
+            || !matches!(right, Value::Property(_) | Value::Null))
+    {
+        return Ok(Value::Property(PropertyValue::Null));
+    }
+
     let left_prop = match left {
         Value::Property(p) => p,
         Value::Null => PropertyValue::Null,

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -5640,8 +5640,57 @@ impl QueryPlanner {
             })
             .unwrap_or_default();
 
-        let where_predicate = with_clause.where_clause.as_ref()
-            .map(|wc| wc.predicate.clone());
+        // A `WITH ... WHERE ...` may filter on variables the projection does not
+        // carry forward:
+        //
+        //     WITH types[i] AS lhs, types[j] AS rhs
+        //     WHERE i <> j
+        //
+        // Applied inside the barrier, after the projection has dropped them,
+        // `i` and `j` evaluate to null for every row and the query returns
+        // **zero rows instead of ninety** -- silently, since a filter that
+        // matches nothing is a legitimate outcome. Neo4j answers this scenario,
+        // so those names are still reachable there (#840).
+        //
+        // Split by conjunct rather than moving the clause wholesale: a
+        // predicate naming a projected alias still belongs after the barrier,
+        // and `WITH n.name AS name WHERE name STARTS WITH 'a'` must keep
+        // working. A conjunct moves ahead only when it names at least one
+        // variable and none of them is a projected alias -- so an aggregate's
+        // output can never be filtered before it is computed.
+        //
+        // This sits in `build_with_barrier` because **both** planner paths call
+        // it. The by-kind stage loop and the clause pipeline each construct
+        // their own WITH stages, and putting the split in one of them would
+        // have fixed the queries that happen to take that path (#797).
+        let aliases: HashSet<String> = with_clause
+            .items
+            .iter()
+            .enumerate()
+            .map(|(idx, item)| item.column_name(idx))
+            .collect();
+        let mut input = input;
+        let mut where_predicate = with_clause.where_clause.as_ref().map(|wc| wc.predicate.clone());
+        if let Some(pred) = where_predicate.take() {
+            let (mut pre, mut post): (Vec<Expression>, Vec<Expression>) = (Vec::new(), Vec::new());
+            for conjunct in flatten_and_predicates(&pred) {
+                let mut vars = HashSet::new();
+                Self::collect_expression_variables(&conjunct, &mut vars);
+                let before = !vars.is_empty() && !vars.iter().any(|v| aliases.contains(v));
+                if before { pre.push(conjunct) } else { post.push(conjunct) }
+            }
+            let join = |v: Vec<Expression>| {
+                v.into_iter().reduce(|acc, p| Expression::Binary {
+                    left: Box::new(acc),
+                    op: BinaryOp::And,
+                    right: Box::new(p),
+                })
+            };
+            if let Some(expr) = join(pre) {
+                input = Box::new(FilterOperator::new(input, expr));
+            }
+            where_predicate = join(post);
+        }
 
         Ok(Box::new(WithBarrierOperator::new(
             input,

--- a/tests/with_where_scope.rs
+++ b/tests/with_where_scope.rs
@@ -1,0 +1,135 @@
+//! A `WITH`'s `WHERE` can see the variables the projection drops (#840).
+//!
+//! ```cypher
+//! UNWIND [0,1] AS i UNWIND [0,1] AS j
+//! WITH i AS a, j AS b
+//! WHERE i <> j
+//! RETURN a, b
+//! ```
+//!
+//! Two rows expected, **zero returned, no error**. The predicate ran inside the
+//! barrier, after the projection had dropped `i` and `j`, so it evaluated to
+//! null for every row — and a filter that matches nothing is a legitimate
+//! outcome, so nothing distinguished this from a correct empty result.
+//!
+//! The split is by conjunct, and both halves are pinned below: a predicate
+//! naming a projected alias must still run *after* the barrier, or an
+//! aggregate would be filtered before it is computed.
+//!
+//! It lives in `build_with_barrier` because **both** planner paths call it. My
+//! first attempt patched the by-kind stage loop and moved nothing, because the
+//! query that motivated it parses into the clause pipeline — the same trap
+//! `ast_shape_parity.rs` exists for (#797).
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+fn rows(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"))
+        .records
+        .len()
+}
+
+fn one_edge() -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE ()-[:T]->()").expect("parses");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("creates");
+    store
+}
+
+/// A predicate naming only dropped variables runs before the barrier.
+#[test]
+fn a_where_may_name_variables_the_with_drops() {
+    let store = GraphStore::new();
+    assert_eq!(rows(&store, "UNWIND [1,2,3] AS i WITH i*10 AS x WHERE i > 1 RETURN x"), 2);
+    assert_eq!(
+        rows(&store, "UNWIND [0,1] AS i UNWIND [0,1] AS j WITH i AS a, j AS b WHERE i <> j RETURN a, b"),
+        2
+    );
+}
+
+/// A predicate naming a projected alias still runs after it — including when
+/// the alias is an aggregate, which cannot be filtered before it exists.
+#[test]
+fn a_where_naming_an_alias_still_runs_after_the_barrier() {
+    let store = GraphStore::new();
+    assert_eq!(rows(&store, "UNWIND [1,2,3] AS i WITH i*10 AS x WHERE x > 10 RETURN x"), 2);
+    assert_eq!(rows(&store, "UNWIND [1,2,3] AS i WITH count(*) AS c WHERE c > 1 RETURN c"), 1);
+    assert_eq!(
+        rows(&store, "UNWIND [1,1,2,2,3] AS i WITH i, count(*) AS c WHERE c > 1 RETURN i"),
+        2
+    );
+}
+
+/// A predicate mixing both scopes is split, not sent wholly to one side.
+#[test]
+fn a_mixed_predicate_is_split_by_conjunct() {
+    let store = GraphStore::new();
+    assert_eq!(
+        rows(&store, "UNWIND [1,2,3] AS i WITH i*10 AS x WHERE i > 1 AND x < 30 RETURN x"),
+        1
+    );
+}
+
+/// Ordering an entity against anything is null, not a `TypeError` — otherwise
+/// one incomparable pair takes down a query that compares many.
+#[test]
+fn ordering_an_entity_yields_null() {
+    let store = one_edge();
+    for expr in ["n < 1", "n < ''", "r < 1", "p < 1", "n < n", "1 > n", "p >= r"] {
+        let cypher = format!("MATCH p = (n)-[r]->() RETURN {expr} AS x");
+        let q = parse_query(&cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+        let batch = QueryExecutor::new(&store)
+            .execute(&q)
+            .unwrap_or_else(|e| panic!("{cypher} raised {e:?} instead of yielding null"));
+        assert!(
+            matches!(
+                batch.records.first().and_then(|r| r.get("x")),
+                Some(samyama::query::executor::Value::Property(
+                    samyama::graph::PropertyValue::Null
+                )) | Some(samyama::query::executor::Value::Null)
+            ),
+            "{cypher} did not yield null"
+        );
+    }
+}
+
+/// Identity comparison on entities is unaffected, and arithmetic on one is
+/// still an error — `null` there would hide a mistake rather than express one.
+#[test]
+fn equality_and_arithmetic_are_unchanged() {
+    let store = one_edge();
+    let q = parse_query("MATCH (n) WITH n LIMIT 1 MATCH (m) WITH n, m LIMIT 1 RETURN n = m AS x")
+        .expect("parses");
+    assert!(QueryExecutor::new(&store).execute(&q).is_ok());
+
+    let bad = parse_query("MATCH (n) RETURN n + 1 AS x").expect("parses");
+    assert!(
+        QueryExecutor::new(&store).execute(&bad).is_err(),
+        "arithmetic on an entity should still raise"
+    );
+}
+
+/// The `Comparison2` scenario end to end: of every pair drawn from one value
+/// per type, only the two numbers order.
+#[test]
+fn only_numbers_order_across_types() {
+    let store = one_edge();
+    let cypher = "
+        MATCH p = (n)-[r]->()
+        WITH [n, r, p, '', 1, 3.14, true, null, [], {}] AS types
+        UNWIND range(0, size(types) - 1) AS i
+        UNWIND range(0, size(types) - 1) AS j
+        WITH types[i] AS lhs, types[j] AS rhs
+        WHERE i <> j
+        WITH lhs, rhs, lhs < rhs AS result
+        WHERE result
+        RETURN lhs, rhs";
+    assert_eq!(rows(&store, cypher), 1);
+}


### PR DESCRIPTION
Closes #840. Two defects that had to be fixed together, because each alone leaves the same scenario failing.

## `WITH … WHERE` lost the pre-projection scope

```cypher
UNWIND [0,1] AS i UNWIND [0,1] AS j
WITH i AS a, j AS b
WHERE i <> j
RETURN a, b
```

Two rows expected, **zero returned — no error**. The predicate is applied inside the barrier, after the projection has dropped `i` and `j`, so it evaluates to null for every row. A filter that matches nothing is a legitimate outcome, so nothing distinguishes this from a correct empty result.

Neo4j answers the `Comparison2` scenario built on this shape — its recorded actuals return `[["1", "3.14"]]` — so the reference behaviour is that those names stay reachable.

**Split by conjunct.** A conjunct moves ahead of the barrier only when it names at least one variable and none of them is a projected alias. `WITH n.name AS name WHERE name STARTS WITH 'a'` still runs after, and an aggregate's output can never be filtered before it is computed.

The split lives in `build_with_barrier` because **both planner paths call it**. My first attempt patched the by-kind stage loop and moved nothing — the query that motivated it parses into the clause pipeline. Same trap `ast_shape_parity.rs` exists for (#797).

## Ordering an entity raised instead of yielding null

```
MATCH (n) RETURN n < 1     -- TypeError("Binary op requires property values")
```

Cypher compares across types as null except between numbers, and a node, relationship or path is another type that does not order. Raising took down the whole query: `Comparison2` builds a list holding one value per type and compares every pair, so one `TypeError` on `node < ''` lost **all 90 rows** — including the numeric pair the scenario is actually about.

Ordering operators only: identity on entities is handled above, and arithmetic stays an error, because there a null would hide a mistake rather than express one.

## Why together

Fixing either alone gains nothing measurable. **I measured the comparison fix on its own: +0, zero regressions** — which is what sent me looking for the second half instead of calling it done.

## Verification

- TCK **3,553 → 3,561**, regression diff against the merge base **empty**. `Comparison2` 10 failures → 6; the rest are lexicographic list ordering, a separate rule.
- Full local suite in addition to CI, since this is a planner change.
- `--min-pass` ratcheted 3553 → 3561.