### PR TITLE
Keep entities in a comprehension's output, and let reduce fold them (#863)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3637
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3639
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1263,14 +1263,36 @@ fn eval_list_comprehension(
         }
 
         // Apply map expression
-        let mapped = eval_expression(map_expr, &inner_record, store)?;
-        match mapped {
-            Value::Property(pv) => result.push(pv),
-            _ => result.push(PropertyValue::Null),
-        }
+        result.push(eval_expression(map_expr, &inner_record, store)?);
     }
 
-    Ok(Value::Property(PropertyValue::Array(result)))
+    // A projection that yields **entities** stays a `Value::List`.
+    //
+    // Every mapped value used to be forced into a `PropertyValue`, and anything
+    // that is not one -- a node, a relationship, a path, a nested entity list --
+    // became `Null`. So `[x IN collect(p) | head(nodes(x))]` answered
+    // `[null, null]` where two nodes belong: a list of the right length, full of
+    // nothing, which no caller can distinguish from a projection that
+    // legitimately produced nulls (#863).
+    //
+    // #800 fixed the *input* side of this same distinction -- a list holding
+    // entities is a `Value::List`, not a `PropertyValue` -- and left the output
+    // side converting them away.
+    //
+    // A list of plain property values still comes back as `PropertyValue::Array`,
+    // because that is what every existing caller of a comprehension expects and
+    // what the storage layer can hold.
+    if result.iter().all(|v| matches!(v, Value::Property(_))) {
+        let props = result
+            .into_iter()
+            .map(|v| match v {
+                Value::Property(p) => p,
+                _ => unreachable!("checked above"),
+            })
+            .collect();
+        return Ok(Value::Property(PropertyValue::Array(props)));
+    }
+    Ok(Value::List(result))
 }
 
 /// Evaluate predicate functions: all(x IN list WHERE pred), any(...), none(...), single(...)
