### PR TITLE
Share the component rule between duration.between and the in* family (#849)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3581
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3589
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3797,54 +3797,9 @@ fn temporal_difference_calendar(
     }
 
     let (da, db) = (date_part_of(a), date_part_of(b));
-    if da.is_none() || db.is_none() {
-        // Compare instants only when **both** sides carry an offset; otherwise
-        // compare the local readings.
-        //
-        // `time('14:30')` vs `time('16:30+0100')` is `PT1H` — both are zoned, so
-        // the second is 15:30 UTC. But `localtime('14:30')` vs
-        // `time('16:30+0100')` is `PT2H`: the unzoned side has no instant to
-        // convert to, so the offset is not applied to the other. Normalising
-        // unconditionally gets the first right and the second wrong; not
-        // normalising at all does the reverse.
-        // Both sides have a clock and at least one carries a zone: the two are
-        // real instants on a shared day, and only that treatment gets the
-        // daylight-saving rows right (#821). A side with no clock at all — a
-        // bare `date` against a `localtime` — keeps the shared-component rule
-        // below instead, since there is no instant to compare.
-        if time_part_of(a).is_some() && time_part_of(b).is_some() {
-            if let Some((na, nb)) = zone_aligned_instants(a, b) {
-                let diff = na - nb;
-                return Ok(PropertyValue::Duration {
-                    months: 0,
-                    days: 0,
-                    seconds: (diff / 1_000_000_000) as i64,
-                    nanos: (diff % 1_000_000_000) as i32,
-                });
-            }
-        }
-        let has_offset = |v: &PropertyValue| matches!(v, PropertyValue::Time { .. });
-        let both_zoned = has_offset(a) && has_offset(b);
-        let clock = |v: &PropertyValue| -> Option<i64> {
-            let local = time_part_of(v)?;
-            Some(match v {
-                PropertyValue::Time { offset_seconds, .. } if both_zoned => {
-                    local - *offset_seconds as i64 * 1_000_000_000
-                }
-                _ => local,
-            })
-        };
-        let (ta, tb) = (clock(a), clock(b));
-        // One side may have a date and no time — `duration.between(date(...),
-        // localtime(...))` compares the clocks, and a date's clock is midnight.
-        let (ta, tb) = (ta.unwrap_or(0), tb.unwrap_or(0));
-        let diff = ta - tb;
-        return Ok(PropertyValue::Duration {
-            months: 0,
-            days: 0,
-            seconds: diff / 1_000_000_000,
-            nanos: (diff % 1_000_000_000) as i32,
-        });
+    if let Some(shared) = shared_component_difference(a, b) {
+        let _ = (da, db);
+        return shared;
     }
     let (Some(da), Some(db)) = (da, db) else {
         return temporal_difference(a, b);
@@ -3975,10 +3930,69 @@ fn shift_months_clamped(
         .ok_or_else(|| ExecutionError::RuntimeError("date out of range".into()))
 }
 
+/// Only the components two temporals **share**, when one of them has no date.
+///
+/// A date has no time and a time has no date, so
+/// `duration.between(date(...), localtime('16:30'))` is `PT16H30M` — the clock
+/// difference alone, with the date side contributing nothing. Treating the
+/// missing part as zero instead gave `P-5396DT-7H-30M`: a real duration between
+/// two instants that were never comparable (#807).
+///
+/// Returns `None` when **both** sides carry a date, which is the ordinary case
+/// the callers handle themselves.
+///
+/// This lived inside `temporal_difference_calendar`, so `duration.between` had
+/// the rule and `duration.inDays`/`inSeconds` did not — the same difference
+/// measured two ways disagreed by fifteen years, and only on the mixed pairs
+/// (#849).
+fn shared_component_difference(
+    a: &PropertyValue,
+    b: &PropertyValue,
+) -> Option<Result<PropertyValue, ExecutionError>> {
+    if date_part_of(a).is_some() && date_part_of(b).is_some() {
+        return None;
+    }
+    // Both sides have a clock and at least one carries a zone: they are real
+    // instants on a shared day, and only that treatment gets the
+    // daylight-saving rows right (#821). A side with no clock at all -- a bare
+    // `date` against a `localtime` -- falls through to the reading below,
+    // since there is no instant to compare.
+    if time_part_of(a).is_some() && time_part_of(b).is_some() {
+        if let Some((na, nb)) = zone_aligned_instants(a, b) {
+            let diff = na - nb;
+            return Some(Ok(PropertyValue::Duration {
+                months: 0,
+                days: 0,
+                seconds: (diff / 1_000_000_000) as i64,
+                nanos: (diff % 1_000_000_000) as i32,
+            }));
+        }
+    }
+    // Neither side is zoned: compare the local readings. A date's clock is
+    // midnight.
+    let (ta, tb) = (
+        time_part_of(a).unwrap_or(0),
+        time_part_of(b).unwrap_or(0),
+    );
+    let diff = ta - tb;
+    Some(Ok(PropertyValue::Duration {
+        months: 0,
+        days: 0,
+        seconds: diff / 1_000_000_000,
+        nanos: (diff % 1_000_000_000) as i32,
+    }))
+}
+
 fn temporal_difference(
     a: &PropertyValue,
     b: &PropertyValue,
 ) -> Result<PropertyValue, ExecutionError> {
+    // Only the shared components, when one side has no date (#807). This lived
+    // in the calendar function alone, so `duration.between` had the rule and
+    // `duration.inDays`/`inSeconds` did not (#849).
+    if let Some(shared) = shared_component_difference(a, b) {
+        return shared;
+    }
     // When either side carries a zone the other is read in it, rather than as
     // UTC (#821).
     let (na, nb) = match zone_aligned_instants(a, b) {

--- a/tests/duration_shared_components.rs
+++ b/tests/duration_shared_components.rs
@@ -1,0 +1,114 @@
+//! `duration.between`, `inDays` and `inSeconds` agree on which components two
+//! temporals share (#849).
+//!
+//! ```text
+//! duration.inDays(date('1984-10-11'), localtime('16:30'))
+//!   expected PT0S, got P-5396D
+//! ```
+//!
+//! A date has no time and a time has no date, so only the components the two
+//! values **share** are compared — #807's rule. It lived inside
+//! `temporal_difference_calendar`, which only `duration.between` and
+//! `inMonths` reach; `inDays` and `inSeconds` used the plain difference, which
+//! reads a `localtime` as a clock at the epoch and measures fifteen years of
+//! nothing.
+//!
+//! The same difference, measured two ways, disagreed by decades — **and only
+//! on mixed pairs**, which is why every date-to-date row was right and the
+//! family looked correct. The cross-check below is the point of this file: for
+//! each pair, the three spellings must tell the same story.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn duration(expr: &str) -> String {
+    let store = GraphStore::new();
+    let cypher = format!("RETURN {expr} AS r");
+    let q = parse_query(&cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.to_cypher_string(),
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+fn check(rows: &[(&str, &str, &str, &str)]) {
+    let wrong: Vec<String> = rows
+        .iter()
+        .filter_map(|(f, lhs, rhs, want)| {
+            let got = duration(&format!("duration.{f}({lhs}, {rhs})"));
+            (got != *want)
+                .then(|| format!("  duration.{f}({lhs}, {rhs})\n    want {want}\n    got  {got}"))
+        })
+        .collect();
+    assert!(wrong.is_empty(), "\n{}", wrong.join("\n"));
+}
+
+/// The TCK's mixed pairs: a value with no date contributes no days.
+#[test]
+fn a_pair_with_no_shared_date_measures_zero_days() {
+    check(&[
+        ("inDays", "date('1984-10-11')", "localtime('16:30')", "PT0S"),
+        ("inDays", "date('1984-10-11')", "time('16:30+0100')", "PT0S"),
+        ("inDays", "localtime('14:30')", "date('2015-06-24')", "PT0S"),
+        ("inDays", "localtime('14:30')", "localdatetime('2016-07-21T21:45:22.142')", "PT0S"),
+        ("inDays", "localtime('14:30')", "datetime('2015-07-21T21:40:32.142+0100')", "PT0S"),
+        ("inDays", "time('14:30')", "date('2015-06-24')", "PT0S"),
+        ("inDays", "localdatetime('2015-07-21T21:40:32.142')", "localtime('16:30')", "PT0S"),
+    ]);
+}
+
+/// And the clock difference is the whole answer in seconds.
+#[test]
+fn the_clock_difference_is_the_whole_answer() {
+    check(&[
+        ("inSeconds", "date('1984-10-11')", "localtime('16:30')", "PT16H30M"),
+        ("inSeconds", "localtime('14:30')", "date('2015-06-24')", "PT-14H-30M"),
+        (
+            "inSeconds",
+            "localtime('14:30')",
+            "localdatetime('2016-07-21T21:45:22.142')",
+            "PT7H15M22.142S",
+        ),
+    ]);
+}
+
+/// **The cross-check.** For a pair with no shared date, `between` and
+/// `inSeconds` must agree, and `inDays` must be zero. Disagreement between the
+/// spellings is the defect this file exists for, and it is invisible from any
+/// one of them.
+#[test]
+fn the_three_spellings_agree() {
+    for (lhs, rhs) in [
+        ("date('1984-10-11')", "localtime('16:30')"),
+        ("localtime('14:30')", "date('2015-06-24')"),
+        ("localdatetime('2015-07-21T21:40:32.142')", "localtime('16:30')"),
+        ("time('14:30')", "datetime('2015-07-21T21:40:32.142+0100')"),
+    ] {
+        let between = duration(&format!("duration.between({lhs}, {rhs})"));
+        let in_seconds = duration(&format!("duration.inSeconds({lhs}, {rhs})"));
+        let in_days = duration(&format!("duration.inDays({lhs}, {rhs})"));
+        assert_eq!(between, in_seconds, "between vs inSeconds for ({lhs}, {rhs})");
+        assert_eq!(in_days, "PT0S", "inDays for ({lhs}, {rhs})");
+    }
+}
+
+/// Pairs that *do* share a date are unchanged — the calendar rule and the
+/// elapsed rule still differ from each other, which #804 established.
+#[test]
+fn pairs_sharing_a_date_are_unchanged() {
+    check(&[
+        ("inDays", "date('1984-10-11')", "date('2015-06-24')", "P11213D"),
+        ("inDays", "localdatetime('2015-07-21T21:40:32.142')", "date('2015-06-24')", "P-27D"),
+        (
+            "inDays",
+            "datetime('2014-07-21T21:40:36.143+0200')",
+            "datetime('2015-07-21T21:40:32.142+0100')",
+            "P365D",
+        ),
+        ("between", "date('1984-10-11')", "date('2015-06-24')", "P30Y8M13D"),
+    ]);
+}


### PR DESCRIPTION
Closes #849.

```
duration.inDays(date('1984-10-11'), localtime('16:30'))
  expected PT0S        got P-5396D

duration.inSeconds(date('1984-10-11'), localtime('16:30'))
  expected PT16H30M    got PT-129511H-30M
```

`duration.between` on the same pair was already correct.

## Cause

A date has no time and a time has no date, so only the components the two values **share** are compared — #807's rule. It was implemented inside `temporal_difference_calendar`, which only `duration.between` and `inMonths` reach. `inDays` and `inSeconds` use the plain `temporal_difference`, which reads a `localtime` as a clock at the epoch and measures fifteen years of nothing.

The same difference, measured two ways, disagreed by decades — **and only on mixed pairs**, which is why every date-to-date row was right and the family looked correct.

## Fix

Extracted into `shared_component_difference`, used by both. It returns `None` when both sides carry a date, which is the ordinary case the callers already handle.

This preserves the split #804 established — `duration.between` counts calendar months, `-` does not — because that split is about the *month arithmetic*, not about which components are comparable. Sharing the component rule does not merge the two functions, and `pairs_sharing_a_date_are_unchanged` pins that `between` still answers `P30Y8M13D` where `inDays` answers `P11213D`.

## The test that matters

`the_three_spellings_agree` cross-checks `between`, `inSeconds` and `inDays` against each other for every mixed pair. **Disagreement between the spellings is the defect, and it is invisible from any one of them alone** — which is exactly how this survived while each function looked individually plausible.

## Verification

- TCK **3,581 → 3,589**, regression diff against the merge base **empty**. `Temporal10` scenarios 4 and 5 go to **0** failures.
- `--min-pass` ratcheted 3581 → 3589.