### PR TITLE
Refresh the README's TCK claim to the measured number

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ into a public-health trifecta.* [Browse the catalogue →](case_studies)
 
 ## The 30-Second Tour
 
-**Cypher queries** — MATCH, CREATE, MERGE, aggregations, path finding, 30+ functions. **97.3% of the openCypher TCK's evaluated scenarios pass** (3,659 of 3,762, at 96.5% coverage of the 3,897-scenario corpus, measured 2026-08-26); on the same corpus and comparator Neo4j 5 scores 79.4%. That is conformance only — not performance or scale — and the competitor figure is a fixed baseline from one run. See [`docs/CYPHER_COMPATIBILITY.md`](docs/CYPHER_COMPATIBILITY.md) for a per-feature matrix verified by an executable probe, and [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) for the full accounting.
+**Cypher queries** — MATCH, CREATE, MERGE, aggregations, path finding, 30+ functions. **98.3% of the openCypher TCK's evaluated scenarios pass** (3,698 of 3,762, at 96.5% coverage of the 3,897-scenario corpus, measured 2026-08-27); on the same corpus and comparator Neo4j 5 scores 79.5%. That is conformance only — not performance or scale — and the competitor figure is a fixed baseline from one run. See [`docs/CYPHER_COMPATIBILITY.md`](docs/CYPHER_COMPATIBILITY.md) for a per-feature matrix verified by an executable probe, and [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) for the full accounting.
 
 ```cypher
 MATCH (a:Person)-[:KNOWS*1..3]->(b:Person)


### PR DESCRIPTION
97.3% (3,659 scenarios) → **98.3%** (3,698 of 3,762), measured 2026-08-27, and the Neo4j 5 comparator to 79.5%.

Found by the claims check added in the benchmarks repo (`2768a17`), which now backs H1 gate condition 6: a registered claim is *stale* when the number drifts in **either** direction, because improving past a published claim still leaves the published claim wrong.

Everything else in the sentence — the 96.5% coverage, the 3,897-scenario corpus, the caveat that this is conformance only and the competitor figure is a fixed baseline — is unchanged and still accurate.