### PR TITLE
MERGE binds the relationships and paths its pattern names (#903)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         # expansion in #756: the ruler got honest and the count fell.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3688
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3691
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -13282,6 +13282,31 @@ impl MergeOperator {
                     record.bind(var.clone(), Value::NodeRef(assignment[i]));
                 }
             }
+            // The relationships the search accepted, bound under the names the
+            // pattern gave them. Only the nodes were bound, so `MERGE
+            // (a)-[r:R]->(b) RETURN r` failed with VariableNotFound and a named
+            // path had nothing to build from (#903).
+            let mut matched_edges: Vec<crate::graph::types::EdgeId> = Vec::with_capacity(pattern_rels.len());
+            for (from, to, ty, props, var) in &pattern_rels {
+                let Some(edge_id) =
+                    Self::merge_edge_match(store, assignment[*from], assignment[*to], ty, props)
+                else {
+                    continue;
+                };
+                matched_edges.push(edge_id);
+                if let Some(var) = var {
+                    record.bind(
+                        var.clone(),
+                        Value::EdgeRef(edge_id, assignment[*from], assignment[*to], ty.clone()),
+                    );
+                }
+            }
+            if let Some(path_var) = &path.path_variable {
+                record.bind(
+                    path_var.clone(),
+                    Value::Path { nodes: assignment.clone(), edges: matched_edges },
+                );
+            }
             let sets = self.on_match_set.clone();
             self.apply_sets(&sets, &record, store, tenant_id)?;
             let entity_sets = self.on_match_entity_set.clone();
@@ -13318,13 +13343,27 @@ impl MergeOperator {
             }
             created.push(node_id);
         }
