### PR TITLE
Bind a named path on a write pattern (#876)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3655
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3656
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -8690,6 +8690,82 @@ impl PhysicalOperator for EagerOperator {
     }
 }
 
+/// Binds `p` for a **named path on a write pattern**: `CREATE p = (a)-[:R]->(b)`.
+///
+/// The parser has always captured `path_variable` on a `CREATE`/`MERGE`
+/// pattern, and the write operators never bound it, so `RETURN p` failed with
+/// `VariableNotFound("p")` — a query that parses and then cannot name what it
+/// just made (#876).
+///
+/// It reads the node and relationship variables the write already bound and
+/// assembles the path from them, rather than teaching every write operator to
+/// build one. Anonymous positions get a synthetic handle from the planner for
+/// the same reason edges do: something has to be nameable for the path to
+/// reference it.
+pub struct BindPathOperator {
+    input: OperatorBox,
+    /// `(path variable, node handles in order, relationship handles in order)`.
+    paths: Vec<(String, Vec<String>, Vec<String>)>,
+}
+
+impl BindPathOperator {
+    /// Wrap `input`, binding each named path from the handles listed.
+    pub fn new(input: OperatorBox, paths: Vec<(String, Vec<String>, Vec<String>)>) -> Self {
+        Self { input, paths }
+    }
+
+    fn bind(&self, mut record: Record) -> Record {
+        for (path_var, node_vars, edge_vars) in &self.paths {
+            let nodes: Vec<NodeId> =
+                node_vars.iter().filter_map(|v| record.get(v).and_then(|x| x.node_id())).collect();
+            // A path whose nodes are not all bound is not a path; leaving the
+            // variable unbound gives the caller the same "not found" it had
+            // before, rather than a plausible shorter path.
+            if nodes.len() != node_vars.len() {
+                continue;
+            }
+            let edges: Vec<crate::graph::types::EdgeId> = edge_vars
+                .iter()
+                .filter_map(|v| match record.get(v) {
+                    Some(Value::EdgeRef(id, ..)) | Some(Value::Edge(id, _)) => Some(*id),
+                    _ => None,
+                })
+                .collect();
+            if edges.len() != edge_vars.len() {
+                continue;
+            }
+            record.bind(path_var.clone(), Value::Path { nodes, edges });
+        }
+        record
+    }
+}
+
+impl PhysicalOperator for BindPathOperator {
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
+    fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        Ok(self.input.next(store)?.map(|r| self.bind(r)))
+    }
+
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        Ok(self.input.next_mut(store, tenant_id)?.map(|r| self.bind(r)))
+    }
+
+    fn reset(&mut self) {
+        self.input.reset();
+    }
+
+    fn describe(&self) -> OperatorDescription {
+        OperatorDescription {
+            name: "BindPath".to_string(),
+            details: self.paths.iter().map(|(p, _, _)| p.clone()).collect::<Vec<_>>().join(", "),
+            children: vec![self.input.describe()],
+        }
+    }
+}
+
 pub struct LimitOperator {
     /// Input operator
     input: OperatorBox,

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1114,6 +1114,15 @@ impl QueryPlanner {
                     .with_entity_sets(on_create_entity, on_match_entity),
                 );
 
+                // `MERGE p = (...)` binds `p` (#876).
+                let merge_paths = named_path_handles(&merge_clause.pattern);
+                if !merge_paths.is_empty() {
+                    operator = Box::new(crate::query::executor::operator::BindPathOperator::new(
+                        operator,
+                        merge_paths,
+                    ));
+                }
+
                 // A bare `SET` after MERGE applies on both branches, unlike ON CREATE /
                 // ON MATCH. It parsed but was dropped here, so `MERGE (m) SET m.x = 1`
                 // silently left the property unset.
@@ -2278,20 +2287,48 @@ impl QueryPlanner {
 
             // Extract edge patterns from MERGE clause
             let mut edges_to_merge = Vec::new();
+            // `MERGE p = (a)-[:R]->(b)` binds `p` (#876). An anonymous
+            // relationship inside a named path is given a synthetic handle, for
+            // the same reason `CREATE` gives one to an anonymous node: the path
+            // has to reference it afterwards.
+            let mut merge_named_paths: Vec<(String, Vec<String>, Vec<String>)> = Vec::new();
+            let mut anon_seq = 0usize;
             for path in &merge_clause.pattern.paths {
                 let mut current_var = path.start.variable.clone();
+                let mut path_nodes: Vec<String> = current_var.iter().cloned().collect();
+                let mut path_edges: Vec<String> = Vec::new();
+                let mut complete = current_var.is_some();
                 for segment in &path.segments {
                     let edge = &segment.edge;
                     let edge_type = edge.types.first().cloned()
                         .unwrap_or_else(|| EdgeType::new("RELATED_TO"));
                     let edge_props = edge.properties.clone().unwrap_or_default();
-                    let edge_var = edge.variable.clone();
+                    let edge_var = match (&edge.variable, &path.path_variable) {
+                        (None, Some(_)) => {
+                            anon_seq += 1;
+                            Some(format!("__merge_path_edge_{anon_seq}"))
+                        }
+                        (other, _) => other.clone(),
+                    };
                     let target_var = segment.node.variable.clone();
+
+                    match (&target_var, &edge_var) {
+                        (Some(t), Some(e)) => {
+                            path_nodes.push(t.clone());
+                            path_edges.push(e.clone());
+                        }
+                        _ => complete = false,
+                    }
 
                     if let (Some(src), Some(tgt)) = (&current_var, &target_var) {
                         edges_to_merge.push((src.clone(), tgt.clone(), edge_type, edge_props, edge_var));
                     }
                     current_var = target_var;
+                }
+                // A path with an unnameable position is left unbound rather
+                // than bound to a shorter path that looks plausible.
+                if let (Some(pv), true) = (&path.path_variable, complete) {
+                    merge_named_paths.push((pv.clone(), path_nodes, path_edges));
                 }
             }
 
@@ -2320,6 +2357,12 @@ impl QueryPlanner {
                     MatchMergeEdgeOperator::new(operator, edges_to_merge, on_create, on_match)
                         .with_entity_sets(on_create_entity, on_match_entity),
                 );
+                if !merge_named_paths.is_empty() {
+                    operator = Box::new(crate::query::executor::operator::BindPathOperator::new(
+                        operator,
+                        merge_named_paths.clone(),
+                    ));
+                }
             } else {
                 // Node-only MERGE, or a whole-pattern MERGE with nothing bound
                 // to hang it off, running once per upstream row.
@@ -2362,6 +2405,12 @@ impl QueryPlanner {
                     )
                     .with_input(operator),
                 );
+                if !merge_named_paths.is_empty() {
+                    operator = Box::new(crate::query::executor::operator::BindPathOperator::new(
+                        operator,
+                        merge_named_paths.clone(),
+                    ));
+                }
             }
             true
         } else {
@@ -4461,6 +4510,16 @@ impl QueryPlanner {
         // TCK fixture and most of our own loaders are written in.
         let mut created_vars: HashSet<String> = HashSet::new();
 
+        // `CREATE p = (a)-[:R]->(b)` binds `p`. The parser has always captured
+        // `path_variable`; nothing bound it, so `RETURN p` failed with
+        // `VariableNotFound("p")` -- a query that parses and then cannot name
+        // what it just made (#876).
+        //
+        // Handles are collected here, where the synthetic names for anonymous
+        // positions are already being minted for edge wiring, and a
+        // `BindPathOperator` assembles the path from them afterwards.
+        let mut named_paths: Vec<(String, Vec<String>, Vec<String>)> = Vec::new();
+
         for path in &pattern.paths {
             // Add start node
             let start = &path.start;
@@ -4497,6 +4556,9 @@ impl QueryPlanner {
                     start.property_exprs.clone(),
                 ));
             }
+
+            let mut path_nodes: Vec<String> = vec![start_handle.clone()];
+            let mut path_edges: Vec<String> = Vec::new();
 
             // Track current source variable for edge creation
             let mut current_source_var = Some(start_handle);
@@ -4550,6 +4612,18 @@ impl QueryPlanner {
                 // `<-` segment points at the *earlier* node. This was previously ignored
                 // entirely, so `CREATE (a)<-[:R]-(b)` stored a->b -- an edge pointing the
                 // opposite way to what was written, with nothing to indicate it.
+                // An anonymous relationship inside a **named** path still needs
+                // a handle, for the same reason an anonymous node does: the
+                // path has to be able to reference it afterwards.
+                let edge_variable = match (&edge_variable, &path.path_variable) {
+                    (None, Some(_)) => Some(next_anon(&declared)),
+                    (other, _) => other.clone(),
+                };
+                if let Some(v) = &edge_variable {
+                    path_edges.push(v.clone());
+                }
+                path_nodes.push(node_handle.clone());
+
                 if let Some(source_var) = &current_source_var {
                     let (from, to) = match segment.edge.direction {
                         Direction::Incoming => (node_handle.clone(), source_var.clone()),
@@ -4572,6 +4646,11 @@ impl QueryPlanner {
                 // Update source variable for next segment
                 current_source_var = Some(node_handle);
             }
+
+            if let Some(pv) = &path.path_variable {
+                output_columns.push(pv.clone());
+                named_paths.push((pv.clone(), path_nodes, path_edges));
+            }
         }
 
         // Build the operator chain
@@ -4587,6 +4666,16 @@ impl QueryPlanner {
             Box::new(CreateNodesAndEdgesOperator::new(node_operator, edges_to_create))
         };
 
+        // Bind any named paths from the handles collected above (#876).
+        let final_operator: OperatorBox = if named_paths.is_empty() {
+            final_operator
+        } else {
+            Box::new(crate::query::executor::operator::BindPathOperator::new(
+                final_operator,
+                named_paths,
+            ))
+        };
+
         // Return execution plan with is_write: true (this mutates the graph)
         Ok(ExecutionPlan {
             root: final_operator,
@@ -4594,6 +4683,48 @@ impl QueryPlanner {
             is_write: true, candidates_evaluated: 0, chosen_plan_cost: 0.0, candidate_costs: Vec::new(),
         })
     }
+}
+
+/// The node and relationship handles a named path on a write pattern needs.
+///
+/// Returns `None` when any position is anonymous and therefore cannot be
+/// referenced afterwards — the path is then left unbound rather than bound to a
+/// shorter one that looks plausible (#876).
+///
+/// An anonymous *relationship* in a named path is given a synthetic handle by
+/// the caller, the way `CREATE` already does for anonymous nodes; an anonymous
+/// *node* cannot be, on the MERGE paths, so those return `None`.
+fn named_path_handles(
+    pattern: &crate::query::ast::Pattern,
+) -> Vec<(String, Vec<String>, Vec<String>)> {
+    let mut out = Vec::new();
+    let mut anon = 0usize;
+    for path in &pattern.paths {
+        let Some(pv) = &path.path_variable else { continue };
+        let Some(start) = &path.start.variable else { continue };
+        let mut nodes = vec![start.clone()];
+        let mut edges = Vec::new();
+        let mut complete = true;
+        for segment in &path.segments {
+            let Some(node) = &segment.node.variable else {
+                complete = false;
+                break;
+            };
+            let edge = match &segment.edge.variable {
+                Some(v) => v.clone(),
+                None => {
+                    anon += 1;
+                    format!("__merge_path_edge_{anon}")
+                }
+            };
+            nodes.push(node.clone());
+            edges.push(edge);
+        }
+        if complete {
+            out.push((pv.clone(), nodes, edges));
+        }
+    }
+    out
 }
 
 impl Default for QueryPlanner {
@@ -5431,6 +5562,18 @@ impl QueryPlanner {
                         )
                         .with_input(operator),
                     );
+                    // `MERGE p = (...)` binds `p` (#876).
+                    let merge_paths = named_path_handles(&mc.pattern);
+                    if !merge_paths.is_empty() {
+                        for (pv, _, _) in &merge_paths {
+                            bound.insert(pv.clone());
+                        }
+                        operator =
+                            Box::new(crate::query::executor::operator::BindPathOperator::new(
+                                operator,
+                                merge_paths,
+                            ));
+                    }
                     for path in &mc.pattern.paths {
                         if let Some(v) = &path.start.variable {
                             bound.insert(v.clone());

--- a/tests/named_path_on_write.rs
+++ b/tests/named_path_on_write.rs
@@ -1,0 +1,84 @@
+//! `CREATE p = (a)-[:R]->(b)` binds `p` (#876).
+//!
+//! ```text
+//! CREATE p = (a {num: 1}) RETURN p    VariableNotFound("p")
+//! ```
+//!
+//! A query that parses, writes, and then cannot name what it just made. The
+//! parser has always captured `path_variable` — `MATCH p = …` and
+//! `CREATE p = …` produce the same AST field — and the write operators never
+//! bound it.
+//!
+//! Anonymous positions need a handle for the path to reference. `CREATE`
+//! already mints synthetic names for anonymous nodes, to wire edges; this
+//! extends the same treatment to an anonymous **relationship** inside a named
+//! path, which had no reason to need one before.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// `(node count, relationship count)` of the path bound to `p`.
+fn path_shape(cypher: &str) -> Option<(usize, usize)> {
+    let mut store = GraphStore::new();
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("p")) {
+        Some(Value::Path { nodes, edges }) => Some((nodes.len(), edges.len())),
+        _ => None,
+    }
+}
+
+/// Every shape, including the anonymous relationship that needed a synthetic
+/// handle.
+#[test]
+fn create_binds_a_named_path() {
+    assert_eq!(path_shape("CREATE p = (a {num: 1}) RETURN p"), Some((1, 0)));
+    assert_eq!(path_shape("CREATE p = (a)-[:R]->(b) RETURN p"), Some((2, 1)));
+    assert_eq!(path_shape("CREATE p = (a)-[r:R]->(b) RETURN p"), Some((2, 1)));
+    assert_eq!(path_shape("CREATE p = (a)-[r:R]->(b)-[:S]->(c) RETURN p"), Some((3, 2)));
+    assert_eq!(path_shape("CREATE p = (a)<-[:R]-(b) RETURN p"), Some((2, 1)));
+}
+
+/// A bare `MERGE` binds it too.
+#[test]
+fn merge_binds_a_named_path() {
+    assert_eq!(path_shape("MERGE p = (a {num: 1}) RETURN p"), Some((1, 0)));
+}
+
+/// An unnamed pattern is unaffected — the binder must not invent a path where
+/// none was asked for.
+#[test]
+fn an_unnamed_pattern_binds_nothing() {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (a)-[:R]->(b) RETURN a").expect("parses");
+    let batch = MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("runs");
+    let rec = batch.records.first().expect("one row");
+    assert!(rec.get("p").is_none(), "bound `p` for a pattern that names no path");
+    assert!(rec.get("a").is_some(), "the node variable is still bound");
+}
+
+/// The write still happens, and happens once — binding a path must not change
+/// what was created.
+#[test]
+fn the_write_is_unchanged() {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE p = (a)-[:R]->(b) RETURN p").expect("parses");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("runs");
+    let count = |cypher: &str| {
+        let p = parse_query(cypher).expect("parses");
+        samyama::query::executor::QueryExecutor::new(&store)
+            .execute(&p)
+            .expect("runs")
+            .records
+            .len()
+    };
+    assert_eq!(count("MATCH (n) RETURN n"), 2);
+    assert_eq!(count("MATCH ()-[r]->() RETURN r"), 1);
+}


### PR DESCRIPTION
Closes #876 partially — see *Left failing* below.

```cypher
CREATE p = (a {num: 1}) RETURN p    -- VariableNotFound("p")
MERGE  p = (a {num: 1}) RETURN p    -- VariableNotFound("p")
```

A query that parses, writes, and then **cannot name what it just made**.

The parser has always captured `path_variable` on a `CREATE`/`MERGE` pattern — `MATCH p = …` and `CREATE p = …` produce the same AST field. The write operators simply never bound it.

## Fix

A `BindPathOperator` that reads the node and relationship variables the write already bound and assembles the path from them, rather than teaching every write operator to build one.

Anonymous positions need a handle for the path to reference. `CREATE` already mints synthetic names for anonymous **nodes** (to wire edges); this extends the same treatment to an anonymous **relationship inside a named path**, which had no reason to need one before.

A path whose positions cannot all be named is **left unbound** rather than bound to a shorter path that looks plausible.

Three planner paths construct these writes and each needed wiring: bare `CREATE`, bare `MERGE`, and the clause pipeline.

## Verification

- TCK **3,655 → 3,656** (`Merge1` scenario 13), regression diff against the merge base **empty**.
- Lib suite green (2,175).
- `an_unnamed_pattern_binds_nothing` and `the_write_is_unchanged` pin that the binder invents nothing and changes nothing about what was written.
- `--min-pass` ratcheted 3655 → 3656.

The `CREATE` half has no scenario reaching it and is fixed anyway: a write that cannot name its own result is a gap whether or not a test asks.

## Left failing on purpose

```cypher
MERGE (a {num: 1}) MERGE (b {num: 2}) MERGE p = (a)-[:R]->(b) RETURN p
```

`MergeOperator` handles the whole pattern internally and binds edges by the *pattern's* variable, so a handle synthesised outside it is never bound. Making that work means injecting the synthetic name into the pattern the operator receives — worth doing, but a separate change from binding the paths that can already be named. `Merge5` scenario 10 stays red, and the issue records why.