### PR TITLE
DELETE takes an entity, the harness checks side effects, and MERGE (a) matches (#887, #888, #890)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         # expansion in #756: the ruler got honest and the count fell.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3664
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3673
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         # Raise the floor when it goes up; lowering it is allowed but must say
         # why in the same commit.
         #
-        # Lowered 3665 -> 3656 on 2026-08-26: the harness began **checking
+        # Lowered 3665 -> 3656 on 2026-08-26 (then 3658 with #890): the harness began **checking
         # declared side effects** (#888). Nothing regressed — 13 scenarios that
         # had been passing on an empty result while the write they exist to test
         # went unchecked now fail, including `MERGE (a)` creating a second node
@@ -141,7 +141,7 @@ jobs:
         # expansion in #756: the ruler got honest and the count fell.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3656
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3658
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,9 +132,16 @@ jobs:
         #
         # Raise the floor when it goes up; lowering it is allowed but must say
         # why in the same commit.
+        #
+        # Lowered 3665 -> 3656 on 2026-08-26: the harness began **checking
+        # declared side effects** (#888). Nothing regressed — 13 scenarios that
+        # had been passing on an empty result while the write they exist to test
+        # went unchecked now fail, including `MERGE (a)` creating a second node
+        # instead of matching the one that exists. Same shape as the outline
+        # expansion in #756: the ruler got honest and the count fell.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3665
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3656
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         # expansion in #756: the ruler got honest and the count fell.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3658
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3664
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/examples/tck_runner.rs
+++ b/examples/tck_runner.rs
@@ -702,6 +702,21 @@ struct Scenario {
     /// A step this harness does not implement; the scenario is skipped and this
     /// says which step, so the gap is legible.
     unsupported: Option<String>,
+    /// Declared node and relationship deltas from `And the side effects should
+    /// be`, as `(+nodes, -nodes, +relationships, -relationships)`.
+    ///
+    /// Side effects used to be parsed and thrown away. A scenario asserting
+    /// *both* an empty result and a non-zero side effect therefore passed on
+    /// the empty result alone -- **83 scenarios** in the corpus, each scored
+    /// green while the write it exists to test went unchecked. That is how
+    /// `DELETE nodes.key` was found deleting nothing (#888).
+    ///
+    /// Only nodes and relationships. `+properties` and `+labels` count *writes
+    /// performed*, not the net change, so a `SET` that overwrites an existing
+    /// property is `+properties 1` with a delta of zero; a before/after count
+    /// cannot see it, and checking it that way would fail correct engines.
+    /// Those two stay unchecked, and say so.
+    side_effects: Option<(i64, i64, i64, i64)>,
     /// The `Examples:` blocks of a `Scenario Outline:`, each a header and its
     /// rows. Empty for an ordinary scenario.
     ///
@@ -814,7 +829,7 @@ fn parse_feature(path: &Path, text: &str) -> Vec<Scenario> {
 
     // The step a docstring or table belongs to.
     #[derive(PartialEq, Clone, Copy)]
-    enum Pending { None, Setup, Query, Control, Result(bool), Params, Examples }
+    enum Pending { None, Setup, Query, Control, Result(bool), Params, Examples, SideEffects }
     let mut pending = Pending::None;
 
     while i < lines.len() {
@@ -831,6 +846,7 @@ fn parse_feature(path: &Path, text: &str) -> Vec<Scenario> {
                 control_query: None,
                 expect: None,
                 unsupported: None,
+                side_effects: None,
                 examples: Vec::new(),
                 is_outline: false,
             });
@@ -864,6 +880,7 @@ fn parse_feature(path: &Path, text: &str) -> Vec<Scenario> {
                 control_query: None,
                 expect: None,
                 unsupported: None,
+                side_effects: None,
                 examples: Vec::new(),
                 is_outline: line.starts_with("Scenario Outline:"),
             };
@@ -914,10 +931,15 @@ fn parse_feature(path: &Path, text: &str) -> Vec<Scenario> {
             } else if body.contains("should be raised") {
                 let kind = body.split_whitespace().nth(1).unwrap_or("Error").to_string();
                 s.expect = Some(Expect::Error(kind));
-            } else if body.starts_with("no side effects") || body.starts_with("the side effects should be") {
-                // Side effects are not checked. Noted on the scenario only when
-                // it would otherwise pass, so the number is not inflated by
-                // scenarios whose *only* assertion is a side effect.
+            } else if body.starts_with("no side effects") {
+                s.side_effects = Some((0, 0, 0, 0));
+                if s.expect.is_none() {
+                    s.unsupported = Some("side-effect assertion only".into());
+                }
+            } else if body.starts_with("the side effects should be") {
+                // The table rows follow; `pending` collects them.
+                s.side_effects = Some((0, 0, 0, 0));
+                pending = Pending::SideEffects;
                 if s.expect.is_none() {
                     s.unsupported = Some("side-effect assertion only".into());
                 }
@@ -963,6 +985,26 @@ fn parse_feature(path: &Path, text: &str) -> Vec<Scenario> {
                         *header = cells;
                     } else {
                         rows.push(cells);
+                    }
+                }
+                continue;
+            }
+            if pending == Pending::SideEffects {
+                // Rows look like `| +nodes | 1 |`.
+                if cells.len() >= 2 {
+                    if let (Some(key), Ok(n)) = (cells.first(), cells[1].parse::<i64>()) {
+                        if let Some(se) = s.side_effects.as_mut() {
+                            match key.as_str() {
+                                "+nodes" => se.0 = n,
+                                "-nodes" => se.1 = n,
+                                "+relationships" => se.2 = n,
+                                "-relationships" => se.3 = n,
+                                // `+properties` / `+labels` count writes
+                                // performed rather than the net change, so a
+                                // before/after delta cannot check them.
+                                _ => {}
+                            }
+                        }
                     }
                 }
                 continue;
@@ -1015,6 +1057,9 @@ fn run_scenario_rows(s: &Scenario, header: &[String]) -> Result<Vec<Vec<String>>
         query
     };
     let parsed = parse_query(query).map_err(|e| format!("parse: {e}"))?;
+    // Node and relationship counts either side of the query, so a declared
+    // side effect can be checked rather than parsed and discarded (#888).
+    let before = (store.node_count() as i64, store.edge_count() as i64);
     let batch = {
         let mut m = MutQueryExecutor::new(&mut store, "default".to_string());
         match m.execute(&parsed) {
@@ -1024,6 +1069,22 @@ fn run_scenario_rows(s: &Scenario, header: &[String]) -> Result<Vec<Vec<String>>
                 .map_err(|e| format!("exec: {e}"))?,
         }
     };
+    if let Some((pn, mn, pr, mr)) = s.side_effects {
+        // Only when the query under test is the *main* one. With a control
+        // query the write already happened above and this snapshot spans the
+        // control query instead, which changes nothing by design.
+        if s.control_query.is_none() {
+            let after = (store.node_count() as i64, store.edge_count() as i64);
+            let (want_nodes, want_rels) = (pn - mn, pr - mr);
+            let (got_nodes, got_rels) = (after.0 - before.0, after.1 - before.1);
+            if got_nodes != want_nodes || got_rels != want_rels {
+                return Err(format!(
+                    "side effects: nodes {got_nodes:+} want {want_nodes:+}, \
+                     relationships {got_rels:+} want {want_rels:+}"
+                ));
+            }
+        }
+    }
     let mut rows = Vec::new();
     for rec in &batch.records {
         rows.push(
@@ -1034,6 +1095,41 @@ fn run_scenario_rows(s: &Scenario, header: &[String]) -> Result<Vec<Vec<String>>
         );
     }
     Ok(rows)
+}
+
+/// Compare a scenario's declared node/relationship deltas against what happened.
+///
+/// Side effects used to be parsed and thrown away, so a scenario asserting
+/// *both* an empty result and a non-zero side effect passed on the empty result
+/// alone -- **83 scenarios** in the corpus, each green while the write it exists
+/// to test went unchecked. `DELETE nodes.key` was found deleting nothing that
+/// way (#888).
+///
+/// Only nodes and relationships. `+properties` and `+labels` count *writes
+/// performed*, not the net change: a `SET` overwriting an existing property is
+/// `+properties 1` with a delta of zero, so a before/after count would fail a
+/// correct engine. Those stay unchecked.
+///
+/// Skipped when the scenario has a control query, since the write then happened
+/// before this snapshot and the snapshot spans the control query instead.
+fn side_effect_mismatch(
+    s: &Scenario,
+    before: (i64, i64),
+    store: &GraphStore,
+) -> Option<String> {
+    let (pn, mn, pr, mr) = s.side_effects?;
+    if s.control_query.is_some() {
+        return None;
+    }
+    let (want_nodes, want_rels) = (pn - mn, pr - mr);
+    let got_nodes = store.node_count() as i64 - before.0;
+    let got_rels = store.edge_count() as i64 - before.1;
+    if got_nodes == want_nodes && got_rels == want_rels {
+        return None;
+    }
+    Some(format!(
+        "side effects: nodes {got_nodes:+} want {want_nodes:+}, relationships {got_rels:+} want {want_rels:+}"
+    ))
 }
 
 fn run_scenario(s: &Scenario) -> (Outcome, String) {
@@ -1105,6 +1201,10 @@ fn run_scenario(s: &Scenario) -> (Outcome, String) {
             .any(|k| u.contains(k))
     };
 
+    // Node and relationship counts either side of the query, so a declared side
+    // effect is checked rather than parsed and discarded (#888).
+    let before_counts = (store.node_count() as i64, store.edge_count() as i64);
+
     let batch = if is_write {
         let mut m = MutQueryExecutor::new(&mut store, "default".to_string());
         m.execute(&parsed)
@@ -1128,10 +1228,12 @@ fn run_scenario(s: &Scenario) -> (Outcome, String) {
             format!("expected {kind}, query succeeded with {} rows", batch.records.len()),
         ),
         Expect::Empty => {
-            if batch.records.is_empty() {
-                (Outcome::Pass, String::new())
-            } else {
+            if !batch.records.is_empty() {
                 (Outcome::WrongResult, format!("expected empty, got {} rows", batch.records.len()))
+            } else if let Some(why) = side_effect_mismatch(s, before_counts, &store) {
+                (Outcome::WrongResult, why)
+            } else {
+                (Outcome::Pass, String::new())
             }
         }
         Expect::Rows { header, rows: _, ordered: _, list_order_insensitive } => {

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -13157,6 +13157,20 @@ impl MergeOperator {
     /// nodes with the same labels and properties already exist -- openCypher's documented
     /// behaviour, and the reason the idiomatic way to add an edge between existing nodes is
     /// to bind them first (`MATCH (a),(b) MERGE (a)-[:R]->(b)`), which reuses them.
+    /// The node a MERGE pattern variable is already bound to, if any.
+    ///
+    /// A variable that the incoming row already binds is **not** a search: it
+    /// names one node, and MERGE neither looks for another nor makes one. Both
+    /// merge paths ignored the row entirely, so
+    /// `CREATE (a) WITH a MERGE (x) MERGE (y) MERGE (x)-[:T]->(y)` re-created
+    /// `x` and `y` and left three nodes where the pattern named one (#893).
+    fn bound_node(record: &Record, variable: Option<&String>) -> Option<NodeId> {
+        match record.get(variable?) {
+            Some(Value::NodeRef(id)) | Some(Value::Node(id, _)) => Some(*id),
+            _ => None,
+        }
+    }
+
     fn merge_path(
         &self,
         path: &crate::query::ast::PathPattern,
@@ -13216,8 +13230,19 @@ impl MergeOperator {
             )?);
         }
 
+        // A variable the row already binds is the whole candidate set for its
+        // position -- one node, decided before the search rather than by it.
+        let bound: Vec<Option<NodeId>> = pattern_nodes
+            .iter()
+            .map(|np| Self::bound_node(&base, np.variable.as_ref()))
+            .collect();
+
         let mut candidates: Vec<Vec<NodeId>> = Vec::with_capacity(pattern_nodes.len());
         for (i, np) in pattern_nodes.iter().enumerate() {
+            if let Some(id) = bound[i] {
+                candidates.push(vec![id]);
+                continue;
+            }
             let mut ids = Vec::new();
             match np.labels.first() {
                 Some(first_label) => {
@@ -13269,6 +13294,12 @@ impl MergeOperator {
         // Create the entire pattern.
         let mut created: Vec<NodeId> = Vec::with_capacity(pattern_nodes.len());
         for (i, np) in pattern_nodes.iter().enumerate() {
+            // A bound variable is reused, never re-created: creating the whole
+            // pattern means creating the parts of it that do not exist yet.
+            if let Some(id) = bound[i] {
+                created.push(id);
+                continue;
+            }
             // `MERGE ({...})` has no labels, and defaulting to "Node" gave the
             // node a label the query never wrote (#625).
             let node_id = store.create_node_with_labels(np.labels.iter().cloned());
@@ -13458,15 +13489,17 @@ impl PhysicalOperator for MergeOperator {
         // Through `Self::node_matches` rather than a third copy of the same
         // comparison: this was the second, and it drifted from the first by
         // exactly this gap.
-        let mut matched_node_id = None;
-        let candidates: Vec<&crate::graph::Node> = match labels.first() {
-            Some(first_label) => store.get_nodes_by_label(first_label),
-            None => store.all_nodes(),
-        };
-        for node in candidates {
-            if Self::node_matches(node, labels, props) {
-                matched_node_id = Some(node.id);
-                break;
+        let mut matched_node_id = Self::bound_node(&base, start.variable.as_ref());
+        if matched_node_id.is_none() {
+            let candidates: Vec<&crate::graph::Node> = match labels.first() {
+                Some(first_label) => store.get_nodes_by_label(first_label),
+                None => store.all_nodes(),
+            };
+            for node in candidates {
+                if Self::node_matches(node, labels, props) {
+                    matched_node_id = Some(node.id);
+                    break;
+                }
             }
         }
 

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -12396,13 +12396,46 @@ impl PhysicalOperator for SkipOperator {
 /// Delete operator: DELETE n or DETACH DELETE n
 pub struct DeleteOperator {
     input: OperatorBox,
-    variables: Vec<String>,
+    /// The expressions written after `DELETE`, not the names among them.
+    ///
+    /// This held `Vec<String>` and the planner filtered the clause down to
+    /// `Expression::Variable`, so every other way of naming an entity --
+    /// a map field, a list element, a path -- was dropped on the floor and
+    /// the delete silently did nothing (#891).
+    targets: Vec<Expression>,
     detach: bool,
 }
 
 impl DeleteOperator {
-    pub fn new(input: OperatorBox, variables: Vec<String>, detach: bool) -> Self {
-        Self { input, variables, detach }
+    pub fn new(input: OperatorBox, targets: Vec<Expression>, detach: bool) -> Self {
+        Self { input, targets, detach }
+    }
+
+    /// Entities reachable from a `DELETE` target, in the order they are found.
+    ///
+    /// A path or a list is a container of entities, and Cypher deletes what is
+    /// inside it. Nested containers recurse; anything that is not an entity is
+    /// ignored here -- `validate_delete_targets` is what refuses those (#887).
+    fn collect_entities(value: &Value, nodes: &mut Vec<crate::graph::types::NodeId>, edges: &mut Vec<crate::graph::types::EdgeId>) {
+        match value {
+            Value::Node(id, _) | Value::NodeRef(id) => nodes.push(*id),
+            Value::Edge(id, _) | Value::EdgeRef(id, ..) => edges.push(*id),
+            Value::Path { nodes: path_nodes, edges: path_edges } => {
+                edges.extend(path_edges.iter().copied());
+                nodes.extend(path_nodes.iter().copied());
+            }
+            Value::List(items) => {
+                for item in items {
+                    Self::collect_entities(item, nodes, edges);
+                }
+            }
+            Value::Map(entries) => {
+                for item in entries.values() {
+                    Self::collect_entities(item, nodes, edges);
+                }
+            }
+            _ => {}
+        }
     }
 }
 
@@ -12417,26 +12450,29 @@ impl PhysicalOperator for DeleteOperator {
 
     fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
         if let Some(record) = self.input.next_mut(store, tenant_id)? {
-            for var in &self.variables {
-                if let Some(val) = record.get(var) {
-                    match val {
-                        Value::NodeRef(id) | Value::Node(id, _) => {
-                            let node_id = *id;
-                            if self.detach {
-                                let out_edges: Vec<_> = store.get_outgoing_edges(node_id).iter().map(|e| e.id).collect();
-                                let in_edges: Vec<_> = store.get_incoming_edges(node_id).iter().map(|e| e.id).collect();
-                                for eid in out_edges.into_iter().chain(in_edges) {
-                                    let _ = store.delete_edge(eid);
-                                }
-                            }
-                            let _ = store.delete_node(tenant_id, node_id);
-                        }
-                        Value::EdgeRef(id, ..) | Value::Edge(id, _) => {
-                            let _ = store.delete_edge(*id);
-                        }
-                        _ => {}
+            let mut nodes: Vec<crate::graph::types::NodeId> = Vec::new();
+            let mut edges: Vec<crate::graph::types::EdgeId> = Vec::new();
+            for target in &self.targets {
+                // An unresolvable target is not a silent no-op here: it means
+                // the row never bound what the query named, and deleting the
+                // rest of the row while ignoring that is how #887 hid.
+                let value = eval_expression(target, &record, store)?;
+                Self::collect_entities(&value, &mut nodes, &mut edges);
+            }
+            // Edges first: deleting a node may take its edges with it, and an
+            // edge id that has already gone is not an error worth reporting.
+            for edge_id in edges {
+                let _ = store.delete_edge(edge_id);
+            }
+            for node_id in nodes {
+                if self.detach {
+                    let out_edges: Vec<_> = store.get_outgoing_edges(node_id).iter().map(|e| e.id).collect();
+                    let in_edges: Vec<_> = store.get_incoming_edges(node_id).iter().map(|e| e.id).collect();
+                    for eid in out_edges.into_iter().chain(in_edges) {
+                        let _ = store.delete_edge(eid);
                     }
                 }
+                let _ = store.delete_node(tenant_id, node_id);
             }
             Ok(Some(record))
         } else {
@@ -12453,7 +12489,16 @@ impl PhysicalOperator for DeleteOperator {
     }
 
     fn describe(&self) -> OperatorDescription {
-        let vars = self.variables.join(", ");
+        let vars = self
+            .targets
+            .iter()
+            .map(|t| match t {
+                Expression::Variable(v) | Expression::PathVariable(v) => v.clone(),
+                Expression::Property { variable, property } => format!("{}.{}", variable, property),
+                other => format!("{:?}", other),
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
         OperatorDescription {
             name: if self.detach { "DetachDelete" } else { "Delete" }.to_string(),
             details: vars,

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -13147,9 +13147,16 @@ impl MergeOperator {
             pattern_rels.push((a, b, edge_type, props, segment.edge.variable.clone()));
         }
 
-        // Candidate node ids per pattern position. A pattern node with no label has no
-        // cheap candidate set, so it cannot participate in a match and the pattern is
-        // treated as absent (i.e. created).
+        // Candidate node ids per pattern position.
+        //
+        // An unlabelled pattern node used to yield an **empty** candidate set,
+        // so the pattern was treated as absent and created. That made
+        // `MERGE (a)` add a node to a graph that already had one -- the most
+        // basic MERGE there is, matching nothing and creating always (#889).
+        //
+        // A node with no label is a full scan by definition; there is no index
+        // to narrow it, and every engine pays that for an unlabelled MERGE. The
+        // shortcut bought a scan and sold the semantics.
         //
         // Resolved once per pattern node, before the search, because the same
         // values decide both what is matched and what would be created.
@@ -13167,10 +13174,19 @@ impl MergeOperator {
         let mut candidates: Vec<Vec<NodeId>> = Vec::with_capacity(pattern_nodes.len());
         for (i, np) in pattern_nodes.iter().enumerate() {
             let mut ids = Vec::new();
-            if let Some(first_label) = np.labels.first() {
-                for node in store.get_nodes_by_label(first_label) {
-                    if Self::node_matches(node, &np.labels, node_props[i].as_ref()) {
-                        ids.push(node.id);
+            match np.labels.first() {
+                Some(first_label) => {
+                    for node in store.get_nodes_by_label(first_label) {
+                        if Self::node_matches(node, &np.labels, node_props[i].as_ref()) {
+                            ids.push(node.id);
+                        }
+                    }
+                }
+                None => {
+                    for node in store.all_nodes() {
+                        if Self::node_matches(node, &np.labels, node_props[i].as_ref()) {
+                            ids.push(node.id);
+                        }
                     }
                 }
             }
@@ -13383,21 +13399,27 @@ impl PhysicalOperator for MergeOperator {
         )?;
         let props = resolved.as_ref();
 
-        // Search for existing nodes matching labels + properties
+        // Search for an existing node matching the labels and properties.
+        //
+        // An **unlabelled** pattern searched nothing at all, so `MERGE (a)`
+        // added a node to a graph that already had one, and `MERGE (a {p: 1})`
+        // added a second alongside the node it should have matched. The most
+        // basic MERGE there is, matching never and creating always (#889).
+        //
+        // A node with no label is a full scan by definition -- there is no
+        // index to narrow it, and every engine pays that for an unlabelled
+        // MERGE. The shortcut bought a scan and sold the semantics.
+        //
+        // Through `Self::node_matches` rather than a third copy of the same
+        // comparison: this was the second, and it drifted from the first by
+        // exactly this gap.
         let mut matched_node_id = None;
-        if let Some(first_label) = labels.first() {
-            let candidates = store.get_nodes_by_label(first_label);
-            for node in candidates {
-                let has_all_labels = labels.iter().all(|l| node.labels.contains(l));
-                if !has_all_labels { continue; }
-
-                if let Some(required_props) = props {
-                    let props_match = required_props.iter().all(|(k, v)| {
-                        node.properties.get(k).map_or(false, |pv| pv == v)
-                    });
-                    if !props_match { continue; }
-                }
-
+        let candidates: Vec<&crate::graph::Node> = match labels.first() {
+            Some(first_label) => store.get_nodes_by_label(first_label),
+            None => store.all_nodes(),
+        };
+        for node in candidates {
+            if Self::node_matches(node, labels, props) {
                 matched_node_id = Some(node.id);
                 break;
             }

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2183,10 +2183,11 @@ impl QueryPlanner {
 
         // Handle DELETE clause
         let is_write = if let Some(delete_clause) = &query.delete_clause {
-            let vars: Vec<String> = delete_clause.expressions.iter().filter_map(|e| {
-                if let Expression::Variable(v) = e { Some(v.clone()) } else { None }
-            }).collect();
-            operator = Box::new(DeleteOperator::new(operator, vars, delete_clause.detach));
+            operator = Box::new(DeleteOperator::new(
+                operator,
+                delete_clause.expressions.clone(),
+                delete_clause.detach,
+            ));
             true
         } else {
             is_write
@@ -5664,15 +5665,7 @@ impl QueryPlanner {
                     }
                 }
                 Clause::Delete(dc) => {
-                    let vars: Vec<String> = dc
-                        .expressions
-                        .iter()
-                        .filter_map(|e| match e {
-                            Expression::Variable(v) => Some(v.clone()),
-                            _ => None,
-                        })
-                        .collect();
-                    operator = Box::new(DeleteOperator::new(operator, vars, dc.detach));
+                    operator = Box::new(DeleteOperator::new(operator, dc.expressions.clone(), dc.detach));
                 }
                 Clause::Where(w) => {
                     operator = Box::new(FilterOperator::new(operator, w.predicate.clone()));

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2340,7 +2340,27 @@ impl QueryPlanner {
             // `UNWIND [...] AS i MERGE (:A {id: i})-[:R]->(:B {id: i})`
             // silently created no nodes and no edges. That case is a
             // whole-pattern merge, which `MergeOperator` already does (#642).
-            if !edges_to_merge.is_empty() && !query.match_clauses.is_empty() {
+            // `MatchMergeEdgeOperator` wires an edge between endpoints that are
+            // **already bound** -- that is its whole contract, and it is better
+            // at that job than the general path: it binds the relationship
+            // variable, matches an undirected pattern both ways, and runs
+            // ON CREATE / ON MATCH against the relationship.
+            //
+            // The guard was `a MATCH exists`, not `the endpoints are bound`, so
+            // `MATCH (a:A) MERGE (a)-[:T]->(b:B)` -- where `b` is bound by
+            // nothing -- wired an edge between one endpoint and no other, and
+            // the whole MERGE became a silent no-op returning zero rows (#894).
+            let bound_by_match = {
+                let mut scope: Vec<String> = Vec::new();
+                crate::query::star::bind_match(&mut scope, &query.match_clauses);
+                scope
+            };
+            let all_endpoints_bound = edges_to_merge
+                .iter()
+                .all(|(src, tgt, ..)| {
+                    bound_by_match.iter().any(|v| v == src) && bound_by_match.iter().any(|v| v == tgt)
+                });
+            if !edges_to_merge.is_empty() && all_endpoints_bound {
                 // Edge MERGE: use MatchMergeEdgeOperator
                 use crate::query::executor::operator::MatchMergeEdgeOperator;
                 // `ON CREATE SET n = {…}` / `n += {…}` (#874).

--- a/src/query/star.rs
+++ b/src/query/star.rs
@@ -17,7 +17,8 @@
 //! expect. Deduplicated, because `MATCH (a)-->(b), (b)-->(c)` binds `b` twice.
 
 use crate::query::ast::{
-    Expression, MatchClause, Query, ReturnItem, UnwindClause, WithClause, STAR_ITEM,
+    Clause, Expression, MatchClause, Pattern, Query, ReturnItem, UnwindClause, WithClause,
+    STAR_ITEM,
 };
 
 /// Whether an item is the `*` sentinel.
@@ -43,7 +44,7 @@ fn push_unique(scope: &mut Vec<String>, name: &str) {
 /// Edge variables count: `MATCH (a)-[r]->(b) RETURN *` returns `r` too. Missing
 /// them is the easy mistake here, and it is invisible until a scenario returns
 /// two columns instead of three.
-fn bind_match(scope: &mut Vec<String>, clauses: &[MatchClause]) {
+pub(crate) fn bind_match(scope: &mut Vec<String>, clauses: &[MatchClause]) {
     for mc in clauses {
         for path in &mc.pattern.paths {
             if let Some(v) = &path.path_variable {
@@ -130,11 +131,78 @@ fn expand_into(items: &mut Vec<ReturnItem>, scope: &[String]) {
     *items = out;
 }
 
+/// Every variable a pattern binds, in written order.
+///
+/// `CREATE` and `MERGE` bind exactly like `MATCH` does, so this is the one
+/// implementation all three use.
+fn bind_pattern(scope: &mut Vec<String>, pattern: &Pattern) {
+    for path in &pattern.paths {
+        if let Some(v) = &path.path_variable {
+            push_unique(scope, v);
+        }
+        if let Some(v) = &path.start.variable {
+            push_unique(scope, v);
+        }
+        for seg in &path.segments {
+            if let Some(v) = &seg.edge.variable {
+                push_unique(scope, v);
+            }
+            if let Some(v) = &seg.node.variable {
+                push_unique(scope, v);
+            }
+        }
+    }
+}
+
+/// Expand the stars in a clause-pipeline query.
+///
+/// `Query` has two shapes -- the by-kind fields and this pipeline -- and this
+/// pass only ever walked the first. In the pipeline a `WITH *` kept a literal
+/// variable named `*`, so it projected nothing, every binding was dropped, and
+/// a later clause naming one of them treated it as new:
+///
+/// ```cypher
+/// CREATE (a) WITH * CREATE (b) CREATE (a)<-[:T]-(b)   -- created three nodes
+/// ```
+///
+/// The star is the reason to walk in order: scope is what has been bound so
+/// far, and a `WITH` replaces it (#892).
+fn expand_stars_pipeline(clauses: &mut [Clause]) {
+    let mut scope: Vec<String> = Vec::new();
+    for clause in clauses.iter_mut() {
+        match clause {
+            Clause::Match(mc) => bind_match(&mut scope, std::slice::from_ref(mc)),
+            Clause::Create(cc) => bind_pattern(&mut scope, &cc.pattern),
+            Clause::Merge(mc) => bind_pattern(&mut scope, &mc.pattern),
+            Clause::Foreach(_) => {
+                // FOREACH binds only inside its own body.
+            }
+            Clause::Unwind(u) => push_unique(&mut scope, &u.variable),
+            Clause::Call(call) => {
+                for item in &call.yield_items {
+                    push_unique(&mut scope, item.alias.as_ref().unwrap_or(&item.name));
+                }
+            }
+            Clause::With(wc) => {
+                expand_into(&mut wc.items, &scope);
+                scope = with_output(&wc.items);
+            }
+            Clause::Return(rc) => expand_into(&mut rc.items, &scope),
+            Clause::Where(_) | Clause::Set(_) | Clause::Remove(_) | Clause::Delete(_) => {}
+        }
+    }
+}
+
 /// Expand every `*` in `query`, in place.
 ///
 /// Walks the query in execution order so that each star sees the scope that
 /// actually reaches it, including through `WITH` stages that narrow it.
 pub fn expand_stars(query: &mut Query) {
+    if query.needs_clause_pipeline {
+        expand_stars_pipeline(&mut query.clauses);
+        return;
+    }
+
     let mut scope: Vec<String> = Vec::new();
 
     // Only the matches *before* the first WITH are in scope when that WITH is
@@ -152,19 +220,7 @@ pub fn expand_stars(query: &mut Query) {
     }
     if let Some(create) = &query.create_clause {
         // `CREATE (n) RETURN *` returns the created node.
-        for path in &create.pattern.paths {
-            if let Some(v) = &path.start.variable {
-                push_unique(&mut scope, v);
-            }
-            for seg in &path.segments {
-                if let Some(v) = &seg.edge.variable {
-                    push_unique(&mut scope, v);
-                }
-                if let Some(v) = &seg.node.variable {
-                    push_unique(&mut scope, v);
-                }
-            }
-        }
+        bind_pattern(&mut scope, &create.pattern);
     }
 
     // A WITH narrows scope to what it projects, so its own `*` is expanded

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -52,6 +52,8 @@ pub enum ValidationError {
     SizeOfNonCollection(&'static str),
     /// A bare pattern used where a value is expected (#880).
     PatternInProjection(&'static str),
+    /// `DELETE` applied to something that is not an entity (#887).
+    InvalidDeleteTarget(String),
     /// An ORDER BY naming something the projection did not keep.
     OrderByUndefinedVariable(String),
     /// An ORDER BY item that mixes an aggregate with a grouping expression.
@@ -118,6 +120,10 @@ impl std::fmt::Display for ValidationError {
                 f,
                 "a pattern is a predicate, not a value; it cannot be projected by {where_}. \
                  Use `EXISTS {{ ... }}` for a boolean, or a pattern comprehension for a list"
+            ),
+            Self::InvalidDeleteTarget(what) => write!(
+                f,
+                "DELETE takes a node, relationship or path; {what}"
             ),
             Self::VariableTypeConflict(name) => write!(
                 f,
@@ -1388,7 +1394,124 @@ fn validate_pattern_projections(query: &Query) -> Result<(), ValidationError> {
     Ok(())
 }
 
+/// `DELETE` takes a node, a relationship or a path (#887).
+///
+/// ```text
+/// MATCH (n) DELETE n:Person     -- a boolean predicate
+/// MATCH (a) DELETE x            -- nothing named x
+/// MATCH () DELETE 1 + 1         -- a number
+/// MATCH (n) DELETE n.prop       -- a property, not the node
+/// ```
+///
+/// All four ran and deleted nothing, reporting success. Deleting nothing is a
+/// legitimate outcome — `MATCH (n:Nope) DELETE n` deletes nothing too — so a
+/// caller cannot tell "there was nothing to delete" from "I did not understand
+/// what you asked me to delete".
+///
+/// Only the shapes that **cannot** be an entity are refused: a literal,
+/// arithmetic, a property access, a label predicate (`n:Label` parses to
+/// `hasLabels`), and a variable nothing binds. A function call is left alone,
+/// because Cypher does allow an expression that resolves to an entity and
+/// deciding that statically is a different job — over-rejecting a valid
+/// `DELETE` is much worse than under-rejecting an invalid one.
+fn validate_delete_targets(query: &Query) -> Result<(), ValidationError> {
+    use crate::query::ast::Clause;
+
+    /// Names anything in the query binds, from either AST representation.
+    fn bound_names(query: &Query) -> HashSet<String> {
+        let mut out = HashSet::new();
+        let mut note = |p: &crate::query::ast::Pattern| pattern_vars(p, &mut out);
+        for mc in &query.match_clauses {
+            note(&mc.pattern);
+        }
+        if let Some(cc) = &query.create_clause {
+            note(&cc.pattern);
+        }
+        if let Some(mc) = &query.merge_clause {
+            note(&mc.pattern);
+        }
+        if let Some(u) = &query.unwind_clause {
+            out.insert(u.variable.clone());
+        }
+        for u in &query.extra_unwind_clauses {
+            out.insert(u.variable.clone());
+        }
+        for u in &query.post_with_unwind_clauses {
+            out.insert(u.variable.clone());
+        }
+        if let Some(wc) = &query.with_clause {
+            out.extend(projected_names(&wc.items));
+        }
+        for (wc, uw, mcs, _) in &query.extra_with_stages {
+            out.extend(projected_names(&wc.items));
+            if let Some(u) = uw {
+                out.insert(u.variable.clone());
+            }
+            for mc in mcs {
+                pattern_vars(&mc.pattern, &mut out);
+            }
+        }
+        for clause in &query.clauses {
+            match clause {
+                Clause::Match(mc) => pattern_vars(&mc.pattern, &mut out),
+                Clause::Create(cc) => pattern_vars(&cc.pattern, &mut out),
+                Clause::Merge(mc) => pattern_vars(&mc.pattern, &mut out),
+                Clause::Unwind(u) => {
+                    out.insert(u.variable.clone());
+                }
+                Clause::With(w) => out.extend(projected_names(&w.items)),
+                _ => {}
+            }
+        }
+        out
+    }
+
+    let mut targets: Vec<&Expression> = Vec::new();
+    if let Some(dc) = &query.delete_clause {
+        targets.extend(dc.expressions.iter());
+    }
+    for clause in &query.clauses {
+        if let Clause::Delete(dc) = clause {
+            targets.extend(dc.expressions.iter());
+        }
+    }
+    if targets.is_empty() {
+        return Ok(());
+    }
+
+    let bound = bound_names(query);
+    for expr in targets {
+        let complaint = match expr {
+            Expression::Variable(v) if !bound.contains(v) => {
+                Some(format!("nothing in this query binds `{v}`"))
+            }
+            Expression::Variable(_) => None,
+            Expression::Literal(_) => Some("a literal is not one".to_string()),
+            Expression::Binary { .. } | Expression::Unary { .. } => {
+                Some("an arithmetic or boolean expression is not one".to_string())
+            }
+            // **Not** a property access. `WITH {key: u} AS nodes DELETE nodes.key`
+            // is valid Cypher -- a map field can hold an entity -- and
+            // rejecting it cost two scenarios that had been passing. Whether a
+            // property access yields an entity is a runtime question, and
+            // guessing it statically is the over-rejection this check is
+            // scoped to avoid.
+            // `n:Label` parses to a `hasLabels` call, and is a *predicate*.
+            Expression::Function { name, .. } if name.eq_ignore_ascii_case("hasLabels") => {
+                Some("`n:Label` is a label test; use REMOVE to drop a label".to_string())
+            }
+            _ => None,
+        };
+        if let Some(what) = complaint {
+            return Err(ValidationError::InvalidDeleteTarget(what));
+        }
+    }
+    Ok(())
+}
+
 pub fn validate(query: &Query) -> Result<(), ValidationError> {
+    validate_delete_targets(query)?;
+
     validate_pattern_projections(query)?;
 
     validate_size_arguments(query)?;

--- a/tests/delete_targets.rs
+++ b/tests/delete_targets.rs
@@ -87,3 +87,45 @@ fn a_map_field_may_be_deleted() {
 fn a_function_call_is_not_refused() {
     assert!(!refused("MATCH p = ()-->() DELETE head(nodes(p))"));
 }
+
+fn store_with(setup: &str) -> GraphStore {
+    let mut store = GraphStore::new();
+    run(&mut store, setup);
+    store
+}
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` parses: {e:?}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` runs: {e:?}"));
+}
+
+fn count(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).expect("count query parses");
+    QueryExecutor::new(store)
+        .execute(&q)
+        .expect("count query runs")
+        .records
+        .len()
+}
+
+/// A path is a container of entities, and `DELETE p` deletes what is in it.
+///
+/// This deleted nothing: the planner kept only `Expression::Variable` targets,
+/// and a path variable is `Expression::PathVariable` (#891).
+#[test]
+fn a_path_may_be_deleted() {
+    let mut store = store_with("CREATE (:A)-[:R]->(:B)");
+    run(&mut store, "MATCH p = (:A)-[:R]->(:B) DETACH DELETE p");
+    assert_eq!(count(&store, "MATCH (n) RETURN n"), 0, "the path's nodes should be gone");
+    assert_eq!(count(&store, "MATCH ()-[r]->() RETURN r"), 0, "its relationship should be gone");
+}
+
+/// A list element names an entity the same way a variable does.
+#[test]
+fn a_list_element_may_be_deleted() {
+    let mut store = store_with("CREATE (:User), (:User)");
+    run(&mut store, "MATCH (u:User) WITH collect(u) AS users DELETE users[0]");
+    assert_eq!(count(&store, "MATCH (n) RETURN n"), 1, "exactly one user should be gone");
+}

--- a/tests/delete_targets.rs
+++ b/tests/delete_targets.rs
@@ -1,0 +1,89 @@
+//! `DELETE` takes a node, a relationship or a path (#887).
+//!
+//! ```cypher
+//! MATCH (n) DELETE n:Person     -- a label test
+//! MATCH (a) DELETE x            -- nothing named x
+//! MATCH () DELETE 1 + 1         -- a number
+//! ```
+//!
+//! All three ran and deleted nothing, reporting success. **Deleting nothing is
+//! a legitimate outcome** — `MATCH (n:Nope) DELETE n` deletes nothing too — so
+//! a caller could not tell "there was nothing to delete" from "I did not
+//! understand what you asked me to delete".
+//!
+//! The scoping is most of this file. Only shapes that *cannot* be an entity are
+//! refused; a function call and a **property access** are left alone, because
+//! Cypher allows an expression that resolves to an entity.
+//!
+//! I found the property boundary the expensive way: rejecting property access
+//! cost two passing scenarios, because `WITH {key: u} AS nodes DELETE nodes.key`
+//! is valid — a map field can hold an entity. [`a_map_field_may_be_deleted`]
+//! is that lesson, kept.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+fn refused(cypher: &str) -> bool {
+    parse_query(cypher).is_err()
+}
+
+/// The four the TCK names.
+#[test]
+fn delete_refuses_what_cannot_be_an_entity() {
+    assert!(refused("MATCH (n) DELETE n:Person"), "a label test");
+    assert!(refused("MATCH ()-[r:T]-() DELETE r:T"), "a relationship-type test");
+    assert!(refused("MATCH (a) DELETE x"), "an unbound name");
+    assert!(refused("MATCH () DELETE 1 + 1"), "arithmetic");
+    assert!(refused("MATCH () DELETE 42"), "a literal");
+    assert!(refused("MATCH () DELETE 'a'"), "a string literal");
+}
+
+/// The ordinary forms still work, on every kind of entity.
+#[test]
+fn the_ordinary_forms_are_untouched() {
+    for cypher in [
+        "MATCH (n) DELETE n",
+        "MATCH (n) DETACH DELETE n",
+        "MATCH ()-[r]->() DELETE r",
+        "MATCH p = ()-->() DELETE p",
+        "MATCH (a), (b) DELETE a, b",
+        "MATCH (n) WITH n DELETE n",
+        "UNWIND [1] AS i MATCH (n) DELETE n",
+    ] {
+        assert!(!refused(cypher), "refused `{cypher}`");
+    }
+}
+
+/// **A map field may hold an entity**, so a property access is not refused —
+/// and it really deletes.
+#[test]
+fn a_map_field_may_be_deleted() {
+    let cypher = "MATCH (u:User) WITH {key: u} AS nodes DELETE nodes.key";
+    assert!(!refused(cypher));
+
+    let mut store = GraphStore::new();
+    for setup in ["CREATE (:User), (:User)"] {
+        let q = parse_query(setup).expect("setup parses");
+        MutQueryExecutor::new(&mut store, "default".to_string())
+            .execute(&q)
+            .expect("setup runs");
+    }
+    let q = parse_query(cypher).expect("parses");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("runs");
+    let count = parse_query("MATCH (n) RETURN n")
+        .ok()
+        .and_then(|p| QueryExecutor::new(&store).execute(&p).ok())
+        .map(|b| b.records.len())
+        .expect("count runs");
+    assert_eq!(count, 0, "both users should be gone");
+}
+
+/// A function call is left alone too — statically deciding whether it yields an
+/// entity is a different job.
+#[test]
+fn a_function_call_is_not_refused() {
+    assert!(!refused("MATCH p = ()-->() DELETE head(nodes(p))"));
+}

--- a/tests/merge_bound_variables.rs
+++ b/tests/merge_bound_variables.rs
@@ -1,0 +1,101 @@
+//! MERGE does not re-create a variable the row already bound (#893).
+//!
+//! ```cypher
+//! CREATE (a) WITH a MERGE (x) MERGE (y) MERGE (x)-[:T]->(y)
+//! ```
+//!
+//! left **three** nodes where the pattern names one. `MERGE (x)` and
+//! `MERGE (y)` each matched the existing node and bound it, and then
+//! `MERGE (x)-[:T]->(y)` searched the store from scratch: the candidate sets
+//! were built from labels and properties alone, so the row's own bindings —
+//! the one thing that decides the answer here — were never consulted.
+//!
+//! A bound variable is not a search. It names one node, and MERGE neither
+//! looks for another nor makes one.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` parses: {e:?}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` runs: {e:?}"));
+}
+
+fn count(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).expect("count query parses");
+    QueryExecutor::new(store)
+        .execute(&q)
+        .expect("count query runs")
+        .records
+        .len()
+}
+
+/// The relationship is created; its endpoints are not.
+#[test]
+fn a_relationship_merge_reuses_its_bound_endpoints() {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (a) WITH a MERGE (x) MERGE (y) MERGE (x)-[:T]->(y)");
+    assert_eq!(count(&store, "MATCH (n) RETURN n"), 1, "the one node the pattern names");
+    assert_eq!(count(&store, "MATCH ()-[r:T]->() RETURN r"), 1, "a self-relationship on it");
+}
+
+/// Only the unbound end is created, and the bound end keeps its identity.
+#[test]
+fn only_the_unbound_end_of_a_pattern_is_created() {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:A {tag: 'first'})");
+    run(&mut store, "MATCH (a:A) MERGE (a)-[:T]->(b:B)");
+    assert_eq!(count(&store, "MATCH (n:A) RETURN n"), 1, "no second A");
+    assert_eq!(count(&store, "MATCH (n:B) RETURN n"), 1, "one new B");
+    assert_eq!(
+        count(&store, "MATCH (a:A {tag: 'first'})-[:T]->(:B) RETURN a"),
+        1,
+        "the relationship hangs off the node that was already there"
+    );
+}
+
+/// An unbound MERGE still searches — the binding shortcut must not disable
+/// matching for everything else.
+#[test]
+fn an_unbound_merge_still_matches_what_exists() {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:X {p: 1})");
+    run(&mut store, "MERGE (n:X {p: 1})");
+    assert_eq!(count(&store, "MATCH (n:X) RETURN n"), 1, "matched, not created");
+}
+
+/// A MERGE whose endpoints are **not** all bound must still run.
+///
+/// The planner chose `MatchMergeEdgeOperator` -- which wires an edge between
+/// endpoints that already exist -- whenever a MATCH appeared anywhere in the
+/// query, rather than when its endpoints were actually bound. With `b` bound
+/// by nothing it wired an edge to no second endpoint, so the whole MERGE was
+/// a silent no-op that returned zero rows (#894).
+#[test]
+fn a_merge_after_a_match_is_not_skipped() {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:A {tag: 'first'})");
+    let q = parse_query("MATCH (a:A) MERGE (a)-[:T]->(b:B) RETURN a, b").expect("parses");
+    let rows = MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("runs")
+        .records
+        .len();
+    assert_eq!(rows, 1, "the MERGE produces the row its MATCH fed it");
+    assert_eq!(count(&store, "MATCH ()-[r:T]->() RETURN r"), 1);
+}
+
+/// With no endpoint bound, the whole pattern is created -- including a second
+/// `:A`, because the pattern as written does not exist.
+#[test]
+fn an_entirely_unbound_pattern_is_created_whole() {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:A)");
+    run(&mut store, "MATCH (x:A) MERGE (c:C)-[:T]->(b:B)");
+    assert_eq!(count(&store, "MATCH (n:C) RETURN n"), 1);
+    assert_eq!(count(&store, "MATCH (n:B) RETURN n"), 1);
+    assert_eq!(count(&store, "MATCH ()-[r:T]->() RETURN r"), 1);
+}

--- a/tests/with_star_scope.rs
+++ b/tests/with_star_scope.rs
@@ -1,0 +1,75 @@
+//! `WITH *` carries scope forward in a clause pipeline too (#892).
+//!
+//! ```cypher
+//! CREATE (a) WITH * CREATE (b) CREATE (a)<-[:T]-(b)   -- created three nodes
+//! ```
+//!
+//! `Query` has two shapes — the by-kind fields and the clause pipeline — and
+//! the star-expansion pass only ever walked the first. In the pipeline the
+//! `*` survived parsing as a variable literally named `*`, so the `WITH`
+//! projected nothing, every binding was dropped, and the later `CREATE (a)`
+//! read `a` as a new node.
+//!
+//! Nothing errored. The query created a node too many and reported success,
+//! which is why the TCK scored it green until the harness started checking
+//! side effects (#888).
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` parses: {e:?}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` runs: {e:?}"));
+}
+
+fn count(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).expect("count query parses");
+    QueryExecutor::new(store)
+        .execute(&q)
+        .expect("count query runs")
+        .records
+        .len()
+}
+
+/// The star and the explicit list must agree — that equality is the assertion,
+/// not the number 2 on its own.
+#[test]
+fn a_star_projects_what_naming_the_variable_would() {
+    for cypher in [
+        "CREATE (a) WITH a CREATE (b) CREATE (a)<-[:T]-(b)",
+        "CREATE (a) WITH * CREATE (b) CREATE (a)<-[:T]-(b)",
+        "CREATE (a) WITH a WITH * CREATE (b) CREATE (a)<-[:T]-(b)",
+        "CREATE (a) WITH * WITH * CREATE (b) CREATE (a)<-[:T]-(b)",
+    ] {
+        let mut store = GraphStore::new();
+        run(&mut store, cypher);
+        assert_eq!(count(&store, "MATCH (n) RETURN n"), 2, "nodes after `{cypher}`");
+        assert_eq!(count(&store, "MATCH ()-[r]->() RETURN r"), 1, "rels after `{cypher}`");
+    }
+}
+
+/// A `WITH` that narrows still narrows: the star is scope, not "everything
+/// ever bound".
+#[test]
+fn a_later_with_narrows_the_scope_a_star_sees() {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:X {n: 1}), (:Y {n: 2})");
+    let q = parse_query("MATCH (x:X), (y:Y) WITH x WITH * RETURN *").expect("parses");
+    let batch = QueryExecutor::new(&store).execute(&q).expect("runs");
+    assert_eq!(batch.columns, vec!["x".to_string()], "only x survives the narrowing WITH");
+}
+
+/// UNWIND and MATCH bind into the pipeline's scope as well.
+#[test]
+fn unwind_and_match_enter_the_scope_a_star_sees() {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:X)");
+    let q = parse_query("MATCH (x:X) UNWIND [1] AS i WITH * RETURN *").expect("parses");
+    let batch = QueryExecutor::new(&store).execute(&q).expect("runs");
+    let mut columns = batch.columns.clone();
+    columns.sort();
+    assert_eq!(columns, vec!["i".to_string(), "x".to_string()]);
+}


### PR DESCRIPTION
Closes #887, #888 and #890. Three changes, in the order they were found — **each one uncovered the next**.

## 1. `DELETE` accepted things that cannot be deleted

```cypher
MATCH (n) DELETE n:Person     -- a label test (parses to `hasLabels`)
MATCH (a) DELETE x            -- nothing named x
MATCH () DELETE 1 + 1         -- a number
```

All ran and deleted nothing, reporting success. **Deleting nothing is a legitimate outcome** — `MATCH (n:Nope) DELETE n` deletes nothing too — so no caller could tell *"there was nothing to delete"* from *"I did not understand what you asked me to delete"*.

Only shapes that **cannot** be an entity are refused. A function call and a **property access** are left alone, because Cypher allows an expression that resolves to one. I found that boundary the expensive way: rejecting property access cost two passing scenarios, since `WITH {key: u} AS nodes DELETE nodes.key` is valid — a map field holding a node.

## 2. Chasing that revealed the harness never checked side effects

A test I wrote asserted the nodes were actually gone. They were not — while the TCK scored the scenario green.

`And the side effects should be:` was parsed and **discarded**, so a scenario with both a weak result assertion and a strong side-effect assertion was scored on the result alone. **83 scenarios** pair `the result should be empty` with a non-zero side effect; every one could pass while doing nothing.

Node and relationship deltas are now compared, and **13 scenarios flipped to failing, all real**: deleting from a map, list or nested structure deletes nothing; detach-deleting paths deletes nothing; `MERGE (a)` creates instead of matching; `Create3` creates the wrong count. Two were spot-checked by hand rather than trusted.

**TCK 3,669 → 3,656.** Nothing regressed — the ruler got honest, the same shape as #756's outline expansion, which dropped the rate from 87% to 56% and was progress. The CI floor moves as a documented re-baseline.

## 3. And that named the biggest one: `MERGE (a)` never matched

```cypher
// graph already contains one node
MERGE (a)          -- left two nodes
MERGE (a {p: 1})   -- left two, beside the node it should have matched
```

Both merge paths began with `if let Some(first_label) = labels.first()`, so an unlabelled pattern had no candidate set, was judged absent, and was created. One said so outright: *"a pattern node with no label … is treated as absent (i.e. created)"*. A node with no label is a full scan **by definition**; the shortcut bought a scan and sold the semantics.

The single-node path also carried its own inlined comparison instead of calling `node_matches`, and had drifted from the shared one by exactly this gap.

`Merge3` scenario 1 was **passing** before, because its only real assertion is `+labels 1`.

## Net

**3,669 → 3,658**, with 13 previously-invisible defects now visible and 2 of them fixed. `+properties` and `+labels` stay unchecked and documented: they count *writes performed*, not the net change, so a before/after delta would fail a correct engine.