### PR TITLE
docs: TCK to 97.3%, wrong answers 86 → 79

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Samyama is a high-performance distributed graph database written in Rust with Redis protocol (RESP) compatibility, multi-tenancy, vector search, NLQ, and graph algorithms. Currently at Phase 4 (High Availability Foundation), version v1.7.0.
 
-Cypher conformance is **measured, not estimated**: 97.0% of the openCypher TCK's evaluated scenarios pass (3,650 of 3,762, 96.5% coverage, 2026-08-26). The `~90% OpenCypher support` this line used to claim was a self-assessment withdrawn in `#437` as unmeasured; the measured figure has now passed it, which settles nothing, because only one of the two can be reproduced. Quote the pass rate **with** its coverage: a high rate over a small evaluated set is how this measurement is usually inflated, and that is exactly what the earlier 87.1% turned out to be.
+Cypher conformance is **measured, not estimated**: 97.3% of the openCypher TCK's evaluated scenarios pass (3,659 of 3,762, 96.5% coverage, 2026-08-26). The `~90% OpenCypher support` this line used to claim was a self-assessment withdrawn in `#437` as unmeasured; the measured figure has now passed it, which settles nothing, because only one of the two can be reproduced. Quote the pass rate **with** its coverage: a high rate over a small evaluated set is how this measurement is usually inflated, and that is exactly what the earlier 87.1% turned out to be.
 
 ## Build & Development Commands
 

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ into a public-health trifecta.* [Browse the catalogue →](case_studies)
 
 ## The 30-Second Tour
 
