### PR TITLE
An undefined variable is refused, not answered with silence (#895)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         # expansion in #756: the ruler got honest and the count fell.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3673
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3680
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/star.rs
+++ b/src/query/star.rs
@@ -198,8 +198,26 @@ fn expand_stars_pipeline(clauses: &mut [Clause]) {
 /// Walks the query in execution order so that each star sees the scope that
 /// actually reaches it, including through `WITH` stages that narrow it.
 pub fn expand_stars(query: &mut Query) {
-    if query.needs_clause_pipeline {
+    // Both representations, always. The parser fills `clauses` even when the
+    // by-kind fields can express the query, and mirrors the RETURN into
+    // `return_clause` -- so expanding only one left a literal `*` in the other
+    // for whatever reads it next.
+    if !query.clauses.is_empty() {
         expand_stars_pipeline(&mut query.clauses);
+    }
+    if query.needs_clause_pipeline {
+        // The parser mirrors the pipeline's RETURN into `return_clause` before
+        // this pass runs, so expanding one leaves the other holding a literal
+        // `*`. Re-mirrored rather than expanded twice: one of them has to be
+        // the copy, and the pipeline is the original.
+        if let Some(Clause::Return(rc)) = query
+            .clauses
+            .iter()
+            .rev()
+            .find(|c| matches!(c, Clause::Return(_)))
+        {
+            query.return_clause = Some(rc.clone());
+        }
         return;
     }
 

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -56,6 +56,8 @@ pub enum ValidationError {
     InvalidDeleteTarget(String),
     /// An ORDER BY naming something the projection did not keep.
     OrderByUndefinedVariable(String),
+    /// A name used in an expression that nothing in the query binds.
+    UnboundVariable(String),
     /// An ORDER BY item that mixes an aggregate with a grouping expression.
     AmbiguousAggregationExpression,
     /// An ORDER BY that aggregates when the projection does not.
@@ -65,6 +67,10 @@ pub enum ValidationError {
 impl std::fmt::Display for ValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::UnboundVariable(v) => write!(
+                f,
+                "`{v}` is not bound: nothing in this query defines it"
+            ),
             Self::OrderByUndefinedVariable(v) => write!(
                 f,
                 "`{v}` is not available to ORDER BY: the projection aggregates or is \
@@ -1509,7 +1515,358 @@ fn validate_delete_targets(query: &Query) -> Result<(), ValidationError> {
     Ok(())
 }
 
+/// A name used in an expression must be bound by something in the query.
+///
+/// ```text
+/// MATCH () RETURN foo                          -> SyntaxError: UndefinedVariable
+/// MATCH (s) WHERE s.name = undefinedVariable   -> SyntaxError: UndefinedVariable
+/// MERGE (n) ON CREATE SET x.num = 1            -> SyntaxError: UndefinedVariable
+/// ```
+///
+/// Every one of these ran and returned zero rows, or set a property on
+/// nothing, and reported success. A typo in a variable name is the single most
+/// ordinary mistake there is, and the engine answered it with silence.
+///
+/// **Deliberately coarse**: the question asked is "does *anything* in this
+/// query bind this name", not "is it in scope *here*". Real scope analysis
+/// would also catch a name dropped by an intervening `WITH`, but it has to be
+/// exactly right about `WITH`, `FOREACH`, comprehension binders, `CALL …
+/// YIELD` and both `Query` representations before it can be trusted -- and
+/// `validate.rs` opens by naming over-rejection as the worse failure. A false
+/// `SyntaxError` breaks a working query; a missed one leaves today's
+/// behaviour. `validate_order_by_in_scope` already covers the narrowing case
+/// where it is cheap to be certain.
+///
+/// Anything that binds anywhere counts as binding everywhere here, which is
+/// why comprehension variables and `FOREACH` loop variables are collected up
+/// front rather than tracked positionally.
+fn validate_variables_are_bound(query: &Query) -> Result<(), ValidationError> {
+    use crate::query::ast::{Clause, RemoveItem, SetClause};
+
+    let mut bound: HashSet<String> = HashSet::new();
+
+    /// Like `pattern_variables`, plus the path variable.
+    ///
+    /// `pattern_variables` exists to answer "what may a later CREATE not
+    /// redeclare", and a path name is not that. Here it is: `MATCH p = (a)-->(b)
+    /// RETURN p` binds `p`, and borrowing the other collector rejected every
+    /// named-path query in the suite.
+    fn pattern_and_path_variables(
+        pattern: &crate::query::ast::Pattern,
+        out: &mut HashSet<String>,
+    ) {
+        pattern_variables(pattern, out);
+        for path in &pattern.paths {
+            if let Some(v) = &path.path_variable {
+                out.insert(v.clone());
+            }
+        }
+    }
+
+    /// Names any expression *introduces*, at any depth.
+    fn binders(e: &Expression, out: &mut HashSet<String>) {
+        match e {
+            Expression::ListComprehension { variable, .. }
+            | Expression::PredicateFunction { variable, .. } => {
+                out.insert(variable.clone());
+            }
+            Expression::Reduce { accumulator, variable, .. } => {
+                out.insert(accumulator.clone());
+                out.insert(variable.clone());
+            }
+            Expression::PatternComprehension { pattern, .. } => pattern_variables(pattern, out),
+            Expression::ExistsSubquery { pattern, .. } => pattern_variables(pattern, out),
+            _ => {}
+        }
+        for child in child_expressions(e) {
+            binders(child, out);
+        }
+    }
+
+    fn note_set(sc: &SetClause, bound: &mut HashSet<String>) {
+        for item in &sc.items {
+            binders(&item.value, bound);
+        }
+        for item in &sc.entity_items {
+            binders(&item.value, bound);
+        }
+    }
+
+    fn note_clause_binders(query: &Query, bound: &mut HashSet<String>) {
+        for mc in &query.match_clauses {
+            pattern_and_path_variables(&mc.pattern, bound);
+        }
+        if let Some(c) = &query.create_clause {
+            pattern_and_path_variables(&c.pattern, bound);
+        }
+        if let Some(m) = &query.merge_clause {
+            pattern_and_path_variables(&m.pattern, bound);
+        }
+        for u in query
+            .unwind_clause
+            .iter()
+            .chain(query.extra_unwind_clauses.iter())
+            .chain(query.post_with_unwind_clauses.iter())
+        {
+            bound.insert(u.variable.clone());
+            binders(&u.expression, bound);
+        }
+        if let Some(f) = &query.foreach_clause {
+            bound.insert(f.variable.clone());
+            for c in &f.create_clauses {
+                pattern_and_path_variables(&c.pattern, bound);
+            }
+            for sc in &f.set_clauses {
+                note_set(sc, bound);
+            }
+        }
+        if let Some(call) = &query.call_clause {
+            for y in &call.yield_items {
+                bound.insert(y.alias.clone().unwrap_or_else(|| y.name.clone()));
+            }
+        }
+        for c in &query.clauses {
+            match c {
+                Clause::Match(mc) => pattern_and_path_variables(&mc.pattern, bound),
+                Clause::Create(cc) => pattern_and_path_variables(&cc.pattern, bound),
+                Clause::Merge(mc) => pattern_and_path_variables(&mc.pattern, bound),
+                Clause::Unwind(u) => {
+                    bound.insert(u.variable.clone());
+                    binders(&u.expression, bound);
+                }
+                Clause::Foreach(f) => {
+                    bound.insert(f.variable.clone());
+                    for cc in &f.create_clauses {
+                        pattern_and_path_variables(&cc.pattern, bound);
+                    }
+                    for sc in &f.set_clauses {
+                        note_set(sc, bound);
+                    }
+                }
+                Clause::Call(call) => {
+                    for y in &call.yield_items {
+                        bound.insert(y.alias.clone().unwrap_or_else(|| y.name.clone()));
+                    }
+                }
+                Clause::Set(sc) => note_set(sc, bound),
+                _ => {}
+            }
+        }
+        for sc in &query.set_clauses {
+            note_set(sc, bound);
+        }
+    }
+
+    note_clause_binders(query, &mut bound);
+
+    // A `CALL { … }` subquery exports the columns its RETURN names, and binds
+    // everything it binds internally. Recursing rather than duplicating the
+    // walk: a subquery is a `Query`.
+    if let Some(sub) = &query.call_subquery {
+        note_clause_binders(sub, &mut bound);
+        for items in sub
+            .return_clause
+            .iter()
+            .map(|r| &r.items)
+            .chain(sub.with_clause.iter().map(|w| &w.items))
+        {
+            for item in items {
+                if let Some(a) = &item.alias {
+                    bound.insert(a.clone());
+                } else if let Expression::Variable(v) = &item.expression {
+                    bound.insert(v.clone());
+                }
+                binders(&item.expression, &mut bound);
+            }
+        }
+        for c in &sub.clauses {
+            let items = match c {
+                Clause::Return(r) => &r.items,
+                Clause::With(w) => &w.items,
+                _ => continue,
+            };
+            for item in items {
+                if let Some(a) = &item.alias {
+                    bound.insert(a.clone());
+                } else if let Expression::Variable(v) = &item.expression {
+                    bound.insert(v.clone());
+                }
+                binders(&item.expression, &mut bound);
+            }
+        }
+    }
+
+    // Projections bind their aliases -- and a bare `RETURN n` keeps `n`.
+    let mut note_items = |items: &[ReturnItem], bound: &mut HashSet<String>| {
+        for item in items {
+            if let Some(a) = &item.alias {
+                bound.insert(a.clone());
+            }
+            binders(&item.expression, bound);
+        }
+    };
+    if let Some(w) = &query.with_clause {
+        note_items(&w.items, &mut bound);
+    }
+    for (w, u, post_matches, post_where) in &query.extra_with_stages {
+        note_items(&w.items, &mut bound);
+        if let Some(u) = u {
+            bound.insert(u.variable.clone());
+            binders(&u.expression, &mut bound);
+        }
+        // A MATCH written after a WITH binds too. Skipping these rejected
+        // `MATCH (m) WITH m MATCH (a)-->(m) WITH m, count(a) AS cnt RETURN cnt`
+        // -- an ordinary two-stage aggregation, and one the TCK does not
+        // cover but the engine's own suite does.
+        for mc in post_matches {
+            pattern_and_path_variables(&mc.pattern, &mut bound);
+        }
+        if let Some(w) = post_where {
+            binders(&w.predicate, &mut bound);
+        }
+    }
+    if let Some(r) = &query.return_clause {
+        note_items(&r.items, &mut bound);
+    }
+    for c in &query.clauses {
+        match c {
+            Clause::With(w) => note_items(&w.items, &mut bound),
+            Clause::Return(r) => note_items(&r.items, &mut bound),
+            _ => {}
+        }
+    }
+    // Binders inside predicates and inline property expressions count too.
+    for e in all_expressions(query) {
+        binders(e, &mut bound);
+    }
+
+    // ---- everything referenced, checked against that set.
+    let mut used: Vec<String> = Vec::new();
+    let mut note_expr = |e: &Expression, used: &mut Vec<String>| collect_all_vars(e, used);
+
+    for e in all_expressions(query) {
+        note_expr(e, &mut used);
+    }
+    let mut note_set_use = |sc: &SetClause, used: &mut Vec<String>| {
+        for item in &sc.items {
+            used.push(item.variable.clone());
+            collect_all_vars(&item.value, used);
+        }
+        for item in &sc.entity_items {
+            used.push(item.variable.clone());
+            collect_all_vars(&item.value, used);
+        }
+        for item in &sc.label_items {
+            used.push(item.variable.clone());
+        }
+    };
+    for sc in &query.set_clauses {
+        note_set_use(sc, &mut used);
+    }
+    for rc in &query.remove_clauses {
+        for item in &rc.items {
+            match item {
+                RemoveItem::Property { variable, .. } => used.push(variable.clone()),
+                RemoveItem::Label { variable, .. } => used.push(variable.clone()),
+            }
+        }
+    }
+    let mut note_merge_use = |mc: &crate::query::ast::MergeClause, used: &mut Vec<String>| {
+        for item in mc.on_create_set.iter().chain(mc.on_match_set.iter()) {
+            used.push(item.variable.clone());
+            collect_all_vars(&item.value, used);
+        }
+        for item in mc
+            .on_create_entity_set
+            .iter()
+            .chain(mc.on_match_entity_set.iter())
+        {
+            used.push(item.variable.clone());
+            collect_all_vars(&item.value, used);
+        }
+    };
+    if let Some(mc) = &query.merge_clause {
+        note_merge_use(mc, &mut used);
+    }
+    for c in &query.clauses {
+        match c {
+            Clause::Set(sc) => note_set_use(sc, &mut used),
+            Clause::Merge(mc) => note_merge_use(mc, &mut used),
+            Clause::Delete(dc) => {
+                for e in &dc.expressions {
+                    collect_all_vars(e, &mut used);
+                }
+            }
+            _ => {}
+        }
+    }
+    if let Some(dc) = &query.delete_clause {
+        for e in &dc.expressions {
+            collect_all_vars(e, &mut used);
+        }
+    }
+    // Inline property expressions in write patterns: `CREATE (b {name: missing})`.
+    for pattern in pattern_property_expressions(query) {
+        collect_all_vars(pattern, &mut used);
+    }
+
+    for name in used {
+        if !bound.contains(&name) {
+            return Err(ValidationError::UnboundVariable(name));
+        }
+    }
+    Ok(())
+}
+
+/// Every expression written inside a pattern's inline property map.
+///
+/// `CREATE (b {name: missing})` hides a reference to `missing` where no
+/// expression walker looks: it is a property map on a pattern node, not an
+/// expression of the clause.
+fn pattern_property_expressions(query: &Query) -> Vec<&Expression> {
+    use crate::query::ast::Clause;
+    let mut out: Vec<&Expression> = Vec::new();
+
+    fn from_pattern<'a>(pattern: &'a crate::query::ast::Pattern, out: &mut Vec<&'a Expression>) {
+        for path in &pattern.paths {
+            let mut nodes = vec![&path.start];
+            for seg in &path.segments {
+                nodes.push(&seg.node);
+                if let Some(pe) = &seg.edge.property_exprs {
+                    out.extend(pe.values());
+                }
+            }
+            for np in nodes {
+                if let Some(pe) = &np.property_exprs {
+                    out.extend(pe.values());
+                }
+            }
+        }
+    }
+
+    for mc in &query.match_clauses {
+        from_pattern(&mc.pattern, &mut out);
+    }
+    if let Some(c) = &query.create_clause {
+        from_pattern(&c.pattern, &mut out);
+    }
+    if let Some(m) = &query.merge_clause {
+        from_pattern(&m.pattern, &mut out);
+    }
+    for c in &query.clauses {
+        match c {
+            Clause::Match(mc) => from_pattern(&mc.pattern, &mut out),
+            Clause::Create(cc) => from_pattern(&cc.pattern, &mut out),
+            Clause::Merge(mc) => from_pattern(&mc.pattern, &mut out),
+            _ => {}
+        }
+    }
+    out
+}
+
 pub fn validate(query: &Query) -> Result<(), ValidationError> {
+    validate_variables_are_bound(query)?;
+
     validate_delete_targets(query)?;
 
     validate_pattern_projections(query)?;

--- a/tests/unbound_variables.rs
+++ b/tests/unbound_variables.rs
@@ -1,0 +1,106 @@
+//! A name used in an expression must be bound by something in the query (#895).
+//!
+//! ```cypher
+//! MATCH () RETURN foo                          -- returned a null column
+//! MATCH (s) WHERE s.name = undefinedVariable   -- returned nothing
+//! MERGE (n) ON CREATE SET x.num = 1            -- set a property on nothing
+//! ```
+//!
+//! Every one ran and reported success. A typo in a variable name is the most
+//! ordinary mistake there is, and the engine answered it with silence — the
+//! result indistinguishable from a query that legitimately matched nothing.
+//!
+//! The check is deliberately coarse: *does anything in this query bind this
+//! name*, not *is it in scope here*. `validate.rs` opens by naming
+//! over-rejection as the worse failure, and a false `SyntaxError` breaks a
+//! working query while a missed one only leaves today's behaviour. Being
+//! coarse is not free — the first attempt, borrowing the collector that
+//! answers "what may a later CREATE not redeclare", rejected **126** valid
+//! scenarios because that collector deliberately omits path variables.
+//! Most of this file is the set of things that must keep parsing.
+
+use samyama::query::parser::parse_query;
+
+fn refused(cypher: &str) -> bool {
+    parse_query(cypher).is_err()
+}
+
+/// The six the TCK names.
+#[test]
+fn an_unbound_name_is_refused() {
+    assert!(refused("MATCH () RETURN foo"), "RETURN");
+    assert!(
+        refused("MATCH (s) WHERE s.name = undefinedVariable AND s.age = 10 RETURN s"),
+        "WHERE"
+    );
+    assert!(
+        refused("MATCH (a) CREATE (a)-[:KNOWS]->(b {name: missing}) RETURN b"),
+        "an inline property map on a created node"
+    );
+    assert!(refused("MERGE (n) ON CREATE SET x.num = 1"), "ON CREATE");
+    assert!(refused("MERGE (n) ON MATCH SET x.num = 1"), "ON MATCH");
+    assert!(refused("MATCH (a) SET a.name = missing RETURN a"), "SET");
+}
+
+/// Everything that binds, binds. Each of these was a false rejection at some
+/// point while the collector was being written.
+#[test]
+fn every_way_of_binding_a_name_counts() {
+    for cypher in [
+        // A named path — the omission that cost 126 scenarios.
+        "MATCH p = (a)-->(b) RETURN p",
+        "MATCH p = (n)-->(b) RETURN nodes(p)",
+        "MATCH p = (a)-[*]->(b) RETURN length(p)",
+        // More than one UNWIND, before and after a WITH.
+        "UNWIND [true, false] AS a UNWIND [true, false] AS b RETURN a, b, (a AND b) AS r",
+        "UNWIND range(1, 2) AS row WITH collect(row) AS rows UNWIND rows AS x RETURN x",
+        "WITH [1, 2, 3] AS list UNWIND list AS x RETURN *",
+        "WITH [1, 2] AS xs, [3, 4] AS ys UNWIND xs AS x UNWIND ys AS y RETURN *",
+        // Comprehension and quantifier binders.
+        "MATCH (n) RETURN [x IN [1, 2] | x + 1] AS l",
+        "MATCH (n) WHERE any(x IN [1, 2] WHERE x > 1) RETURN n",
+        "RETURN reduce(acc = 0, x IN [1, 2] | acc + x) AS total",
+        "MATCH (n) RETURN [(n)-->(m) | m] AS ms",
+        // Aliases, in both directions.
+        "MATCH (n) WITH n AS m RETURN m",
+        "MATCH (n) RETURN n.name AS name ORDER BY name",
+        // Writes.
+        "CREATE (a) WITH a CREATE (b) CREATE (a)<-[:T]-(b)",
+        "MATCH (n) DETACH DELETE n",
+        "MATCH (n) REMOVE n.prop",
+        "MATCH (n) REMOVE n:Label",
+        "MATCH (n) SET n:Label",
+        "MATCH (n) SET n = {a: 1}",
+        "FOREACH (i IN [1, 2] | CREATE (:N {v: i}))",
+        // A CALL subquery binds inside itself and exports its columns.
+        "CALL { RETURN 1 AS n } RETURN n",
+        "CALL { MATCH (p:P) RETURN p.n AS n } RETURN n",
+        // A parameter is not a variable.
+        "MATCH (n) WHERE n.id = $id RETURN n",
+        // A MATCH written *after* a WITH binds too. Both of these are ordinary
+        // two-stage aggregations, neither covered by the TCK; the engine's own
+        // suite is what caught them.
+        "MATCH (m:M) WITH m LIMIT 5 MATCH (a:A)-[:R]->(m) WITH m, count(a) AS cnt RETURN m.name, cnt",
+        "MATCH (r:R) WHERE r.term CONTAINS 'X' WITH r MATCH (c:C)-[:E]->(r) WITH r, count(c) AS cases RETURN r.term, cases",
+    ] {
+        assert!(!refused(cypher), "wrongly refused `{cypher}`");
+    }
+}
+
+/// `RETURN *` is resolved before this check sees it, in **both** AST shapes.
+///
+/// The parser mirrors a pipeline's RETURN into the by-kind field before star
+/// expansion runs, so expanding one left the other holding a variable
+/// literally named `*` — and the first thing to read it reported `*` as an
+/// undefined name.
+#[test]
+fn a_star_is_never_seen_as_a_name() {
+    for cypher in [
+        "MATCH (n) RETURN *",
+        "MATCH (n) WITH * RETURN *",
+        "WITH [1, 2, 3] AS list UNWIND list AS x RETURN *",
+        "CREATE (a) WITH * CREATE (b) RETURN *",
+    ] {
+        assert!(!refused(cypher), "wrongly refused `{cypher}`");
+    }
+}


### PR DESCRIPTION
Closes #895.

`MATCH () RETURN foo` returned a null column. `MATCH (a) SET a.name = missing` set a property to nothing. `MERGE (n) ON CREATE SET x.num = 1` wrote to a name bound nowhere. Every one reported success — indistinguishable from a query that legitimately matched nothing.

The rule is coarse by design: *does anything in this query bind this name*, not *is it in scope here*. `validate.rs` opens by naming over-rejection as the worse failure, and that is not theoretical — the first version reused `pattern_variables`, the collector that deliberately omits path variables, and **rejected 126 valid scenarios**.

Two more gaps were invisible to the TCK and caught only by the engine's own suite: a MATCH written after a WITH, and `CALL { … }` subquery exports. Shipping on the TCK alone would have rejected `MATCH (m) WITH m MATCH (a)-->(m) WITH m, count(a) AS cnt RETURN cnt` — an ordinary two-stage aggregation.

Also fixes a latent trap: the parser mirrors a clause pipeline's RETURN into the by-kind field *before* star expansion, so expanding one left the other holding a variable literally named `*`. The mirror is re-synced afterwards.

**TCK 3,673 → 3,680** (97.8%), zero regressions, full workspace suite green.