### PR TITLE
ON CREATE SET n = {...} is applied, and null removes a property (#874)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3650
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3655
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -799,6 +799,15 @@ pub struct MergeClause {
     pub on_create_labels: Vec<SetLabelItem>,
     /// Labels added by `ON MATCH SET n:Label`.
     pub on_match_labels: Vec<SetLabelItem>,
+    /// Whole-entity assignment in `ON CREATE SET n = {…}` / `n += {…}`.
+    ///
+    /// The grammar has always parsed these -- `set_entry` includes
+    /// `set_entity_item` -- but `parse_merge_clause` matched only `set_item`
+    /// and `set_label_item`, so they fell through its `match` and the clause
+    /// the user wrote was **silently discarded** (#874).
+    pub on_create_entity_set: Vec<SetEntityItem>,
+    /// The same for `ON MATCH SET`.
+    pub on_match_entity_set: Vec<SetEntityItem>,
 }
 
 /// WITH clause

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -11231,6 +11231,9 @@ pub struct MatchMergeEdgeOperator {
     edges_to_merge: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>)>,
     on_create_set: Vec<(String, String, Expression)>,
     on_match_set: Vec<(String, String, Expression)>,
+    /// Whole-entity `ON CREATE`/`ON MATCH SET`; see `MergeOperator` (#874).
+    on_create_entity_set: Vec<(String, bool, Expression)>,
+    on_match_entity_set: Vec<(String, bool, Expression)>,
     done: bool,
     results: Vec<Record>,
     result_index: usize,
@@ -11243,7 +11246,28 @@ impl MatchMergeEdgeOperator {
         on_create_set: Vec<(String, String, Expression)>,
         on_match_set: Vec<(String, String, Expression)>,
     ) -> Self {
-        Self { input, edges_to_merge, on_create_set, on_match_set, done: false, results: Vec::new(), result_index: 0 }
+        Self {
+            input,
+            edges_to_merge,
+            on_create_set,
+            on_match_set,
+            on_create_entity_set: Vec::new(),
+            on_match_entity_set: Vec::new(),
+            done: false,
+            results: Vec::new(),
+            result_index: 0,
+        }
+    }
+
+    /// Attach the whole-entity `ON CREATE`/`ON MATCH SET` items (#874).
+    pub fn with_entity_sets(
+        mut self,
+        on_create: Vec<(String, bool, Expression)>,
+        on_match: Vec<(String, bool, Expression)>,
+    ) -> Self {
+        self.on_create_entity_set = on_create;
+        self.on_match_entity_set = on_match;
+        self
     }
 }
 