-**Cypher queries** — MATCH, CREATE, MERGE, aggregations, path finding, 30+ functions. **97.0% of the openCypher TCK's evaluated scenarios pass** (3,650 of 3,762, at 96.5% coverage of the 3,897-scenario corpus, measured 2026-08-26); on the same corpus and comparator Neo4j 5 scores 79.4%. That is conformance only — not performance or scale — and the competitor figure is a fixed baseline from one run. See [`docs/CYPHER_COMPATIBILITY.md`](docs/CYPHER_COMPATIBILITY.md) for a per-feature matrix verified by an executable probe, and [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) for the full accounting.
+**Cypher queries** — MATCH, CREATE, MERGE, aggregations, path finding, 30+ functions. **97.3% of the openCypher TCK's evaluated scenarios pass** (3,659 of 3,762, at 96.5% coverage of the 3,897-scenario corpus, measured 2026-08-26); on the same corpus and comparator Neo4j 5 scores 79.4%. That is conformance only — not performance or scale — and the competitor figure is a fixed baseline from one run. See [`docs/CYPHER_COMPATIBILITY.md`](docs/CYPHER_COMPATIBILITY.md) for a per-feature matrix verified by an executable probe, and [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) for the full accounting.
 
 ```cypher
 MATCH (a:Person)-[:KNOWS*1..3]->(b:Person)

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -140,14 +140,14 @@ cargo run --release --example tck_runner -- --features <openCypher>/tck/features
 |---|---:|
 | scenarios in the TCK | 3,897 |
 | **evaluated** by the harness | **3,762** (96.5%) |
-| pass | 3,650 |
+| pass | 3,659 |
 | skipped | 135 |
-| **pass rate, of evaluated** | **97.0%** |
+| **pass rate, of evaluated** | **97.3%** |
 | gate `CH-TCK ≥ 85%` | **met** |
-| gate *≥ best competitor* | **met** — 17.4 points ahead |
-| wrong answers, of the 112 failures | 86 |
+| gate *≥ best competitor* | **met** — 17.6 points ahead |
+| wrong answers, of the 103 failures | 79 |
 
-Measured at `a0343b7`; the CI floor is a **count**, currently `--min-pass 3650`,
+Measured at `7708d60`; the CI floor is a **count**, currently `--min-pass 3659`,
 and rises with each merge that earns it.
 
 The last row is tracked separately from the pass rate because the two failure
@@ -159,7 +159,7 @@ scorecard shows a met requirement inside a failing envelope.
 ### The corpus tripled, and the old figure was measured on a third of it
 
 The table above replaces `1,244 evaluated / 81.9%`. Nothing regressed — the
-pass *count* went from 1,019 to 3,650. The harness had been skipping every
+pass *count* went from 1,019 to 3,659. The harness had been skipping every
 `Scenario Outline`: 274 of them, expanding to ~2,280 concrete cases, and the
 harder ones, because an outline is how the TCK enumerates a feature's edge
 cases once its happy path is established (#756).
@@ -176,12 +176,12 @@ executes and renders:
 
 | Engine | 1,249-scenario set (2026-08-19) | 3,766-scenario set |
 |---|---:|---:|
-| **Samyama** `a0343b7` | 81.9% | **96.8%** |
+| **Samyama** `7708d60` | 81.9% | **97.0%** |
 | Neo4j 5 | 98.9% | 79.4% |
 | Memgraph | 89.8% | 65.9% |
 | FalkorDB | 89.1% | 65.7% |
 
-The Samyama row reads **96.8%** where the table above reads 97.0%, and both are
+The Samyama row reads **97.0%** where the table above reads 97.3%, and both are
 right: the cross-engine comparison scores 3,766 scenarios through the judge
 path, the direct run evaluates 3,762. The judge scores five the direct run
 skips and passes five fewer, identically across measurements. The judge figure

--- a/docs/CYPHER_COMPATIBILITY.md
+++ b/docs/CYPHER_COMPATIBILITY.md
@@ -8,9 +8,9 @@
 The openCypher TCK **has now been run** (#434), so this page can give a measured
 number instead of withholding one:
 
-> **97.0% of evaluated scenarios** — 3,650 of 3,762, from 3,897 total with 135
+> **97.3% of evaluated scenarios** — 3,659 of 3,762, from 3,897 total with 135
 > skipped as unjudgeable by the harness. Measured 2026-08-26 at commit
-> `a0343b7`.
+> `7708d60`.
 
 Two numbers, both of which matter. The pass rate says what the engine gets
 right among scenarios the harness can judge; the **96.5% coverage** says how
@@ -23,10 +23,10 @@ The harness had been skipping every `Scenario Outline` — 274 of them, expandin
 to ~2,280 concrete cases, and the harder ones, since an outline is how the TCK
 enumerates a feature's edge cases once its happy path is established (#756).
 Nothing regressed when they were included: the pass **count** went from 1,079
-to 3,650.
+to 3,659.
 
 On the same corpus and comparator, Neo4j 5 scores 79.4%, Memgraph 65.9% and
-FalkorDB 65.7% (#759). Samyama is **17.4 points ahead of the best of them** —
+FalkorDB 65.7% (#759). Samyama is **17.6 points ahead of the best of them** —
 having been 17 points behind on the old, smaller set. Every engine's number
 falls on the wider corpus, which is the evidence the expansion is sound rather
 than malformed.
@@ -42,7 +42,7 @@ was self-assessed, never checked against the TCK, and an earlier internal
 assessment of the same engine put it at 40–50%. It was withdrawn rather than
 defended.
 
-The measured number has since passed it — 97.0% against the withdrawn "~90%" —
+The measured number has since passed it — 97.3% against the withdrawn "~90%" —
 but the two are not comparable, and passing it settles nothing: one is a
 reproducible count over a named corpus at a named commit, the other was a
 guess. The point of withdrawing it was never the value.


### PR DESCRIPTION
Five merges take the direct-run rate from **97.0% (3,650) to 97.3% (3,659)** at `7708d60`, and the judge path from 96.8% to **97.0%** — **17.6 points ahead** of Neo4j on the same corpus and comparator.

## Two of the five were not about the count

- **#878 removed a panic.** `MATCH (a)-[:R*..-2]->(c)` crashed the thread on `.unwrap()` of a `ParseIntError`. The same function also read `*-2..` as `*1..` and returned rows for a query nobody wrote.
- **#874 fixed a silently discarded clause.** `ON CREATE SET r = a` parsed and did nothing — `parse_merge_clause` matched only `set_item` and `set_label_item`, so `set_entity_item` fell through its `match` arm.

## Wrong answers

**79 of 103 failures**, from 86 of 112, and 242 at the start of the 2026-08-25 fourth cycle. That count matters more than the rate: an error reaches the caller and a wrong answer does not.

Companion commit in the benchmarks repo: `16d3c5c` (`CROSS-ENGINE-2026-08-26b.md`, `SCORECARD.json`/`.md` regenerated, `ch_tck.py` baseline line).