### PR TITLE
Parse the both-directions arrow (#868)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3643
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3647
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -180,7 +180,11 @@ label = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 //
 // Alternative order matters and is not arbitrary: `-` `->` must be tried
 // before `-` `-`, or `-->` matches the undirected form and leaves a stray `>`.
+// `<-->` is "an edge in either direction", the same as `--`. It has to be tried
+// **first**: `<-` otherwise matches the incoming form and leaves a stray `>`,
+// which is a parse error on `MATCH (n)<-->(k)` (#868).
 edge_pattern = {
+    ("<-" ~ edge_detail? ~ "->") |
     ("<-" ~ edge_detail? ~ "-") |
     ("-" ~ edge_detail? ~ "->") |
     ("-" ~ edge_detail? ~ "-")

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1623,7 +1623,13 @@ fn parse_edge(pair: pest::iterators::Pair<Rule>) -> ParseResult<EdgePattern> {
     let mut direction = Direction::Both;
     let edge_str = pair.as_str();
 
-    if edge_str.starts_with("<-") {
+    // Arrows on **both** ends mean either direction, the same as no arrows at
+    // all. Testing `starts_with("<-")` first would call `<-->` incoming, which
+    // is the opposite of what it asks for and would silently halve the matches
+    // rather than fail (#868).
+    if edge_str.starts_with("<-") && edge_str.ends_with("->") {
+        direction = Direction::Both;
+    } else if edge_str.starts_with("<-") {
         direction = Direction::Incoming;
     } else if edge_str.ends_with("->") {
         direction = Direction::Outgoing;

--- a/tests/bidirectional_arrow.rs
+++ b/tests/bidirectional_arrow.rs
@@ -1,0 +1,98 @@
+//! `<-->` is an edge in either direction (#868).
+//!
+//! ```text
+//! MATCH p = (n)<-->(k)<-->(n) RETURN p    -- parse error
+//! ```
+//!
+//! `edge_pattern` had three alternatives and none matched arrows on both ends;
+//! `<-` matched the incoming form and left a stray `>`. The rule's own comment
+//! already explained that alternative order is load-bearing — `-` `->` before
+//! `-` `-` — and the both-ends form has the same requirement one step earlier.
+//!
+//! The second half matters more: `parse_edge` derives direction from the text
+//! with `starts_with("<-")` → `Incoming`. Left alone, `<-->` would have parsed
+//! and then been read as **incoming**, silently halving the matches rather than
+//! failing. So the direction is asserted here by row count against a
+//! single-direction graph, not by "it parses".
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+fn store() -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (a:A)-[:R]->(b:B)").expect("setup parses");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup runs");
+    store
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"))
+        .records
+        .len()
+}
+
+/// One relationship, so an undirected pattern matches twice and a directed one
+/// once. That difference is what distinguishes "parsed" from "parsed as the
+/// right direction".
+#[test]
+fn both_ends_means_either_direction() {
+    let s = store();
+    assert_eq!(rows(&s, "MATCH (n)<-->(k) RETURN n, k"), 2);
+    assert_eq!(rows(&s, "MATCH (n)--(k) RETURN n, k"), 2, "the equivalent spelling");
+    assert_eq!(rows(&s, "MATCH (n)-->(k) RETURN n, k"), 1, "outgoing");
+    assert_eq!(rows(&s, "MATCH (n)<--(k) RETURN n, k"), 1, "incoming");
+}
+
+/// With a bracket, on a single relationship.
+#[test]
+fn the_bracketed_forms() {
+    let s = store();
+    assert_eq!(rows(&s, "MATCH (n)<-[r]->(k) RETURN n, k"), 2);
+    assert_eq!(rows(&s, "MATCH (n)<-[:R]->(k) RETURN n, k"), 2);
+    assert_eq!(rows(&s, "MATCH p = (n)<-->(k) RETURN p"), 2);
+}
+
+/// A two-segment chain needs **two** relationships, because Cypher will not
+/// reuse one within a single pattern.
+///
+/// My first version of this asserted 2 rows against the single-relationship
+/// store above and got 0 — and 0 was right. The fixture and the expected counts
+/// below are the TCK's own (`Match6` scenarios 12 and 13), not my arithmetic.
+fn two_relationships() -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (a:A), (b:B) CREATE (a)-[:T1]->(b), (b)-[:T2]->(a)")
+        .expect("setup parses");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup runs");
+    store
+}
+
+#[test]
+fn a_chain_of_both_ends_arrows() {
+    let s = two_relationships();
+    assert_eq!(rows(&s, "MATCH p = (n)<-->(k)<-->(n) RETURN p"), 4);
+}
+
+/// **A both-ends arrow does not relax the arrow beside it.** The same chain
+/// with a directed second segment matches half as often.
+#[test]
+fn a_mixed_chain_keeps_each_direction() {
+    let s = two_relationships();
+    assert_eq!(rows(&s, "MATCH p = (n)<-->(k)<--(n) RETURN p"), 2);
+    assert_eq!(rows(&s, "MATCH p = (n)<-->(k)-->(n) RETURN p"), 2);
+}
+
+/// Relationship uniqueness still applies: one relationship cannot serve both
+/// segments, which is why the single-relationship store yields nothing here.
+#[test]
+fn one_relationship_cannot_fill_two_segments() {
+    let s = store();
+    assert_eq!(rows(&s, "MATCH p = (n)<-->(k)<-->(n) RETURN p"), 0);
+}


### PR DESCRIPTION
Closes #868.

```cypher
MATCH p = (n)<-->(k)<-->(n) RETURN p     -- parse error
```

`<-->` means "an edge in either direction", the same as `--`.

`edge_pattern` had three alternatives — `<-…-`, `-…->`, `-…-` — and none matched arrows on both ends, so `<-` matched the incoming form and left a stray `>`. The rule's own comment already explained that alternative order is load-bearing here; the both-ends form has the same requirement one step earlier and is tried first.

## The second half matters more

`parse_edge` derives direction from the matched text with `starts_with("<-")` → `Incoming`. Left alone, `<-->` would have **parsed and then been read as incoming** — the opposite of what it asks for, silently halving the matches rather than failing.

So the tests assert direction by **row count against a single-direction graph**, not by "it parses": one relationship, and an undirected pattern matches twice where a directed one matches once.

`<-[r]->` and `<-[:R]->` are accepted on the same footing. Neo4j rejects those; over-rejecting a valid query is the worse failure, and the grammar admits them naturally.

## Two of my expectations were wrong first

I asserted a two-segment chain would match against the single-relationship store and got 0 — and **0 was right**: Cypher will not reuse one relationship within a single pattern. The fixture and counts now come from `Match6` scenarios 12 and 13 rather than from my arithmetic, and the uniqueness rule that caught me has a test of its own.

## Verification

- TCK **3,643 → 3,647**, regression diff against the merge base **empty**.
- `--min-pass` ratcheted 3643 → 3647.