-        for (from, to, edge_type, props, _var) in &pattern_rels {
+        let mut created_edges: Vec<crate::graph::types::EdgeId> = Vec::with_capacity(pattern_rels.len());
+        for (from, to, edge_type, props, var) in &pattern_rels {
             let edge_id = store
                 .create_edge(created[*from], created[*to], edge_type.clone())
                 .map_err(|e| ExecutionError::GraphError(e.to_string()))?;
             for (k, v) in props {
                 store.set_edge_property_sparse(edge_id, k.clone(), v.clone());
             }
+            created_edges.push(edge_id);
+            if let Some(var) = var {
+                record.bind(
+                    var.clone(),
+                    Value::EdgeRef(edge_id, created[*from], created[*to], edge_type.clone()),
+                );
+            }
+        }
+        if let Some(path_var) = &path.path_variable {
+            record.bind(
+                path_var.clone(),
+                Value::Path { nodes: created.clone(), edges: created_edges },
+            );
         }
 
         let sets = self.on_create_set.clone();
@@ -13336,6 +13375,42 @@ self.apply_sets(&sets, &record, store, tenant_id)?;
 
     /// Assign candidate nodes position by position, keeping only assignments whose
     /// relationships all exist in the store.
+    /// The edge from `src` to `dst` that satisfies a MERGE pattern segment.
+    ///
+    /// One implementation, used by the search *and* by the binding that follows
+    /// it, so a relationship variable cannot be bound to an edge the search did
+    /// not accept.
+    ///
+    /// The properties are part of the question. The search compared type and
+    /// endpoints only, so `MERGE (a)-[:R {k: 1}]->(b)` matched a bare `:R`
+    /// edge, bound nothing, and left the graph without the property the query
+    /// asked for (#903).
+    fn merge_edge_match(
+        store: &GraphStore,
+        src: NodeId,
+        dst: NodeId,
+        ty: &EdgeType,
+        props: &HashMap<String, PropertyValue>,
+    ) -> Option<crate::graph::types::EdgeId> {
+        store
+            .get_outgoing_edge_targets(src)
+            .iter()
+            .find(|(eid, _s, t, et)| {
+                if *t != dst || et != ty {
+                    return false;
+                }
+                if props.is_empty() {
+                    return true;
+                }
+                store.get_edge(*eid).is_some_and(|edge| {
+                    props
+                        .iter()
+                        .all(|(k, v)| edge.properties.get(k).is_some_and(|have| have == v))
+                })
+            })
+            .map(|(eid, ..)| *eid)
+    }
+
     fn search(
         candidates: &[Vec<NodeId>],
         rels: &[(usize, usize, EdgeType, HashMap<String, PropertyValue>, Option<String>)],
@@ -13353,16 +13428,12 @@ self.apply_sets(&sets, &record, store, tenant_id)?;
             }
             assignment.push(cand);
             // Check every relationship whose endpoints are now both assigned.
-            let ok = rels.iter().all(|(from, to, ty, _p, _v)| {
+            let ok = rels.iter().all(|(from, to, ty, props, _v)| {
                 if *from > i || *to > i {
                     return true;
                 }
-                let src = assignment[*from];
-                let dst = assignment[*to];
-                store
-                    .get_outgoing_edge_targets(src)
-                    .iter()
-                    .any(|(_eid, _s, t, et)| *t == dst && et == ty)
+                Self::merge_edge_match(store, assignment[*from], assignment[*to], ty, props)
+                    .is_some()
             });
             if ok {
                 if let Some(found) = Self::search(candidates, rels, store, assignment) {

--- a/tests/merge_binds_relationships.rs
+++ b/tests/merge_binds_relationships.rs
@@ -1,0 +1,96 @@
+//! MERGE binds the relationships and paths its pattern names (#903).
+//!
+//! ```cypher
+//! MERGE (a)-[r:R]->(b) RETURN r   -- VariableNotFound("r")
+//! MERGE p = (a)-[:R]->(b) RETURN p -- VariableNotFound("p")
+//! ```
+//!
+//! `merge_path` bound the node positions and stopped. The relationship
+//! variables were carried through the whole search — collected from the
+//! pattern, threaded into the backtracking — and then dropped, so a named path
+//! had nothing to build from either.
+//!
+//! The search also compared **type and endpoints only**, ignoring the
+//! properties it was given. `MERGE (a)-[:R {k: 1}]->(b)` matched a bare `:R`
+//! edge and left the graph without the property the query asked for — the same
+//! shape as #893, where the candidate set was built from less than the pattern
+//! actually said.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) -> Vec<samyama::query::executor::Record> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` parses: {e:?}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` runs: {e:?}"))
+        .records
+}
+
+fn count(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).expect("count query parses");
+    QueryExecutor::new(store).execute(&q).expect("count runs").records.len()
+}
+
+/// On the create branch and on the match branch — the same name, both times.
+#[test]
+fn a_relationship_variable_is_bound_whether_created_or_matched() {
+    let mut store = GraphStore::new();
+
+    let created = run(&mut store, "MERGE (a:A)-[r:R]->(b:B) RETURN r");
+    assert!(
+        matches!(created.first().and_then(|r| r.get("r")), Some(Value::EdgeRef(..)) | Some(Value::Edge(..))),
+        "created: {:?}", created.first()
+    );
+
+    let matched = run(&mut store, "MERGE (a:A)-[r:R]->(b:B) RETURN r");
+    assert!(
+        matches!(matched.first().and_then(|r| r.get("r")), Some(Value::EdgeRef(..)) | Some(Value::Edge(..))),
+        "matched: {:?}", matched.first()
+    );
+    assert_eq!(count(&store, "MATCH ()-[r:R]->() RETURN r"), 1, "the second MERGE matched");
+}
+
+#[test]
+fn a_named_path_is_bound_on_both_branches() {
+    let mut store = GraphStore::new();
+    for _ in 0..2 {
+        let rows = run(&mut store, "MERGE p = (a:A)-[:R]->(b:B) RETURN p");
+        match rows.first().and_then(|r| r.get("p")) {
+            Some(Value::Path { nodes, edges }) => {
+                assert_eq!(nodes.len(), 2);
+                assert_eq!(edges.len(), 1);
+            }
+            other => panic!("expected a path, got {other:?}"),
+        }
+    }
+}
+
+/// The properties are part of what the pattern asks for.
+#[test]
+fn relationship_properties_are_part_of_the_match() {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE (:A)-[:R]->(:B)");
+    run(&mut store, "MERGE (a:A)-[:R {k: 1}]->(b:B)");
+    assert_eq!(
+        count(&store, "MATCH ()-[r:R]->() RETURN r"),
+        2,
+        "the bare edge does not satisfy `{{k: 1}}`, so the pattern is created"
+    );
+    assert_eq!(count(&store, "MATCH ()-[r:R {k: 1}]->() RETURN r"), 1);
+}
+
+/// And an edge that does satisfy them is matched, not duplicated.
+#[test]
+fn a_relationship_with_the_right_properties_is_matched() {
+    let mut store = GraphStore::new();
+    run(&mut store, "MERGE (a:A)-[:R {k: 1}]->(b:B)");
+    run(&mut store, "MERGE (a:A)-[:R {k: 1}]->(b:B)");
+    assert_eq!(count(&store, "MATCH ()-[r:R]->() RETURN r"), 1);
+    let rows = run(&mut store, "MATCH ()-[r:R]->() RETURN r.k AS k");
+    assert_eq!(
+        rows.first().and_then(|r| r.get("k")),
+        Some(&Value::Property(PropertyValue::Integer(1)))
+    );
+}


### PR DESCRIPTION
Closes #903.

`MERGE (a)-[r:R]->(b) RETURN r` failed with `VariableNotFound("r")`. The relationship variables were collected from the pattern and threaded through the entire backtracking search, then dropped at the end — only node positions were bound. A named path had nothing to build from, so `BindPathOperator` (#876) bound nothing either.

## The search asked a smaller question than the pattern

```rust
.any(|(_eid, _s, t, et)| *t == dst && et == ty)   // properties ignored
```

`MERGE (a)-[:R {k: 1}]->(b)` matched a bare `:R` edge and left the graph without the property the query asked for. Same shape as #893 — the candidate set built from less than the pattern said, and the caller cannot tell.

Both now go through one `merge_edge_match`. That is what makes the binding right *by construction*: a relationship variable cannot be bound to an edge the search would not have accepted, because it is the same function answering both times.

**TCK 3,688 → 3,691**, errored 22 → 19, zero regressions, full workspace suite green.