### PR TITLE
Make CREATE/MERGE bound-variable checks WITH-aware (#764)

### DIFF
--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -214,6 +214,34 @@ enum WriteKind {
     Merge,
 }
 
+/// A `WITH` re-scopes: only names it projects *by name* stay bound on the far
+/// side, so a name it drops is free again and a later CREATE/MERGE may reuse it.
+///
+/// This mirrors `carry_kinds_through_with` for the bound-variable checks.
+/// Without it, `MATCH (a)-[r]->(b) WITH a CREATE (r:X)` was rejected because `r`
+/// looked already-bound, even though the WITH does not carry it through — a
+/// valid query refused for no reason the user can act on (#764).
+///
+/// Only a bare `WITH v` (optionally `AS alias`) keeps a name bound as an entity.
+/// `WITH count(r) AS r` recomputes the name into a scalar that is no longer the
+/// original entity, so it does not carry forward here — reusing that name in a
+/// CREATE is legal, and any genuine type conflict is `validate_variable_kinds`'
+/// concern, not this one.
+fn carry_names_through_with(
+    bound: &HashSet<String>,
+    wc: &crate::query::ast::WithClause,
+) -> HashSet<String> {
+    let mut next = HashSet::new();
+    for item in &wc.items {
+        if let Expression::Variable(v) = &item.expression {
+            if bound.contains(v) {
+                next.insert(item.alias.clone().unwrap_or_else(|| v.clone()));
+            }
+        }
+    }
+    next
+}
+
 /// Every write pattern in the order it was written, each paired with the
 /// variables in scope *before* it.
 ///
@@ -245,18 +273,29 @@ fn write_patterns(query: &Query) -> Vec<(WriteKind, &crate::query::ast::Pattern,
                     out.push((WriteKind::Merge, &mc.pattern, bound.clone()));
                     pattern_variables(&mc.pattern, &mut bound);
                 }
-                // A WITH re-projects rather than binds new pattern variables,
-                // and its aliases are what survive it. Anything this does not
-                // model can only *shrink* the bound set, which risks accepting
-                // an invalid query rather than rejecting a valid one -- the
-                // trade this module states up front.
+                // A WITH re-scopes: only the names it projects survive it, so a
+                // name it drops is free for a later CREATE/MERGE to reuse. Not
+                // applying this boundary rejected valid queries like
+                // `MATCH (a)-[r]->(b) WITH a CREATE (r:X)` (#764).
+                Clause::With(wc) => bound = carry_names_through_with(&bound, wc),
                 _ => {}
             }
         }
         return out;
     }
 
