### PR TITLE
An aggregate may follow a write, and toBoolean answers null (#907)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         # expansion in #756: the ruler got honest and the count fell.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3694
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3696
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3494,7 +3494,13 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                 Value::Property(PropertyValue::String(s)) => match s.to_lowercase().as_str() {
                     "true" => Ok(Value::Property(PropertyValue::Boolean(true))),
                     "false" => Ok(Value::Property(PropertyValue::Boolean(false))),
-                    _ => Err(ExecutionError::TypeError(format!("Cannot convert '{}' to boolean", s))),
+                    // A string that is not a boolean converts to null, not to
+                    // an error: `toBoolean('')` is a *question* about the
+                    // string, and "no" is an answer. Erroring killed the whole
+                    // query -- `UNWIND [null, '', ' tru '] AS x RETURN
+                    // toBoolean(x)` returned nothing at all rather than three
+                    // nulls (#907).
+                    _ => Ok(Value::Property(PropertyValue::Null)),
                 },
                 Value::Property(PropertyValue::Integer(i)) => Ok(Value::Property(PropertyValue::Boolean(*i != 0))),
                 Value::Null | Value::Property(PropertyValue::Null) => Ok(Value::Null),

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -543,6 +543,54 @@ pub struct QueryPlanner {
     trail_enumeration: std::sync::atomic::AtomicBool,
 }
 
+/// Project a `RETURN` list, building an aggregation when any item aggregates.
+///
+/// The write paths projected their return items directly, with no aggregate
+/// handling at all, so `CREATE (a) RETURN count(*)` and `MERGE (a) RETURN
+/// count(*)` died on `Unknown function: count` -- an everyday query, failing
+/// because the *planner* never routed `count` to the operator that implements
+/// it. Adding `WITH a` in the middle made it work, which is the tell: the
+/// aggregation was there, only unreachable from this branch.
+///
+/// This is the small, shared version. The read path keeps its own assembly
+/// because it also chooses between O(1) shortcuts (label count, edge count)
+/// that need the MATCH to decide, and none of those apply after a write.
+fn plan_return_projection(
+    input: OperatorBox,
+    return_clause: &crate::query::ast::ReturnClause,
+) -> (OperatorBox, Vec<String>) {
+    let mut output_columns = Vec::new();
+    let mut aggregates = Vec::new();
+    let mut group_by: Vec<(Expression, String)> = Vec::new();
+    let mut projections: Vec<(Expression, String)> = Vec::new();
+    let mut post_projections: Vec<(Expression, String)> = Vec::new();
+    let mut has_aggregation = false;
+    let mut agg_counter = 0usize;
+
+    for (idx, item) in return_clause.items.iter().enumerate() {
+        let alias = item.column_name(idx);
+        output_columns.push(alias.clone());
+        let (rewritten, extracted) = extract_nested_aggregates(&item.expression, &mut agg_counter);
+        if extracted.is_empty() {
+            group_by.push((item.expression.clone(), alias.clone()));
+            projections.push((item.expression.clone(), alias.clone()));
+            post_projections.push((Expression::Variable(alias.clone()), alias.clone()));
+        } else {
+            has_aggregation = true;
+            aggregates.extend(extracted);
+            post_projections.push((rewritten, alias.clone()));
+        }
+    }
+
+    let operator: OperatorBox = if has_aggregation {
+        let aggregated = Box::new(AggregateOperator::new(input, group_by, aggregates));
+        Box::new(ProjectOperator::new(aggregated, post_projections))
+    } else {
+        Box::new(ProjectOperator::new(input, projections))
+    };
+    (operator, output_columns)
+}
+
 impl QueryPlanner {
     /// Create a new query planner
     pub fn new() -> Self {
@@ -1140,12 +1188,9 @@ impl QueryPlanner {
 
                 let mut output_columns = Vec::new();
                 if let Some(return_clause) = &query.return_clause {
-                    let projections: Vec<(Expression, String)> = return_clause.items.iter().enumerate().map(|(i, item)| {
-                        let alias = item.column_name(i);
-                        output_columns.push(alias.clone());
-                        (item.expression.clone(), alias)
-                    }).collect();
-                            operator = Box::new(ProjectOperator::new(operator, projections));
+                    let (projected, columns) = plan_return_projection(operator, return_clause);
+                    operator = projected;
+                    output_columns = columns;
                 }
 
                 return Ok(ExecutionPlan {
@@ -1170,14 +1215,9 @@ impl QueryPlanner {
                 let mut plan = self.plan_create_only(create_clause)?;
                 // CY-12: Wrap with ProjectOperator if RETURN clause is present
                 if let Some(return_clause) = &query.return_clause {
-                    let mut output_columns = Vec::new();
-                    let projections: Vec<(Expression, String)> = return_clause.items.iter().enumerate().map(|(i, item)| {
-                        let alias = item.column_name(i);
-                        output_columns.push(alias.clone());
-                        (item.expression.clone(), alias)
-                    }).collect();
-                    plan.root = Box::new(ProjectOperator::new(plan.root, projections));
-                    plan.output_columns = output_columns;
+                    let (projected, columns) = plan_return_projection(plan.root, return_clause);
+                    plan.root = projected;
+                    plan.output_columns = columns;
 
                     // `ORDER BY`, `SKIP` and `LIMIT` after a bare `CREATE`.
                     //

--- a/tests/aggregate_after_write.rs
+++ b/tests/aggregate_after_write.rs
@@ -1,0 +1,127 @@
+//! An aggregate in the `RETURN` of a write query (#907).
+//!
+//! ```cypher
+//! CREATE (a) RETURN count(*) AS n   -- Runtime error: Unknown function: count
+//! MERGE (a) RETURN count(*) AS n    -- the same
+//! CREATE (a) WITH a RETURN count(*) -- worked
+//! ```
+//!
+//! An everyday query, failing on a function the engine implements. The tell is
+//! the third line: inserting a `WITH` made it work, so the aggregation was
+//! present and merely unreachable from that planner branch.
+//!
+//! The write paths built their projection inline — `return_clause.items` mapped
+//! straight into a `ProjectOperator` — with no aggregate handling at all, so
+//! `count` was evaluated as an ordinary scalar function and no such function
+//! exists. Two such copies, neither of which had ever been taught.
+//!
+//! They now share `plan_return_projection` with each other. The read path keeps
+//! its own assembly because it also picks between O(1) shortcuts (label count,
+//! edge count) that need the MATCH to decide, and none apply after a write.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn scalar(cypher: &str, setup: &[&str]) -> Value {
+    let mut store = GraphStore::new();
+    for s in setup {
+        let q = parse_query(s).expect("setup parses");
+        MutQueryExecutor::new(&mut store, "default".to_string())
+            .execute(&q)
+            .expect("setup runs");
+    }
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` parses: {e:?}"));
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` runs: {e}"))
+        .records
+        .first()
+        .and_then(|r| r.get("n"))
+        .cloned()
+        .unwrap_or(Value::Null)
+}
+
+fn int(v: Value) -> i64 {
+    match v {
+        Value::Property(PropertyValue::Integer(n)) => n,
+        other => panic!("expected an integer, got {other:?}"),
+    }
+}
+
+#[test]
+fn create_and_merge_can_count_what_they_produced() {
+    assert_eq!(int(scalar("CREATE (a) RETURN count(*) AS n", &[])), 1);
+    assert_eq!(int(scalar("MERGE (a) RETURN count(*) AS n", &[])), 1);
+    assert_eq!(int(scalar("MERGE (a) RETURN count(a) AS n", &[])), 1);
+    assert_eq!(int(scalar("CREATE (a), (b) RETURN count(*) AS n", &[])), 1);
+}
+
+/// The form that already worked must keep working, and agree.
+#[test]
+fn the_with_form_gives_the_same_answer() {
+    assert_eq!(
+        int(scalar("CREATE (a) WITH a RETURN count(*) AS n", &[])),
+        int(scalar("CREATE (a) RETURN count(*) AS n", &[])),
+    );
+}
+
+/// Other aggregates, and grouping, go through the same path.
+#[test]
+fn other_aggregates_work_too() {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (a:X) RETURN collect(a) AS n").expect("parses");
+    let rows = MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("runs")
+        .records;
+    match rows.first().and_then(|r| r.get("n")) {
+        Some(Value::List(items)) => assert_eq!(items.len(), 1),
+        other => panic!("expected a list, got {other:?}"),
+    }
+}
+
+/// A non-aggregating RETURN after a write is untouched.
+#[test]
+fn a_plain_projection_after_a_write_is_unchanged() {
+    let mut store = GraphStore::new();
+    let q = parse_query("CREATE (a:X {v: 1}) RETURN a.v AS n").expect("parses");
+    let rows = MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("runs")
+        .records;
+    assert_eq!(
+        rows.first().and_then(|r| r.get("n")),
+        Some(&Value::Property(PropertyValue::Integer(1)))
+    );
+}
+
+/// `toBoolean()` asks a question about a string, and "no" is an answer.
+///
+/// Erroring killed the whole query: this returned nothing at all rather than
+/// four rows.
+#[test]
+fn to_boolean_answers_null_for_a_string_that_is_not_one() {
+    let mut store = GraphStore::new();
+    let q = parse_query("UNWIND [null, '', ' tru ', 'f alse'] AS t RETURN toBoolean(t) AS b")
+        .expect("parses");
+    let rows = MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("runs")
+        .records;
+    assert_eq!(rows.len(), 4);
+    for row in &rows {
+        assert!(
+            matches!(row.get("b"), Some(Value::Null) | Some(Value::Property(PropertyValue::Null))),
+            "{:?}", row.get("b")
+        );
+    }
+
+    let q = parse_query("UNWIND ['true', 'FALSE'] AS t RETURN toBoolean(t) AS b").expect("parses");
+    let rows = MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("runs")
+        .records;
+    assert_eq!(rows[0].get("b"), Some(&Value::Property(PropertyValue::Boolean(true))));
+    assert_eq!(rows[1].get("b"), Some(&Value::Property(PropertyValue::Boolean(false))));
+}


### PR DESCRIPTION
Closes #907.

`CREATE (a) RETURN count(*)` died on `Unknown function: count`, as did the MERGE form. Adding `WITH a` in the middle made it work — which is the tell: the aggregation was implemented and merely unreachable from that planner branch.

Both write paths mapped `return_clause.items` straight into a `ProjectOperator` with no aggregate handling, so `count` was evaluated as an ordinary scalar function. Two copies, neither ever taught, while the read path a few hundred lines below does the whole job.

They now share `plan_return_projection`. The read path keeps its own assembly because it also picks between O(1) shortcuts (label count, edge count) that need the MATCH to decide, and none apply after a write.

Also: `toBoolean('')` raised a `TypeError` and killed the query — `UNWIND [null, '', ' tru '] AS x RETURN toBoolean(x)` returned **nothing at all** instead of three nulls. It asks a question about a string, and "no" is an answer.

**TCK 3,694 → 3,696**, errored 18 → 16, zero regressions.