### PR TITLE
Every parent operator carries a write, and percentiles use their argument (#870, #871)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3647
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3650
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -4424,6 +4424,37 @@ impl MultiObjectiveProblem for GraphOptimizationProblem {
 }
 
 /// Physical operator trait - all operators implement this
+/// Drain a pass-through operator's input **mutably**, once, and replace it with
+/// the rows it produced.
+///
+/// A pass-through operator's default `next_mut` delegates to `next`, which
+/// reads its input read-only -- so any write beneath it refuses outright with
+/// "requires mutable store access". That defect has now been fixed four times
+/// on different operators (#622 barriers, #624 joins, #649 SKIP and LIMIT, #866
+/// SORT and FILTER), each time for the ones a failing query happened to name.
+///
+/// This is the shared body for the rest. Draining first is not merely
+/// convenient: it lets each operator keep its single `next` implementation
+/// instead of growing a second, mutable copy of its own logic -- which is the
+/// duplication that produced most of this cycle's defects. It also matches
+/// Cypher, where a write is eager anyway; and `next_mut` is only reached when
+/// the query writes, so a read-only plan still streams (#870).
+fn drain_input_for_write(
+    input: &mut OperatorBox,
+    store: &mut GraphStore,
+    tenant_id: &str,
+) -> ExecutionResult<()> {
+    if input.is_materialized() {
+        return Ok(());
+    }
+    let mut rows = Vec::new();
+    while let Some(r) = input.next_mut(store, tenant_id)? {
+        rows.push(r);
+    }
+    *input = Box::new(MaterializedOperator::new(rows));
+    Ok(())
+}
+
 pub trait PhysicalOperator: Send {
     /// Get the next record from this operator (read-only operations)
     fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>>;
@@ -4441,6 +4472,15 @@ pub trait PhysicalOperator: Send {
     /// Returns `true` if the hint was accepted somewhere in the subtree.
     /// The caller may still need to apply a `LimitOperator` on top — this
     /// hint is purely an optimization to avoid unnecessary work upstream.
+    /// Whether this operator replays an already-computed set of rows.
+    ///
+    /// Used by `drain_input_for_write` to tell "I have already drained my
+    /// input" from "I have not", without giving every pass-through operator a
+    /// bookkeeping field of its own (#870).
+    fn is_materialized(&self) -> bool {
+        false
+    }
+
     fn try_push_limit(&mut self, _n: usize) -> bool {
         false
     }
@@ -5980,6 +6020,15 @@ impl ExpandOperator {
 }
 
 impl PhysicalOperator for ExpandOperator {
+    // A write beneath this operator refused with "requires mutable store
+    // access", because the default `next_mut` delegates to `next` and `next`
+    // reads its input read-only. Shared body rather than a second, mutable copy
+    // of this operator's own logic -- see `drain_input_for_write` (#870).
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        drain_input_for_write(&mut self.input, store, tenant_id)?;
+        self.next(store)
+    }
+
     fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
         vec![&mut self.input]
     }
@@ -6843,6 +6892,15 @@ fn reconstruct_path(
 }
 
 impl PhysicalOperator for VarLengthExpandOperator {
+    // A write beneath this operator refused with "requires mutable store
+    // access", because the default `next_mut` delegates to `next` and `next`
+    // reads its input read-only. Shared body rather than a second, mutable copy
+    // of this operator's own logic -- see `drain_input_for_write` (#870).
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        drain_input_for_write(&mut self.input, store, tenant_id)?;
+        self.next(store)
+    }
+
     fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
         vec![&mut self.input]
     }
@@ -7100,6 +7158,13 @@ pub struct AggregateFunction {
     pub expr: Expression,
     pub alias: String,
     pub distinct: bool,
+    /// The percentile argument of `percentileCont` / `percentileDisc`.
+    ///
+    /// The struct held one expression, so the **second** argument was dropped
+    /// at extraction and the aggregator's `pct` stayed at its initial `0.5`:
+    /// every percentile call returned the median, whatever was asked for
+    /// (#871).
+    pub percentile: Option<Expression>,
 }
 
 /// Internal state for an aggregator
@@ -7238,6 +7303,37 @@ impl AggregatorState {
             (AggregateType::StDev, _) => AggregatorState::StDev { values: Vec::new(), population: false },
             (AggregateType::StDevP, _) => AggregatorState::StDev { values: Vec::new(), population: true },
         }
+    }
+
+    /// Set the percentile from the call's second argument.
+    ///
+    /// Cypher requires it in `[0, 1]` and raises otherwise. The finalizer used
+    /// to clamp the index with `.min(n - 1)` instead, so an out-of-range
+    /// percentile quietly returned the last element (#871).
+    fn set_percentile(&mut self, value: &Value) -> ExecutionResult<()> {
+        let AggregatorState::Percentile { pct, .. } = self else {
+            return Ok(());
+        };
+        let p = match value.as_property() {
+            Some(PropertyValue::Float(f)) => *f,
+            Some(PropertyValue::Integer(i)) => *i as f64,
+            // A null percentile leaves the aggregate undecidable; Cypher's own
+            // answer is null, which the finalizer already gives for no values.
+            Some(PropertyValue::Null) | None => return Ok(()),
+            Some(other) => {
+                return Err(ExecutionError::TypeError(format!(
+                    "percentile must be a number between 0 and 1, not {}",
+                    other.type_name()
+                )))
+            }
+        };
+        if !(0.0..=1.0).contains(&p) {
+            return Err(ExecutionError::RuntimeError(format!(
+                "percentile must be between 0.0 and 1.0 inclusive, got {p}"
+            )));
+        }
+        *pct = p;
+        Ok(())
     }
 
     fn update(&mut self, value: &Value) {
@@ -7869,6 +7965,9 @@ impl AggregateOperator {
                     for (i, reader) in readers.iter_mut().enumerate() {
                         let val = reader.read(&record, store)?;
                         states[i].update(&val);
+                        if let Some(p) = &self.aggregates[i].percentile {
+                            states[i].set_percentile(&eval_expression(p, &record, store)?)?;
+                        }
                     }
                 }
             }