-    for mc in &query.match_clauses {
+    // Pre-WITH matches bind first; a WITH then re-scopes the set to only what
+    // it projects, so a CREATE/MERGE after the WITH may reuse a name the WITH
+    // dropped (#764). `with_split_index` marks where the leading WITH cuts the
+    // match list.
+    let upto = query.with_split_index.unwrap_or(query.match_clauses.len());
+    for mc in query.match_clauses.iter().take(upto) {
+        pattern_variables(&mc.pattern, &mut bound);
+    }
+    if let Some(wc) = &query.with_clause {
+        bound = carry_names_through_with(&bound, wc);
+    }
+    for mc in query.match_clauses.iter().skip(upto) {
         pattern_variables(&mc.pattern, &mut bound);
     }
     if let Some(create) = &query.create_clause {

--- a/tests/variable_kind_conflict.rs
+++ b/tests/variable_kind_conflict.rs
@@ -74,26 +74,37 @@ fn a_pattern_after_with_may_reuse_a_dropped_name() {
     assert!(accepted("MATCH (a)-[r]->(b) WITH a MATCH (r) RETURN a, r"));
 }
 
-/// The `CREATE`/`MERGE` forms of the same thing are rejected, but **not by
-/// this rule** -- `CreateOnBoundVariable` and `MergeOnBoundVariable` predate
-/// it and are not WITH-aware:
+/// The `CREATE`/`MERGE` forms of the same thing are now WITH-aware too (#764).
 ///
 /// ```text
-/// MATCH (a)-[r]->(b) WITH a CREATE (r:X)
-///   -> Variable `r` already declared; CREATE cannot add labels or properties to it
+/// MATCH (a)-[r]->(b) WITH a CREATE (r:X) RETURN a
 /// ```
 ///
-/// `r` is *not* carried through that WITH, so it is out of scope and the
-/// CREATE should bind a fresh node. Filed separately (#764) rather than fixed
-/// here, because it is a different rule with its own scope question. Asserting
-/// the current behaviour keeps this file honest about what it does and does
-/// not cover -- and turns red the moment #764 is fixed, which is the point.
+/// `r` is *not* carried through that WITH, so it is out of scope and the CREATE
+/// binds a fresh node that happens to share the name. `CreateOnBoundVariable`
+/// and `MergeOnBoundVariable` used to collect every name ever bound without
+/// applying the WITH boundary and rejected this valid query; `write_patterns`
+/// now re-scopes through each WITH via `carry_names_through_with`, so only
+/// projected names stay bound.
 #[test]
-fn create_and_merge_after_with_are_over_rejected_by_an_older_rule() {
-    assert!(rejected("MATCH (a)-[r]->(b) WITH a CREATE (r:X) RETURN a"));
-    assert!(rejected("MATCH (a)-[r]->(b) WITH a MERGE (r:X) RETURN a"));
-    // Not the kind rule: a fresh name is accepted in the same position.
+fn create_and_merge_after_with_may_reuse_a_dropped_name() {
+    assert!(accepted("MATCH (a)-[r]->(b) WITH a CREATE (r:X) RETURN a"));
+    assert!(accepted("MATCH (a)-[r]->(b) WITH a MERGE (r:X) RETURN a"));
+    // A fresh name in the same position was always accepted.
     assert!(accepted("MATCH (a)-[r]->(b) WITH a CREATE (z:X) RETURN a"));
+}
+
+/// The reset is not an escape hatch: a name the WITH *does* project stays
+/// bound, so relabelling it in a CREATE/MERGE is still rejected.
+///
+/// `WITH *` carries every name forward — it is expanded to explicit items
+/// before validation, so it must not be a loophole either.
+#[test]
+fn a_create_on_a_name_carried_through_with_is_still_rejected() {
+    assert!(rejected("MATCH (a) WITH a CREATE (a:Foo) RETURN a"));
+    assert!(rejected("MATCH (a) WITH a AS b CREATE (b:Foo) RETURN b"));
+    assert!(rejected("MATCH (a) WITH a MERGE (a:Foo) RETURN a"));
+    assert!(rejected("MATCH (a) WITH * CREATE (a:Foo) RETURN a"));
 }
 
 /// A name carried *through* a WITH keeps its kind, so the conflict still


### PR DESCRIPTION
Closes #764. This is #822's diff replayed onto `main` at `5c8b177` — that PR's head is on a fork, eleven merges behind, and no CI ever ran on it. Original authorship is #822's; this PR exists to get the change verified against current `main` and merged.

## The defect

```cypher
MATCH (a)-[r]->(b) WITH a CREATE (r:X) RETURN a
-- Semantic error: Variable `r` already declared; CREATE cannot add labels or properties to it
```

`r` is not projected through the `WITH`, so `CREATE (r:X)` binds a fresh node and the query is valid. A different name in the same position (`CREATE (z:X)`) was always accepted, which is what shows the rule fired on the **name** rather than on scope.

`write_patterns` accumulated every name ever bound without applying the `WITH` boundary, unlike `validate_variable_kinds`, which re-scopes at each `WITH` through `carry_kinds_through_with`.

As `validate.rs` says up front, over-rejecting a valid query is the worse failure — a user hitting this had no way forward but to rename a variable for no reason.

## Verification after the rebase

- **TCK 3,561 → 3,561**, regression diff against the merge base **empty**. No change is the expected outcome: this fixes an over-rejection of a valid query and the TCK does not exercise the shape. The measurement is here to show the change costs nothing, not to claim it gains anything.
- `variable_kind_conflict`, `property_access_targets`, `pattern_predicate_scope`, `boolean_operands`, `order_by_scope` — 33 tests, all pass.
- The ratchet is untouched, because the count did not move.

This closes the third of the four issues deliberately left open at the end of cycle 3. #785 closed earlier today; #769 and #798 remain, with their reasons intact.