### PR TITLE
One comparison engine, and it knows about entities and numbers (#860)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3630
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3637
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -1623,11 +1623,23 @@ mod tests {
                 node.set_property("active", PropertyValue::Boolean(i % 2 == 0));
             }
         }
-        // Query: compare Boolean property to String literal 'true'
+        // Comparing a Boolean property to the *string* 'true' matches nothing.
+        //
+        // This asserted 2 rows, on the strength of a String/Boolean coercion in
+        // `coerced_eq` that Cypher does not have. Comparing across types is
+        // false: `1 = '1'` is false for the same reason, which the TCK settles
+        // in `Comparison1` scenario 9. The test encoded the coercion rather than
+        // the language, and was corrected against the reference when the second
+        // comparison engine that provided it was deleted (#860).
         let executor = QueryExecutor::new(&store);
         let query = parse_query("MATCH (i:Item) WHERE i.active = 'true' RETURN i.name").unwrap();
         let result = executor.execute(&query).unwrap();
-        // Item0=true, Item1=false, Item2=true, Item3=false
+        assert_eq!(result.records.len(), 0, "a boolean never equals a string");
+
+        // The same property compared to a boolean still works, so this is not
+        // simply everything matching nothing.
+        let query = parse_query("MATCH (i:Item) WHERE i.active = true RETURN i.name").unwrap();
+        let result = executor.execute(&query).unwrap();
         assert_eq!(result.records.len(), 2, "Expected 2 active items");
     }
 

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -160,6 +160,22 @@ fn cypher_equals(a: &PropertyValue, b: &PropertyValue) -> Option<bool> {
             }
             if unknown { None } else { Some(true) }
         }
+        // **A number equals a number across the two representations.**
+        // `1 = 1.0` is true in Cypher, and `PropertyValue`'s derived `PartialEq`
+        // compares variants, so it was answering false -- a wrong answer in the
+        // most ordinary comparison there is, and one that reads as a legitimate
+        // "these differ" (#860).
+        //
+        // Compared as integers rather than through `as f64`, so no bit is lost
+        // above 2^53: a float with a fractional part cannot equal an integer,
+        // and one without is exact.
+        (Integer(x), Float(y)) | (Float(y), Integer(x)) => Some(
+            y.is_finite()
+                && y.fract() == 0.0
+                && *y >= i64::MIN as f64
+                && *y <= i64::MAX as f64
+                && (*y as i64) == *x,
+        ),
         _ => Some(a == b),
     }
 }
