### PR TITLE
A bare pattern cannot be projected (#880)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3657
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3659
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -50,6 +50,8 @@ pub enum ValidationError {
     PatternInSetValue,
     /// `size()` applied to a pattern or a path (#843).
     SizeOfNonCollection(&'static str),
+    /// A bare pattern used where a value is expected (#880).
+    PatternInProjection(&'static str),
     /// An ORDER BY naming something the projection did not keep.
     OrderByUndefinedVariable(String),
     /// An ORDER BY item that mixes an aggregate with a grouping expression.
@@ -111,6 +113,11 @@ impl std::fmt::Display for ValidationError {
                 f,
                 "size() takes a list or a string, not {what}; \
                  use length() for a path"
+            ),
+            Self::PatternInProjection(where_) => write!(
+                f,
+                "a pattern is a predicate, not a value; it cannot be projected by {where_}. \
+                 Use `EXISTS {{ ... }}` for a boolean, or a pattern comprehension for a list"
             ),
             Self::VariableTypeConflict(name) => write!(
                 f,
@@ -1332,7 +1339,58 @@ fn validate_size_arguments(query: &Query) -> Result<(), ValidationError> {
     Ok(())
 }
 
+/// A bare pattern cannot be **projected** (#880).
+///
+/// ```text
+/// MATCH (n) RETURN (n)-[]->()
+/// MATCH (n) WITH (n)-[]->() AS x RETURN x
+/// ```
+///
+/// Both must fail at compile time. A pattern in that position is a predicate
+/// written where a value belongs, and the engine happily evaluated it as one
+/// and projected the boolean -- an answer to a question nobody asked.
+///
+/// Only the **top level** of a projection item is checked, and only a *bare*
+/// pattern. `EXISTS { ... }` desugars to the same AST node and is legal
+/// anywhere (`bare_pattern` is what separates them, as #798 established); a
+/// pattern comprehension is a different node; and a bare pattern nested inside
+/// a list comprehension's own `WHERE` is a predicate in a predicate position.
+/// Walking the whole tree would reject all three, and over-rejecting a valid
+/// query is the worse failure.
+fn validate_pattern_projections(query: &Query) -> Result<(), ValidationError> {
+    use crate::query::ast::Clause;
+
+    fn check(items: &[crate::query::ast::ReturnItem], what: &'static str) -> Result<(), ValidationError> {
+        for item in items {
+            if matches!(item.expression, Expression::ExistsSubquery { bare_pattern: true, .. }) {
+                return Err(ValidationError::PatternInProjection(what));
+            }
+        }
+        Ok(())
+    }
+
+    if let Some(rc) = &query.return_clause {
+        check(&rc.items, "RETURN")?;
+    }
+    if let Some(wc) = &query.with_clause {
+        check(&wc.items, "WITH")?;
+    }
+    for (wc, _, _, _) in &query.extra_with_stages {
+        check(&wc.items, "WITH")?;
+    }
+    for clause in &query.clauses {
+        match clause {
+            Clause::Return(rc) => check(&rc.items, "RETURN")?,
+            Clause::With(wc) => check(&wc.items, "WITH")?,
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
 pub fn validate(query: &Query) -> Result<(), ValidationError> {
+    validate_pattern_projections(query)?;
+
     validate_size_arguments(query)?;
 
     validate_pattern_predicate_vars(query)?;

--- a/tests/pattern_in_projection.rs
+++ b/tests/pattern_in_projection.rs
@@ -1,0 +1,58 @@
+//! A bare pattern cannot be projected (#880).
+//!
+//! ```cypher
+//! MATCH (n) RETURN (n)-[]->()
+//! MATCH (n) WITH (n)-[]->() AS x RETURN x
+//! ```
+//!
+//! A pattern there is a **predicate written where a value belongs**. The engine
+//! evaluated it as one and projected the boolean — an answer to a question
+//! nobody asked, in a column the user thought would hold something else.
+//!
+//! The scoping is the interesting part, and most of this file guards it.
+//! `EXISTS { … }` desugars to the same AST node and is legal anywhere; a
+//! pattern comprehension is a different node; and a bare pattern inside a list
+//! comprehension's own `WHERE` is a predicate in a predicate position. A rule
+//! that walked the whole expression tree would reject all three — and #798 is
+//! the precedent for what that costs.
+
+use samyama::query::parser::parse_query;
+
+/// The two forms the TCK names.
+#[test]
+fn a_bare_pattern_cannot_be_projected() {
+    assert!(parse_query("MATCH (n) RETURN (n)-[]->()").is_err());
+    assert!(parse_query("MATCH (n) WITH (n)-[]->() AS x RETURN x").is_err());
+    assert!(parse_query("MATCH (n) RETURN (n)-[:R]->(m) AS x").is_err());
+    // Through a later WITH stage too.
+    assert!(parse_query("MATCH (n) WITH n WITH (n)-[]->() AS x RETURN x").is_err());
+}
+
+/// **Everything else that looks similar must still parse.**
+#[test]
+fn the_legitimate_uses_are_untouched() {
+    for cypher in [
+        // A pattern predicate in a WHERE is the position it belongs in.
+        "MATCH (n) WHERE (n)-[]->() RETURN n",
+        "MATCH (n) WHERE NOT (n)-[]->() RETURN n",
+        // EXISTS is a value expression and may be projected.
+        "MATCH (n) RETURN EXISTS { (n)-[]->() } AS e",
+        "MATCH (n) WITH EXISTS { (n)-[]->() } AS e RETURN e",
+        // A pattern comprehension is a list, and may be projected.
+        "MATCH (n) RETURN [(n)-->(m) | m] AS c",
+        // Ordinary projections.
+        "MATCH (n) RETURN n",
+        "MATCH (n) RETURN n.name AS name",
+        "MATCH (n) WITH n AS m RETURN m",
+    ] {
+        assert!(parse_query(cypher).is_ok(), "refused `{cypher}`");
+    }
+}
+
+/// The message says what to use instead, since the fix for the query is not
+/// obvious from "unexpected syntax".
+#[test]
+fn the_error_suggests_the_alternative() {
+    let e = format!("{:?}", parse_query("MATCH (n) RETURN (n)-[]->()").unwrap_err());
+    assert!(e.contains("EXISTS"), "error does not point at EXISTS: {e}");
+}


### PR DESCRIPTION
Closes #880 partially — two rows in the same feature stay open, see below.

```cypher
MATCH (n) RETURN (n)-[]->()
MATCH (n) WITH (n)-[]->() AS x RETURN x
```

Both must fail at compile time. Both succeeded: a pattern there is a **predicate written where a value belongs**, and the engine evaluated it as one and projected the boolean — an answer to a question nobody asked, in a column the user thought would hold something else.

## The scoping is most of the change

`validate_pattern_projections` rejects a projection item whose **top-level** expression is a **bare** pattern. Both restrictions are deliberate:

- **`bare_pattern` only.** `EXISTS { … }` desugars to the same AST node and is legal anywhere; that flag is what separates them, as #798 established *after* a broader rule rejected every `EXISTS` in the codebase.
- **Top level only.** A pattern comprehension is a different node, and a bare pattern nested inside a list comprehension's own `WHERE` is a predicate in a predicate position. Walking the whole expression tree would reject both, and over-rejecting a valid query is the worse failure.

`the_legitimate_uses_are_untouched` pins all of them, and the error names `EXISTS` as the alternative since the fix is not obvious from "unexpected syntax".

## Verification

- TCK **3,657 → 3,659** (`Pattern1` scenarios 22 and 23), regression diff against the merge base **empty**.
- `--min-pass` ratcheted 3657 → 3659.

## Left open

- `MATCH (n) WHERE (n) RETURN n` wants `InvalidArgumentType`. `(n)` parses as a parenthesised **variable**, not a pattern, so refusing it is a different rule — a node used where a boolean belongs. Same reason #798 left its row.
- `MATCH (n) WHERE [(a)] RETURN n` wants `UndefinedVariable`: an unbound variable inside a list literal is not diagnosed at all.