### PR TITLE
Refuse a negative variable-length bound instead of panicking (#878)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3656
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3657
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1706,6 +1706,22 @@ fn parse_edge(pair: pest::iterators::Pair<Rule>) -> ParseResult<EdgePattern> {
     })
 }
 
+/// One bound of a variable-length pattern.
+///
+/// The `integer` grammar rule accepts a leading `-`, and the bounds are
+/// `usize`, so a negative bound could not be parsed. It was handled three
+/// different ways in three lines: `*..-2` **panicked the process** on
+/// `.unwrap()` of a `ParseIntError`, `*-2..` was silently read as `*1..` by
+/// `unwrap_or(1)` and returned rows, and `*-2` reached neither. Cypher requires
+/// a SyntaxError at compile time for all of them (#878).
+fn parse_length_bound(text: &str, what: &str) -> ParseResult<usize> {
+    text.parse::<usize>().map_err(|_| {
+        ParseError::SemanticError(format!(
+            "a variable-length {what} bound must be a non-negative integer, not `{text}`"
+        ))
+    })
+}
+
 fn parse_length_pattern(pair: pest::iterators::Pair<Rule>) -> ParseResult<LengthPattern> {
     for inner in pair.into_inner() {
         if inner.as_rule() == Rule::range_pattern {
@@ -1715,18 +1731,18 @@ fn parse_length_pattern(pair: pest::iterators::Pair<Rule>) -> ParseResult<Length
             let min = if parts[0].is_empty() {
                 Some(1)
             } else {
-                Some(parts[0].parse().unwrap_or(1))
+                Some(parse_length_bound(parts[0].trim(), "lower")?)
             };
 
             let max = if parts.len() > 1 && !parts[1].is_empty() {
-                Some(parts[1].parse().unwrap())
+                Some(parse_length_bound(parts[1].trim(), "upper")?)
             } else {
                 None
             };
 
             return Ok(LengthPattern { min, max });
         } else if inner.as_rule() == Rule::integer {
-            let exact = inner.as_str().parse().unwrap();
+            let exact = parse_length_bound(inner.as_str().trim(), "exact")?;
             return Ok(LengthPattern {
                 min: Some(exact),
                 max: Some(exact),

--- a/tests/variable_length_bounds.rs
+++ b/tests/variable_length_bounds.rs
@@ -1,0 +1,63 @@
+//! A negative variable-length bound is refused, not a panic (#878).
+//!
+//! ```text
+//! MATCH (a)-[:R*..-2]->(c)
+//!   thread panicked: called `Result::unwrap()` on an `Err` value: ParseIntError
+//! ```
+//!
+//! The `integer` grammar rule accepts a leading `-` and the bounds are `usize`,
+//! so a negative bound cannot be parsed. `parse_length_pattern` handled that
+//! three different ways in three adjacent lines: two `.unwrap()`s that panicked
+//! and one `unwrap_or(1)` that silently read `*-2..` as `*1..` and returned
+//! rows for a different query.
+//!
+//! The quiet one is the worse defect; the panic is the louder one. Both are
+//! covered, and so are the bounds that must keep working — a fix that rejected
+//! every bound would satisfy the first half of this file.
+
+use samyama::query::parser::parse_query;
+
+/// Every position a negative bound can occupy. `parse_query` returning `Err`
+/// is the assertion: a panic would fail the test by aborting it.
+#[test]
+fn a_negative_bound_is_refused() {
+    for cypher in [
+        "MATCH (a)-[:R*-2]->(c) RETURN c",
+        "MATCH (a)-[:R*-2..]->(c) RETURN c",
+        "MATCH (a)-[:R*..-2]->(c) RETURN c",
+        "MATCH (a)-[:R*-2..-1]->(c) RETURN c",
+        "MATCH (a)-[r*-1]->(c) RETURN r",
+    ] {
+        assert!(parse_query(cypher).is_err(), "accepted `{cypher}`");
+    }
+}
+
+/// The error names what was wrong, rather than being a generic parse failure —
+/// the caller has to be able to see which bound is at fault.
+#[test]
+fn the_error_names_the_bound() {
+    let e = format!("{:?}", parse_query("MATCH (a)-[:R*..-2]->(c) RETURN c").unwrap_err());
+    assert!(e.contains("-2"), "error does not mention the offending text: {e}");
+    assert!(
+        e.contains("non-negative") || e.contains("upper"),
+        "error does not say what was expected: {e}"
+    );
+}
+
+/// **Valid bounds are unaffected.** A fix that rejected everything would pass
+/// the tests above.
+#[test]
+fn valid_bounds_still_parse() {
+    for cypher in [
+        "MATCH (a)-[:R*]->(c) RETURN c",
+        "MATCH (a)-[:R*1]->(c) RETURN c",
+        "MATCH (a)-[:R*0]->(c) RETURN c",
+        "MATCH (a)-[:R*1..2]->(c) RETURN c",
+        "MATCH (a)-[:R*..3]->(c) RETURN c",
+        "MATCH (a)-[:R*2..]->(c) RETURN c",
+        // Max below min is not a *syntax* error; it simply matches nothing.
+        "MATCH (a)-[:R*2..1]->(c) RETURN c",
+    ] {
+        assert!(parse_query(cypher).is_ok(), "refused `{cypher}`");
+    }
+}


### PR DESCRIPTION
Closes #878.

```
MATCH (a)-[:R*..-2]->(c) RETURN c
-- thread panicked at src/query/parser.rs:1722:
--   called `Result::unwrap()` on an `Err` value: ParseIntError { kind: InvalidDigit }
```

A **panic on malformed query text** — not an error a caller can catch; the thread dies.

## Three lines, three behaviours

The `integer` grammar rule accepts a leading `-` and the bounds are `usize`, so a negative bound cannot be parsed. `parse_length_pattern` handled that three different ways in three adjacent lines:

| written | what happened |
|---|---|
| `*..-2` | `parts[1].parse().unwrap()` → **panic** |
| `*-2..` | `parts[0].parse().unwrap_or(1)` → silently read as `*1..`, **returned rows** |
| `*-2` | `inner.as_str().parse().unwrap()` → **panic** |

The middle one is the quieter defect: a query asking for something impossible came back with results for a *different* query, and nothing said so.

## Fix

One `parse_length_bound` used by all three positions, returning a `SemanticError` that names the bound and the offending text.

`*`, `*0`, `*1..2`, `*..3`, `*2..` and `*2..1` are unaffected — a fix that rejected every bound would satisfy the negative cases, so `valid_bounds_still_parse` pins them.

## Verification

- TCK **3,656 → 3,657** (`Match4` scenario 10), regression diff against the merge base **empty**.
- `--min-pass` ratcheted 3656 → 3657.

The panic matters more than the count: an engine that can be crashed by a malformed pattern is a different class of problem from one that answers it wrongly.