### PR TITLE
Week-date overrides use the ISO week year, in every constructor (#851)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3589
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3597
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1763,10 +1763,19 @@ fn apply_date_overrides(
         chrono::NaiveDate::from_yo_opt(year, ord as u32)
             .ok_or_else(|| ExecutionError::RuntimeError(format!("invalid ordinalDay {ord}")))?
     } else if map.contains_key("week") || map.contains_key("dayOfWeek") {
+        // In a week date the year is the **ISO week year**, which is not the
+        // calendar year near a year boundary: 1816-12-30 is a Monday belonging
+        // to 1817-W01, so `{date: date('1816-12-30'), week: 2}` is in January
+        // 1817. Defaulting to `cur.year()` sent it to 1816-W02, eleven and a
+        // half months early -- a real date, in the wrong year (#851).
+        //
+        // An explicit `year` still wins, and is likewise read as the week year:
+        // `{date: date('1816-12-31'), year: 1817, week: 2}` is 1817-W02.
+        let week_year = g("year").unwrap_or(cur.iso_week().year() as i64) as i32;
         let week = g("week").unwrap_or(cur.iso_week().week() as i64) as u32;
         let dow = g("dayOfWeek").unwrap_or(cur.weekday().number_from_monday() as i64) as u32;
-        chrono::NaiveDate::from_isoywd_opt(year, week, weekday_from_iso_num(dow))
-            .ok_or_else(|| ExecutionError::RuntimeError(format!("invalid week date {year}-W{week}-{dow}")))?
+        chrono::NaiveDate::from_isoywd_opt(week_year, week, weekday_from_iso_num(dow))
+            .ok_or_else(|| ExecutionError::RuntimeError(format!("invalid week date {week_year}-W{week}-{dow}")))?
     } else if map.contains_key("quarter") || map.contains_key("dayOfQuarter") {
         let q = g("quarter").unwrap_or(((cur.month() - 1) / 3 + 1) as i64);
         // The day within the quarter defaults to the **current** one, exactly
@@ -1876,23 +1885,21 @@ fn compose_date_and_time(
         }
     };
 
-    // Date overrides on top of a selected date.
-    if base_date.is_some()
-        && ["year", "month", "day", "ordinalDay", "week", "dayOfWeek", "quarter", "dayOfQuarter"]
-            .iter()
-            .any(|k| map.contains_key(*k))
-    {
-        let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1).expect("epoch");
-        let cur = epoch
-            .checked_add_signed(chrono::Duration::days(days as i64))
-            .ok_or_else(|| ExecutionError::RuntimeError("date out of range".into()))?;
-        let y = map.get("year").and_then(|v| v.as_integer()).unwrap_or(cur.year() as i64) as i32;
-        let mo = map.get("month").and_then(|v| v.as_integer()).unwrap_or(cur.month() as i64) as u32;
-        let d = map.get("day").and_then(|v| v.as_integer()).unwrap_or(cur.day() as i64) as u32;
-        days = chrono::NaiveDate::from_ymd_opt(y, mo, d)
-            .ok_or_else(|| ExecutionError::RuntimeError(format!("invalid date {y}-{mo}-{d}")))?
-            .signed_duration_since(epoch)
-            .num_days() as i32;
+    // Date overrides on top of a selected date, through the same function
+    // `date()` uses.
+    //
+    // This was a **second implementation** of the rule, and it tested for
+    // `week`, `dayOfWeek`, `ordinalDay`, `quarter` and `dayOfQuarter` in its
+    // condition and then handled only `year`/`month`/`day`. So
+    // `localdatetime({date: date('1816-12-31'), week: 2})` entered the branch,
+    // recomputed the same y/m/d it started with, and returned the date
+    // unchanged -- a correct-looking value from an override that did nothing.
+    //
+    // Routing both through `apply_date_overrides` also gives the composite
+    // constructors the week-year rule (#851) and the `quarter` fix (#838),
+    // neither of which they had (#851).
+    if base_date.is_some() {
+        days = apply_date_overrides(days, map)?;
     }
 
     let clock_keys = ["hour", "minute", "second", "millisecond", "microsecond", "nanosecond"];

--- a/tests/week_date_overrides.rs
+++ b/tests/week_date_overrides.rs
@@ -1,0 +1,103 @@
+//! A week-date override uses the **ISO week year**, and every constructor
+//! applies the same override rule (#851).
+//!
+//! ```text
+//! date({date: date('1816-12-31'), week: 2})            1817-01-07, was 1816-01-05
+//! localdatetime({date: date('1816-12-31'), week: 2})   1817-01-07T00:00, was unchanged
+//! ```
+//!
+//! Two defects. The year in a week date is the ISO week year, not the calendar
+//! year: 1816-12-30 is a Monday belonging to 1817-W01. And
+//! `compose_date_and_time` had a **second implementation** of the override
+//! rule, which tested for `week`, `quarter` and the rest in its condition and
+//! then handled only `year`/`month`/`day` — so the composite constructors
+//! entered the branch, recomputed the date they already had, and returned it
+//! unchanged.
+//!
+//! Every case is therefore asserted through `date()`, `localdatetime()` and
+//! `datetime()`, because a fix to one of them says nothing about the others.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn rendered(expr: &str) -> String {
+    let store = GraphStore::new();
+    let cypher = format!("RETURN {expr} AS r");
+    let q = parse_query(&cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.to_cypher_string(),
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+fn check(rows: &[(String, &str)]) {
+    let wrong: Vec<String> = rows
+        .iter()
+        .filter_map(|(expr, want)| {
+            let got = rendered(expr);
+            (got != *want).then(|| format!("  {expr}\n    want {want}\n    got  {got}"))
+        })
+        .collect();
+    assert!(wrong.is_empty(), "\n{}", wrong.join("\n"));
+}
+
+/// The year boundary, where the week year and the calendar year differ.
+#[test]
+fn a_week_override_uses_the_iso_week_year() {
+    check(&[
+        ("date({date: date('1816-12-30'), week: 2, dayOfWeek: 3})".into(), "1817-01-08"),
+        ("date({date: date('1816-12-31'), week: 2})".into(), "1817-01-07"),
+        // An explicit year is read as the week year too.
+        ("date({date: date('1816-12-31'), year: 1817, week: 2})".into(), "1817-01-07"),
+    ]);
+}
+
+/// **The same three cases through the composite constructors**, which had
+/// their own copy of the rule and applied none of it.
+#[test]
+fn the_composite_constructors_apply_the_same_rule() {
+    check(&[
+        ("localdatetime({date: date('1816-12-31'), week: 2})".into(), "1817-01-07T00:00"),
+        (
+            "localdatetime({date: date('1816-12-30'), week: 2, dayOfWeek: 3})".into(),
+            "1817-01-08T00:00",
+        ),
+        ("datetime({date: date('1816-12-31'), week: 2})".into(), "1817-01-07T00:00Z"),
+        ("datetime({date: date('1816-12-31'), year: 1817, week: 2})".into(), "1817-01-07T00:00Z"),
+        // And the `quarter` rule from #838, which the composite path never had.
+        ("localdatetime({date: date('1984-11-11'), quarter: 3})".into(), "1984-08-11T00:00"),
+    ]);
+}
+
+/// Away from the boundary the two years agree, so these would pass either way —
+/// they are here to show the fix did not simply shift everything by a year.
+///
+/// 11 October 1984 is a **Thursday**, and the Thursday of 1984-W02 is
+/// 12 January. My first version of this test said the 11th.
+#[test]
+fn mid_year_week_dates_are_unchanged() {
+    check(&[
+        ("date({date: date('1984-10-11'), week: 2})".into(), "1984-01-12"),
+        ("date({year: 1984, week: 10, dayOfWeek: 3})".into(), "1984-03-07"),
+    ]);
+}
+
+/// Ordinary overrides and selections still work through every constructor — a
+/// change that routed everything through one function could have broken these
+/// and satisfied every case above.
+#[test]
+fn ordinary_overrides_are_undisturbed() {
+    check(&[
+        ("date({year: 1984, month: 10, day: 11})".into(), "1984-10-11"),
+        ("date({date: date('1984-10-11'), month: 3})".into(), "1984-03-11"),
+        ("localdatetime({date: date('1984-10-11'), month: 3})".into(), "1984-03-11T00:00"),
+        (
+            "localdatetime({date: date('1984-10-11'), time: localtime('12:31')})".into(),
+            "1984-10-11T12:31",
+        ),
+    ]);
+}


### PR DESCRIPTION
Closes #851.

```
date({date: date('1816-12-31'), week: 2})
  expected 1817-01-07          got 1816-01-05

localdatetime({date: date('1816-12-31'), week: 2})
  expected 1817-01-07T00:00    got 1816-12-31T00:00   -- unchanged
```

## Two defects

**The year in a week date is the ISO week year.** 1816-12-30 is a Monday belonging to 1817-W01, so `{date: date('1816-12-30'), week: 2}` lands in January 1817. Defaulting to `cur.year()` sent it to 1816-W02 — eleven and a half months early, and a perfectly real date. An explicit `year` is read as the week year too.

**The composite constructors had a second implementation of the whole override rule.** `compose_date_and_time` tested for `week`, `dayOfWeek`, `ordinalDay`, `quarter` and `dayOfQuarter` in its condition — and then handled only `year`/`month`/`day`. So `localdatetime({date: d, week: 2})` entered the branch, recomputed the year-month-day it already had, and returned the date **unchanged**: a correct-looking value from an override that did nothing.

Both now go through `apply_date_overrides`, which also gives the composite constructors #838's `quarter` fix, which they never had.

This is the third instance this cycle of **one rule implemented twice**, after #831's six write paths and #849's two difference functions — so every case in the tests is asserted through `date()`, `localdatetime()` *and* `datetime()`.

## A correction worth recording

My control expectation for `date({date: date('1984-10-11'), week: 2})` was `1984-01-11`; the engine said `1984-01-12`. **The engine was right** — 11 October 1984 is a Thursday, and the Thursday of 1984-W02 is the 12th. The test now carries the correct value and a note, since it is the obvious thing to get wrong when reading it back.

## Verification

- TCK **3,589 → 3,597**, regression diff against the merge base **empty**. `Temporal1`'s week-date scenarios go to **0**.
- `--min-pass` ratcheted 3589 → 3597.