@@ -7975,6 +8074,9 @@ impl AggregateOperator {
                     for (i, reader) in readers.iter_mut().enumerate() {
                         let val = reader.read(&record, store)?;
                         states[i].update(&val);
+                        if let Some(p) = &self.aggregates[i].percentile {
+                            states[i].set_percentile(&eval_expression(p, &record, store)?)?;
+                        }
                     }
                 }
             }
@@ -8030,6 +8132,9 @@ impl AggregateOperator {
                     for (i, reader) in readers.iter_mut().enumerate() {
                         let val = reader.read(&record, store)?;
                         states[i].update(&val);
+                        if let Some(p) = &self.aggregates[i].percentile {
+                            states[i].set_percentile(&eval_expression(p, &record, store)?)?;
+                        }
                     }
                 }
             }
@@ -8080,6 +8185,9 @@ impl AggregateOperator {
                     for (i, reader) in readers.iter_mut().enumerate() {
                         let val = reader.read(&record, store)?;
                         states[i].update(&val);
+                        if let Some(p) = &self.aggregates[i].percentile {
+                            states[i].set_percentile(&eval_expression(p, &record, store)?)?;
+                        }
                     }
                 }
             }
@@ -8388,6 +8496,15 @@ impl AdjacencyCountAggregateOperator {
 }
 
 impl PhysicalOperator for AdjacencyCountAggregateOperator {
+    // A write beneath this operator refused with "requires mutable store
+    // access", because the default `next_mut` delegates to `next` and `next`
+    // reads its input read-only. Shared body rather than a second, mutable copy
+    // of this operator's own logic -- see `drain_input_for_write` (#870).
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        drain_input_for_write(&mut self.input, store, tenant_id)?;
+        self.next(store)
+    }
+
     fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
         vec![&mut self.input]
     }
