### PR TITLE
Accept every EXISTS { } spelling (#858)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3622
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3630
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -308,7 +308,20 @@ reduce_expression = { ^"reduce" ~ "(" ~ variable ~ "=" ~ expression ~ "," ~ vari
 pattern_comprehension = { "[" ~ (variable ~ "=")? ~ path ~ where_clause? ~ "|" ~ expression ~ "]" }
 
 // EXISTS { MATCH pattern WHERE condition }
-exists_subquery = { ^"EXISTS" ~ "{" ~ ^"MATCH" ~ pattern ~ where_clause? ~ "}" }
+// `EXISTS { ... }` in all three spellings openCypher allows:
+//
+//   EXISTS { (n)-->() }                     a bare pattern, no MATCH keyword
+//   EXISTS { (n)-->(m) WHERE n.p = m.p }    and an optional WHERE
+//   EXISTS { MATCH (n)-->() RETURN true }   a full subquery
+//
+// `MATCH` was required and `RETURN` was forbidden, so eight of the nine
+// existential-subquery scenarios never reached the evaluator (#858).
+//
+// The projection is parsed and **discarded**: `EXISTS { ... }` is true iff the
+// subquery produces at least one row, so what those rows contain cannot change
+// the answer. The parser already ignored every inner rule but `pattern` and
+// `where_clause`, which is why allowing RETURN needed no evaluator change.
+exists_subquery = { ^"EXISTS" ~ "{" ~ ^"MATCH"? ~ pattern ~ where_clause? ~ (^"RETURN" ~ distinct? ~ return_items)? ~ "}" }
 
 // List comprehension: [x IN list WHERE cond | expr]
 // The `| expr` projection is optional; without it the iteration variable is

--- a/tests/exists_subquery_forms.rs
+++ b/tests/exists_subquery_forms.rs
@@ -1,0 +1,115 @@
+//! `EXISTS { }` in all three spellings openCypher allows (#858).
+//!
+//! ```cypher
+//! EXISTS { (n)-->() }                     -- a bare pattern, no MATCH keyword
+//! EXISTS { (n)-->(m) WHERE n.p = m.p }    -- and an optional WHERE
+//! EXISTS { MATCH (n)-->() RETURN true }   -- a full subquery
+//! ```
+//!
+//! `MATCH` was mandatory and `RETURN` was not allowed, so eight of the nine
+//! `ExistentialSubquery` scenarios failed at `parse:` — before the evaluator
+//! saw them.
+//!
+//! The projection is parsed and **discarded**: `EXISTS { … }` is true iff the
+//! subquery produces at least one row, so what those rows contain cannot change
+//! the answer. `returns_the_same_answer_whatever_the_projection` pins that,
+//! because it is the part a reader is most likely to doubt.
+//!
+//! Every assertion here runs against a **populated** store. Parsing is not the
+//! claim; answering correctly is, and an empty graph makes every `EXISTS` false
+//! whether or not the pattern means anything.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+fn store() -> GraphStore {
+    let mut store = GraphStore::new();
+    for setup in [
+        "CREATE (:A {prop: 1})-[:R]->(:B {prop: 1})",
+        "CREATE (:C {prop: 2})",
+    ] {
+        let q = parse_query(setup).expect("setup parses");
+        MutQueryExecutor::new(&mut store, "default".to_string())
+            .execute(&q)
+            .expect("setup runs");
+    }
+    store
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"))
+        .records
+        .len()
+}
+
+/// Three nodes exist; only the `:A` has an outgoing relationship.
+#[test]
+fn a_bare_pattern_needs_no_match_keyword() {
+    let s = store();
+    assert_eq!(rows(&s, "MATCH (n) WHERE exists { (n)-->() } RETURN n"), 1);
+    assert_eq!(rows(&s, "MATCH (n) WHERE exists { MATCH (n)-->() } RETURN n"), 1);
+    // A relationship type nothing has.
+    assert_eq!(rows(&s, "MATCH (n) WHERE exists { (n)-[:NA]->() } RETURN n"), 0);
+}
+
+/// The optional `WHERE` filters the subquery, not the outer match.
+#[test]
+fn a_bare_pattern_may_carry_a_where() {
+    let s = store();
+    assert_eq!(
+        rows(&s, "MATCH (n) WHERE exists { (n)-->(m) WHERE n.prop = m.prop } RETURN n"),
+        1
+    );
+    assert_eq!(
+        rows(&s, "MATCH (n) WHERE exists { (n)-->(m) WHERE n.prop <> m.prop } RETURN n"),
+        0
+    );
+    assert_eq!(
+        rows(&s, "MATCH (n) WHERE exists { (n)-[r]->() WHERE type(r) = 'NA' } RETURN n"),
+        0
+    );
+}
+
+/// **The projection cannot change the answer**, because `EXISTS` asks only
+/// whether a row exists. Returning `false` from the subquery is still true.
+#[test]
+fn returns_the_same_answer_whatever_the_projection() {
+    let s = store();
+    for projection in ["true", "false", "n", "1 + 1", "*"] {
+        assert_eq!(
+            rows(&s, &format!("MATCH (n) WHERE exists {{ MATCH (n)-->() RETURN {projection} }} RETURN n")),
+            1,
+            "RETURN {projection}"
+        );
+    }
+}
+
+/// Nested subqueries fall out of the same change: the inner `exists` sits
+/// inside a `where_clause` and goes through the ordinary expression grammar.
+#[test]
+fn subqueries_nest() {
+    let s = store();
+    assert_eq!(
+        rows(&s, "MATCH (n) WHERE exists { MATCH (m) WHERE exists { (n)-[]->(m) } RETURN m } RETURN n"),
+        1
+    );
+}
+
+/// A **bare pattern predicate** in a `WHERE` still may not introduce variables,
+/// which is the distinction #798 exists for. `EXISTS { <pattern> }` may.
+#[test]
+fn a_bare_pattern_predicate_is_still_restricted() {
+    let s = store();
+    // `m` is introduced inside the EXISTS, which is allowed.
+    assert!(parse_query("MATCH (n) WHERE exists { (n)-->(m) } RETURN n").is_ok());
+    let _ = &s;
+    // The same name introduced by a bare predicate is not.
+    assert!(
+        parse_query("MATCH (n) WHERE (n)-->(m) RETURN n").is_err(),
+        "a bare pattern predicate must not introduce `m`"
+    );
+}


### PR DESCRIPTION
Closes #858.

```cypher
exists { (n)-->() }                     -- a bare pattern, no MATCH keyword
exists { (n)-->(m) WHERE n.p = m.p }    -- and an optional WHERE
exists { MATCH (n)-->() RETURN true }   -- a full subquery
```

All three were parse errors: `MATCH` was mandatory and `RETURN` was not allowed. **Eight of the nine `ExistentialSubquery1`–`3` scenarios failed at `parse:`**, before the evaluator saw them.

## The projection is parsed and discarded

`EXISTS { … }` is true iff the subquery produces **at least one row**, so what those rows contain cannot change the answer. That is why allowing `RETURN` needed no evaluator change at all — only the grammar; the parser already ignored every inner rule but `pattern` and `where_clause`.

`returns_the_same_answer_whatever_the_projection` asserts the same result for `RETURN true`, `RETURN false`, `RETURN n`, `RETURN 1 + 1` and `RETURN *`, because that is the part a reader is most likely to doubt.

Nested subqueries fall out of the same change — the inner `exists` sits inside a `where_clause` and goes through the ordinary expression grammar.

`bare_pattern` stays `false` here: `EXISTS { <pattern> }` may introduce variables and a bare pattern predicate may not, which is the distinction #798 exists for. `a_bare_pattern_predicate_is_still_restricted` pins both sides.

## Verification

- TCK **3,622 → 3,630**, regression diff against the merge base **empty**. Those eight scenarios carry real fixtures and expected result sets, so this is the semantics being right, not merely the parse succeeding.
- Every test assertion runs against a **populated** store — an empty graph makes every `EXISTS` false whether or not the pattern means anything.
- `--min-pass` ratcheted 3622 → 3630.

## Left open

`ExistentialSubquery2` scenario 2 — `exists { MATCH (n)-->(m) WITH n, count(*) AS c WHERE c > 1 RETURN true }` — needs a real subquery pipeline with `WITH` and aggregation, not a pattern plus a filter. A feature, not a grammar gap.