### PR TITLE
A null slice bound is not an absent one (#845)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3570
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3575
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -625,6 +625,20 @@ fn type_name_of(v: &Value) -> &'static str {
 }
 
 fn eval_list_slice(collection: Value, start: Option<Value>, end: Option<Value>) -> ExecutionResult<Value> {
+    // A bound that is present and **null** makes the whole slice null:
+    // `[1,2,3][1..null]` is null, not `[2,3]` (#845).
+    //
+    // An *absent* bound is a different thing and still means "to the end":
+    // `[1,2,3][1..]` is `[2,3]`. The two were indistinguishable here because
+    // both arms fell through to the same `_` default, so a null bound was
+    // silently read as an omitted one -- and the result is a perfectly good
+    // list, which is why nothing downstream noticed.
+    let is_null = |b: &Option<Value>| {
+        matches!(b, Some(Value::Property(PropertyValue::Null)) | Some(Value::Null))
+    };
+    if is_null(&start) || is_null(&end) {
+        return Ok(Value::Property(PropertyValue::Null));
+    }
     match &collection {
         Value::Property(PropertyValue::Array(arr)) => {
             let len = arr.len() as i64;

--- a/tests/list_slice_null_bounds.rs
+++ b/tests/list_slice_null_bounds.rs
@@ -1,0 +1,72 @@
+//! A null slice bound is not an absent one (#845).
+//!
+//! ```text
+//! [1,2,3][1..null]   is null,  was [2, 3]
+//! [1,2,3][1..]       is [2, 3]
+//! ```
+//!
+//! `eval_list_slice` matched an integer bound and sent everything else to one
+//! `_` arm, so a bound that was **present and null** became indistinguishable
+//! from one that was **omitted**. The result is a perfectly good list, which is
+//! why nothing downstream noticed.
+//!
+//! Both halves are pinned: a fix that returned null for an omitted bound would
+//! satisfy the null cases and break every ordinary slice.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn slice(expr: &str) -> PropertyValue {
+    let store = GraphStore::new();
+    let cypher = format!("WITH [1, 2, 3] AS list RETURN list{expr} AS r");
+    let q = parse_query(&cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.clone(),
+        Some(Value::Null) | None => PropertyValue::Null,
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+fn list(items: &[i64]) -> PropertyValue {
+    PropertyValue::Array(items.iter().map(|i| PropertyValue::Integer(*i)).collect())
+}
+
+/// Every position a null can occupy.
+#[test]
+fn a_null_bound_makes_the_whole_slice_null() {
+    for expr in ["[..null]", "[1..null]", "[null..3]", "[null..]", "[null..null]"] {
+        assert_eq!(slice(expr), PropertyValue::Null, "list{expr}");
+    }
+}
+
+/// **An omitted bound is a different thing** and still means "to the end".
+#[test]
+fn an_omitted_bound_is_unchanged() {
+    assert_eq!(slice("[1..2]"), list(&[2]));
+    assert_eq!(slice("[..2]"), list(&[1, 2]));
+    assert_eq!(slice("[1..]"), list(&[2, 3]));
+    assert_eq!(slice("[..]"), list(&[1, 2, 3]));
+    assert_eq!(slice("[-2..]"), list(&[2, 3]));
+    assert_eq!(slice("[..-1]"), list(&[1, 2]));
+    // Out of range stays an empty list, not null.
+    assert_eq!(slice("[5..9]"), list(&[]));
+    assert_eq!(slice("[2..1]"), list(&[]));
+}
+
+/// A null bound reached through a variable behaves the same as a literal one —
+/// the check is on the value, not on the syntax.
+#[test]
+fn a_null_bound_from_a_variable_behaves_the_same() {
+    let store = GraphStore::new();
+    let cypher = "WITH [1, 2, 3] AS list, null AS n RETURN list[1..n] AS r";
+    let q = parse_query(cypher).expect("parses");
+    let batch = QueryExecutor::new(&store).execute(&q).expect("runs");
+    assert!(matches!(
+        batch.records.first().and_then(|r| r.get("r")),
+        Some(Value::Property(PropertyValue::Null)) | Some(Value::Null) | None
+    ));
+}


### PR DESCRIPTION
Closes #845.

```
WITH [1, 2, 3] AS list RETURN list[1..null]
  expected null    got [2, 3]
```

Same for `[..null]`, `[null..3]`, `[null..]` and `[null..null]`.

## Cause

`eval_list_slice` matched an integer bound and sent everything else to one `_` arm:

```rust
let s = match start {
    Some(Value::Property(PropertyValue::Integer(i))) => resolve_idx(i),
    _ => 0,
};
```

So a bound that is **present and null** became indistinguishable from one that is **omitted**, and `[1..null]` became the same query as `[1..]`. They are not: an omitted bound means "to the end"; a null bound makes the whole slice null.

The result is a perfectly good list, which is why nothing downstream noticed.

## Both halves pinned

A fix that returned null for an *omitted* bound would satisfy every null scenario and break every ordinary slice, so `an_omitted_bound_is_unchanged` covers `[..]`, `[1..]`, `[..2]`, negative bounds and out-of-range bounds. A null arriving through a variable rather than as a literal is covered too — the check is on the value, not the syntax.

## Verification

- TCK **3,570 → 3,575**, regression diff against the merge base **empty**.
- `--min-pass` ratcheted 3570 → 3575.