### PR TITLE
A zero-length named path binds, and `:A|:B` parses (#909)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         # expansion in #756: the ruler got honest and the count fell.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3696
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3698
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -190,7 +190,10 @@ edge_pattern = {
     ("-" ~ edge_detail? ~ "-")
 }
 edge_detail = { "[" ~ variable? ~ edge_types? ~ length_pattern? ~ properties? ~ "]" }
-edge_types = { ":" ~ edge_type ~ (("|" | ":") ~ edge_type)* }
+// `MATCH ()-[:A|:B]->()` repeats the colon on each alternative, which is the
+// spelling openCypher's own scenarios use. Only `:A|B` and `:A:B` parsed, so
+// the query failed outright rather than matching either type (#909).
+edge_types = { ":" ~ edge_type ~ (("|" ~ ":"? | ":") ~ edge_type)* }
 edge_type = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 // Variable length: *1..5 or * or *3..

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1935,6 +1935,35 @@ impl QueryPlanner {
 
         let mut operator = operator.unwrap();
 
+        // `MATCH p = (a)` binds `p` to a path of one node and no relationships.
+        //
+        // A named path is bound by the expand that walks it, so a pattern with
+        // no segments had no expand and nothing bound `p`: `MATCH p = (a)
+        // RETURN p` parsed and then failed with VariableNotFound. The
+        // zero-length path is the one case where there is nothing to walk, and
+        // it is exactly the case the walking code cannot reach (#909).
+        //
+        // `named_path_handles` already produces the right handle for a
+        // segment-less path -- it is what MERGE uses -- so this is the same
+        // description, bound by the same operator.
+        {
+            let mut zero_length: Vec<(String, Vec<String>, Vec<String>)> = Vec::new();
+            for mc in &query.match_clauses {
+                for path in &mc.pattern.paths {
+                    if path.segments.is_empty() && path.path_variable.is_some() {
+                        let single = crate::query::ast::Pattern { paths: vec![path.clone()] };
+                        zero_length.extend(named_path_handles(&single));
+                    }
+                }
+            }
+            if !zero_length.is_empty() {
+                operator = Box::new(crate::query::executor::operator::BindPathOperator::new(
+                    operator,
+                    zero_length,
+                ));
+            }
+        }
+
         // A *leading* UNWIND is planned before the WITH barriers, above, so that
         // a following WITH has its variable bound. It still lands below the
         // WHERE, which is what `UNWIND [1,2] AS x MATCH (p) WHERE p.n = x`

--- a/tests/zero_length_path_and_alternation.rs
+++ b/tests/zero_length_path_and_alternation.rs
@@ -1,0 +1,104 @@
+//! Two patterns that parsed nowhere and bound nothing (#909).
+//!
+//! ```cypher
+//! MATCH (a)-[:T|:T]->(b) RETURN b   -- parse error
+//! MATCH p = (a) RETURN p            -- VariableNotFound("p")
+//! ```
+//!
+//! `:A|:B` repeats the colon on each alternative, which is the spelling
+//! openCypher's own scenarios use; only `:A|B` and `:A:B` parsed, so the query
+//! failed outright rather than matching either type.
+//!
+//! A named path is bound by the expand that walks it — so a pattern with **no
+//! segments** had no expand and nothing bound `p`. The zero-length path is the
+//! one case where there is nothing to walk, and it is exactly the case the
+//! walking code cannot reach.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn setup(cypher: &str) -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query(cypher).expect("setup parses");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup runs");
+    store
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> Vec<samyama::query::executor::Record> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` parses: {e:?}"));
+    QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` runs: {e}"))
+        .records
+}
+
+/// Every spelling of the alternation means the same thing.
+#[test]
+fn a_repeated_colon_in_a_type_alternation_parses() {
+    let store = setup("CREATE (a:A)-[:T]->(b:B)");
+    for cypher in [
+        "MATCH (a)-[:T]->(b) RETURN b",
+        "MATCH (a)-[:T|T]->(b) RETURN b",
+        "MATCH (a)-[:T|:T]->(b) RETURN b",
+        "MATCH (a)-[:T|:U]->(b) RETURN b",
+        "MATCH (a)-[:U|:T]->(b) RETURN b",
+        "MATCH (a)-[r:T|:U|:V]->(b) RETURN b",
+    ] {
+        assert_eq!(rows(&store, cypher).len(), 1, "`{cypher}`");
+    }
+}
+
+/// A type that is not there still matches nothing — the alternation is a
+/// filter, not a wildcard.
+#[test]
+fn an_alternation_of_absent_types_matches_nothing() {
+    let store = setup("CREATE (a:A)-[:T]->(b:B)");
+    assert_eq!(rows(&store, "MATCH (a)-[:U|:V]->(b) RETURN b").len(), 0);
+}
+
+/// One node, no relationships.
+#[test]
+fn a_zero_length_named_path_binds() {
+    let store = setup("CREATE ()");
+    let found = rows(&store, "MATCH p = (a) RETURN p");
+    assert_eq!(found.len(), 1);
+    match found[0].get("p") {
+        Some(Value::Path { nodes, edges }) => {
+            assert_eq!(nodes.len(), 1, "the one node it matched");
+            assert!(edges.is_empty(), "and no relationships");
+        }
+        other => panic!("expected a path, got {other:?}"),
+    }
+}
+
+/// The node variable is still bound alongside it, and a labelled form works.
+#[test]
+fn the_node_is_bound_beside_the_path() {
+    let store = setup("CREATE (:A {v: 1})");
+    let found = rows(&store, "MATCH p = (a:A) RETURN p, a");
+    assert_eq!(found.len(), 1);
+    assert!(matches!(found[0].get("p"), Some(Value::Path { .. })));
+    assert!(matches!(
+        found[0].get("a"),
+        Some(Value::Node(..)) | Some(Value::NodeRef(_))
+    ));
+}
+
+/// A path *with* segments is untouched — that is the case the expand already
+/// handled, and it must keep working.
+#[test]
+fn a_path_with_segments_still_binds() {
+    let store = setup("CREATE (:A)-[:T]->(:B)");
+    let found = rows(&store, "MATCH p = (a:A)-[:T]->(b:B) RETURN p");
+    assert_eq!(found.len(), 1);
+    match found[0].get("p") {
+        Some(Value::Path { nodes, edges }) => {
+            assert_eq!(nodes.len(), 2);
+            assert_eq!(edges.len(), 1);
+        }
+        other => panic!("expected a path, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Closes #909.

Two gaps that share a shape — the ordinary spelling works and the edge of the same construct does not.

**`:A|:B`** — the grammar accepted `:A|B` and `:A:B`, but not the colon repeated on each alternative. That is the spelling openCypher's own scenarios use, and the query failed outright rather than matching either type.

**`MATCH p = (a)`** — a named path is bound by the *expand that walks it*, and a pattern with no segments has no expand. The zero-length path is the one case where there is nothing to walk, which makes it exactly the case the walking code cannot reach. `named_path_handles` already describes a segment-less path correctly for MERGE, so the same description is bound by the same operator rather than a second implementation.

**TCK 3,696 → 3,698**, errored 16 → 14, zero regressions, full workspace suite green (201 suites).