@@ -11263,6 +11380,10 @@ impl MaterializedOperator {
 }
 
 impl PhysicalOperator for MaterializedOperator {
+    fn is_materialized(&self) -> bool {
+        true
+    }
+
     fn next(&mut self, _store: &GraphStore) -> ExecutionResult<Option<Record>> {
         if self.idx >= self.records.len() {
             Ok(None)
@@ -12554,6 +12675,15 @@ impl UnwindOperator {
 }
 
 impl PhysicalOperator for UnwindOperator {
+    // A write beneath this operator refused with "requires mutable store
+    // access", because the default `next_mut` delegates to `next` and `next`
+    // reads its input read-only. Shared body rather than a second, mutable copy
+    // of this operator's own logic -- see `drain_input_for_write` (#870).
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        drain_input_for_write(&mut self.input, store, tenant_id)?;
+        self.next(store)
+    }
+
     fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
         vec![&mut self.input]
     }
@@ -13487,6 +13617,15 @@ impl ShortestPathOperator {
 }
 
 impl PhysicalOperator for ShortestPathOperator {
+    // A write beneath this operator refused with "requires mutable store
+    // access", because the default `next_mut` delegates to `next` and `next`
+    // reads its input read-only. Shared body rather than a second, mutable copy
+    // of this operator's own logic -- see `drain_input_for_write` (#870).
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        drain_input_for_write(&mut self.input, store, tenant_id)?;
+        self.next(store)
+    }
+
     fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
         vec![&mut self.input]
     }
@@ -13926,6 +14065,15 @@ impl ExpandIntoOperator {
 }
 
 impl PhysicalOperator for ExpandIntoOperator {
+    // A write beneath this operator refused with "requires mutable store
+    // access", because the default `next_mut` delegates to `next` and `next`
+    // reads its input read-only. Shared body rather than a second, mutable copy
+    // of this operator's own logic -- see `drain_input_for_write` (#870).
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        drain_input_for_write(&mut self.input, store, tenant_id)?;
+        self.next(store)
+    }
+
     fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
         vec![&mut self.input]
     }
@@ -14354,6 +14502,7 @@ mod tests {
                 expr: Expression::Variable("n".to_string()),
                 alias: "count".to_string(),
                 distinct: false,
+                percentile: None,
             }]
         );
 

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -168,11 +168,25 @@ fn extract_agg_inner(
                         .unwrap_or(Expression::Literal(PropertyValue::Null))
                 };
 
+                // `percentileCont`/`percentileDisc` take the percentile as
+                // their **second** argument. It was dropped here, so the
+                // aggregator's `pct` never moved off its initial 0.5 and every
+                // percentile call returned the median (#871).
+                let percentile = if matches!(
+                    func,
+                    AggregateType::PercentileCont | AggregateType::PercentileDisc
+                ) {
+                    args.get(1).cloned()
+                } else {
+                    None
+                };
+
                 aggs.push(AggregateFunction {
                     func,
                     expr: arg_expr,
                     alias: alias.clone(),
                     distinct: *distinct,
+                    percentile,
                 });
 
                 Expression::Variable(alias)
@@ -606,6 +620,7 @@ impl QueryPlanner {
                             expr: Expression::Variable(fact_var),
                             alias: alias.clone(),
                             distinct,
+                            percentile: None,
                         },
                         alias,
                     ),
@@ -618,6 +633,7 @@ impl QueryPlanner {
                             },
                             alias: alias.clone(),
                             distinct: false,
+                            percentile: None,
                         },
                         alias,
                     ),
@@ -660,6 +676,7 @@ impl QueryPlanner {
                                 expr: Expression::Variable(var),
                                 alias: alias.clone(),
                                 distinct: false,
+                                percentile: None,
                             }],
                         )),
                         output_columns: vec![alias],

