### PR TITLE
Order lists lexicographically, and NaN as false (#855)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3611
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3622
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -301,6 +301,27 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
             _ => return Err(ExecutionError::TypeError("XOR requires boolean operands".to_string())),
         },
         BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge => {
+            // **NaN orders as false, not null.** `partial_cmp` returns `None`
+            // for it, which this branch maps to null -- the same answer it
+            // gives for two values that cannot be compared at all. Cypher
+            // separates the two: incomparable is null, NaN is false, and all
+            // four operators are false including `>=` against itself (#855).
+            //
+            // Only against another **number**. `0.0/0.0 < 'a'` is still null,
+            // because comparing across types is null before NaN is considered
+            // -- returning false there says "I compared them and they did not
+            // order", which is a different claim. A blanket NaN rule cost one
+            // scenario exactly that way.
+            let is_nan = |p: &PropertyValue| matches!(p, PropertyValue::Float(f) if f.is_nan());
+            let numeric = |p: &PropertyValue| {
+                matches!(p, PropertyValue::Float(_) | PropertyValue::Integer(_))
+            };
+            if (is_nan(&left_prop) || is_nan(&right_prop))
+                && numeric(&left_prop)
+                && numeric(&right_prop)
+            {
+                return Ok(Value::Property(PropertyValue::Boolean(false)));
+            }
             let cmp = cypher_ordering(&left_prop, &right_prop);
             match (op, cmp) {
                 (BinaryOp::Lt, Some(std::cmp::Ordering::Less)) => PropertyValue::Boolean(true),
@@ -1638,6 +1659,27 @@ fn cypher_ordering(left: &PropertyValue, right: &PropertyValue) -> Option<std::c
         // that had been passing went red, which is the duplicated-evaluator
         // shape this codebase keeps producing: patching the copy in front of
         // you fixes nothing.
+        // Lists order **lexicographically**, then by length: `[1, 0] >= [1]`
+        // is true because the shared prefix is equal and the left is longer.
+        // There was no arm for this at all, so every list comparison fell to
+        // `_ => None` and answered null (#855).
+        //
+        // A null at a position that has to be compared makes the answer
+        // undecidable, which is what `None` means here. It is not reached by a
+        // list that is merely *longer* than the other: `[1, null] >= [1]` is
+        // decided by the length, the null never compared.
+        (Array(l), Array(r)) => {
+            for (a, b) in l.iter().zip(r.iter()) {
+                if matches!(a, Null) || matches!(b, Null) {
+                    return None;
+                }
+                match cypher_ordering(a, b) {
+                    Some(std::cmp::Ordering::Equal) => continue,
+                    other => return other,
+                }
+            }
+            Some(l.len().cmp(&r.len()))
+        }
         (Date(l), Date(r)) => Some(l.cmp(r)),
         (LocalTime(l), LocalTime(r)) => Some(l.cmp(r)),
         (

--- a/tests/list_and_nan_ordering.rs
+++ b/tests/list_and_nan_ordering.rs
@@ -1,0 +1,101 @@
+//! Lists order lexicographically, and NaN orders as false (#855).
+//!
+//! Two defects that both produced **null** — the answer the engine also gives
+//! for values it genuinely cannot compare, so neither looked like a bug.
+//!
+//! `cypher_ordering` had no `Array` arm at all, so every list comparison fell
+//! to `_ => None`. And `partial_cmp` returns `None` for NaN, which the same
+//! branch maps to null; Cypher wants false there.
+//!
+//! The line between them is the interesting part: **incomparable is null, NaN
+//! is false, and a NaN against a string is null again** — because comparing
+//! across types is settled before NaN is considered. A blanket NaN rule cost
+//! exactly that one scenario.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// `Some(bool)` for a definite answer, `None` for null.
+fn truth(expr: &str) -> Option<bool> {
+    let store = GraphStore::new();
+    let cypher = format!("RETURN {expr} AS r");
+    let q = parse_query(&cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(PropertyValue::Boolean(b))) => Some(*b),
+        _ => None,
+    }
+}
+
+/// The TCK's rows, plus the ordinary cases that had also been answering null.
+#[test]
+fn lists_order_lexicographically_then_by_length() {
+    for (expr, want) in [
+        ("[1, 0] >= [1]", Some(true)),
+        ("[1, 2] >= [3, null]", Some(false)),
+        ("[1, null] >= [1]", Some(true)),
+        ("[1] >= [1]", Some(true)),
+        ("[2] >= [1]", Some(true)),
+        ("[1] >= [2]", Some(false)),
+        ("[1, 2] > [1]", Some(true)),
+        ("[1] < [1, 0]", Some(true)),
+        ("[] < [1]", Some(true)),
+        ("['a', 'b'] < ['a', 'c']", Some(true)),
+    ] {
+        assert_eq!(truth(expr), want, "{expr}");
+    }
+}
+
+/// A null only makes the answer null when it is at a position that has to be
+/// compared. `[1, null] >= [1]` is decided by the length.
+#[test]
+fn a_null_matters_only_where_it_is_compared() {
+    assert_eq!(truth("[1, null] >= [1]"), Some(true));
+    assert_eq!(truth("[1, 2] >= [3, null]"), Some(false));
+    // Here it does have to be compared.
+    assert_eq!(truth("[1, null] >= [1, 2]"), None);
+    assert_eq!(truth("[null] >= [1]"), None);
+}
+
+/// All four operators are false against NaN, `>=` against itself included.
+#[test]
+fn nan_orders_as_false_against_a_number() {
+    for other in ["0.0 / 0.0", "1", "1.0", "-1"] {
+        for op in [">", ">=", "<", "<="] {
+            assert_eq!(
+                truth(&format!("0.0 / 0.0 {op} {other}")),
+                Some(false),
+                "0.0/0.0 {op} {other}"
+            );
+            assert_eq!(
+                truth(&format!("{other} {op} 0.0 / 0.0")),
+                Some(false),
+                "{other} {op} 0.0/0.0"
+            );
+        }
+    }
+}
+
+/// **But NaN against a non-number is still null**, because comparing across
+/// types is settled first. This is the row a blanket NaN rule breaks.
+#[test]
+fn nan_against_another_type_is_still_null() {
+    for other in ["'a'", "true", "[1]", "null"] {
+        assert_eq!(truth(&format!("0.0 / 0.0 < {other}")), None, "0.0/0.0 < {other}");
+        assert_eq!(truth(&format!("0.0 / 0.0 >= {other}")), None, "0.0/0.0 >= {other}");
+    }
+}
+
+/// Ordinary numeric and string ordering is untouched — a change that made
+/// every comparison false or null would satisfy several tests above.
+#[test]
+fn ordinary_ordering_is_unchanged() {
+    assert_eq!(truth("1 < 2"), Some(true));
+    assert_eq!(truth("2.5 >= 2"), Some(true));
+    assert_eq!(truth("'a' < 'b'"), Some(true));
+    assert_eq!(truth("1 < 'a'"), None);
+    assert_eq!(truth("1.0 / 0.0 > 1"), Some(true));
+}


### PR DESCRIPTION
Closes #855. Two defects that both produced **null** — the answer the engine also gives for values it genuinely cannot compare, so neither looked like a bug.

## Lists never ordered

```
[1, 0] >= [1]        expected true    got null
[1, 2] >= [3, null]  expected false   got null
[1, null] >= [1]     expected true    got null
```

`cypher_ordering` had **no `Array` arm at all**, so every list comparison fell to `_ => None`. Lists order lexicographically, then by length.

A null makes the answer undecidable only when it sits at a position that has to be compared: `[1, null] >= [1]` is decided by the *length*, and the null is never reached. Both halves are pinned.

## NaN ordered as null

```
0.0/0.0 > 1,  >= 1,  < 1,  <= 1     expected false ×4    got null ×4
```

`partial_cmp` returns `None` for NaN, which this branch maps to null. Cypher wants false — all four operators, `>=` against itself included.

**Only against another number.** `0.0/0.0 < 'a'` is still null: comparing across types is settled *before* NaN is considered, and returning false there would claim "I compared them and they did not order", which is a different statement. A blanket NaN rule cost exactly that scenario, and the regression diff named it — `nan_against_another_type_is_still_null` now pins it.

## Verification

- TCK **3,611 → 3,622**, regression diff against the merge base **empty**. `Comparison2` goes to **0** failures. Pass rate **96.3%**.
- `--min-pass` ratcheted 3611 → 3622.

## Left open deliberately

`Return2` scenario 18 wants an **unknown function** to raise at compile time. The engine raises at runtime, and the scenario's empty graph means the call is never reached — the same shape as #843. But the fix needs the validator to know every name the dispatcher accepts, and a name it fails to list becomes a **rejected valid query**, which is the worse failure. Filed on #855 rather than guessed at.