### PR TITLE
Refuse an overflowing float literal; render negative zero unsigned (#883)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3659
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3662
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/examples/tck_runner.rs
+++ b/examples/tck_runner.rs
@@ -169,6 +169,21 @@ fn float_repr(f: f64) -> String {
     if f.is_infinite() {
         return if f > 0.0 { "Inf".into() } else { "-Inf".into() };
     }
+    // Negative zero renders as `0`.
+    //
+    // `-0.0 == 0.0` is true, and this function turns a float into a string for
+    // a **string** comparison -- so rendering them differently makes the
+    // comparator disagree with the equality it is standing in for. `-0.0`
+    // arrived as `-0.000000000`, which trims to `-0` rather than to the empty
+    // string the guard below was written for, and `RETURN -0.0` was scored
+    // wrong against an expected `0.0` (#883).
+    //
+    // This is a fix to the ruler, not to the engine's score: it is only
+    // defensible because the two values are equal, and it applies to the
+    // expected side as much as the actual one.
+    if f == 0.0 {
+        return "0".into();
+    }
     // Enough digits to distinguish, few enough that 1.0 and 1.0000000001 do not
     // both appear as distinct-but-equal-looking.
     let s = format!("{f:.9}");

--- a/src/graph/property.rs
+++ b/src/graph/property.rs
@@ -807,6 +807,11 @@ impl fmt::Display for PropertyValue {
             | PropertyValue::ZonedDateTime { .. } => write!(f, "{}", self.to_cypher_string()),
             PropertyValue::String(s) => write!(f, "\"{}\"", s),
             PropertyValue::Integer(i) => write!(f, "{}", i),
+            // Negative zero prints as `0`, not `-0`. IEEE keeps the sign bit and
+            // Cypher does not show it: `RETURN -0.0` is `0.0`. The value is left
+            // alone -- only the rendering drops the sign, so a computed `-0.0`
+            // still compares equal to `0.0` as it always did (#883).
+            PropertyValue::Float(fl) if *fl == 0.0 => write!(f, "0"),
             PropertyValue::Float(fl) => write!(f, "{}", fl),
             PropertyValue::Boolean(b) => write!(f, "{}", b),
             PropertyValue::DateTime(dt) => write!(f, "DateTime({})", dt),

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1839,12 +1839,22 @@ fn parse_value(pair: pest::iterators::Pair<Rule>) -> ParseResult<PropertyValue> 
                 return Ok(PropertyValue::Integer(parse_integer_literal(inner.as_str())?));
             }
             Rule::float => {
-                let val = inner.as_str().trim().parse().map_err(|_| {
-                    ParseError::SemanticError(format!(
-                        "float literal out of range: `{}`",
-                        inner.as_str()
-                    ))
+                let text = inner.as_str().trim();
+                let val: f64 = text.parse().map_err(|_| {
+                    ParseError::SemanticError(format!("float literal out of range: `{text}`"))
                 })?;
+                // Rust's `parse` returns `Ok(inf)` on overflow rather than an
+                // error, so `1.34E999` became a perfectly usable infinity.
+                // Cypher rejects an over-large *literal* at compile time.
+                //
+                // Only a literal: an infinity that a computation produces --
+                // `1.0 / 0.0` -- is a legitimate value and is untouched (#883).
+                if !val.is_finite() {
+                    return Err(ParseError::SemanticError(format!(
+                        "float literal `{text}` overflows to {}; the largest finite double is about 1.8e308",
+                        if val.is_sign_negative() { "-infinity" } else { "infinity" }
+                    )));
+                }
                 return Ok(PropertyValue::Float(val));
             }
             Rule::string => {

--- a/tests/float_literals.rs
+++ b/tests/float_literals.rs
@@ -1,0 +1,70 @@
+//! Float literals: overflow is refused, negative zero prints unsigned (#883).
+//!
+//! ```text
+//! RETURN 1.34E999   -- returned inf; must be a compile-time error
+//! RETURN -0.0       -- printed "-0"; Cypher shows 0.0
+//! ```
+//!
+//! Rust's `str::parse::<f64>` returns `Ok(inf)` on overflow rather than an
+//! error, so the literal became a perfectly usable infinity.
+//!
+//! Only a **literal**. An infinity a computation produces is a legitimate
+//! value, and `a_computed_infinity_is_still_allowed` pins that — a fix that
+//! rejected infinity everywhere would satisfy the overflow cases and break
+//! division.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn value(expr: &str) -> Result<PropertyValue, String> {
+    let store = GraphStore::new();
+    let cypher = format!("RETURN {expr} AS r");
+    let q = parse_query(&cypher).map_err(|e| format!("parse: {e:?}"))?;
+    let batch = QueryExecutor::new(&store).execute(&q).map_err(|e| format!("exec: {e:?}"))?;
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => Ok(p.clone()),
+        other => Err(format!("got {other:?}")),
+    }
+}
+
+/// An over-large literal is refused before it runs.
+#[test]
+fn an_overflowing_literal_is_refused() {
+    for expr in ["1.34E999", "-1.34E999", "1e400", "9" .repeat(400).as_str()] {
+        assert!(value(expr).is_err(), "accepted `{expr}`");
+    }
+}
+
+/// **A computed infinity is still a value.** This is the half a blanket
+/// "reject infinity" rule would break.
+#[test]
+fn a_computed_infinity_is_still_allowed() {
+    assert_eq!(value("1.0 / 0.0"), Ok(PropertyValue::Float(f64::INFINITY)));
+    assert_eq!(value("-1.0 / 0.0"), Ok(PropertyValue::Float(f64::NEG_INFINITY)));
+}
+
+/// Literals that fit are unaffected — a fix that rejected large-but-finite
+/// values would pass the tests above.
+#[test]
+fn large_but_finite_literals_still_parse() {
+    for expr in ["1.0E308", "1.7e308", "-1.0E308", "0.5", "1.0", "3.14159"] {
+        assert!(value(expr).is_ok(), "refused `{expr}`");
+    }
+}
+
+/// Negative zero renders without a sign, and keeps its numeric identity.
+#[test]
+fn negative_zero_prints_unsigned() {
+    assert_eq!(value("-0.0").unwrap().to_string(), "0");
+    assert_eq!(value("0.0").unwrap().to_string(), "0");
+    assert_eq!(value("-.0").unwrap().to_string(), "0");
+    // Still equal, and still not equal to something else.
+    assert_eq!(
+        value("-0.0 = 0.0"),
+        Ok(PropertyValue::Boolean(true)),
+        "-0.0 and 0.0 must compare equal"
+    );
+    // A non-zero negative keeps its sign.
+    assert_eq!(value("-1.5").unwrap().to_string(), "-1.5");
+}


### PR DESCRIPTION
Closes #883. Two defects — one in the engine, one in the harness. **Separating them matters, because only the first is a change to the score.**

## Engine: an over-large literal became infinity

```cypher
RETURN 1.34E999    -- returned inf
```

Rust's `str::parse::<f64>` returns `Ok(inf)` on overflow rather than an error, so the literal became a perfectly usable infinity. Cypher rejects an over-large *literal* at compile time.

**Only a literal.** An infinity a computation produces — `1.0 / 0.0` — is a legitimate value and is untouched. `a_computed_infinity_is_still_allowed` pins it, because a blanket "reject infinity" rule would satisfy every overflow case and break division.

`Display` for a float also renders zero without a sign now, so `-0.0` prints as `0`. IEEE keeps the sign bit; Cypher does not show it. The stored value is unchanged and `-0.0 = 0.0` still holds.

## Harness: the comparator made two equal floats differ

`float_repr` in `examples/tck_runner.rs` turns a float into a string for a **string** comparison. `-0.0` formatted to `-0.000000000`, which trims to `-0` — not the empty string its guard was written for — so `RETURN -0.0` was scored wrong against an expected `0.0`.

`-0.0 == 0.0` is true. A comparator standing in for equality must not render equal values differently, and this applies to the *expected* side exactly as much as the actual one.

**This is a fix to the ruler.** Two of the three scenarios closed here were scored wrong by the harness rather than answered wrong by the engine — the engine's `-0.0` was already numerically correct. Recording that split rather than banking all three as engine progress.

## Verification

- TCK **3,659 → 3,662** (`Literals5` scenarios 9, 10, 27 — **one engine, two comparator**), regression diff against the merge base **empty**.
- `--min-pass` ratcheted 3659 → 3662.