@@ -212,10 +228,46 @@ pub(crate) mod statement_clock {
 
 /// Shared binary operator evaluation used by Project, Aggregate, and Sort operators
 fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<Value> {
-    // Node/edge identity comparison (Cypher: n1 = n2, n1 <> n2)
+    // Identity comparison for the three entity kinds (Cypher: n1 = n2, r1 = r2,
+    // p1 = p2).
+    //
+    // Only *nodes* were handled, so `r = r` on a relationship and `p1 = p2` on
+    // two paths raised "Binary op requires property values" -- an error from
+    // the most ordinary comparison there is, and the reason `WITH a MATCH ...
+    // WHERE a = b` could not be written at all (#860).
     if matches!(op, BinaryOp::Eq | BinaryOp::Ne) {
-        if let (Some(lid), Some(rid)) = (node_id_of(&left), node_id_of(&right)) {
-            let eq = lid == rid;
+        let same = match (&left, &right) {
+            (Value::NodeRef(a) | Value::Node(a, _), Value::NodeRef(b) | Value::Node(b, _)) => {
+                Some(a == b)
+            }
+            (
+                Value::EdgeRef(a, ..) | Value::Edge(a, _),
+                Value::EdgeRef(b, ..) | Value::Edge(b, _),
+            ) => Some(a == b),
+            // Paths are equal when they visit the same nodes and traverse the
+            // same relationships in the same order. The TCK's scenario is a
+            // self-loop, where a path and its reverse have the identical node
+            // sequence -- so structural equality is what it asks for, and a
+            // direction-insensitive rule would be inventing something it does
+            // not test.
+            (
+                Value::Path { nodes: n1, edges: e1 },
+                Value::Path { nodes: n2, edges: e2 },
+            ) => Some(n1 == n2 && e1 == e2),
+            // An entity is never equal to a non-entity, and that is `false`
+            // rather than an error or a null: the two are comparable, they
+            // simply differ.
+            (Value::NodeRef(_) | Value::Node(..) | Value::EdgeRef(..) | Value::Edge(..)
+                | Value::Path { .. }, other)
+            | (other, Value::NodeRef(_) | Value::Node(..) | Value::EdgeRef(..) | Value::Edge(..)
+                | Value::Path { .. })
+                if !matches!(other, Value::Property(PropertyValue::Null) | Value::Null) =>
+            {
+                Some(false)
+            }
+            _ => None,
+        };
+        if let Some(eq) = same {
             return Ok(Value::Property(PropertyValue::Boolean(
                 if matches!(op, BinaryOp::Eq) { eq } else { !eq }
             )));
@@ -5220,246 +5272,33 @@ impl FilterOperator {
         }
     }
 
+    /// The filter's binary operator, **delegated** to `eval_binary_op` (#860).
+    ///
+    /// This was a second, drifted implementation -- 67 lines against 346 -- and
+    /// its own comment already said so: *"Note this is a second comparison
+    /// implementation, the two must agree, and did not."* It agreed on the easy
+    /// things and diverged on every rule added since, so a `WHERE` attached to a
+    /// `MATCH` quietly used a weaker comparison engine than the same expression
+    /// in a `RETURN` or after a `WITH`:
+    ///
+    /// ```text
+    /// MATCH ()-[a]->() MATCH ()-[b]->() WHERE a = b   TypeError
+    /// MATCH ()-[a]->() MATCH ()-[b]->() RETURN a = b  true
+    /// ```
+    ///
+    /// It was missing relationship and path identity, the three-valued list and
+    /// map equality of `cypher_equals`, the NaN and list ordering rules, and
+    /// integer-float equality -- every comparison rule fixed this cycle applied
+    /// everywhere *except* the clause most queries filter in.
+    ///
+    /// The seventeen `coerced_eq` / `compare_*` / `arithmetic_*` helpers it
+    /// called are **deleted**, not left unused. One of them carried a rule
+    /// Cypher does not have -- a String/Boolean coercion that made
+    /// `i.active = 'true'` match the boolean `true` -- and keeping them as dead
+    /// code invites the next change to route through them again, which is how
+    /// the two engines drifted apart in the first place.
     fn evaluate_binary_op(&self, op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<Value> {
-        // Node/edge identity comparison (Cypher: n1 = n2, n1 <> n2)
-        if matches!(op, BinaryOp::Eq | BinaryOp::Ne) {
-            if let (Some(lid), Some(rid)) = (node_id_of(&left), node_id_of(&right)) {
-                let eq = lid == rid;
-                return Ok(Value::Property(PropertyValue::Boolean(
-                    if matches!(op, BinaryOp::Eq) { eq } else { !eq }
-                )));
-            }
-        }
-
-        // Extract property values
-        let left_prop = match left {
-            Value::Property(p) => p,
-            Value::Null => PropertyValue::Null,
-            _ => return Err(ExecutionError::TypeError("Binary op requires property values".to_string())),
-        };
-
-        let right_prop = match right {
-            Value::Property(p) => p,
-            Value::Null => PropertyValue::Null,
-            _ => return Err(ExecutionError::TypeError("Binary op requires property values".to_string())),
-        };
-
-        // Three-valued logic, same rule as `eval_binary_op`: a comparison with a null
-        // operand is unknown, and a WHERE excludes unknown. `null <> 1` evaluating to true
-        // kept every row whose property was merely absent. Note this is a *second*
-        // comparison implementation — the two must agree, and did not.
-        if matches!(
-            op,
-            BinaryOp::Eq | BinaryOp::Ne | BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge
-        ) && (matches!(left_prop, PropertyValue::Null)
-            || matches!(right_prop, PropertyValue::Null))
-        {
-            return Ok(Value::Property(PropertyValue::Null));
-        }
-
-        let result = match op {
-            BinaryOp::Eq => PropertyValue::Boolean(self.coerced_eq(&left_prop, &right_prop)),
-            BinaryOp::Ne => PropertyValue::Boolean(!self.coerced_eq(&left_prop, &right_prop)),
-            BinaryOp::Lt => self.compare_lt(&left_prop, &right_prop)?,
-            BinaryOp::Le => self.compare_le(&left_prop, &right_prop)?,
-            BinaryOp::Gt => self.compare_gt(&left_prop, &right_prop)?,
-            BinaryOp::Ge => self.compare_ge(&left_prop, &right_prop)?,
-            BinaryOp::And => self.logical_and(&left_prop, &right_prop)?,
-            BinaryOp::Or => self.logical_or(&left_prop, &right_prop)?,
-            // Delegated so `^` and XOR have one definition rather than two that
-            // can drift; this evaluator differs from `eval_binary_op` only in
-            // its comparison coercions, which neither operator uses.
-            BinaryOp::Pow | BinaryOp::Xor => {
-                match eval_binary_op(op, Value::Property(left_prop.clone()), Value::Property(right_prop.clone()))? {
-                    Value::Property(p) => p,
-                    other => return Err(ExecutionError::TypeError(format!("unexpected {other:?}"))),
-                }
-            }
-            BinaryOp::Add => self.arithmetic_add(&left_prop, &right_prop)?,
-            BinaryOp::Sub => self.arithmetic_sub(&left_prop, &right_prop)?,
-            BinaryOp::Mul => self.arithmetic_mul(&left_prop, &right_prop)?,
-            BinaryOp::Div => self.arithmetic_div(&left_prop, &right_prop)?,
-            BinaryOp::Mod => self.arithmetic_mod(&left_prop, &right_prop)?,
-            BinaryOp::StartsWith => self.string_starts_with(&left_prop, &right_prop)?,
-            BinaryOp::EndsWith => self.string_ends_with(&left_prop, &right_prop)?,
-            BinaryOp::Contains => self.string_contains(&left_prop, &right_prop)?,
-            BinaryOp::In => self.eval_in(&left_prop, &right_prop)?,
-            BinaryOp::RegexMatch => self.regex_match(&left_prop, &right_prop)?,
-        };
-
-        Ok(Value::Property(result))
-    }
-
-    /// Equality with type coercion: Integer↔Float numeric promotion,
-    /// String↔Boolean coercion ("true"/"false"), and Null handling.
-    fn coerced_eq(&self, left: &PropertyValue, right: &PropertyValue) -> bool {
-        match (left, right) {
-            // Same-type: use derived PartialEq
-            _ if std::mem::discriminant(left) == std::mem::discriminant(right) => left == right,
-            // Integer ↔ Float promotion
-            (PropertyValue::Integer(l), PropertyValue::Float(r)) => (*l as f64) == *r,
-            (PropertyValue::Float(l), PropertyValue::Integer(r)) => *l == (*r as f64),
-            // DateTime ↔ Integer coercion (DateTime stores epoch millis as i64)
-            (PropertyValue::DateTime(l), PropertyValue::Integer(r)) |
-            (PropertyValue::Integer(r), PropertyValue::DateTime(l)) => l == r,
-            // String ↔ Boolean coercion (LLMs often generate `prop = 'true'`)
-            (PropertyValue::Boolean(b), PropertyValue::String(s)) |
-            (PropertyValue::String(s), PropertyValue::Boolean(b)) => {
-                match s.to_lowercase().as_str() {
-                    "true" => *b,
-                    "false" => !*b,
-                    _ => false,
-                }
-            }
-            // Everything else: not equal
-            _ => false,
-        }
-    }
-
-    fn compare_lt(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        // Incomparable types are null, not an error: raising here aborted
-        // the whole query, so rows that *did* compare never came back (#607).
-        Ok(match cypher_ordering(left, right) {
-            Some(std::cmp::Ordering::Less) => PropertyValue::Boolean(true),
-            Some(_) => PropertyValue::Boolean(false),
-            None => PropertyValue::Null,
-        })
-    }
-
-    fn compare_le(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        // Incomparable types are null, not an error: raising here aborted
-        // the whole query, so rows that *did* compare never came back (#607).
-        Ok(match cypher_ordering(left, right) {
-            Some(std::cmp::Ordering::Less | std::cmp::Ordering::Equal) => PropertyValue::Boolean(true),
-            Some(_) => PropertyValue::Boolean(false),
-            None => PropertyValue::Null,
-        })
-    }
-
-    fn compare_gt(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        // Incomparable types are null, not an error: raising here aborted
-        // the whole query, so rows that *did* compare never came back (#607).
-        Ok(match cypher_ordering(left, right) {
-            Some(std::cmp::Ordering::Greater) => PropertyValue::Boolean(true),
-            Some(_) => PropertyValue::Boolean(false),
-            None => PropertyValue::Null,
-        })
-    }
-
-    fn compare_ge(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        // Incomparable types are null, not an error: raising here aborted
-        // the whole query, so rows that *did* compare never came back (#607).
-        Ok(match cypher_ordering(left, right) {
-            Some(std::cmp::Ordering::Greater | std::cmp::Ordering::Equal) => PropertyValue::Boolean(true),
-            Some(_) => PropertyValue::Boolean(false),
-            None => PropertyValue::Null,
-        })
-    }
-
-    fn logical_and(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        // Cypher three-valued logic: false AND x → false, true AND null → null
-        match (left, right) {
-            (PropertyValue::Boolean(l), PropertyValue::Boolean(r)) => Ok(PropertyValue::Boolean(*l && *r)),
-            (PropertyValue::Boolean(false), _) | (_, PropertyValue::Boolean(false)) => Ok(PropertyValue::Boolean(false)),
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
-            _ => Err(ExecutionError::TypeError("AND requires boolean operands".to_string())),
-        }
-    }
-
-    fn logical_or(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        // Cypher three-valued logic: true OR x → true, false OR null → null
-        match (left, right) {
-            (PropertyValue::Boolean(l), PropertyValue::Boolean(r)) => Ok(PropertyValue::Boolean(*l || *r)),
-            (PropertyValue::Boolean(true), _) | (_, PropertyValue::Boolean(true)) => Ok(PropertyValue::Boolean(true)),
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
-            _ => Err(ExecutionError::TypeError("OR requires boolean operands".to_string())),
-        }
-    }
-
-    fn arithmetic_add(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        match (left, right) {
-            (PropertyValue::Integer(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Integer(l + r)),
-            (PropertyValue::Float(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(l + r)),
-            (PropertyValue::Integer(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(*l as f64 + r)),
-            (PropertyValue::Float(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Float(l + *r as f64)),
-            (PropertyValue::String(l), PropertyValue::String(r)) => Ok(PropertyValue::String(format!("{}{}", l, r))),
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
-            _ => Err(ExecutionError::TypeError("Addition requires numeric or string operands".to_string())),
-        }
-    }
-
-    fn arithmetic_sub(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        match (left, right) {
-            (PropertyValue::Integer(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Integer(l - r)),
-            (PropertyValue::Float(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(l - r)),
-            (PropertyValue::Integer(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(*l as f64 - r)),
-            (PropertyValue::Float(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Float(l - *r as f64)),
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
-            _ => Err(ExecutionError::TypeError("Subtraction requires numeric operands".to_string())),
-        }
-    }
-
-    fn arithmetic_mul(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        match (left, right) {
-            (PropertyValue::Integer(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Integer(l * r)),
-            (PropertyValue::Float(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(l * r)),
-            (PropertyValue::Integer(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(*l as f64 * r)),
-            (PropertyValue::Float(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Float(l * *r as f64)),
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
-            _ => Err(ExecutionError::TypeError("Multiplication requires numeric operands".to_string())),
-        }
-    }
-
-    fn arithmetic_div(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        match (left, right) {
-            (PropertyValue::Integer(_), PropertyValue::Integer(0)) => Err(ExecutionError::RuntimeError("Division by zero".to_string())),
-            (PropertyValue::Integer(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Integer(l / r)),
-            (PropertyValue::Float(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(l / r)),
-            (PropertyValue::Integer(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(*l as f64 / r)),
-            (PropertyValue::Float(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Float(l / *r as f64)),
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
-            _ => Err(ExecutionError::TypeError("Division requires numeric operands".to_string())),
-        }
-    }
-
-    fn arithmetic_mod(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        match (left, right) {
-            (PropertyValue::Integer(_), PropertyValue::Integer(0)) => Err(ExecutionError::RuntimeError("Modulo by zero".to_string())),
-            (PropertyValue::Integer(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Integer(l % r)),
-            (PropertyValue::Float(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(l % r)),
-            (PropertyValue::Integer(l), PropertyValue::Float(r)) => Ok(PropertyValue::Float(*l as f64 % r)),
-            (PropertyValue::Float(l), PropertyValue::Integer(r)) => Ok(PropertyValue::Float(l % *r as f64)),
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
-            _ => Err(ExecutionError::TypeError("Modulo requires numeric operands".to_string())),
-        }
-    }
-
-    fn string_starts_with(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        Ok(string_position_op(StringPositionOp::StartsWith, left, right))
-    }
-
-    fn string_ends_with(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        Ok(string_position_op(StringPositionOp::EndsWith, left, right))
-    }
-
-    fn string_contains(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        Ok(string_position_op(StringPositionOp::Contains, left, right))
-    }
-
-    fn eval_in(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        eval_in_list(left, right)
-            .ok_or_else(|| ExecutionError::TypeError("IN requires a list on the right side".to_string()))
-    }
-
-    fn regex_match(&self, left: &PropertyValue, right: &PropertyValue) -> ExecutionResult<PropertyValue> {
-        match (left, right) {
-            (PropertyValue::String(text), PropertyValue::String(pattern)) => {
-                let re = regex::Regex::new(pattern).map_err(|e| ExecutionError::RuntimeError(format!("Invalid regex: {}", e)))?;
-                Ok(PropertyValue::Boolean(re.is_match(text)))
-            }
-            (PropertyValue::Null, _) | (_, PropertyValue::Null) => Ok(PropertyValue::Null),
-            _ => Err(ExecutionError::TypeError("=~ requires string operands".to_string())),
-        }
+        eval_binary_op(op, left, right)
     }
 
     // evaluate_function removed — FilterOperator now delegates to global eval_function

--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -1269,7 +1269,12 @@ fn temporal_component(v: &PropertyValue, property: &str) -> PropertyValue {
         }),
         "week" => date.map_or(PropertyValue::Null, |d| int(d.iso_week().week() as i64)),
         "weekYear" => date.map_or(PropertyValue::Null, |d| int(d.iso_week().year() as i64)),
-        "dayOfWeek" => date.map_or(PropertyValue::Null, |d| {
+        // Cypher spells the **accessor** `weekDay` and the **constructor key**
+        // `dayOfWeek`, for the same quantity. Only the constructor spelling was
+        // here, so `d.weekDay` returned null -- indistinguishable from a
+        // component the value does not have, which is what a date's `hour`
+        // legitimately returns (#862).
+        "weekDay" | "dayOfWeek" => date.map_or(PropertyValue::Null, |d| {
             int(d.weekday().number_from_monday() as i64)
         }),
         "ordinalDay" => date.map_or(PropertyValue::Null, |d| int(d.ordinal() as i64)),

--- a/tests/comparison_engine_parity.rs
+++ b/tests/comparison_engine_parity.rs
@@ -1,0 +1,151 @@
+//! Every comparison rule holds in a `MATCH`'s `WHERE` too (#860).
+//!
+//! ```text
+//! MATCH ()-[a]->() MATCH ()-[b]->() WHERE a = b     TypeError
+//! MATCH ()-[a]->() MATCH ()-[b]->() RETURN a = b    true
+//! ```
+//!
+//! `FilterOperator::evaluate_binary_op` was a second implementation — 67 lines
+//! against the free function's 346 — and its own comment already said so. It
+//! agreed on the easy things and diverged on every rule added since: entity
+//! identity, `cypher_equals`' three-valued list and map equality, the NaN and
+//! list-ordering rules (#855), the entity-ordering rule (#840), and
+//! integer-float equality. So every comparison rule fixed this cycle applied
+//! everywhere **except the clause most queries filter in**.
+//!
+//! The parity test below is the point of this file: the same expression is
+//! evaluated in a `MATCH … WHERE`, after a `WITH`, and in a `RETURN`, and the
+//! three must agree. A test that checked only one of them is what let the two
+//! engines drift for as long as they did.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn store() -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (:A {n: 1, f: 1.0})-[:R]->(:B {n: 2})").expect("setup parses");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup runs");
+    store
+}
+
+fn truth(store: &GraphStore, cypher: &str) -> Option<bool> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(PropertyValue::Boolean(b))) => Some(*b),
+        _ => None,
+    }
+}
+
+/// **The parity check.** One predicate, three clauses, one answer.
+///
+/// `MATCH … WHERE` is evaluated by the filter; `WITH … WHERE` and `RETURN` go
+/// through the general evaluator.
+///
+/// The predicates here are over **entities**, deliberately. I first wrote this
+/// over property values — `1 = 1.0`, list equality, NaN — and it passed against
+/// the old filter engine as well as the new one, because that engine's
+/// `coerced_eq` and `compare_*` helpers had kept up on scalars. What it had
+/// never gained was the entity arms. A parity test over the cases that already
+/// agreed would have been the sort of check that cannot fail.
+#[test]
+fn an_entity_predicate_means_the_same_in_every_clause() {
+    let s = store();
+    for pred in [
+        "a = a",
+        "a <> a",
+        "a = b",
+        "id(a) = id(b)",
+    ] {
+        let in_where =
+            truth(&s, &format!("MATCH ()-[a]->() MATCH ()-[b]->() WHERE {pred} RETURN true AS r"));
+        let after_with = truth(
+            &s,
+            &format!("MATCH ()-[a]->() MATCH ()-[b]->() WITH a, b WHERE {pred} RETURN true AS r"),
+        );
+        let in_return =
+            truth(&s, &format!("MATCH ()-[a]->() MATCH ()-[b]->() RETURN {pred} AS r"));
+        assert_eq!(
+            in_where == Some(true),
+            in_return == Some(true),
+            "`{pred}`: MATCH…WHERE disagrees with RETURN ({in_return:?})"
+        );
+        assert_eq!(
+            after_with == Some(true),
+            in_return == Some(true),
+            "`{pred}`: WITH…WHERE disagrees with RETURN ({in_return:?})"
+        );
+    }
+}
+
+/// The scalar rules, checked in all three clauses too. These already agreed
+/// before the delegation — they are here so that a *future* divergence in
+/// either engine is caught, not because they caught this one.
+#[test]
+fn a_scalar_predicate_means_the_same_in_every_clause() {
+    let s = store();
+    for pred in [
+        "1 = 1.0",
+        "[1, 2] = [1, 2]",
+        "0.0 / 0.0 < 1",
+        "[1, 0] >= [1]",
+        "2 ^ 3 = 8.0",
+        "1 IN [1.0]",
+    ] {
+        let in_where = truth(&s, &format!("MATCH (x) WHERE {pred} RETURN true AS r LIMIT 1"));
+        let in_return = truth(&s, &format!("RETURN {pred} AS r"));
+        assert_eq!(
+            in_where == Some(true),
+            in_return == Some(true),
+            "`{pred}`: MATCH…WHERE disagrees with RETURN ({in_return:?})"
+        );
+    }
+}
+
+/// A number equals a number across the two representations.
+#[test]
+fn an_integer_equals_an_equal_float() {
+    let s = store();
+    assert_eq!(truth(&s, "RETURN 1 = 1.0 AS r"), Some(true));
+    assert_eq!(truth(&s, "RETURN 1.0 = 1 AS r"), Some(true));
+    assert_eq!(truth(&s, "RETURN 1 = 1.5 AS r"), Some(false));
+    assert_eq!(truth(&s, "RETURN 1 <> 1.0 AS r"), Some(false));
+    // Not a number: still false, not an error.
+    assert_eq!(truth(&s, "RETURN 1 = '1' AS r"), Some(false));
+    assert_eq!(truth(&s, "RETURN 1 = true AS r"), Some(false));
+    // NaN equals nothing, itself included.
+    assert_eq!(truth(&s, "RETURN 1 = 0.0 / 0.0 AS r"), Some(false));
+}
+
+/// All three entity kinds have identity, and an entity is never equal to a
+/// non-entity — false, not an error.
+#[test]
+fn every_entity_kind_has_identity() {
+    let s = store();
+    assert_eq!(truth(&s, "MATCH ()-[r]->() RETURN r = r AS r"), Some(true));
+    assert_eq!(truth(&s, "MATCH ()-[r]->() RETURN r <> r AS r"), Some(false));
+    assert_eq!(truth(&s, "MATCH (a)-[]->() RETURN a = a AS r"), Some(true));
+    assert_eq!(
+        truth(&s, "MATCH p1 = ()-->() MATCH p2 = ()-->() RETURN p1 = p2 AS r"),
+        Some(true)
+    );
+    assert_eq!(truth(&s, "MATCH (a), ()-[r]->() RETURN a = r AS r"), Some(false));
+}
+
+/// The shape the TCK scenario uses, which the filter engine could not run.
+#[test]
+fn a_relationship_compares_across_a_with_barrier() {
+    let s = store();
+    let cypher = "MATCH ()-[a]->() WITH a MATCH ()-[b]->() WHERE a = b RETURN count(b) AS r";
+    let q = parse_query(cypher).expect("parses");
+    let batch = QueryExecutor::new(&s).execute(&q).expect("runs");
+    assert_eq!(
+        batch.records.first().and_then(|r| r.get("r")),
+        Some(&Value::Property(PropertyValue::Integer(1)))
+    );
+}


### PR DESCRIPTION
Closes #860. Three defects, one story: **a `WHERE` attached to a `MATCH` was using a different, weaker comparison implementation than the same expression anywhere else.**

```
MATCH ()-[a]->() MATCH ()-[b]->() WHERE a = b     TypeError
MATCH ()-[a]->() MATCH ()-[b]->() RETURN a = b    true
```

`FilterOperator::evaluate_binary_op` was a second implementation — **67 lines against the free function's 346** — and its own comment already said so:

> *Note this is a **second** comparison implementation — the two must agree, and did not.*

It agreed on the easy things and diverged on every rule added since: relationship and path identity, `cypher_equals`' three-valued list and map equality, the NaN and list-ordering rules (#855), the entity-ordering rule (#840). **Every comparison rule fixed this cycle applied everywhere except the clause most queries actually filter in.** It already delegated `^` and `XOR` "so they have one definition rather than two that can drift"; now it delegates everything.

## `1 = 1.0` was false

`cypher_equals` ended in `_ => Some(a == b)`, and `PropertyValue`'s derived `PartialEq` compares *variants* — so an integer never equalled a float. Compared **as integers** now, not through `as f64`: a float with a fractional part cannot equal an integer, and one without is exact, so no bit is lost above 2^53.

## Relationships and paths had no identity arm

Only nodes did. Paths compare structurally — the TCK's scenario is a **self-loop**, where a path and its reverse have the identical node sequence, so a direction-insensitive rule would be inventing something it does not test.

## The parity test was rewritten after it failed to earn its keep

I wrote it first over property values — `1 = 1.0`, list equality, NaN — and **it passed against the old engine too**, because that engine's scalar helpers had kept up. What it had never gained was the entity arms.

It now compares *entity* predicates across `MATCH … WHERE`, `WITH … WHERE` and `RETURN`, and I verified it **fails against the reverted code** rather than assuming it would. The scalar cases are kept and labelled as guarding a future divergence rather than as having caught this one.

## Verification

- TCK **3,630 → 3,633**, regression diff against the merge base **empty**. The count understates it: the scenarios that exercise these rules mostly do so in a `RETURN`, where they already worked.
- `--min-pass` ratcheted 3630 → 3633.