### PR TITLE
Parse backtick-delimited property names (#847)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3575
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3581
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -204,7 +204,16 @@ property = { property_key ~ ":" ~ (value ~ !expression_continues | expression) }
 // A literal followed by an operator is really the start of an expression
 // (`{n: 1 + 2}`), so `value` must not win in that case.
 expression_continues = { "+" | "-" | "*" | "/" | "%" | "." | "[" | "=" | "<" | ">" | "!" }
-property_key = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
+// A property key may be written **delimited in backticks**, which is how
+// Cypher spells a name that is a keyword, starts with a digit, or contains
+// punctuation: `{`null`: 'x'}.`null``. A literal backtick inside is doubled.
+//
+// The rule stays atomic, so `as_str()` returns the text with its delimiters
+// still on; every read site goes through `unescape_name`, because a key stored
+// with its backticks still round-trips through the engine and only shows up as
+// a property nobody can find (#847).
+escaped_name = @{ "`" ~ ("``" | (!"`" ~ ANY))* ~ "`" }
+property_key = @{ escaped_name | ((ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")*) }
 
 // RETURN items
 //

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -515,7 +515,7 @@ fn parse_create_index_statement(pair: pest::iterators::Pair<Rule>, query: &mut Q
     for inner in pair.into_inner() {
         match inner.as_rule() {
             Rule::label => label = Some(Label::new(inner.as_str())),
-            Rule::property_key => properties.push(inner.as_str().to_string()),
+            Rule::property_key => properties.push(unescape_name(inner.as_str())),
             _ => {}
         }
     }
@@ -571,7 +571,7 @@ fn parse_create_hierarchy_index_statement(
                 for part in &parts {
                     match part.as_rule() {
                         Rule::label => measure_label = Some(part.as_str().to_string()),
-                        Rule::property_key => measure_property = Some(part.as_str().to_string()),
+                        Rule::property_key => measure_property = Some(unescape_name(part.as_str())),
                         _ => {}
                     }
                 }
@@ -609,7 +609,7 @@ fn parse_drop_index_statement(pair: pest::iterators::Pair<Rule>, query: &mut Que
     for inner in pair.into_inner() {
         match inner.as_rule() {
             Rule::label => label = Some(Label::new(inner.as_str())),
-            Rule::property_key => property = Some(inner.as_str().to_string()),
+            Rule::property_key => property = Some(unescape_name(inner.as_str())),
             _ => {}
         }
     }
@@ -652,7 +652,7 @@ fn parse_create_constraint_statement(pair: pest::iterators::Pair<Rule>, query: &
                 // Extract property from property_access (variable.property)
                 for pa in inner.into_inner() {
                     if pa.as_rule() == Rule::property_key {
-                        property = Some(pa.as_str().to_string());
+                        property = Some(unescape_name(pa.as_str()));
                     }
                 }
             }
@@ -687,7 +687,7 @@ fn parse_create_vector_index_statement(pair: pest::iterators::Pair<Rule>, query:
                 label = Some(Label::new(inner.as_str()));
             }
             Rule::property_key => {
-                property_key = Some(inner.as_str().to_string());
+                property_key = Some(unescape_name(inner.as_str()));
             }
             Rule::options => {
                 let options_map = parse_properties(inner)?;
@@ -800,6 +800,23 @@ fn parse_call_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) ->
         }
     }
     Ok(())
+}
+
+/// A name written delimited in backticks, with its delimiters removed.
+///
+/// Cypher spells a name that is a keyword, starts with a digit or contains
+/// punctuation by wrapping it in backticks, and doubles a literal backtick
+/// inside. Undelimited names pass through unchanged.
+///
+/// Every `Rule::property_key` read site goes through this. There are fourteen,
+/// and a key left with its backticks on round-trips through the engine
+/// perfectly well -- it just becomes a property nobody can find under the name
+/// they wrote (#847).
+fn unescape_name(raw: &str) -> String {
+    match raw.strip_prefix('`').and_then(|r| r.strip_suffix('`')) {
+        Some(inner) => inner.replace("``", "`"),
+        None => raw.to_string(),
+    }
 }
 
 /// Strip the surrounding quotes from a string literal and interpret its escape sequences.
@@ -1244,7 +1261,7 @@ fn parse_set_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<SetClause>
                         for pa in si.into_inner() {
                             match pa.as_rule() {
                                 Rule::variable => variable = pa.as_str().to_string(),
-                                Rule::property_key => property = pa.as_str().to_string(),
+                                Rule::property_key => property = unescape_name(pa.as_str()),
                                 _ => {}
                             }
                         }
@@ -1279,7 +1296,7 @@ fn parse_remove_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<RemoveC
                 for pa in children[0].clone().into_inner() {
                     match pa.as_rule() {
                         Rule::variable => variable = pa.as_str().to_string(),
-                        Rule::property_key => property = pa.as_str().to_string(),
+                        Rule::property_key => property = unescape_name(pa.as_str()),
                         _ => {}
                     }
                 }
@@ -1438,7 +1455,7 @@ fn parse_set_item(pair: pest::iterators::Pair<Rule>) -> ParseResult<SetItem> {
                 for pa in inner.into_inner() {
                     match pa.as_rule() {
                         Rule::variable => variable = pa.as_str().to_string(),
-                        Rule::property_key => property = pa.as_str().to_string(),
+                        Rule::property_key => property = unescape_name(pa.as_str()),
                         _ => {}
                     }
                 }
@@ -1711,7 +1728,7 @@ fn parse_properties_split(pair: pest::iterators::Pair<Rule>) -> ParseResult<Spli
                     let mut key = String::new();
                     for part in prop.into_inner() {
                         match part.as_rule() {
-                            Rule::property_key => key = part.as_str().to_string(),
+                            Rule::property_key => key = unescape_name(part.as_str()),
                             Rule::value => {
                                 literals.insert(key.clone(), parse_value(part)?);
                             }
@@ -1743,7 +1760,7 @@ fn parse_properties(pair: pest::iterators::Pair<Rule>) -> ParseResult<HashMap<St
                     for part in prop.into_inner() {
                         match part.as_rule() {
                             Rule::property_key => {
-                                key = part.as_str().to_string();
+                                key = unescape_name(part.as_str());
                             }
                             Rule::value => {
                                 value = parse_value(part)?;
@@ -1821,7 +1838,7 @@ fn parse_value(pair: pest::iterators::Pair<Rule>) -> ParseResult<PropertyValue> 
                         
                         for part in entry.into_inner() {
                             match part.as_rule() {
-                                Rule::property_key => key = part.as_str().to_string(),
+                                Rule::property_key => key = unescape_name(part.as_str()),
                                 Rule::string => {
                                     key = unescape_string_literal(part.as_str());
                                 }
@@ -2133,7 +2150,7 @@ fn parse_term(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
                     let key = index
                         .into_inner()
                         .find(|p| p.as_rule() == Rule::property_key)
-                        .map(|p| p.as_str().to_string())
+                        .map(|p| unescape_name(p.as_str()))
                         .ok_or_else(|| {
                             ParseError::SemanticError("member access without a name".to_string())
                         })?;
@@ -2259,7 +2276,7 @@ fn parse_nested_property_access(pair: pest::iterators::Pair<Rule>) -> ParseResul
     for inner in pair.into_inner() {
         match inner.as_rule() {
             Rule::variable => variable = Some(inner.as_str().to_string()),
-            Rule::property_key => keys.push(inner.as_str().to_string()),
+            Rule::property_key => keys.push(unescape_name(inner.as_str())),
             _ => {}
         }
     }
@@ -2367,7 +2384,7 @@ fn parse_primary(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
                     let mut value = None;
                     for part in entry.into_inner() {
                         match part.as_rule() {
-                            Rule::property_key => key = part.as_str().to_string(),
+                            Rule::property_key => key = unescape_name(part.as_str()),
                             Rule::string => {
                                 key = unescape_string_literal(part.as_str());
                             }
@@ -2636,7 +2653,12 @@ fn parse_property_access(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expre
     }
 
     let variable = parts[0].as_str().to_string();
-    let property = parts[1].as_str().to_string();
+    // The fifteenth read site, and the one a grep for `Rule::property_key`
+    // does not find: this one indexes positionally. Without the unescape,
+    // `map.`name`` parsed to `Property { property: "`name`" }` and looked up a
+    // key with backticks in its name -- null, from a query that had just been
+    // taught to parse (#847).
+    let property = unescape_name(parts[1].as_str());
 
     Ok(Expression::Property { variable, property })
 }

--- a/tests/delimited_identifiers.rs
+++ b/tests/delimited_identifiers.rs
@@ -1,0 +1,93 @@
+//! Backtick-delimited property names (#847).
+//!
+//! Cypher spells a name that is a keyword, starts with a digit, or contains
+//! punctuation by delimiting it in backticks, doubling any literal backtick
+//! inside. The grammar had no such rule.
+//!
+//! The fix has two halves, and the second is the one that matters: the rule
+//! stays **atomic**, so `as_str()` returns the text with its delimiters still
+//! on, and every read site has to strip them. Fourteen sites are spelled
+//! `Rule::property_key => … .as_str()` and a grep finds them all. The
+//! fifteenth, `parse_property_access`, indexes positionally — and with it
+//! missed, `map.`name`` *parsed* and then looked up a key literally named
+//! `` `name` ``. Null, from a query that had just been taught to accept it,
+//! which is worse than the parse error it replaced.
+//!
+//! So every case below is asserted through **both** spellings: a map in a
+//! variable (`property_access`) and a map literal (`member_op`, which desugars
+//! to an index). The literal form worked from the first change alone, which is
+//! exactly what made the variable form look like a separate feature.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn value(cypher: &str) -> Option<PropertyValue> {
+    let store = GraphStore::new();
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(PropertyValue::Null)) | Some(Value::Null) | None => None,
+        Some(Value::Property(p)) => Some(p.clone()),
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+fn s(text: &str) -> Option<PropertyValue> {
+    Some(PropertyValue::String(text.to_string()))
+}
+
+/// Both spellings, every row of the TCK's table.
+fn both_ways(map: &str, key: &str, want: Option<PropertyValue>) {
+    assert_eq!(
+        value(&format!("WITH {map} AS map RETURN map.{key} AS r")),
+        want,
+        "through a variable: map.{key}"
+    );
+    assert_eq!(
+        value(&format!("RETURN {map}.{key} AS r")),
+        want,
+        "on a literal: {map}.{key}"
+    );
+}
+
+#[test]
+fn a_delimited_name_reads_the_field_it_names() {
+    let m = "{name: 'Mats', nome: 'Pontus'}";
+    both_ways(m, "`name`", s("Mats"));
+    both_ways(m, "`nome`", s("Pontus"));
+    // A delimited name that matches a *value* rather than a key is still absent.
+    both_ways(m, "`Mats`", None);
+}
+
+/// **Keywords as keys**, which is the reason delimiting exists — and `null` and
+/// `NULL` are two different names.
+#[test]
+fn a_keyword_may_be_a_field_name_and_case_matters() {
+    let m = "{null: 'Mats', NULL: 'Pontus'}";
+    both_ways(m, "`null`", s("Mats"));
+    both_ways(m, "`NULL`", s("Pontus"));
+    both_ways("{name: 'Mats', nome: 'Pontus'}", "`null`", None);
+}
+
+/// Punctuation, spaces, and an escaped backtick.
+#[test]
+fn punctuation_and_escaped_backticks() {
+    both_ways("{`a b`: 1}", "`a b`", Some(PropertyValue::Integer(1)));
+    both_ways("{`a-b`: 1}", "`a-b`", Some(PropertyValue::Integer(1)));
+    both_ways("{`a``b`: 1}", "`a``b`", Some(PropertyValue::Integer(1)));
+}
+
+/// Undelimited names are unchanged — a fix that stripped the first and last
+/// character unconditionally would pass everything above.
+#[test]
+fn undelimited_names_are_unchanged() {
+    both_ways("{name: 'Mats'}", "name", s("Mats"));
+    both_ways("{n: 'x'}", "n", s("x"));
+    assert_eq!(
+        value("WITH {name: 'Mats'} AS map RETURN map.missing AS r"),
+        None
+    );
+}


### PR DESCRIPTION
Closes #847.

```cypher
WITH {name: 'Mats', nome: 'Pontus'} AS map RETURN map.`name`
-- ParsingError: expected property_key
```

Cypher spells a name that is a keyword, starts with a digit, or contains punctuation by delimiting it in backticks, doubling any literal backtick inside.

## Two halves, and the second is the one that matters

**The grammar.** `property_key` now also matches an `escaped_name`. The rule stays atomic, so `as_str()` returns the text with its delimiters still on — which makes the second half mandatory rather than tidy.

**Fifteen read sites.** Fourteen are spelled `Rule::property_key => … .as_str().to_string()`, and a grep finds them all. The fifteenth, `parse_property_access`, indexes **positionally**:

```rust
let property = parts[1].as_str().to_string();
```

Nothing on that line mentions `property_key`. With it missed, `` map.`name` `` **parsed** and then looked up a key literally named `` `name` `` — null, from a query that had just been taught to accept it. That is worse than the parse error it replaced: a parse error is visible, a null property is not.

The literal form `` {name: 'Mats'}.`name` `` goes down a different path (`member_op`, desugared to an index) and worked from the grammar change alone — which is exactly what made the variable form look like a separate feature rather than a missed site. **Every case in the tests is asserted through both spellings** for that reason.

`null` and `NULL` as distinct keys, spaces, punctuation and escaped backticks are covered, and `undelimited_names_are_unchanged` pins that a fix stripping the first and last character unconditionally would not pass.

## Verification

- TCK **3,575 → 3,581**, regression diff against the merge base **empty**. `Map1` goes from 6 failures to **0**.
- `--min-pass` ratcheted 3575 → 3581.