### PR TITLE
A row limit trims the result set, not the write (#866)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3639
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3643
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -5356,6 +5356,20 @@ impl PhysicalOperator for FilterOperator {
         Ok(None)
     }
 
+    // A pass-through operator's default `next_mut` delegates to `next`, which
+    // reads its input read-only -- so a write beneath a FILTER refused outright
+    // with "requires mutable store access". Same defect class as #649, which
+    // fixed it for SKIP and LIMIT and named them "the last two pass-through
+    // operators that still had it"; SORT and FILTER also had it (#866).
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        while let Some(record) = self.input.next_mut(store, tenant_id)? {
+            if self.evaluate_predicate(&record, store)? {
+                return Ok(Some(record));
+            }
+        }
+        Ok(None)
+    }
+
     fn next_batch(&mut self, store: &GraphStore, batch_size: usize) -> ExecutionResult<Option<RecordBatch>> {
         let mut filtered_records = Vec::new();
 
@@ -8465,6 +8479,100 @@ impl PhysicalOperator for AdjacencyCountAggregateOperator {
 }
 
 /// Limit operator: LIMIT 10
+/// Drains its input completely on the first pull, then replays the rows.
+///
+/// Cypher's rule is that `SKIP` and `LIMIT` trim the **result set** and not the
+/// **side effects**: `CREATE (n:N) RETURN n LIMIT 0` still creates the node.
+/// Without this, `LimitOperator(0)` never pulls, so the create beneath it never
+/// runs and the write is silently skipped -- a query that reports success and
+/// changes nothing (#866).
+///
+/// It is the standard "eager" barrier, placed between a write and a row-count
+/// clause. Only there: making every `LIMIT` eager would undo the whole point of
+/// a limit on a read, which is to stop early.
+pub struct EagerOperator {
+    input: OperatorBox,
+    skip: usize,
+    limit: Option<usize>,
+    buffered: Vec<Record>,
+    idx: usize,
+    drained: bool,
+}
+
+impl EagerOperator {
+    /// Wrap `input` so it runs to completion, then replay it trimmed by `skip`
+    /// and `limit`.
+    ///
+    /// The trimming is **this operator's job** rather than a `Skip`/`Limit`
+    /// above it, because `LimitOperator(0)` returns without pulling at all --
+    /// so a lazy barrier beneath it is never reached and the write never runs.
+    /// Being outermost is what makes the write happen.
+    pub fn new(input: OperatorBox, skip: usize, limit: Option<usize>) -> Self {
+        Self { input, skip, limit, buffered: Vec::new(), idx: 0, drained: false }
+    }
+
+    fn emit(&mut self) -> Option<Record> {
+        let start = self.skip;
+        let end = match self.limit {
+            Some(l) => (start + l).min(self.buffered.len()),
+            None => self.buffered.len(),
+        };
+        let pos = start + self.idx;
+        if pos >= end {
+            return None;
+        }
+        self.idx += 1;
+        Some(self.buffered[pos].clone())
+    }
+}
+
+impl PhysicalOperator for EagerOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
+    fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        if !self.drained {
+            while let Some(r) = self.input.next(store)? {
+                self.buffered.push(r);
+            }
+            self.drained = true;
+        }
+        Ok(self.emit())
+    }
+
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        if !self.drained {
+            while let Some(r) = self.input.next_mut(store, tenant_id)? {
+                self.buffered.push(r);
+            }
+            self.drained = true;
+        }
+        Ok(self.emit())
+    }
+
+    /// **Refuses a pushed-down limit.** Accepting one would let the limit reach
+    /// the write again, which is the defect this operator exists to prevent.
+    fn try_push_limit(&mut self, _n: usize) -> bool {
+        false
+    }
+
+    fn reset(&mut self) {
+        self.input.reset();
+        self.buffered.clear();
+        self.idx = 0;
+        self.drained = false;
+    }
+
+    fn describe(&self) -> OperatorDescription {
+        OperatorDescription {
+            name: "Eager".to_string(),
+            details: String::new(),
+            children: vec![self.input.describe()],
+        }
+    }
+}
+
 pub struct LimitOperator {
     /// Input operator
     input: OperatorBox,
@@ -8780,6 +8888,34 @@ impl PhysicalOperator for SortOperator {
 
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
         if !self.executed {
+            self.execute_all(store)?;
+        }
+
+        if self.current >= self.records.len() {
+            return Ok(None);
+        }
+
+        let record = self.records[self.current].clone();
+        self.current += 1;
+        Ok(Some(record))
+    }
+
+    // Same as the FILTER above: a write beneath a SORT refused with "requires
+    // mutable store access", which is what `CREATE (n) RETURN n ORDER BY n.x`
+    // hit (#866).
+    //
+    // The input is drained **mutably first** and replaced with the rows it
+    // produced, so the ordinary `execute_all` does the sorting. Duplicating the
+    // decorate-sort-undecorate path -- with its limit hint and its amortised
+    // trimming -- would be a second implementation of the one thing this
+    // operator does.
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        if !self.executed {
+            let mut rows = Vec::new();
+            while let Some(r) = self.input.next_mut(store, tenant_id)? {
+                rows.push(r);
+            }
+            self.input = Box::new(MaterializedOperator::new(rows));
             self.execute_all(store)?;
         }
 

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1138,6 +1138,45 @@ impl QueryPlanner {
                     }).collect();
                     plan.root = Box::new(ProjectOperator::new(plan.root, projections));
                     plan.output_columns = output_columns;
