### PR TITLE
A fractional week carries, and toInteger reads a float-valued string (#885)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         # why in the same commit.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3662
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3665
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2403,8 +2403,18 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                 // failing the query. Erroring made `toInteger` unusable for the
                 // thing it is mostly used for -- checking whether input is a
                 // number at all (#606).
+                // A string holding a **float** converts too, truncating:
+                // `toInteger('2.9')` is 2, the same as `toInteger(2.9)`. Only
+                // `parse::<i64>()` was tried, so it answered null -- the same
+                // null it gives for `'foo'`, which is the answer that means
+                // "not a number at all" (#885).
                 Value::Property(PropertyValue::String(s)) => Ok(Value::Property(
-                    s.parse::<i64>()
+                    s.trim()
+                        .parse::<i64>()
+                        .ok()
+                        .or_else(|| {
+                            s.trim().parse::<f64>().ok().filter(|f| f.is_finite()).map(|f| f as i64)
+                        })
                         .map(PropertyValue::Integer)
                         .unwrap_or(PropertyValue::Null),
                 )),
@@ -4256,7 +4266,16 @@ fn parse_iso_duration(s: &str) -> ExecutionResult<Value> {
                     // constructor derives (#829).
                     match unit {
                         'Y' | 'y' => months += scaled(sign, &int_digits, &frac_digits, 12),
-                        'W' | 'w' => days += scaled(sign, &int_digits, &frac_digits, 7),
+                        // A week's fraction carries into the day and then into
+                        // the clock, like a day's does: `P2.5W` is 17 days and
+                        // 12 hours, not 17 days. Scaling straight to whole days
+                        // truncated the half away (#885).
+                        'W' | 'w' => {
+                            let total =
+                                scaled(sign, &int_digits, &frac_digits, NPS * 86_400 * 7);
+                            days += total / (NPS * 86_400);
+                            time_nanos += total % (NPS * 86_400);
+                        }
                         'D' | 'd' if !is_time => {
                             let total = scaled(sign, &int_digits, &frac_digits, NPS * 86_400);
                             days += total / (NPS * 86_400);

--- a/tests/conversion_fractions.rs
+++ b/tests/conversion_fractions.rs
@@ -1,0 +1,83 @@
+//! A week's fraction carries, and `toInteger` reads a float-valued string
+//! (#885).
+//!
+//! ```text
+//! duration('P2.5W')     P17D,   want P17DT12H
+//! toInteger('2.9')      null,   want 2
+//! ```
+//!
+//! Both answer **null or a smaller value** where a number belongs, which is
+//! the shape that does not look like a defect: `P17D` is a real duration and
+//! `null` is what `toInteger` legitimately gives for `'foo'`.
+//!
+//! The week case came from #853's parser rewrite, which gave `D` and `M` the
+//! carry and left `W` scaling to a whole unit — while the *map* constructor had
+//! it right from #829. So both spellings are asserted here, since the working
+//! one is what hid the broken one.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn value(expr: &str) -> PropertyValue {
+    let store = GraphStore::new();
+    let cypher = format!("RETURN {expr} AS r");
+    let q = parse_query(&cypher).unwrap_or_else(|e| panic!("{cypher}\n  parse: {e:?}"));
+    let batch = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}\n  exec: {e:?}"));
+    match batch.records.first().and_then(|r| r.get("r")) {
+        Some(Value::Property(p)) => p.clone(),
+        // `toInteger(null)` yields the bare `Value::Null` rather than a
+        // `PropertyValue::Null`; both mean null here.
+        Some(Value::Null) | None => PropertyValue::Null,
+        other => panic!("{cypher}\n  got {other:?}"),
+    }
+}
+
+/// The string and map spellings must agree, on fractions and on whole units.
+#[test]
+fn a_fractional_week_carries_into_the_clock() {
+    for (text, map, want) in [
+        ("P2.5W", "{weeks: 2.5}", "P17DT12H"),
+        ("P2W", "{weeks: 2}", "P14D"),
+        ("P1.5W", "{weeks: 1.5}", "P10DT12H"),
+        ("P0.5W", "{weeks: 0.5}", "P3DT12H"),
+    ] {
+        assert_eq!(value(&format!("duration('{text}')")).to_cypher_string(), want, "{text}");
+        assert_eq!(value(&format!("duration({map})")).to_cypher_string(), want, "{map}");
+    }
+}
+
+/// Other fractional units keep working — the fix must not have moved only `W`
+/// while breaking its neighbours.
+#[test]
+fn the_other_fractional_units_are_unchanged() {
+    assert_eq!(value("duration('P0.75M')").to_cypher_string(), "P22DT19H51M49.5S");
+    assert_eq!(value("duration('P1.5D')").to_cypher_string(), "P1DT12H");
+    assert_eq!(value("duration('PT1.5H')").to_cypher_string(), "PT1H30M");
+}
+
+/// A string holding a float converts, truncating; a string holding nothing
+/// numeric is still null.
+#[test]
+fn to_integer_reads_a_float_valued_string() {
+    for (expr, want) in [
+        ("toInteger('2')", Some(2)),
+        ("toInteger('2.9')", Some(2)),
+        ("toInteger('1.7')", Some(1)),
+        ("toInteger('-1.7')", Some(-1)),
+        ("toInteger(2.9)", Some(2)),
+        ("toInteger(2)", Some(2)),
+        // Not a number: still null, which is the answer that means exactly that.
+        ("toInteger('foo')", None),
+        ("toInteger('')", None),
+        ("toInteger(null)", None),
+    ] {
+        let got = value(expr);
+        match want {
+            Some(n) => assert_eq!(got, PropertyValue::Integer(n), "{expr}"),
+            None => assert_eq!(got, PropertyValue::Null, "{expr}"),
+        }
+    }
+}


### PR DESCRIPTION
Closes #885. Two conversion defects, both answering **null or a smaller value** where a number belongs — the shape that does not look like a defect, because `P17D` is a real duration and `null` is what `toInteger` legitimately gives for `'foo'`.

## `duration('P2.5W')` was `P17D`

A week's fraction has to carry into the day and then into the clock, the way a day's does. The unit was scaled straight to whole days, and `2.5 × 7` in integer arithmetic is 17.

**Introduced by #853's own parser rewrite**, which gave `D` and `M` the carry and left `W` scaling to a whole unit — while the *map* constructor (`duration({weeks: 2.5})`) had it right from #829. The two spellings disagreed, and the working one is what hid the broken one, so both are asserted now.

## `toInteger('2.9')` was null

```
WITH ['2', '2.9', 'foo'] AS numbers RETURN [n IN numbers | toInteger(n)]
  expected [2, 2, null]    got [2, null, null]
```

Only `parse::<i64>()` was tried, so a string holding a **float** answered the same null that means *"not a number at all"*. `toInteger(2.9)` on the float itself was already 2; only the string form differed.

## Verification

- TCK **3,662 → 3,665**, regression diff against the merge base **empty**. Wrong answers 76 → 73.
- `--min-pass` ratcheted 3662 → 3665.