@@ -1370,8 +1392,20 @@ fn eval_reduce(
     let list_val = eval_expression(list_expr, record, store)?;
     // See the note in `eval_list_comprehension`: an all-float list literal is a
     // `Vector`, and giving up here returned the seed unchanged (#605).
-    let items = match list_val {
-        Value::Property(ref p) if p.as_list_items().is_some() => p.as_list_items().unwrap(),
+    //
+    // A list holding **entities** is a `Value::List`, and it fell into the same
+    // give-up arm: `reduce(acc = 0, x IN nodes(p) | acc + 1)` returned **0** for
+    // a two-node path. The seed is a legitimate answer for an empty list, so
+    // nothing distinguishes "nothing to fold" from "I did not recognise your
+    // list" (#863).
+    let items: Vec<Value> = match list_val {
+        Value::Property(ref p) if p.as_list_items().is_some() => p
+            .as_list_items()
+            .unwrap()
+            .into_iter()
+            .map(Value::Property)
+            .collect(),
+        Value::List(items) => items,
         _ => return Ok(init_val),
     };
 
@@ -1379,7 +1413,7 @@ fn eval_reduce(
     for item in items {
         let mut inner_record = record.clone();
         inner_record.bind(accumulator.to_string(), acc);
-        inner_record.bind(variable.to_string(), Value::Property(item));
+        inner_record.bind(variable.to_string(), item);
         acc = eval_expression(expression, &inner_record, store)?;
     }
     Ok(acc)

--- a/tests/comprehension_entity_output.rs
+++ b/tests/comprehension_entity_output.rs
@@ -1,0 +1,126 @@
+//! A list comprehension keeps entities, and `reduce` folds them (#863).
+//!
+//! ```text
+//! [x IN collect(p) | head(nodes(x))]      [(:A), (:A)], was [null, null]
+//! reduce(acc = 0, x IN nodes(p) | acc+1)  2,            was 0
+//! ```
+//!
+//! Both are the `Value::List` versus `PropertyValue::Array` distinction on
+//! paths #800 fixed only halfway. The comprehension forced every mapped value
+//! into a `PropertyValue`, so an entity became `Null` — a list of the right
+//! length full of nothing, indistinguishable from a projection that
+//! legitimately produced nulls. `reduce` fell into its give-up arm and returned
+//! the seed, which is a legitimate answer for an empty list.
+//!
+//! `eval_pattern_comprehension` already did this correctly, citing #662. The
+//! fix is to make the list form behave like the pattern form sitting beside it.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn store() -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (a:A) CREATE (a)-[:T]->(:B), (a)-[:T]->(:C)").expect("setup parses");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup runs");
+    store
+}
+
+fn value(store: &GraphStore, cypher: &str) -> Value {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"))
+        .records
+        .first()
+        .and_then(|r| r.get("r"))
+        .cloned()
+        .unwrap_or(Value::Null)
+}
+
+/// Nodes survive the projection. Asserted as **nodes**, not merely as
+/// "not null": a list of two nulls has the right length and the wrong contents,
+/// which is exactly what this returned.
+#[test]
+fn a_comprehension_projecting_nodes_returns_nodes() {
+    let s = store();
+    match value(&s, "MATCH p = (n)-->() RETURN [x IN collect(p) | head(nodes(x))] AS r") {
+        Value::List(items) => {
+            assert_eq!(items.len(), 2);
+            for item in &items {
+                assert!(
+                    matches!(item, Value::NodeRef(_) | Value::Node(..)),
+                    "expected a node, got {item:?}"
+                );
+            }
+        }
+        other => panic!("expected a list of nodes, got {other:?}"),
+    }
+}
+
+/// Paths, relationships and nested entity lists too.
+#[test]
+fn every_entity_kind_survives_a_comprehension() {
+    let s = store();
+    for (cypher, want) in [
+        ("MATCH p = (n)-->() RETURN [x IN collect(p) | x] AS r", 2),
+        ("MATCH p = (n)-->() RETURN [x IN nodes(p) | x] AS r", 2),
+        ("MATCH p = (n)-->() RETURN [x IN relationships(p) | x] AS r", 1),
+        ("MATCH p = (n)-->() RETURN [x IN collect(p) | nodes(x)] AS r", 2),
+    ] {
+        match value(&s, cypher) {
+            Value::List(items) => {
+                assert_eq!(items.len(), want, "{cypher}");
+                assert!(
+                    !items.iter().any(|i| matches!(i, Value::Null | Value::Property(PropertyValue::Null))),
+                    "{cypher} produced a null"
+                );
+            }
+            other => panic!("{cypher}\n  got {other:?}"),
+        }
+    }
+}
+
+/// **A scalar comprehension still returns a `PropertyValue::Array`**, which is
+/// what existing callers expect and what the storage layer can hold. A change
+/// that returned `Value::List` unconditionally would satisfy everything above.
+#[test]
+fn a_scalar_comprehension_is_still_a_property_array() {
+    let s = store();
+    assert_eq!(
+        value(&s, "RETURN [x IN [1, 2, 3] | x * 2] AS r"),
+        Value::Property(PropertyValue::Array(vec![
+            PropertyValue::Integer(2),
+            PropertyValue::Integer(4),
+            PropertyValue::Integer(6),
+        ]))
+    );
+    // And a projection that genuinely yields nulls still does.
+    assert_eq!(
+        value(&s, "RETURN [x IN [1, 2] | null] AS r"),
+        Value::Property(PropertyValue::Array(vec![PropertyValue::Null, PropertyValue::Null]))
+    );
+}
+
+/// `reduce` folds an entity list instead of returning its seed.
+#[test]
+fn reduce_folds_a_list_of_entities() {
+    let s = store();
+    for (cypher, want) in [
+        ("MATCH p = (n)-->() RETURN reduce(acc = 0, x IN nodes(p) | acc + 1) AS r", 2),
+        ("MATCH p = (n)-->() RETURN reduce(acc = 0, x IN relationships(p) | acc + 1) AS r", 1),
+        // Scalars unchanged.
+        ("RETURN reduce(acc = 0, x IN [1, 2, 3] | acc + x) AS r", 6),
+        // An empty list still gives the seed, which is the answer this used to
+        // give for every list.
+        ("RETURN reduce(acc = 7, x IN [] | acc + x) AS r", 7),
+    ] {
+        assert_eq!(
+            value(&s, cypher),
+            Value::Property(PropertyValue::Integer(want)),
+            "{cypher}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #863.

```
MATCH p = (n)-->() RETURN [x IN collect(p) | head(nodes(x))]
  expected [(:A), (:A)]    got [null, null]

MATCH p = (n)-->() RETURN reduce(acc = 0, x IN nodes(p) | acc + 1)
  expected 2               got 0
```

Both are the `Value::List` versus `PropertyValue::Array` distinction on paths #800 fixed only halfway.

**The comprehension's output** forced every mapped value into a `PropertyValue`, so an entity became `Null` — a list of the right length full of nothing, indistinguishable from a projection that legitimately produced nulls. #800 fixed the *input* side of exactly this distinction and left the output converting entities away.

**`reduce`'s input** fell into the give-up arm and returned the seed unchanged. The seed is a legitimate answer for an *empty* list, so nothing separates "nothing to fold" from "I did not recognise your list".

## The correct implementation was one function away

`eval_pattern_comprehension` already collects `Vec<Value>` and narrows to `PropertyValue::Array` only when every element is scalar — its comment says so, citing #662. `eval_list_comprehension` sat beside it doing the opposite. The fix is to match the sibling, not to invent anything.

A scalar comprehension still returns a `PropertyValue::Array`, and `a_scalar_comprehension_is_still_a_property_array` pins it — returning `Value::List` unconditionally would satisfy every other case in the file.

## Verification

- TCK **3,637 → 3,639**, regression diff against the merge base **empty**.
- The `reduce` half gains nothing measurable — no scenario covers it — and is fixed anyway, because returning the seed for a non-empty list is a wrong answer no caller can see.
- `--min-pass` ratcheted 3637 → 3639.

## Filed separately

**#864** — an aggregate inside a `reduce`'s list expression is never extracted, so `reduce(acc = 0, x IN collect(n) | …)` raises `Unknown function: collect`. That one at least fails loudly.