+
+                    // `ORDER BY`, `SKIP` and `LIMIT` after a bare `CREATE`.
+                    //
+                    // This path returned straight after projecting, so
+                    // `CREATE (n:N) RETURN n LIMIT 0` produced a row -- the one
+                    // shape where the clause was silently dropped. It works
+                    // wherever the create has input rows
+                    // (`UNWIND [1,2,3] AS x CREATE ... RETURN n LIMIT 2` is
+                    // correct), because that goes through a different planner
+                    // path which applies them.
+                    //
+                    // The side effects still happen: the nodes are created and
+                    // only the *result set* is trimmed, which is exactly what
+                    // `Create6` asserts (#866).
+                    if let Some(order_by) = &query.order_by {
+                        let sort_items: Vec<(Expression, bool)> = order_by
+                            .items
+                            .iter()
+                            .map(|i| (i.expression.clone(), i.ascending))
+                            .collect();
+                        plan.root = Box::new(SortOperator::new(plan.root, sort_items));
+                    }
+                    // `SKIP`/`LIMIT` go through an **eager** barrier that does
+                    // the trimming itself.
+                    //
+                    // A `LimitOperator(0)` returns without pulling, so a lazy
+                    // plan would never run the create beneath it: the query
+                    // reported success and changed nothing. Cypher trims the
+                    // result set and not the side effects -- `CREATE (n:N)
+                    // RETURN n LIMIT 0` still creates the node (#866).
+                    if query.skip.is_some() || query.limit.is_some() {
+                        plan.root = Box::new(
+                            crate::query::executor::operator::EagerOperator::new(
+                                plan.root,
+                                query.skip.unwrap_or(0),
+                                query.limit,
+                            ),
+                        );
+                    }
                 }
                 return Ok(plan);
             }

--- a/tests/write_with_row_limits.rs
+++ b/tests/write_with_row_limits.rs
@@ -1,0 +1,97 @@
+//! `SKIP` and `LIMIT` trim the result set, not the side effects (#866).
+//!
+//! ```text
+//! CREATE (n:N {num: 42}) RETURN n LIMIT 0   -> 0 rows, and the node exists
+//! ```
+//!
+//! Two defects in sequence. The bare-`CREATE`-plus-`RETURN` planner path never
+//! applied `ORDER BY`/`SKIP`/`LIMIT` at all — it works when the create has
+//! input rows, which is a different path. And applying them *lazily* skipped
+//! the write, because `LimitOperator(0)` returns without pulling.
+//!
+//! So both halves are asserted everywhere below: **the row count and the side
+//! effect**. Checking only the row count is what the first fix passed while
+//! creating nothing.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+/// Runs `cypher` against a fresh store; returns (rows returned, nodes existing).
+fn run(cypher: &str) -> (usize, usize) {
+    let mut store = GraphStore::new();
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let rows = MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"))
+        .records
+        .len();
+    let count = parse_query("MATCH (n) RETURN n")
+        .ok()
+        .and_then(|p| QueryExecutor::new(&store).execute(&p).ok())
+        .map(|b| b.records.len())
+        .expect("count runs");
+    (rows, count)
+}
+
+/// The TCK's four `Create6` shapes.
+#[test]
+fn a_row_limit_does_not_cancel_the_write() {
+    assert_eq!(run("CREATE (n:N {num: 42}) RETURN n LIMIT 0"), (0, 1));
+    assert_eq!(run("CREATE (n:N {num: 42}) RETURN n SKIP 1"), (0, 1));
+    // Two nodes, one relationship.
+    assert_eq!(run("CREATE ()-[r:R]->() RETURN r LIMIT 0"), (0, 2));
+    assert_eq!(run("CREATE ()-[r:R]->() RETURN r SKIP 1"), (0, 2));
+}
+
+/// The clause still trims when it should, and a create with input rows — which
+/// always worked, via a different planner path — is undisturbed.
+#[test]
+fn a_row_limit_still_trims() {
+    assert_eq!(run("CREATE (n:N {num: 42}) RETURN n LIMIT 1"), (1, 1));
+    assert_eq!(run("UNWIND [1, 2, 3] AS x CREATE (n:N {num: x}) RETURN n LIMIT 2"), (2, 3));
+    assert_eq!(run("UNWIND [1, 2, 3] AS x CREATE (n:N {num: x}) RETURN n SKIP 2"), (1, 3));
+}
+
+/// **`ORDER BY` above a write.** This raised "requires mutable store access",
+/// because `SortOperator` had no `next_mut` — the defect class #649 declared
+/// closed on `SKIP` and `LIMIT`.
+#[test]
+fn a_sort_above_a_write_runs() {
+    assert_eq!(run("CREATE (n:N {num: 42}) RETURN n ORDER BY n.num LIMIT 0"), (0, 1));
+    assert_eq!(run("CREATE (n:N {num: 42}) RETURN n ORDER BY n.num"), (1, 1));
+    assert_eq!(
+        run("UNWIND [3, 1, 2] AS x CREATE (n:N {num: x}) RETURN n ORDER BY n.num LIMIT 2"),
+        (2, 3)
+    );
+}
+
+/// **A filter above a write** had the same gap.
+#[test]
+fn a_filter_above_a_write_runs() {
+    assert_eq!(
+        run("UNWIND [1, 2, 3] AS x CREATE (n:N {num: x}) WITH n WHERE n.num > 1 RETURN n"),
+        (2, 3)
+    );
+}
+
+/// Reads are untouched: a limit on a read must still stop early rather than
+/// draining, which is the whole point of one.
+#[test]
+fn reads_are_unaffected() {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (:A), (:A), (:A)").expect("setup parses");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup runs");
+    for (cypher, want) in [
+        ("MATCH (n) RETURN n LIMIT 0", 0),
+        ("MATCH (n) RETURN n LIMIT 2", 2),
+        ("MATCH (n) RETURN n SKIP 2", 1),
+        ("MATCH (n) RETURN n", 3),
+    ] {
+        let p = parse_query(cypher).expect("parses");
+        let rows = QueryExecutor::new(&store).execute(&p).expect("runs").records.len();
+        assert_eq!(rows, want, "{cypher}");
+    }
+}


