### PR TITLE
Refuse size() on a pattern or a path at compile time (#843)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3561
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3570
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -48,6 +48,8 @@ pub enum ValidationError {
         second: &'static str,
     },
     PatternInSetValue,
+    /// `size()` applied to a pattern or a path (#843).
+    SizeOfNonCollection(&'static str),
     /// An ORDER BY naming something the projection did not keep.
     OrderByUndefinedVariable(String),
     /// An ORDER BY item that mixes an aggregate with a grouping expression.
@@ -104,6 +106,11 @@ impl std::fmt::Display for ValidationError {
                 "AND, OR and XOR need boolean operands, and this one is {what}. \
                  A value whose type is only known at run time is fine here; a \
                  literal of the wrong type is not."
+            ),
+            Self::SizeOfNonCollection(what) => write!(
+                f,
+                "size() takes a list or a string, not {what}; \
+                 use length() for a path"
             ),
             Self::VariableTypeConflict(name) => write!(
                 f,
@@ -1254,7 +1261,80 @@ fn validate_pattern_predicate_vars(query: &Query) -> Result<(), ValidationError>
     Ok(())
 }
 
+/// `size()` takes a list or a string, and nothing else (#843).
+///
+/// ```text
+/// MATCH (a), (b), (c) RETURN size((a)-[:REL]->(b))
+/// MATCH p = (a)-[*]->(b) RETURN size(p)
+/// ```
+///
+/// Both must fail **at compile time**, and the reason the TCK insists on that
+/// rather than accepting a runtime error is visible in these very scenarios:
+/// they run against an empty graph, so `MATCH (a), (b), (c)` binds nothing, the
+/// argument is never evaluated, and a runtime check never fires. The query
+/// "succeeds" with zero rows.
+///
+/// The engine did raise a `TypeError` -- but only when the pattern matched
+/// something. A probe against an empty store showed the error and a probe with
+/// data showed it too; what neither showed is that the *scenario* never reaches
+/// either, because the failure has to happen before any row exists.
+///
+/// `size()` on a path is a separate spelling error rather than a type error:
+/// `length()` is the function for a path, and `size()` accepted one silently.
+fn validate_size_arguments(query: &Query) -> Result<(), ValidationError> {
+    // Every name bound as a path, from both AST representations.
+    let mut paths: HashSet<String> = HashSet::new();
+    let mut note = |pattern: &crate::query::ast::Pattern| {
+        for path in &pattern.paths {
+            if let Some(v) = &path.path_variable {
+                paths.insert(v.clone());
+            }
+        }
+    };
+    for mc in &query.match_clauses {
+        note(&mc.pattern);
+    }
+    for clause in &query.clauses {
+        if let crate::query::ast::Clause::Match(mc) = clause {
+            note(&mc.pattern);
+        }
+    }
+
+    fn walk(e: &Expression, paths: &HashSet<String>) -> Result<(), ValidationError> {
+        if let Expression::Function { name, args, .. } = e {
+            if name.eq_ignore_ascii_case("size") {
+                for arg in args {
+                    match arg {
+                        // A bare pattern. `EXISTS { ... }` desugars to the same
+                        // node, so the flag is what separates them -- widening
+                        // this to both would reject `size(...)` nowhere and
+                        // `EXISTS` everywhere, which is how #798 went wrong.
+                        Expression::ExistsSubquery { bare_pattern: true, .. } => {
+                            return Err(ValidationError::SizeOfNonCollection("a pattern"));
+                        }
+                        Expression::Variable(v) if paths.contains(v) => {
+                            return Err(ValidationError::SizeOfNonCollection("a path"));
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        for child in child_expressions(e) {
+            walk(child, paths)?;
+        }
+        Ok(())
+    }
+
+    for e in all_expressions(query) {
+        walk(e, &paths)?;
+    }
+    Ok(())
+}
+
 pub fn validate(query: &Query) -> Result<(), ValidationError> {
+    validate_size_arguments(query)?;
+
     validate_pattern_predicate_vars(query)?;
 
     validate_property_access_targets(query)?;

--- a/tests/size_argument_types.rs
+++ b/tests/size_argument_types.rs
@@ -1,0 +1,78 @@
+//! `size()` takes a list or a string, and rejects anything else at compile
+//! time (#843).
+//!
+//! ```cypher
+//! MATCH (a), (b), (c) RETURN size((a)-[:REL]->(b))
+//! MATCH p = (a)-[*]->(b) RETURN size(p)
+//! ```
+//!
+//! The engine already raised a `TypeError` for the pattern form — **but only
+//! when the pattern matched something.** The TCK's scenarios run against an
+//! empty graph, so nothing binds, the argument is never evaluated, and the
+//! query "succeeds with 0 rows". That is why openCypher requires the error at
+//! compile time: a runtime check is not a weaker version of the same thing, it
+//! is a different thing that an empty result silently satisfies.
+//!
+//! So every rejection below is asserted **against an empty store**, which is
+//! the condition the runtime check passes and the compile-time one does not.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// `Err` if the query is refused before it runs.
+fn compiles(cypher: &str) -> bool {
+    parse_query(cypher).is_ok()
+}
+
+/// **Against an empty store**, where a runtime check cannot fire.
+#[test]
+fn size_of_a_pattern_is_refused_before_it_runs() {
+    for pattern in [
+        "()--()",
+        "()--(a)",
+        "(a)-->()",
+        "(a)-[:REL]->(b)",
+        "(a)<--(a {})",
+        "()-[:REL*0..2]->()<-[:REL]-(:A {num: 5})",
+        "(a)-[:REL]->(:C)<-[:REL]-(a {num: 5})",
+    ] {
+        let cypher = format!("MATCH (a), (b), (c) RETURN size({pattern})");
+        assert!(!compiles(&cypher), "accepted size({pattern})");
+    }
+}
+
+/// A path has `length()`, not `size()` — and this one returned a number.
+#[test]
+fn size_of_a_path_is_refused() {
+    assert!(!compiles("MATCH p = (a)-[*]->(b) RETURN size(p)"));
+    assert!(!compiles("MATCH p = (a)-->(b) RETURN size(p)"));
+    // The same variable name not bound as a path is fine.
+    assert!(compiles("WITH [1,2] AS p RETURN size(p)"));
+}
+
+/// `EXISTS { ... }` desugars to the same AST node as a bare pattern. The
+/// `bare_pattern` flag is the only thing separating them, and widening the
+/// check to both is how #798 rejected every `EXISTS` in the codebase.
+#[test]
+fn exists_subqueries_are_untouched() {
+    assert!(compiles("MATCH (a) WHERE EXISTS { MATCH (a)-->(b) } RETURN a"));
+    assert!(compiles("MATCH (a) RETURN EXISTS { MATCH (a)-->(b) } AS e"));
+}
+
+/// The legitimate arguments still work, and still return the right answers —
+/// a check that refuses everything would pass the tests above.
+#[test]
+fn lists_and_strings_still_work() {
+    let store = GraphStore::new();
+    for (expr, want) in [("size([1,2,3])", 3), ("size('abc')", 3), ("size(keys({a:1}))", 1)] {
+        let cypher = format!("RETURN {expr} AS r");
+        let q = parse_query(&cypher).unwrap_or_else(|e| panic!("{cypher} refused: {e:?}"));
+        let batch = QueryExecutor::new(&store).execute(&q).expect("runs");
+        assert_eq!(
+            batch.records.first().and_then(|r| r.get("r")),
+            Some(&Value::Property(samyama::graph::PropertyValue::Integer(want))),
+            "{expr}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #843.

```cypher
MATCH (a), (b), (c) RETURN size((a)-[:REL]->(b))
MATCH p = (a)-[*]->(b) RETURN size(p)
```

Both must raise a `SyntaxError` **at compile time**.

## Why compile time is the whole point

The engine *did* raise a `TypeError` for the pattern form — but only when the pattern matched something. These scenarios run against an **empty graph**, so `MATCH (a), (b), (c)` binds nothing, the argument is never evaluated, and the runtime check never fires. The query "succeeds with 0 rows".

A runtime check is not a weaker version of a compile-time one here. It is a different thing that an empty result silently satisfies. Every test added asserts against an empty store, which is precisely the condition that separates them.

This is the earlier `size()`/`type()` trap one layer down: probing an empty store showed nothing, probing *with data* showed the `TypeError` and made the engine look correct — and neither probe reaches the requirement.

`size()` on a path returned a number. `length()` is the function for a path.

## The check

`validate_size_arguments`, alongside the other compile-time passes. It rejects:

- a **bare** pattern predicate — `bare_pattern: true` is what separates it from `EXISTS { ... }`, which desugars to the same AST node. Widening to both is how #798 rejected every `EXISTS` in the codebase, so `exists_subqueries_are_untouched` pins it;
- a variable bound as a **path**, collected from the `MATCH` clauses of *both* AST representations.

`size([1,2,3])`, `size('abc')` and `size(keys(...))` are unaffected — and asserted for their values, not just their acceptance, since a check that refused everything would pass the rejection tests.

## Verification

- TCK **3,561 → 3,570**, regression diff against the merge base **empty**. `List6` goes from 9 failures to **0**. Pass rate **94.9%**.
- The manifest diff reports 8 fixed against +9 pass: two `Examples:` rows render to the same scenario name, so deduplicating by name undercounts by one. The pass count is the honest figure.
- `--min-pass` ratcheted 3561 → 3570.