### PR TITLE
A DELETE no longer un-produces rows its MATCH found (#899)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         # expansion in #756: the ruler got honest and the count fell.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3683
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3685
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2183,6 +2183,15 @@ impl QueryPlanner {
 
         // Handle DELETE clause
         let is_write = if let Some(delete_clause) = &query.delete_clause {
+            // The read is fully materialised before the delete touches
+            // anything. `MATCH (a)-[r]-(b) DELETE r, a, b RETURN count(*)`
+            // counted 1: the first row's delete removed the edge, and the
+            // lazy expansion re-read adjacency to produce the second row and
+            // found nothing left. Cypher's rule is that a write does not
+            // un-produce rows the read had already matched (#899).
+            operator = Box::new(crate::query::executor::operator::EagerOperator::new(
+                operator, 0, None,
+            ));
             operator = Box::new(DeleteOperator::new(
                 operator,
                 delete_clause.expressions.clone(),
@@ -5685,6 +5694,10 @@ impl QueryPlanner {
                     }
                 }
                 Clause::Delete(dc) => {
+                    // Materialised first -- see the by-kind path (#899).
+                    operator = Box::new(crate::query::executor::operator::EagerOperator::new(
+                        operator, 0, None,
+                    ));
                     operator = Box::new(DeleteOperator::new(operator, dc.expressions.clone(), dc.detach));
                 }
                 Clause::Where(w) => {

--- a/tests/eager_before_delete.rs
+++ b/tests/eager_before_delete.rs
@@ -1,0 +1,97 @@
+//! A write does not un-produce rows the read already matched (#899).
+//!
+//! ```cypher
+//! CREATE ()-[:R]->();
+//! MATCH (a)-[r]-(b) DELETE r, a, b RETURN count(*) AS c   -- returned 1, not 2
+//! ```
+//!
+//! An undirected pattern over one relationship matches twice, once in each
+//! orientation — and `MATCH (a)-[r]-(b) RETURN a, b` really does return two
+//! rows. Add the delete and the count drops to 1: the first row's delete
+//! removed the edge, and the lazy expansion re-read adjacency to produce the
+//! second row and found nothing there.
+//!
+//! The read is what decides how many rows there are. Cypher settles this with
+//! an eager barrier — the read is fully materialised before the write touches
+//! anything — and the engine had one, used only for `SKIP`/`LIMIT`.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+use samyama::graph::PropertyValue;
+
+fn setup(cypher: &str) -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query(cypher).expect("setup parses");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup runs");
+    store
+}
+
+fn count_of(store: &mut GraphStore, cypher: &str) -> i64 {
+    let q = parse_query(cypher).expect("parses");
+    let batch = MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .expect("runs");
+    match batch.records.first().and_then(|r| r.get("c")) {
+        Some(Value::Property(PropertyValue::Integer(n))) => *n,
+        other => panic!("expected an integer count, got {other:?}"),
+    }
+}
+
+#[test]
+fn an_undirected_expand_still_counts_both_orientations() {
+    let mut store = setup("CREATE ()-[:R]->()");
+    assert_eq!(
+        count_of(&mut store, "MATCH (a)-[r]-(b) DELETE r, a, b RETURN count(*) AS c"),
+        2
+    );
+}
+
+/// The same shape through a variable-length pattern.
+#[test]
+fn a_variable_length_expand_counts_every_path_it_matched() {
+    let mut store = setup("CREATE (a)-[:R]->(b)-[:R]->(c)");
+    let n = count_of(
+        &mut store,
+        "MATCH (a)-[r*]-(b) DETACH DELETE a, b RETURN count(*) AS c",
+    );
+    assert!(n > 2, "every matched path counts, got {n}");
+}
+
+/// The count is the read's, so it does not change when the write does.
+#[test]
+fn the_count_matches_the_read_without_the_delete() {
+    let mut read_only = setup("CREATE ()-[:R]->()");
+    let q = parse_query("MATCH (a)-[r]-(b) RETURN count(*) AS c").expect("parses");
+    let read = QueryExecutor::new(&read_only)
+        .execute(&q)
+        .expect("runs")
+        .records
+        .first()
+        .and_then(|r| r.get("c"))
+        .cloned();
+    assert!(matches!(read, Some(Value::Property(PropertyValue::Integer(2)))), "{read:?}");
+
+    assert_eq!(
+        count_of(&mut read_only, "MATCH (a)-[r]-(b) DELETE r, a, b RETURN count(*) AS c"),
+        2,
+        "adding the DELETE must not change the count"
+    );
+}
+
+/// And the delete still deletes.
+#[test]
+fn everything_matched_is_still_deleted() {
+    let mut store = setup("CREATE ()-[:R]->(), ()-[:R]->()");
+    let q = parse_query("MATCH (a)-[r]->(b) DELETE r, a, b").expect("parses");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("runs");
+    let remaining = parse_query("MATCH (n) RETURN n").expect("parses");
+    assert_eq!(
+        QueryExecutor::new(&store).execute(&remaining).expect("runs").records.len(),
+        0
+    );
+}


### PR DESCRIPTION
Closes #899.

```cypher
CREATE ()-[:R]->();
MATCH (a)-[r]-(b) DELETE r, a, b RETURN count(*) AS c   -- 1, should be 2
```

The read alone is right — `MATCH (a)-[r]-(b) RETURN a, b` returns two rows, and `count(*)` returns 2. Add the delete and it becomes 1: the first row's delete removes the edge, and the lazy expansion re-reads adjacency for the second row and finds nothing. The write changed the answer to the read that produced it.

**How many rows there are is the read's decision.** `EagerOperator` already existed for the other half of this rule — between a write and a `SKIP`/`LIMIT` (#866, where `CREATE (n) RETURN n LIMIT 0` created nothing). It is now placed between the read and the delete in both planner paths.

## The cost, stated plainly

`MATCH (n) DELETE n` now materialises what it matched before deleting any of it — memory the streaming version did not spend. That is what eager semantics costs, and a delete already touches everything it matched. **Read-only plans are untouched**, so the complex-read benchmarks do not move.

**TCK 3,683 → 3,685** (`Delete4` [1] and [2]), zero regressions, full workspace suite green.