### PR DESCRIPTION
Closes #866.

```cypher
CREATE (n:N {num: 42}) RETURN n LIMIT 0
```

Returned **one row** — and once the row count was fixed, created **no node**. Cypher trims the *result set* and not the *side effects*: `Create6` scenario 1 asserts 0 rows **and** `+nodes 1`.

## Three defects, each uncovered by fixing the one before

**1. The clause was dropped entirely.** The bare-`CREATE`+`RETURN` planner path wrapped the create in a projection and returned, never applying `ORDER BY`, `SKIP` or `LIMIT`. It works wherever the create has input rows — `UNWIND [1,2,3] AS x CREATE (n) RETURN n LIMIT 2` is correct — because that is a different path. One shape, silently missing the clause.

**2. Applying it lazily skipped the write.** `LimitOperator(0)` returns without pulling, so the create beneath it never ran: the query reported success and changed nothing. A lazy barrier underneath does not help, because nothing pulls that either.

The new `EagerOperator` is therefore **outermost** and does the trimming itself: drain the input (running the write), then replay trimmed by skip and limit. It **refuses a pushed-down limit**, since accepting one would let the limit reach the write again — the very thing it exists to prevent. Only on this path: making every `LIMIT` eager would undo the point of a limit on a read, and `reads_are_unaffected` pins that.

**3. `SortOperator` and `FilterOperator` had no `next_mut`.** Adding `ORDER BY` raised `CreateNodeOperator requires mutable store access` — a write beneath either refused outright. That is the defect class of #649, whose comment called `SKIP` and `LIMIT` *"the last two pass-through operators that still had it"*. They were not the last two.

`SortOperator` drains its input mutably and replaces it with the rows produced, so the ordinary `execute_all` still sorts. Duplicating the decorate-sort-undecorate path — with its limit hint and amortised trimming — would be a second implementation of the one thing that operator does.

## Every test asserts both halves

Row count **and** side effect, everywhere. Checking only the row count is exactly what my first attempt passed while creating nothing.

## Verification

- TCK **3,639 → 3,643**, regression diff against the merge base **empty**. `Create6` goes to **0** failures.
- Lib tests 2,175, all green.
- `--min-pass` ratcheted 3639 → 3643.

## Filed, not fixed here

`MERGE (n) RETURN n LIMIT 0` creates nothing and `MATCH (n) DELETE n RETURN 1 LIMIT 0` deletes nothing — the same lazy-limit defect on other write paths, which no TCK scenario currently reaches. The `DELETE` one is the worse: a user asked to delete and nothing happened, with no error. Extending the barrier there touches fourteen `SKIP`/`LIMIT` sites and wants doing deliberately rather than as a rider on this change.