### PR TITLE
Reading a deleted entity: an error, or the reference (#905)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         # expansion in #756: the ruler got honest and the count fell.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3691
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3694
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -124,6 +124,15 @@ pub enum ExecutionError {
     /// Variable not found
     #[error("Variable not found: {0}")]
     VariableNotFound(String),
+
+    /// A read of an entity that is no longer in the graph.
+    ///
+    /// Distinct from `RuntimeError` because the *caller* can tell these apart
+    /// and a null cannot: an unset property and a deleted node both answered
+    /// `null`, so a query that read a node it had already deleted looked
+    /// exactly like a query reading a property nobody set.
+    #[error("{0} was deleted in this query and cannot be read")]
+    EntityNotFound(String),
 }
 
 pub type ExecutionResult<T> = Result<T, ExecutionError>;

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -763,6 +763,20 @@ fn read_property(
     if let Value::Map(entries) = val {
         return Ok(entries.get(property).cloned().unwrap_or(Value::Null));
     }
+    // A property read of something the query has already deleted is an error,
+    // not a null. `resolve_property` answers `null` for a missing entity, which
+    // is also the honest answer for a property nobody set -- so `MATCH (n)
+    // DELETE n RETURN n.num` was indistinguishable from reading an unset
+    // property, and reported success (#905).
+    match val {
+        Value::NodeRef(id) | Value::Node(id, _) if store.get_node(*id).is_none() => {
+            return Err(ExecutionError::EntityNotFound(format!("node {}", id.as_u64())));
+        }
+        Value::EdgeRef(id, ..) | Value::Edge(id, _) if store.get_edge(*id).is_none() => {
+            return Err(ExecutionError::EntityNotFound(format!("relationship {}", id.as_u64())));
+        }
+        _ => {}
+    }
     Ok(Value::Property(val.resolve_property(property, store)))
 }
 
@@ -7001,17 +7015,22 @@ impl ProjectOperator {
                     .cloned()
                     .ok_or_else(|| ExecutionError::VariableNotFound(var.clone()))?;
                 // Materialize refs at projection time (RETURN n)
+                // A reference the store can no longer resolve is kept as a
+                // reference rather than refused. It still carries the
+                // structural data it was built with, which is what survives a
+                // delete: `MATCH ()-[r]->() DELETE r RETURN type(r)` is a
+                // legal query, and materialising `r` first turned it into
+                // "Edge not found" (#905). A *property* read of the same
+                // reference does fail -- see `read_property`.
                 match val {
-                    Value::NodeRef(id) => {
-                        let node = store.get_node(id)
-                            .ok_or_else(|| ExecutionError::RuntimeError(format!("Node {:?} not found", id)))?;
-                        Ok(Value::Node(id, Box::new(node.clone())))
-                    }
-                    Value::EdgeRef(id, ..) => {
-                        let edge = store.get_edge(id)
-                            .ok_or_else(|| ExecutionError::RuntimeError(format!("Edge {:?} not found", id)))?;
-                        Ok(Value::Edge(id, Box::new(edge.clone())))
-                    }
+                    Value::NodeRef(id) => Ok(match store.get_node(id) {
+                        Some(node) => Value::Node(id, Box::new(node.clone())),
+                        None => Value::NodeRef(id),
+                    }),
+                    Value::EdgeRef(id, src, dst, ref ty) => Ok(match store.get_edge(id) {
+                        Some(edge) => Value::Edge(id, Box::new(edge.clone())),
+                        None => Value::EdgeRef(id, src, dst, ty.clone()),
+                    }),
                     other => Ok(other),
                 }
             }

--- a/tests/deleted_entity_access.rs
+++ b/tests/deleted_entity_access.rs
@@ -1,0 +1,100 @@
+//! Reading an entity the query already deleted (#905).
+//!
+//! ```cypher
+//! MATCH (n) DELETE n RETURN n.num              -- returned null, reported success
+//! MATCH ()-[r]->() DELETE r RETURN type(r)     -- "Edge not found"
+//! ```
+//!
+//! Both directions were wrong, from one cause: whether a read resolves through
+//! the store or through the reference it already holds.
+//!
+//! A property read went to the store, got nothing, and answered `null` — which
+//! is *also* the honest answer for a property nobody set. The caller could not
+//! tell "this is unset" from "you deleted this two clauses ago". openCypher
+//! makes it an error, and the reason is exactly that ambiguity.
+//!
+//! `type()` is the opposite case. A relationship's type is **structural data
+//! the reference carries** — `Value::EdgeRef(id, src, dst, type)` — so it does
+//! not need the store at all. Projection materialised the reference before the
+//! function ran, and materialising something deleted failed.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::graph::PropertyValue;
+use samyama::query::parser::parse_query;
+
+fn setup(cypher: &str) -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query(cypher).expect("setup parses");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup runs");
+    store
+}
+
+fn run(store: &mut GraphStore, cypher: &str) -> Result<Vec<samyama::query::executor::Record>, String> {
+    let q = parse_query(cypher).map_err(|e| format!("{e:?}"))?;
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .map(|b| b.records)
+        .map_err(|e| format!("{e}"))
+}
+
+#[test]
+fn a_property_of_a_deleted_node_is_an_error_not_a_null() {
+    let mut store = setup("CREATE ({num: 0})");
+    let err = run(&mut store, "MATCH (n) DELETE n RETURN n.num").expect_err("must fail");
+    assert!(err.contains("deleted"), "{err}");
+}
+
+#[test]
+fn a_property_of_a_deleted_relationship_is_an_error_too() {
+    let mut store = setup("CREATE ()-[:T {num: 0}]->()");
+    let err = run(&mut store, "MATCH ()-[r]->() DELETE r RETURN r.num").expect_err("must fail");
+    assert!(err.contains("deleted"), "{err}");
+}
+
+/// The type survives the delete, because the reference carries it.
+#[test]
+fn the_type_of_a_deleted_relationship_still_reads() {
+    let mut store = setup("CREATE ()-[:T]->()");
+    let rows = run(&mut store, "MATCH ()-[r]->() DELETE r RETURN type(r) AS t").expect("must succeed");
+    assert_eq!(
+        rows.first().and_then(|r| r.get("t")),
+        Some(&Value::Property(PropertyValue::String("T".to_string())))
+    );
+}
+
+/// The distinction this restores: an unset property is still null, and still
+/// not an error.
+#[test]
+fn an_unset_property_on_a_live_entity_is_still_null() {
+    let store = setup("CREATE (:A)");
+    let q = parse_query("MATCH (n:A) RETURN n.nothing AS v").expect("parses");
+    let rows = QueryExecutor::new(&store).execute(&q).expect("runs").records;
+    assert!(
+        matches!(
+            rows.first().and_then(|r| r.get("v")),
+            Some(Value::Null) | Some(Value::Property(PropertyValue::Null))
+        ),
+        "{:?}", rows.first()
+    );
+}
+
+/// And an ordinary read of a live entity is untouched.
+#[test]
+fn a_live_entity_reads_normally() {
+    let store = setup("CREATE (:A {num: 7})-[:T {w: 1}]->(:B)");
+    for (cypher, want) in [
+        ("MATCH (n:A) RETURN n.num AS v", 7i64),
+        ("MATCH ()-[r:T]->() RETURN r.w AS v", 1),
+    ] {
+        let q = parse_query(cypher).expect("parses");
+        let rows = QueryExecutor::new(&store).execute(&q).expect("runs").records;
+        assert_eq!(
+            rows.first().and_then(|r| r.get("v")),
+            Some(&Value::Property(PropertyValue::Integer(want))),
+            "{cypher}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #905.

```cypher
MATCH (n) DELETE n RETURN n.num             -- null, reported success
MATCH ()-[r]->() DELETE r RETURN type(r)    -- RuntimeError("Edge not found")
```

Both wrong, in opposite directions, from one cause: **whether a read goes to the store or to the reference it already holds.**

**The property read should fail and did not.** It answered `null` — which is also the honest answer for a property nobody set. A query reading a node it deleted two clauses earlier was indistinguishable from one reading an unset property. That ambiguity is exactly why openCypher raises `EntityNotFound` here.

**The type read should succeed and did not.** `Value::EdgeRef(id, src, dst, type)` carries the type — that is what late materialization is for, and `type()` already reads it from the value. But projection materialised the reference *before* the function ran. The engine refused a legal query while holding the answer in its hand.

A reference the store can no longer resolve is now kept as a reference. Structural data survives a delete; property data does not, and asking for it is an error. New `ExecutionError::EntityNotFound`, separate from `RuntimeError` because a caller can act on the difference.

A test pins the distinction this restores: **an unset property on a live entity is still null, and still not an error.**

**TCK 3,691 → 3,694**, wrong answers 52 → 50, zero regressions, full workspace suite green.