@@ -11279,9 +11303,30 @@ impl PhysicalOperator for MatchMergeEdgeOperator {
                         for (var, prop, expr) in &self.on_match_set {
                             if edge_var.as_deref() == Some(var) || var == "_edge" {
                                 let val = eval_expression(expr, &result_record, store)?;
-                                if let Value::Property(pv) = val {
-                                    let _ = store.set_edge_property(edge_id, prop.clone(), pv);
+                                // Setting null removes the property (#874).
+                                match val {
+                                    Value::Property(PropertyValue::Null) | Value::Null => {
+                                        store.remove_edge_property(edge_id, prop);
+                                    }
+                                    Value::Property(pv) => {
+                                        let _ = store.set_edge_property(edge_id, prop.clone(), pv);
+                                    }
+                                    _ => {}
                                 }
+                            }
+                        }
+                        let matched_target = Value::EdgeRef(
+                            edge_id,
+                            source_id,
+                            target_id,
+                            edge_type.clone(),
+                        );
+                        for (var, merge, expr) in &self.on_match_entity_set {
+                            if edge_var.as_deref() == Some(var) || var == "_edge" {
+                                let value = eval_expression(expr, &result_record, store)?;
+                                apply_entity_assignment(
+                                    &matched_target, &value, *merge, store, tenant_id,
+                                )?;
                             }
                         }
                         if let Some(ref ev) = edge_var {
@@ -11301,9 +11346,30 @@ impl PhysicalOperator for MatchMergeEdgeOperator {
                         for (var, prop, expr) in &self.on_create_set {
                             if edge_var.as_deref() == Some(var) || var == "_edge" {
                                 let val = eval_expression(expr, &result_record, store)?;
-                                if let Value::Property(pv) = val {
-                                    let _ = store.set_edge_property(edge_id, prop.clone(), pv);
+                                // Setting null removes the property (#874).
+                                match val {
+                                    Value::Property(PropertyValue::Null) | Value::Null => {
+                                        store.remove_edge_property(edge_id, prop);
+                                    }
+                                    Value::Property(pv) => {
+                                        let _ = store.set_edge_property(edge_id, prop.clone(), pv);
+                                    }
+                                    _ => {}
                                 }
+                            }
+                        }
+
+                        // `ON CREATE SET r = a` / `r += {…}` (#874).
+                        let target = Value::EdgeRef(
+                            edge_id,
+                            source_id,
+                            target_id,
+                            edge_type.clone(),
+                        );
+                        for (var, merge, expr) in &self.on_create_entity_set {
+                            if edge_var.as_deref() == Some(var) || var == "_edge" {
+                                let value = eval_expression(expr, &result_record, store)?;
+                                apply_entity_assignment(&target, &value, *merge, store, tenant_id)?;
                             }
                         }
 
@@ -12304,6 +12370,63 @@ impl PhysicalOperator for DeleteOperator {
 }
 
 /// Set property operator: SET n.name = "Alice"
+/// Apply `SET x = <map|node>` or `SET x += <map|node>` to one entity.
+///
+/// Shared, because `SET` and `MERGE ... ON CREATE/ON MATCH SET` both need it
+/// and the second had **no implementation at all**: `parse_merge_clause`
+/// matched only `set_item` and `set_label_item`, so a `set_entity_item` fell
+/// through its `match` and the clause the user wrote was silently discarded
+/// (#874).
+///
+/// `=` replaces -- every property not in the incoming map goes away -- and `+=`
+/// merges. Removing the leftovers first keeps the two spellings from differing
+/// only in what they forgot to clear.
+fn apply_entity_assignment(
+    target: &Value,
+    value: &Value,
+    merge: bool,
+    store: &mut GraphStore,
+    tenant_id: &str,
+) -> ExecutionResult<()> {
+    let incoming = SetPropertyOperator::source_properties(value, store)?;
+    match target {
+        Value::NodeRef(id) | Value::Node(id, _) => {
+            let id = *id;
+            if !merge {
+                for key in store.node_properties_full(id).keys().cloned().collect::<Vec<_>>() {
+                    if !incoming.contains_key(&key) {
+                        store.remove_node_property(id, &key);
+                    }
+                }
+            }
+            for (k, v) in incoming {
+                store
+                    .set_node_property(tenant_id, id, k, v)
+                    .map_err(|e| ExecutionError::GraphError(e.to_string()))?;
+            }
+        }
+        Value::EdgeRef(id, ..) | Value::Edge(id, _) => {
+            let id = *id;
+            if !merge {
+                let existing: Vec<String> = store
+                    .get_edge(id)
+                    .map(|e| e.properties.keys().cloned().collect())
+                    .unwrap_or_default();
+                for key in existing {
+                    if !incoming.contains_key(&key) {
+                        store.remove_edge_property(id, &key);
+                    }
+                }
+            }
+            for (k, v) in incoming {
+                let _ = store.set_edge_property(id, k, v);
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
 pub struct SetPropertyOperator {
     input: OperatorBox,
     items: Vec<(String, String, Expression)>, // (variable, property, value_expr)
@@ -12331,7 +12454,7 @@ impl SetPropertyOperator {
     /// own properties, which is what makes `SET a = b` a copy. Anything else
     /// is a type error rather than a silent no-op — assigning a scalar to an
     /// entity has no sensible meaning and guessing one would hide the mistake.
-    fn source_properties(
+    pub(crate) fn source_properties(
         value: &Value,
         store: &GraphStore,
     ) -> ExecutionResult<HashMap<String, PropertyValue>> {
@@ -12418,13 +12541,27 @@ impl PhysicalOperator for SetPropertyOperator {
             for (var, prop, val) in &evaluated {
 
                 if let Some(node_val) = record.get(var) {
+                    // `SET n.prop = null` **removes** the property. Storing a
+                    // null instead left the key present, so `keys(n)` still
+                    // listed it and a later `n.prop IS NULL` could not tell an
+                    // explicitly-nulled property from a removed one -- which is
+                    // the whole distinction (#874).
+                    let remove = matches!(val, PropertyValue::Null);
                     match node_val {
                         Value::NodeRef(id) | Value::Node(id, _) => {
-                            store.set_node_property(tenant_id, *id, prop.clone(), val.clone())
-                                .map_err(|e| ExecutionError::GraphError(e.to_string()))?;
+                            if remove {
+                                store.remove_node_property(*id, prop);
+                            } else {
+                                store.set_node_property(tenant_id, *id, prop.clone(), val.clone())
+                                    .map_err(|e| ExecutionError::GraphError(e.to_string()))?;
+                            }
                         }
                         Value::EdgeRef(id, ..) | Value::Edge(id, _) => {
-                            let _ = store.set_edge_property(*id, prop.clone(), val.clone());
+                            if remove {
+                                store.remove_edge_property(*id, prop);
+                            } else {
+                                let _ = store.set_edge_property(*id, prop.clone(), val.clone());
+                            }
                         }
                         _ => {}
                     }
@@ -12437,45 +12574,7 @@ impl PhysicalOperator for SetPropertyOperator {
             for (var, merge, expr) in &self.entity_items {
                 let Some(target) = record.get(var).cloned() else { continue };
                 let value = eval_expression(expr, &record, store)?;
-                let incoming = Self::source_properties(&value, store)?;
-
-                match target {
-                    Value::NodeRef(id) | Value::Node(id, _) => {
-                        if !merge {
-                            // `=` replaces: every property not in the incoming
-                            // map goes away. Removing them first, then writing,
-                            // keeps the two spellings from differing only in
-                            // leftovers.
-                            for key in store.node_properties_full(id).keys().cloned().collect::<Vec<_>>() {
-                                if !incoming.contains_key(&key) {
-                                    let _ = store.remove_node_property(id, &key);
-                                }
-                            }
-                        }
-                        for (k, v) in incoming {
-                            store
-                                .set_node_property(tenant_id, id, k, v)
-                                .map_err(|e| ExecutionError::GraphError(e.to_string()))?;
-                        }
-                    }
-                    Value::EdgeRef(id, ..) | Value::Edge(id, _) => {
-                        if !merge {
-                            let existing: Vec<String> = store
-                                .get_edge(id)
-                                .map(|e| e.properties.keys().cloned().collect())
-                                .unwrap_or_default();
-                            for key in existing {
-                                if !incoming.contains_key(&key) {
-                                    let _ = store.remove_edge_property(id, &key);
-                                }
-                            }
-                        }
-                        for (k, v) in incoming {
-                            let _ = store.set_edge_property(id, k, v);
-                        }
-                    }
-                    _ => {}
-                }
+                apply_entity_assignment(&target, &value, *merge, store, tenant_id)?;
             }
 
             Ok(Some(record))
@@ -12777,10 +12876,32 @@ pub struct MergeOperator {
     on_create_labels: Vec<(String, Vec<Label>)>,
     /// `(variable, labels)` from `ON MATCH SET n:Label`.
     on_match_labels: Vec<(String, Vec<Label>)>,
+    /// `(variable, is_merge, value)` from `ON CREATE SET n = {…}` / `n += {…}`.
+    ///
+    /// The grammar always parsed these; `parse_merge_clause` matched only
+    /// `set_item` and `set_label_item`, so they fell through and the clause was
+    /// silently discarded (#874).
+    on_create_entity_set: Vec<(String, bool, Expression)>,
+    /// The same for `ON MATCH SET`.
+    on_match_entity_set: Vec<(String, bool, Expression)>,
     executed: bool,
 }
 
 impl MergeOperator {
+    /// Attach the whole-entity `ON CREATE`/`ON MATCH SET` items.
+    ///
+    /// A builder rather than two more `new` parameters, so the existing call
+    /// sites keep compiling and the addition stays reviewable (#874).
+    pub fn with_entity_sets(
+        mut self,
+        on_create: Vec<(String, bool, Expression)>,
+        on_match: Vec<(String, bool, Expression)>,
+    ) -> Self {
+        self.on_create_entity_set = on_create;
+        self.on_match_entity_set = on_match;
+        self
+    }
+
     pub fn new(
         pattern: Pattern,
         on_create_set: Vec<(String, String, Expression)>,
@@ -12795,6 +12916,8 @@ impl MergeOperator {
             on_match_set,
             on_create_labels,
             on_match_labels,
+            on_create_entity_set: Vec::new(),
+            on_match_entity_set: Vec::new(),
             executed: false,
         }
     }
@@ -12980,6 +13103,8 @@ impl MergeOperator {
             }
             let sets = self.on_match_set.clone();
             self.apply_sets(&sets, &record, store, tenant_id)?;
+            let entity_sets = self.on_match_entity_set.clone();
+            self.apply_entity_sets(&entity_sets, &record, store, tenant_id)?;
             let labels = self.on_match_labels.clone();
             Self::apply_labels(&labels, &record, store, tenant_id);
             return Ok(Some(record));
@@ -13016,7 +13141,9 @@ impl MergeOperator {
         }
 
         let sets = self.on_create_set.clone();
-        self.apply_sets(&sets, &record, store, tenant_id)?;
+self.apply_sets(&sets, &record, store, tenant_id)?;
+        let entity_sets = self.on_create_entity_set.clone();
+        self.apply_entity_sets(&entity_sets, &record, store, tenant_id)?;
         Ok(Some(record))
     }
 
@@ -13073,9 +13200,33 @@ impl MergeOperator {
                 continue;
             };
             let val = eval_expression(expr, record, store)?;
-            if let Value::Property(pv) = val {
-                let _ = store.set_node_property(tenant_id, node_id, prop.clone(), pv);
+            // `SET n.prop = null` removes the property (#874), the same rule
+            // the plain `SET` clause follows.
+            match val {
+                Value::Property(PropertyValue::Null) | Value::Null => {
+                    store.remove_node_property(node_id, prop);
+                }
+                Value::Property(pv) => {
+                    let _ = store.set_node_property(tenant_id, node_id, prop.clone(), pv);
+                }
+                _ => {}
             }
+        }
+        Ok(())
+    }
+
+    /// `ON CREATE SET n = {…}` / `n += {…}` (#874).
+    fn apply_entity_sets(
+        &self,
+        sets: &[(String, bool, Expression)],
+        record: &Record,
+        store: &mut GraphStore,
+        tenant_id: &str,
+    ) -> ExecutionResult<()> {
+        for (var, merge, expr) in sets {
+            let Some(target) = record.get(var).cloned() else { continue };
+            let value = eval_expression(expr, record, store)?;
+            apply_entity_assignment(&target, &value, *merge, store, tenant_id)?;
         }
         Ok(())
     }
@@ -13192,11 +13343,19 @@ impl PhysicalOperator for MergeOperator {
             for (var, prop, expr) in &self.on_create_set {
                 if var == &start_var {
                     let val = eval_expression(expr, &record, store)?;
-                    if let Value::Property(pv) = val {
-                        let _ = store.set_node_property(tenant_id, node_id, prop.clone(), pv);
+                    match val {
+                        Value::Property(PropertyValue::Null) | Value::Null => {
+                            store.remove_node_property(node_id, prop);
+                        }
+                        Value::Property(pv) => {
+                            let _ = store.set_node_property(tenant_id, node_id, prop.clone(), pv);
+                        }
+                        _ => {}
                     }
                 }
             }
+            let entity_sets = self.on_create_entity_set.clone();
+            self.apply_entity_sets(&entity_sets, &record, store, tenant_id)?;
             Self::apply_labels(&self.on_create_labels, &record, store, tenant_id);
         }
 

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1092,13 +1092,27 @@ impl QueryPlanner {
                     .map(|l| (l.variable.clone(), l.labels.clone()))
                     .collect();
 
-                let mut operator: OperatorBox = Box::new(MergeOperator::new(
-                    merge_clause.pattern.clone(),
-                    on_create,
-                    on_match,
-                    on_create_labels,
-                    on_match_labels,
-                ));
+                // `ON CREATE SET n = {…}` / `n += {…}` (#874).
+                let on_create_entity: Vec<(String, bool, Expression)> = merge_clause
+                    .on_create_entity_set
+                    .iter()
+                    .map(|i| (i.variable.clone(), i.merge, i.value.clone()))
+                    .collect();
+                let on_match_entity: Vec<(String, bool, Expression)> = merge_clause
+                    .on_match_entity_set
+                    .iter()
+                    .map(|i| (i.variable.clone(), i.merge, i.value.clone()))
+                    .collect();
+                let mut operator: OperatorBox = Box::new(
+                    MergeOperator::new(
+                        merge_clause.pattern.clone(),
+                        on_create,
+                        on_match,
+                        on_create_labels,
+                        on_match_labels,
+                    )
+                    .with_entity_sets(on_create_entity, on_match_entity),
+                );
 
                 // A bare `SET` after MERGE applies on both branches, unlike ON CREATE /
                 // ON MATCH. It parsed but was dropped here, so `MERGE (m) SET m.x = 1`
@@ -2291,9 +2305,21 @@ impl QueryPlanner {
             if !edges_to_merge.is_empty() && !query.match_clauses.is_empty() {
                 // Edge MERGE: use MatchMergeEdgeOperator
                 use crate::query::executor::operator::MatchMergeEdgeOperator;
-                operator = Box::new(MatchMergeEdgeOperator::new(
-                    operator, edges_to_merge, on_create, on_match,
-                ));
+                // `ON CREATE SET n = {…}` / `n += {…}` (#874).
+                let on_create_entity: Vec<(String, bool, Expression)> = merge_clause
+                    .on_create_entity_set
+                    .iter()
+                    .map(|i| (i.variable.clone(), i.merge, i.value.clone()))
+                    .collect();
+                let on_match_entity: Vec<(String, bool, Expression)> = merge_clause
+                    .on_match_entity_set
+                    .iter()
+                    .map(|i| (i.variable.clone(), i.merge, i.value.clone()))
+                    .collect();
+                operator = Box::new(
+                    MatchMergeEdgeOperator::new(operator, edges_to_merge, on_create, on_match)
+                        .with_entity_sets(on_create_entity, on_match_entity),
+                );
             } else {
                 // Node-only MERGE, or a whole-pattern MERGE with nothing bound
                 // to hang it off, running once per upstream row.
@@ -2321,6 +2347,18 @@ impl QueryPlanner {
                         on_match,
                         on_create_labels,
                         on_match_labels,
+                    )
+                    .with_entity_sets(
+                        merge_clause
+                            .on_create_entity_set
+                            .iter()
+                            .map(|i| (i.variable.clone(), i.merge, i.value.clone()))
+                            .collect(),
+                        merge_clause
+                            .on_match_entity_set
+                            .iter()
+                            .map(|i| (i.variable.clone(), i.merge, i.value.clone()))
+                            .collect(),
                     )
                     .with_input(operator),
                 );
@@ -5380,6 +5418,16 @@ impl QueryPlanner {
                             on_match,
                             on_create_labels,
                             on_match_labels,
+                        )
+                        .with_entity_sets(
+                            mc.on_create_entity_set
+                                .iter()
+                                .map(|i| (i.variable.clone(), i.merge, i.value.clone()))
+                                .collect(),
+                            mc.on_match_entity_set
+                                .iter()
+                                .map(|i| (i.variable.clone(), i.merge, i.value.clone()))
+                                .collect(),
                         )
                         .with_input(operator),
                     );

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1198,6 +1198,34 @@ fn parse_delete_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<DeleteC
     Ok(DeleteClause { expressions, detach })
 }
 
+/// `SET n = {…}` / `SET n += {…}`, in a `SET` clause or in `ON CREATE`/`ON MATCH`.
+///
+/// Extracted because `MERGE`'s arms need it too and had no implementation at
+/// all -- `parse_merge_clause` matched only `set_item` and `set_label_item`, so
+/// this form fell through and was silently discarded (#874).
+fn parse_set_entity_item(
+    pair: pest::iterators::Pair<Rule>,
+) -> ParseResult<crate::query::ast::SetEntityItem> {
+    let mut variable = String::new();
+    let mut merge = false;
+    let mut value = None;
+    for part in pair.into_inner() {
+        match part.as_rule() {
+            Rule::variable if variable.is_empty() => variable = part.as_str().to_string(),
+            Rule::set_entity_op => merge = part.as_str().trim() == "+=",
+            Rule::expression => value = Some(parse_expression(part)?),
+            _ => {}
+        }
+    }
+    Ok(crate::query::ast::SetEntityItem {
+        variable,
+        merge,
+        value: value.ok_or_else(|| {
+            ParseError::SemanticError("SET <entity> = missing a value".to_string())
+        })?,
+    })
+}
+
 /// `variable (":" label)+` — the label form of a SET item.
 ///
 /// Shared by `SET`, `ON CREATE SET` and `ON MATCH SET`. Kept as one function
@@ -1230,24 +1258,7 @@ fn parse_set_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<SetClause>
             continue;
         }
         if inner.as_rule() == Rule::set_entity_item {
-            let mut variable = String::new();
-            let mut merge = false;
-            let mut value = None;
-            for part in inner.into_inner() {
-                match part.as_rule() {
-                    Rule::variable if variable.is_empty() => variable = part.as_str().to_string(),
-                    Rule::set_entity_op => merge = part.as_str().trim() == "+=",
-                    Rule::expression => value = Some(parse_expression(part)?),
-                    _ => {}
-                }
-            }
-            entity_items.push(crate::query::ast::SetEntityItem {
-                variable,
-                merge,
-                value: value.ok_or_else(|| {
-                    ParseError::SemanticError("SET <entity> = missing a value".to_string())
-                })?,
-            });
+            entity_items.push(parse_set_entity_item(inner)?);
             continue;
         }
         if inner.as_rule() == Rule::set_item {
@@ -1351,6 +1362,8 @@ fn parse_merge_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
     let mut on_match_set = Vec::new();
     let mut on_create_labels = Vec::new();
     let mut on_match_labels = Vec::new();
+    let mut on_create_entity_set = Vec::new();
+    let mut on_match_entity_set = Vec::new();
 
     for inner in pair.into_inner() {
         match inner.as_rule() {
@@ -1359,6 +1372,7 @@ fn parse_merge_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
                 for si in inner.into_inner() {
                     match si.as_rule() {
                         Rule::set_item => on_create_set.push(parse_set_item(si)?),
+                        Rule::set_entity_item => on_create_entity_set.push(parse_set_entity_item(si)?),
                         Rule::set_label_item => on_create_labels.push(parse_set_label_item(si)?),
                         _ => {}
                     }
@@ -1368,6 +1382,7 @@ fn parse_merge_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
                 for si in inner.into_inner() {
                     match si.as_rule() {
                         Rule::set_item => on_match_set.push(parse_set_item(si)?),
+                        Rule::set_entity_item => on_match_entity_set.push(parse_set_entity_item(si)?),
                         Rule::set_label_item => on_match_labels.push(parse_set_label_item(si)?),
                         _ => {}
                     }
@@ -1396,6 +1411,8 @@ fn parse_merge_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
         on_match_set,
         on_create_labels,
         on_match_labels,
+        on_create_entity_set,
+        on_match_entity_set,
     });
     Ok(())
 }
@@ -1406,6 +1423,8 @@ fn parse_merge_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<MergeCla
     let mut on_match_set = Vec::new();
     let mut on_create_labels = Vec::new();
     let mut on_match_labels = Vec::new();
+    let mut on_create_entity_set = Vec::new();
+    let mut on_match_entity_set = Vec::new();
 
     for inner in pair.into_inner() {
         match inner.as_rule() {
@@ -1414,6 +1433,9 @@ fn parse_merge_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<MergeCla
                 for si in inner.into_inner() {
                     match si.as_rule() {
                         Rule::set_item => on_create_set.push(parse_set_item(si)?),
+                        Rule::set_entity_item => {
+                            on_create_entity_set.push(parse_set_entity_item(si)?)
+                        }
                         Rule::set_label_item => on_create_labels.push(parse_set_label_item(si)?),
                         _ => {}
                     }
@@ -1423,6 +1445,9 @@ fn parse_merge_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<MergeCla
                 for si in inner.into_inner() {
                     match si.as_rule() {
                         Rule::set_item => on_match_set.push(parse_set_item(si)?),
+                        Rule::set_entity_item => {
+                            on_match_entity_set.push(parse_set_entity_item(si)?)
+                        }
                         Rule::set_label_item => on_match_labels.push(parse_set_label_item(si)?),
                         _ => {}
                     }
@@ -1441,6 +1466,8 @@ fn parse_merge_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<MergeCla
         on_match_set,
         on_create_labels,
         on_match_labels,
+        on_create_entity_set,
+        on_match_entity_set,
     })
 }
 

--- a/tests/merge_set_forms.rs
+++ b/tests/merge_set_forms.rs
@@ -1,0 +1,131 @@
+//! `ON CREATE`/`ON MATCH SET` support every form `SET` does, and assigning
+//! null removes a property (#874).
+//!
+//! ```cypher
+//! MERGE (a)-[r:TYPE]->(b) ON CREATE SET r = a   -- created r with no properties
+//! SET n.prop = null                             -- left the key in place
+//! ```
+//!
+//! The grammar always parsed `SET n = {…}` in a `MERGE` arm — `set_entry`
+//! includes `set_entity_item` — but `parse_merge_clause` matched only
+//! `set_item` and `set_label_item`, so the item **fell through its `match`**
+//! and was discarded with no error.
+//!
+//! The plain `SET` clause handled the same form correctly, which is what hid
+//! it: the defect reads as something about `MERGE` rather than a missing arm.
+//! So every case below is asserted through `SET`, `ON CREATE SET` **and**
+//! `ON MATCH SET`.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn exec(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+}
+
+/// Sorted property keys of whatever the read query returns as `r`.
+fn keys(store: &GraphStore, read: &str) -> Vec<String> {
+    let q = parse_query(read).expect("read parses");
+    let batch = QueryExecutor::new(store).execute(&q).expect("read runs");
+    let mut out: Vec<String> = match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(PropertyValue::Array(items))) => items
+            .iter()
+            .filter_map(|i| match i {
+                PropertyValue::String(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect(),
+        other => panic!("{read}\n  got {other:?}"),
+    };
+    out.sort();
+    out
+}
+
+fn two_nodes() -> GraphStore {
+    let mut store = GraphStore::new();
+    exec(&mut store, "CREATE (:A {x: 1}), (:B {y: 2})");
+    store
+}
+
+/// `=` replaces and `+=` merges, in a plain `SET`. These already worked and are
+/// the reference the `MERGE` arms have to match.
+#[test]
+fn a_plain_set_replaces_or_merges() {
+    let mut s = two_nodes();
+    exec(&mut s, "MATCH (a:A), (b:B) SET b = a");
+    assert_eq!(keys(&s, "MATCH (b:B) RETURN keys(b) AS r"), vec!["x"]);
+
+    let mut s = two_nodes();
+    exec(&mut s, "MATCH (a:A), (b:B) SET b += a");
+    assert_eq!(keys(&s, "MATCH (b:B) RETURN keys(b) AS r"), vec!["x", "y"]);
+
+    let mut s = two_nodes();
+    exec(&mut s, "MATCH (b:B) SET b = {z: 3}");
+    assert_eq!(keys(&s, "MATCH (b:B) RETURN keys(b) AS r"), vec!["z"]);
+}
+
+/// **`ON CREATE SET r = a`**, which was discarded entirely.
+#[test]
+fn on_create_set_copies_from_a_node_or_a_map() {
+    let mut s = two_nodes();
+    exec(&mut s, "MATCH (a:A), (b:B) MERGE (a)-[r:T]->(b) ON CREATE SET r = a");
+    assert_eq!(keys(&s, "MATCH ()-[r:T]->() RETURN keys(r) AS r"), vec!["x"]);
+
+    let mut s = two_nodes();
+    exec(
+        &mut s,
+        "MATCH (a:A), (b:B) MERGE (a)-[r:T]->(b) ON CREATE SET r = {name: 'bar', name2: 'baz'}",
+    );
+    assert_eq!(keys(&s, "MATCH ()-[r:T]->() RETURN keys(r) AS r"), vec!["name", "name2"]);
+
+    // `+=` on a node created by MERGE.
+    let mut s = two_nodes();
+    exec(&mut s, "MATCH (a:A) MERGE (n:N {p: 1}) ON CREATE SET n += a");
+    assert_eq!(keys(&s, "MATCH (n:N) RETURN keys(n) AS r"), vec!["p", "x"]);
+}
+
+/// **`ON MATCH SET`** takes the same forms, on the branch where the pattern
+/// already exists.
+#[test]
+fn on_match_set_copies_too() {
+    let mut s = two_nodes();
+    exec(&mut s, "MATCH (a:A), (b:B) CREATE (a)-[:T]->(b)");
+    exec(&mut s, "MATCH (a:A), (b:B) MERGE (a)-[r:T]->(b) ON MATCH SET r = a");
+    assert_eq!(keys(&s, "MATCH ()-[r:T]->() RETURN keys(r) AS r"), vec!["x"]);
+}
+
+/// Assigning null **removes** the property, on every path that sets one.
+#[test]
+fn setting_null_removes_the_property() {
+    let mut s = two_nodes();
+    exec(&mut s, "MATCH (b:B) SET b.y = null");
+    assert_eq!(keys(&s, "MATCH (b:B) RETURN keys(b) AS r"), Vec::<String>::new());
+
+    let mut s = two_nodes();
+    exec(
+        &mut s,
+        "MATCH (a:A), (b:B) MERGE (a)-[r:T {k: 1}]->(b) ON CREATE SET r.k = null",
+    );
+    assert_eq!(keys(&s, "MATCH ()-[r:T]->() RETURN keys(r) AS r"), Vec::<String>::new());
+
+    let mut s = two_nodes();
+    exec(&mut s, "MERGE (n:N {p: 1}) ON CREATE SET n.p = null");
+    assert_eq!(keys(&s, "MATCH (n:N) RETURN keys(n) AS r"), Vec::<String>::new());
+}
+
+/// A non-null value still sets, so "remove on null" has not become
+/// "remove always".
+#[test]
+fn a_non_null_value_still_sets() {
+    let mut s = two_nodes();
+    exec(&mut s, "MATCH (b:B) SET b.z = 3");
+    assert_eq!(keys(&s, "MATCH (b:B) RETURN keys(b) AS r"), vec!["y", "z"]);
+
+    let mut s = two_nodes();
+    exec(&mut s, "MERGE (n:N) ON CREATE SET n.p = 1");
+    assert_eq!(keys(&s, "MATCH (n:N) RETURN keys(n) AS r"), vec!["p"]);
+}


### PR DESCRIPTION
Closes #874. Two defects in `SET` — one structural, one general.

## `ON CREATE SET r = a` was thrown away

```cypher
MATCH (a {name: 'A'}), (b {name: 'B'})
MERGE (a)-[r:TYPE]->(b)
  ON CREATE SET r = a
```

The relationship was created with **no properties**. The clause did nothing and reported nothing.

The grammar has always parsed it — `set_entry` includes `set_entity_item` beside `set_item` and `set_label_item`. But `parse_merge_clause` matched only the latter two, so `set_entity_item` **fell through its `match` arm** and was discarded: a clause the user wrote, dropped with no error and no trace.

**The plain `SET` clause handles the same form correctly, which is what hid it.** `SET b = a` works, so the defect reads as something about `MERGE` rather than a missing match arm — so every case in the tests is asserted through `SET`, `ON CREATE SET` *and* `ON MATCH SET`.

The items now ride on `MergeClause` and are applied through a **shared** `apply_entity_assignment`, extracted from `SetPropertyOperator` rather than copied beside it. The operators take them through a builder, so the existing constructor call sites stay untouched and the diff stays reviewable.

## `SET n.prop = null` did not remove the property

Cypher removes a property assigned null. The engine stored a null instead, so `keys(n)` still listed it and nothing could distinguish an explicitly-nulled property from a removed one — which is the entire distinction.

Present on **four** paths: the plain `SET` clause, `MERGE`'s node sets, and both of the edge merge operator's set loops.

## Verification

- TCK **3,650 → 3,655**, regression diff against the merge base **empty**: `Merge6` scenarios 4, 6, 7 and `Merge7` scenarios 4, 5.
- Lib suite green (2,175).
- `--min-pass` ratcheted 3650 → 3655.