--- a/tests/writes_under_every_operator.rs
+++ b/tests/writes_under_every_operator.rs
@@ -1,0 +1,124 @@
+//! Every parent operator can carry a write beneath it (#870).
+//!
+//! A pass-through operator's default `next_mut` delegates to `next`, which
+//! reads its input **read-only** — so any write beneath it refuses with
+//! "requires mutable store access".
+//!
+//! This class has now been fixed five times: #622 (barriers), #624 (joins),
+//! #649 (`SKIP`, `LIMIT`), #866 (`SORT`, `FILTER`), and #870 (six more).
+//! #649's comment called `SKIP` and `LIMIT` *"the last two pass-through
+//! operators that still had it"*. They were not.
+//!
+//! So this file does not test the operators a failing query happened to name.
+//! [`every_parent_operator_implements_next_mut`] reads the source and fails if
+//! any `impl PhysicalOperator` block that has children lacks `next_mut` — the
+//! sixth time is meant to be the last.
+
+use std::collections::BTreeSet;
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+/// Reads `operator.rs` and reports any operator that has children but no
+/// `next_mut`.
+///
+/// Source-reading is the point: a behavioural test can only cover the shapes
+/// someone thought to write, and every previous round of this defect was found
+/// by a query nobody had thought to write.
+///
+/// Verified by removing `UnwindOperator::next_mut` and watching this fail while
+/// [`a_write_runs_beneath_each_parent_operator`] below **still passed** — which
+/// is the whole argument for reading the source rather than trusting a
+/// behavioural sample.
+#[test]
+fn every_parent_operator_implements_next_mut() {
+    let src = include_str!("../src/query/executor/operator.rs");
+
+    let mut blocks: Vec<(String, usize)> = Vec::new();
+    for (offset, _) in src.match_indices("impl PhysicalOperator for ") {
+        let rest = &src[offset + "impl PhysicalOperator for ".len()..];
+        let name: String = rest.chars().take_while(|c| c.is_alphanumeric() || *c == '_').collect();
+        blocks.push((name, offset));
+    }
+    assert!(
+        blocks.len() >= 40,
+        "expected to find the operator impls; found {} — has the file moved?",
+        blocks.len()
+    );
+
+    let mut missing = BTreeSet::new();
+    for (i, (name, start)) in blocks.iter().enumerate() {
+        let end = blocks.get(i + 1).map(|(_, o)| *o).unwrap_or(src.len());
+        let body = &src[*start..end];
+        // An operator with children is one that pulls from an input.
+        let has_children = body.contains("fn children_mut");
+        if has_children && !body.contains("fn next_mut") {
+            missing.insert(name.clone());
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "these operators have children but no `next_mut`, so a write beneath them \
+         will refuse with \"requires mutable store access\": {missing:?}"
+    );
+}
+
+fn run(cypher: &str) -> Result<usize, String> {
+    let mut store = GraphStore::new();
+    for setup in ["CREATE (a:A {n: 1}), (b:B {n: 2})", "CREATE (:C)-[:R]->(:D)"] {
+        let q = parse_query(setup).expect("setup parses");
+        MutQueryExecutor::new(&mut store, "default".to_string())
+            .execute(&q)
+            .expect("setup runs");
+    }
+    let q = parse_query(cypher).map_err(|e| format!("parse: {e:?}"))?;
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .map(|b| b.records.len())
+        .map_err(|e| format!("{e:?}"))
+}
+
+/// One write beneath each kind of parent, so the source check above is backed
+/// by queries that actually exercise the paths.
+#[test]
+fn a_write_runs_beneath_each_parent_operator() {
+    for cypher in [
+        // UNWIND
+        "UNWIND [1, 2] AS x CREATE (:N {v: x})",
+        "MATCH (a:A) WITH a UNWIND [1, 2] AS x CREATE (a)-[:R {v: x}]->(:N)",
+        // Expand
+        "MATCH (c:C)-[:R]->(d:D) CREATE (d)-[:BACK]->(c)",
+        // ExpandInto
+        "MATCH (c:C), (d:D) MERGE (c)-[:R2]->(d)",
+        // Var-length expand
+        "MATCH (c:C)-[:R*1..2]->(d) CREATE (:Seen {x: 1})",
+        // Sort and Filter above a write
+        "UNWIND [2, 1] AS x CREATE (n:N {v: x}) WITH n ORDER BY n.v RETURN n",
+        "UNWIND [1, 2] AS x CREATE (n:N {v: x}) WITH n WHERE n.v > 1 RETURN n",
+    ] {
+        assert!(run(cypher).is_ok(), "{cypher}\n  -> {:?}", run(cypher));
+    }
+}
+
+/// Reads still stream — `next_mut` is only reached when the query writes, so
+/// making the write path eager must not have made every plan eager.
+#[test]
+fn reads_are_unaffected() {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (:A)-[:R]->(:B)").expect("setup parses");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup runs");
+    for (cypher, want) in [
+        ("MATCH (n) RETURN n", 2),
+        ("MATCH (a)-->(b) RETURN a, b", 1),
+        ("UNWIND [1, 2, 3] AS x RETURN x", 3),
+        ("MATCH (a)-[*1..2]->(b) RETURN a, b", 1),
+    ] {
+        let p = parse_query(cypher).expect("parses");
+        let rows = QueryExecutor::new(&store).execute(&p).expect("runs").records.len();
+        assert_eq!(rows, want, "{cypher}");
+    }
+}


