### PR TITLE
Round-trip durations, and drop a duration's date part on a time (#853)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3597
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3611
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3677,13 +3677,22 @@ fn shift_temporal(
     // to the same day — so this only showed up on subtraction and on
     // mixed-sign durations (#817).
     let drop_sub_day = matches!(v, PropertyValue::Date(_));
+    // A time of day has no calendar, so a duration's **date part is dropped**:
+    // months and days cannot move a clock. This is the mirror of the rule
+    // above, and it is why `localtime('12:31:14') + duration({months: 1,
+    // days: -14, hours: 16})` is a time sixteen hours later and not an error
+    // (#853).
+    let drop_date_part = matches!(v, PropertyValue::LocalTime(_) | PropertyValue::Time { .. });
     let exact = if drop_sub_day {
         days as i128 * 86_400 * 1_000_000_000
+    } else if drop_date_part {
+        seconds as i128 * 1_000_000_000 + nanos as i128
     } else {
         days as i128 * 86_400 * 1_000_000_000
             + seconds as i128 * 1_000_000_000
             + nanos as i128
     };
+    let months = if drop_date_part { 0 } else { months };
 
     // Calendar months first, on whatever date part the value has.
     let month_shift_nanos = if months == 0 {
@@ -4051,63 +4060,110 @@ fn add_duration_to_datetime(dt_millis: i64, months: i64, days: i64, seconds: i64
 }
 
 /// Parse ISO 8601 duration string (e.g. "P1Y2M3DT4H5M6S")
+/// Parse an ISO-8601 duration, with **per-component signs** (#853).
+///
+/// `toString` renders a mixed-sign duration as `P1DT-0.001S`, and Cypher
+/// requires `duration(toString(d)) = d`. The old scanner accepted only digits
+/// and `.` into its number buffer, so a `-` was silently skipped and the value
+/// came back positive -- a round trip that returned a *different duration* and
+/// reported success.
+///
+/// It also computed the fraction as `(val - val.floor()) * 1e9` in `f64`, so
+/// `PT-2.001S` came back as `PT2.000999999S`: wrong sign and one nanosecond
+/// short. The fraction is now read from its digits, which is exact.
+///
+/// Time components are summed in nanoseconds and split once at the end, so the
+/// result's seconds and nanoseconds share the sign of their total (#806).
 fn parse_iso_duration(s: &str) -> ExecutionResult<Value> {
-    let s = s.trim();
-    if !s.starts_with('P') && !s.starts_with('p') {
+    let text = s.trim();
+    if !text.starts_with('P') && !text.starts_with('p') {
         return Err(ExecutionError::RuntimeError(format!("Invalid duration format: {}", s)));
     }
-    let rest = &s[1..];
-    let mut months: i64 = 0;
-    let mut days: i64 = 0;
-    let mut seconds: i64 = 0;
-    let mut nanos: i32 = 0;
-    let _ = nanos; // suppress warning
-
-    let (date_part, time_part) = if let Some(idx) = rest.find(|c: char| c == 'T' || c == 't') {
-        (&rest[..idx], &rest[idx + 1..])
-    } else {
-        (rest, "")
+    let rest = &text[1..];
+    let (date_part, time_part) = match rest.find(|c: char| c == 'T' || c == 't') {
+        Some(idx) => (&rest[..idx], &rest[idx + 1..]),
+        None => (rest, ""),
     };
 
-    // Parse date part: Y, M, D
-    let mut num_buf = String::new();
-    for ch in date_part.chars() {
-        if ch.is_ascii_digit() || ch == '.' {
-            num_buf.push(ch);
-        } else {
-            let val: f64 = num_buf.parse().unwrap_or(0.0);
-            num_buf.clear();
-            match ch {
-                'Y' | 'y' => months += (val * 12.0) as i64,
-                'M' | 'm' => months += val as i64,
-                'W' | 'w' => days += (val * 7.0) as i64,
-                'D' | 'd' => days += val as i64,
-                _ => {}
-            }
+    const NPS: i128 = 1_000_000_000;
+    // A mean Gregorian month is exactly 2,629,746 seconds (#829).
+    const MEAN_MONTH_NANOS: i128 = 2_629_746 * NPS;
+
+    let mut months: i128 = 0;
+    let mut days: i128 = 0;
+    let mut time_nanos: i128 = 0;
+
+    /// One component: an optional sign, digits, an optional fraction, a unit.
+    ///
+    /// Returns the value scaled to `unit_nanos`, exactly -- the fraction is
+    /// read from its digits rather than through a float, so `.001` is a
+    /// million nanoseconds and not 999,999.
+    fn scaled(sign: i128, int_digits: &str, frac_digits: &str, unit_nanos: i128) -> i128 {
+        let whole: i128 = int_digits.parse().unwrap_or(0);
+        let mut out = whole * unit_nanos;
+        if !frac_digits.is_empty() {
+            let num: i128 = frac_digits.parse().unwrap_or(0);
+            let denom = 10i128.checked_pow(frac_digits.len() as u32).unwrap_or(1);
+            out += num * unit_nanos / denom;
         }
+        sign * out
     }
 
-    // Parse time part: H, M, S
-    num_buf.clear();
-    for ch in time_part.chars() {
-        if ch.is_ascii_digit() || ch == '.' {
-            num_buf.push(ch);
-        } else {
-            let val: f64 = num_buf.parse().unwrap_or(0.0);
-            num_buf.clear();
+    let mut scan = |section: &str, is_time: bool| -> Result<(), ExecutionError> {
+        let mut sign: i128 = 1;
+        let mut int_digits = String::new();
+        let mut frac_digits = String::new();
+        let mut in_fraction = false;
+        for ch in section.chars() {
             match ch {
-                'H' | 'h' => seconds += (val * 3600.0) as i64,
-                'M' | 'm' => seconds += (val * 60.0) as i64,
-                'S' | 's' => {
-                    seconds += val as i64;
-                    nanos = ((val - val.floor()) * 1_000_000_000.0) as i32;
+                '-' if int_digits.is_empty() && frac_digits.is_empty() => sign = -1,
+                '+' if int_digits.is_empty() && frac_digits.is_empty() => sign = 1,
+                '.' | ',' => in_fraction = true,
+                c if c.is_ascii_digit() => {
+                    if in_fraction { frac_digits.push(c) } else { int_digits.push(c) }
                 }
-                _ => {}
+                unit => {
+                    // Years, weeks and a fractional month or day contribute to
+                    // the next unit down, using the same constants the map
+                    // constructor derives (#829).
+                    match unit {
+                        'Y' | 'y' => months += scaled(sign, &int_digits, &frac_digits, 12),
+                        'W' | 'w' => days += scaled(sign, &int_digits, &frac_digits, 7),
+                        'D' | 'd' if !is_time => {
+                            let total = scaled(sign, &int_digits, &frac_digits, NPS * 86_400);
+                            days += total / (NPS * 86_400);
+                            time_nanos += total % (NPS * 86_400);
+                        }
+                        'M' | 'm' if !is_time => {
+                            let total = scaled(sign, &int_digits, &frac_digits, MEAN_MONTH_NANOS);
+                            months += total / MEAN_MONTH_NANOS;
+                            let rem = total % MEAN_MONTH_NANOS;
+                            days += rem / (NPS * 86_400);
+                            time_nanos += rem % (NPS * 86_400);
+                        }
+                        'H' | 'h' => time_nanos += scaled(sign, &int_digits, &frac_digits, NPS * 3600),
+                        'M' | 'm' => time_nanos += scaled(sign, &int_digits, &frac_digits, NPS * 60),
+                        'S' | 's' => time_nanos += scaled(sign, &int_digits, &frac_digits, NPS),
+                        _ => {}
+                    }
+                    sign = 1;
+                    int_digits.clear();
+                    frac_digits.clear();
+                    in_fraction = false;
+                }
             }
         }
-    }
+        Ok(())
+    };
+    scan(date_part, false)?;
+    scan(time_part, true)?;
 
-    Ok(Value::Property(PropertyValue::Duration { months, days, seconds, nanos }))
+    Ok(Value::Property(PropertyValue::Duration {
+        months: months as i64,
+        days: days as i64,
+        seconds: (time_nanos / NPS) as i64,
+        nanos: (time_nanos % NPS) as i32,
+    }))
 }
 
 /// Shared CASE expression evaluation

--- a/tests/duration_round_trip.rs
+++ b/tests/duration_round_trip.rs
@@ -1,0 +1,102 @@
+//! `duration(toString(d)) = d`, and a time drops a duration's date part (#853).
+//!
+//! Two defects found by the same pair of scenarios.
+//!
+//! **The round trip returned a different duration.** `toString` was correct
+//! throughout; the parser dropped per-component minus signs — its scanner
+//! accepted only digits and `.`, so a `-` was silently skipped — and computed
+//! the fraction as `(val - val.floor()) * 1e9`, turning `.001` into 999,999
+//! nanoseconds. `PT-2.001S` came back as `PT2.000999999S`: wrong sign, one
+//! nanosecond short, and reported as success.
+//!
+//! **A duration with months could not be added to a time.** A clock has no
+//! calendar, so the date part is dropped — the exact mirror of #817, where a
+//! date has no clock and the sub-day part is dropped.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn one(cypher: &str) -> PropertyValue {
+    let store = GraphStore::new();
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.clone(),
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+fn rendered(expr: &str) -> String {
+    one(&format!("RETURN {expr} AS r")).to_cypher_string()
+}
+
+/// The TCK's serialization table, asserted as the round trip it actually is:
+/// the rendered text **and** that parsing it back gives the same value.
+#[test]
+fn every_duration_survives_a_round_trip() {
+    for (map, text) in [
+        ("{days: 1, milliseconds: -1}", "P1DT-0.001S"),
+        ("{seconds: -2, milliseconds: -1}", "PT-2.001S"),
+        ("{seconds: -2, milliseconds: 1}", "PT-1.999S"),
+        ("{seconds: -60, milliseconds: -1}", "PT-1M-0.001S"),
+        ("{seconds: -60, milliseconds: 1}", "PT-59.999S"),
+        ("{years: 12, months: 5, days: -14, hours: 16}", "P12Y5M-14DT16H"),
+        ("{seconds: 2, milliseconds: -1}", "PT1.999S"),
+        ("{nanoseconds: -1}", "PT-0.000000001S"),
+    ] {
+        assert_eq!(rendered(&format!("toString(duration({map}))")), format!("\"{text}\""), "{map}");
+        assert_eq!(
+            one(&format!("WITH duration({map}) AS d RETURN duration(toString(d)) = d AS r")),
+            PropertyValue::Boolean(true),
+            "round trip of {map} (rendered {text})"
+        );
+    }
+}
+
+/// **The fraction is exact.** Computed through an `f64` subtraction, `.001`
+/// became 999,999 nanoseconds — a value that renders plausibly and is wrong.
+#[test]
+fn a_fraction_is_read_from_its_digits() {
+    assert_eq!(rendered("duration('PT2.001S')"), "PT2.001S");
+    assert_eq!(rendered("duration('PT-2.001S')"), "PT-2.001S");
+    assert_eq!(rendered("duration('PT0.000000001S')"), "PT0.000000001S");
+    assert_eq!(rendered("duration('PT1.5S')"), "PT1.5S");
+}
+
+/// Signs attach to components, not to the whole duration.
+#[test]
+fn each_component_carries_its_own_sign() {
+    assert_eq!(rendered("duration('P1DT-0.001S')"), "P1DT-0.001S");
+    assert_eq!(rendered("duration('P12Y5M-14DT16H')"), "P12Y5M-14DT16H");
+    assert_eq!(rendered("duration('P-1DT1H')"), "P-1DT1H");
+}
+
+/// A clock has no calendar: months and days are dropped, and only the time
+/// part moves it. The TCK's own expected values.
+#[test]
+fn a_time_drops_the_date_part_of_a_duration() {
+    let x = "localtime({hour: 12, minute: 31, second: 14, nanosecond: 1})";
+    let d1 = "duration({months: 1, days: -14, hours: 16, minutes: -12, seconds: 70})";
+    let d2 = "duration({years: 12, months: 5, days: 14, hours: 16, minutes: 12, seconds: 70, nanoseconds: 2})";
+    assert_eq!(rendered(&format!("{x} + {d2}")), "04:44:24.000000003");
+    assert_eq!(rendered(&format!("{x} - {d2}")), "20:18:03.999999999");
+    assert_eq!(rendered(&format!("{x} + {d1}")), "04:20:24.000000001");
+    assert_eq!(rendered(&format!("{x} - {d1}")), "20:42:04.000000001");
+
+    // A zoned time keeps its offset while its clock moves.
+    let t = "time({hour: 12, minute: 31, second: 14, nanosecond: 1, timezone: '+01:00'})";
+    assert_eq!(rendered(&format!("{t} + duration({{hours: 1}})")), "13:31:14.000000001+01:00");
+}
+
+/// A date-time still applies **both** parts, so the two mirrored rules cannot
+/// be over-applied to the type that has a calendar and a clock.
+#[test]
+fn a_datetime_applies_both_parts() {
+    assert_eq!(
+        rendered("localdatetime({year: 1984, month: 10, day: 11, hour: 12}) + duration({months: 1, hours: 3})"),
+        "1984-11-11T15:00"
+    );
+}


### PR DESCRIPTION
Closes #853. Two defects, both found by the same pair of scenarios.

## `duration(toString(d))` returned a different duration

```
duration({days: 1, milliseconds: -1})      toString "P1DT-0.001S"  parsed back  P1DT0.001S
duration({seconds: -2, milliseconds: -1})  toString "PT-2.001S"    parsed back  PT2.000999999S
```

**`toString` was correct in every case.** The parser was not:

- **Per-component signs were dropped.** The scanner accepted only digits and `.` into its number buffer, so a `-` was skipped silently and the value came back positive — a round trip that returns a *different duration* and reports success.
- **The fraction was computed in floating point** as `(val - val.floor()) * 1e9`, turning `.001` into 999,999 nanoseconds. Hence `PT2.000999999S`: wrong sign *and* one nanosecond short. It is now read from its digits, which is exact.

Time components are summed in nanoseconds and split once at the end, so seconds and nanoseconds share the sign of their total (#806).

## A duration with months could not be added to a time

```
localtime('12:31:14') + duration({months: 1, days: -14, hours: 16, minutes: -12, seconds: 70})
-- TypeError: cannot add months to a value with no date part
```

A clock has no calendar, so the duration's **date part is dropped**. This is the exact mirror of #817, where a date has no clock and the sub-day part is dropped — and `a_datetime_applies_both_parts` pins that the two mirrored rules are not over-applied to the type that has both.

All four expected values are the TCK's own, not my arithmetic.

## Verification

- TCK **3,597 → 3,611**, regression diff against the merge base **empty**. `Temporal6`'s serialization scenarios and `Temporal8`'s time rows both go to **0**.
- The round-trip test asserts the rendered text *and* that parsing it back equals the original — the assertion the scenario actually makes, which the previous test file did not.
- `--min-pass` ratcheted 3597 → 3611.