### PR DESCRIPTION
Closes #870 and #871.

## Six more operators had no `next_mut`

A pass-through operator's default `next_mut` delegates to `next`, which reads its input **read-only** — so any write beneath it refuses with `requires mutable store access`.

This class has now been fixed **five times**: #622 (barriers), #624 (joins), #649 (`SKIP`, `LIMIT`), #866 (`SORT`, `FILTER`), and these. #649's comment called `SKIP` and `LIMIT` *"the last two pass-through operators that still had it"*. They were not, and neither were `SORT` and `FILTER`.

So rather than fix the one in front of me again, I enumerated every `impl PhysicalOperator` block. Six were missing it: `Expand`, `VarLengthExpand`, `ExpandInto`, `Unwind`, `AdjacencyCountAggregate`, `ShortestPath`.

One shared body, `drain_input_for_write`. Each operator keeps its **single** `next` implementation instead of growing a second, mutable copy of its own logic — the duplication that produced most of this cycle's other defects. Draining is eager, which is fine: `next_mut` is only reached when the query writes, where Cypher is eager anyway, and a read-only plan still streams.

### The standing test is the point

`every_parent_operator_implements_next_mut` reads the source and fails if any operator with children lacks `next_mut`.

I verified it by removing `UnwindOperator::next_mut` — it failed and named the operator, **while the behavioural test beside it still passed**. That is the whole argument for checking the source rather than a sample of queries someone thought to write: every previous round of this defect was found by a query nobody had thought to write.

## Percentiles ignored their percentile argument

```cypher
MATCH (v:V) RETURN percentileDisc(v.x, 0.9)   -- over 1..10, returned 5
```

`AggregateFunction` held one expression, so extraction kept `args.first()` and dropped the second; `pct` was initialised to `0.5` and never assigned. **Every percentile returned the median.** A number came back, in range, of the right type — nothing about it said the argument had been ignored.

Cypher also requires the percentile in `[0, 1]` and raises otherwise; the finalizer clamped with `.min(n - 1)` instead.

### How it surfaced

`Aggregation6` scenario 5 had been **passing for the wrong reason**: its setup query needed `next_mut` through `UnwindOperator`, and the resulting error satisfied the scenario's *"an error should be raised"*. Fixing the setup made the query run and raise nothing.

A scenario that expects an error can pass on any error. Worth remembering when one goes green.

## Verification

- TCK **3,647 → 3,650**, regression diff against the merge base **empty**.
- `--min-pass` ratcheted 3647 → 3650.