### PR TITLE
SKIP and LIMIT take an expression (#912)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         # expansion in #756: the ruler got honest and the count fell.
         run: |
           git clone --depth 1 --branch 2024.3             https://github.com/opencypher/openCypher.git /tmp/openCypher
-          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3698
+          cargo run --release --example tck_runner --             --features /tmp/openCypher/tck/features --min-pass 3700
 
       - name: CH-DETERM-THREADS — the answer does not depend on the thread count
         # LANG-14 (#611). CH-DETERM varies the *process*, which catches a

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -145,8 +145,18 @@ remove_item = { property_access | variable ~ (":" ~ label)+ }
 return_clause = { ^"RETURN" ~ distinct? ~ return_items }
 distinct = { ^"DISTINCT" }
 order_by_clause = { ^"ORDER" ~ ^"BY" ~ order_items }
-skip_clause = { ^"SKIP" ~ integer }
-limit_clause = { ^"LIMIT" ~ integer }
+// `SKIP`/`LIMIT` take an expression, not only a literal: `LIMIT
+// toInteger(ceil(1.7))` is legal Cypher. The grammar accepted `integer`
+// alone, so those queries failed to parse at all (#912). The expression may
+// not depend on variables -- Cypher's own rule -- which is what lets the
+// parser fold it to a number once, where the rest of the engine already
+// expects one.
+// `expression` first, not `integer`: pest's choice is ordered, so `integer`
+// matched the `1` of `LIMIT 1 + 1` and left `+ 1` unconsumed, failing the whole
+// parse. A bare integer is a valid expression, so nothing is lost by trying the
+// wider rule first.
+skip_clause = { ^"SKIP" ~ (expression | integer) }
+limit_clause = { ^"LIMIT" ~ (expression | integer) }
 
 // Standalone CREATE clause
 // Adjacent `CREATE` clauses are one create: `CREATE (a) CREATE (b)` and

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -781,7 +781,7 @@ fn read_property(
 }
 
 /// Standalone expression evaluator usable from any operator
-fn eval_expression(expr: &Expression, record: &Record, store: &GraphStore) -> ExecutionResult<Value> {
+pub(crate) fn eval_expression(expr: &Expression, record: &Record, store: &GraphStore) -> ExecutionResult<Value> {
     match expr {
         Expression::Variable(var) => {
             record.get(var).cloned()

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -198,18 +198,10 @@ fn parse_clause_pipeline(input: &str) -> ParseResult<Query> {
                                 query.order_by = Some(parse_order_by_clause(c)?);
                             }
                             Rule::skip_clause => {
-                                for i in c.into_inner() {
-                                    if i.as_rule() == Rule::integer {
-                                        query.skip = i.as_str().parse().ok();
-                                    }
-                                }
+                                query.skip = parse_row_count(c)?;
                             }
                             Rule::limit_clause => {
-                                for i in c.into_inner() {
-                                    if i.as_rule() == Rule::integer {
-                                        query.limit = i.as_str().parse().ok();
-                                    }
-                                }
+                                query.limit = parse_row_count(c)?;
                             }
                             // Anything this builder cannot lower has to be an
                             // error. Falling through silently was the worse
@@ -298,6 +290,58 @@ fn parse_count_literal(text: &str) -> ParseResult<usize> {
     let value = parse_integer_literal(text)?;
     usize::try_from(value)
         .map_err(|_| ParseError::SemanticError(format!("SKIP/LIMIT must not be negative: `{text}`")))
+}
+
+/// The row count a `SKIP` or `LIMIT` names.
+///
+/// `LIMIT toInteger(ceil(1.7))` is legal Cypher, and the grammar took only an
+/// integer literal, so the whole query failed to parse (#912).
+///
+/// Cypher requires the expression not to depend on variables, which is exactly
+/// what makes folding it here correct: it is evaluated **once**, against no
+/// row, and the rest of the engine goes on receiving the `usize` it already
+/// expects. `LIMIT toInteger(rand() * 9)` therefore picks one number for the
+/// whole query rather than a different one per row -- which is the specified
+/// behaviour, not a shortcut.
+///
+/// Four parse sites did this inline, each testing for `Rule::integer` and
+/// silently ignoring anything else. One implementation now, because "silently
+/// ignoring anything else" is how a LIMIT goes missing.
+fn parse_row_count(pair: pest::iterators::Pair<Rule>) -> ParseResult<Option<usize>> {
+    for inner in pair.into_inner() {
+        match inner.as_rule() {
+            // Through `parse_count_literal`, so `LIMIT -1` keeps saying what is
+            // wrong with it rather than becoming a silent `None`.
+            Rule::integer => return parse_count_literal(inner.as_str()).map(Some),
+            Rule::expression => {
+                let text = inner.as_str().to_string();
+                let expr = parse_expression(inner)?;
+                let store = crate::graph::GraphStore::new();
+                let record = crate::query::executor::Record::new();
+                let value =
+                    crate::query::executor::operator::eval_expression(&expr, &record, &store)
+                        .map_err(|e| {
+                            ParseError::SemanticError(format!(
+                                "SKIP/LIMIT must not depend on the rows it is trimming: \
+                                 `{text}` could not be evaluated on its own ({e})"
+                            ))
+                        })?;
+                return match value {
+                    crate::query::executor::Value::Property(
+                        crate::graph::PropertyValue::Integer(n),
+                    ) if n >= 0 => Ok(Some(n as usize)),
+                    crate::query::executor::Value::Property(
+                        crate::graph::PropertyValue::Float(f),
+                    ) if f >= 0.0 && f.fract() == 0.0 => Ok(Some(f as usize)),
+                    other => Err(ParseError::SemanticError(format!(
+                        "SKIP/LIMIT takes a non-negative whole number; `{text}` is {other:?}"
+                    ))),
+                };
+            }
+            _ => {}
+        }
+    }
+    Ok(None)
 }
 
 pub fn parse_query(input: &str) -> ParseResult<Query> {
@@ -458,18 +502,10 @@ fn parse_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -> Pars
                             query.order_by = Some(parse_order_by_clause(child)?);
                         }
                         Rule::skip_clause => {
-                            for skip_inner in child.into_inner() {
-                                if skip_inner.as_rule() == Rule::integer {
-                                    query.skip = skip_inner.as_str().parse::<usize>().ok();
-                                }
-                            }
+                            query.skip = parse_row_count(child)?;
                         }
                         Rule::limit_clause => {
-                            for limit_inner in child.into_inner() {
-                                if limit_inner.as_rule() == Rule::integer {
-                                    query.limit = limit_inner.as_str().parse::<usize>().ok();
-                                }
-                            }
+                            query.limit = parse_row_count(child)?;
                         }
                         _ => {}
                     }
@@ -485,18 +521,10 @@ fn parse_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -> Pars
                             query.order_by = Some(parse_order_by_clause(child)?);
                         }
                         Rule::skip_clause => {
-                            for skip_inner in child.into_inner() {
-                                if skip_inner.as_rule() == Rule::integer {
-                                    query.skip = skip_inner.as_str().parse::<usize>().ok();
-                                }
-                            }
+                            query.skip = parse_row_count(child)?;
                         }
                         Rule::limit_clause => {
-                            for limit_inner in child.into_inner() {
-                                if limit_inner.as_rule() == Rule::integer {
-                                    query.limit = limit_inner.as_str().parse::<usize>().ok();
-                                }
-                            }
+                            query.limit = parse_row_count(child)?;
                         }
                         _ => {}
                     }
@@ -783,18 +811,10 @@ fn parse_call_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) ->
                 query.order_by = Some(parse_order_by_clause(inner)?);
             }
             Rule::skip_clause => {
-                for i in inner.into_inner() {
-                    if i.as_rule() == Rule::integer {
-                        query.skip = i.as_str().parse::<usize>().ok();
-                    }
-                }
+                query.skip = parse_row_count(inner)?;
             }
             Rule::limit_clause => {
-                for i in inner.into_inner() {
-                    if i.as_rule() == Rule::integer {
-                        query.limit = i.as_str().parse::<usize>().ok();
-                    }
-                }
+                query.limit = parse_row_count(inner)?;
             }
             _ => {}
         }
@@ -1072,18 +1092,10 @@ fn parse_match_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
                 query.order_by = Some(parse_order_by_clause(inner)?);
             }
             Rule::skip_clause => {
-                for skip_inner in inner.into_inner() {
-                    if skip_inner.as_rule() == Rule::integer {
-                        query.skip = Some(parse_count_literal(skip_inner.as_str())?);
-                    }
-                }
+                query.skip = parse_row_count(inner)?;
             }
             Rule::limit_clause => {
-                for limit_inner in inner.into_inner() {
-                    if limit_inner.as_rule() == Rule::integer {
-                        query.limit = Some(parse_count_literal(limit_inner.as_str())?);
-                    }
-                }
+                query.limit = parse_row_count(inner)?;
             }
             _ => {}
         }
@@ -1119,18 +1131,10 @@ fn parse_create_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) 
                 query.order_by = Some(parse_order_by_clause(inner)?);
             }
             Rule::skip_clause => {
-                for i in inner.into_inner() {
-                    if i.as_rule() == Rule::integer {
-                        query.skip = i.as_str().parse::<usize>().ok();
-                    }
-                }
+                query.skip = parse_row_count(inner)?;
             }
             Rule::limit_clause => {
-                for i in inner.into_inner() {
-                    if i.as_rule() == Rule::integer {
-                        query.limit = i.as_str().parse::<usize>().ok();
-                    }
-                }
+                query.limit = parse_row_count(inner)?;
             }
             _ => {}
         }
@@ -1164,18 +1168,10 @@ fn parse_with_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<WithClaus
                 order_by = Some(parse_order_by_clause(inner)?);
             }
             Rule::skip_clause => {
-                for skip_inner in inner.into_inner() {
-                    if skip_inner.as_rule() == Rule::integer {
-                        skip = Some(parse_count_literal(skip_inner.as_str())?);
-                    }
-                }
+                skip = parse_row_count(inner)?;
             }
             Rule::limit_clause => {
-                for limit_inner in inner.into_inner() {
-                    if limit_inner.as_rule() == Rule::integer {
-                        limit = Some(parse_count_literal(limit_inner.as_str())?);
-                    }
-                }
+                limit = parse_row_count(inner)?;
             }
             _ => {}
         }

--- a/tests/skip_limit_expression.rs
+++ b/tests/skip_limit_expression.rs
@@ -1,0 +1,95 @@
+//! `SKIP` and `LIMIT` take an expression (#912).
+//!
+//! ```cypher
+//! MATCH (n) RETURN n LIMIT toInteger(ceil(1.7))   -- parse error
+//! MATCH (n) WITH n SKIP toInteger(rand() * 9) ...  -- parse error
+//! ```
+//!
+//! The grammar accepted an integer literal and nothing else, so these failed to
+//! parse at all.
+//!
+//! Cypher requires the expression **not to depend on variables**, and that rule
+//! is what makes folding it at parse time correct rather than a shortcut: it is
+//! evaluated once, against no row, so `LIMIT toInteger(rand() * 9)` picks one
+//! number for the whole query instead of a different one per row — which is the
+//! specified behaviour. The rest of the engine goes on receiving the `usize` it
+//! already expected, so nothing downstream changed.
+//!
+//! Six parse sites did this inline, each testing for `Rule::integer` and
+//! silently ignoring anything else. They share one function now, because
+//! "silently ignoring anything else" is how a LIMIT goes missing.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+fn ten_nodes() -> GraphStore {
+    let mut store = GraphStore::new();
+    let q = parse_query("UNWIND range(1, 10) AS i CREATE ({nr: i})").expect("setup parses");
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .expect("setup runs");
+    store
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` parses: {e:?}"));
+    QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` runs: {e}"))
+        .records
+        .len()
+}
+
+#[test]
+fn limit_takes_an_expression() {
+    let store = ten_nodes();
+    assert_eq!(rows(&store, "MATCH (n) RETURN n LIMIT 2"), 2, "the literal still works");
+    assert_eq!(rows(&store, "MATCH (n) RETURN n LIMIT toInteger(ceil(1.7))"), 2);
+    assert_eq!(rows(&store, "MATCH (n) RETURN n LIMIT 1 + 1"), 2);
+    assert_eq!(rows(&store, "MATCH (n) RETURN n LIMIT toInteger('3')"), 3);
+}
+
+#[test]
+fn skip_takes_an_expression() {
+    let store = ten_nodes();
+    assert_eq!(rows(&store, "MATCH (n) RETURN n SKIP 8"), 2);
+    assert_eq!(rows(&store, "MATCH (n) RETURN n SKIP toInteger(ceil(7.2))"), 2);
+    assert_eq!(rows(&store, "MATCH (n) WITH n SKIP 4 RETURN n"), 6);
+    assert_eq!(rows(&store, "MATCH (n) WITH n SKIP toInteger(2 * 2) RETURN n"), 6);
+}
+
+/// Evaluated once, not per row — so a random bound still trims to a single
+/// number and the query returns a consistent count.
+#[test]
+fn a_random_bound_is_evaluated_once() {
+    let store = ten_nodes();
+    for _ in 0..8 {
+        let n = rows(&store, "MATCH (n) WITH n SKIP toInteger(rand() * 9) RETURN n");
+        assert!((1..=10).contains(&n), "got {n} rows, which is not a single consistent trim");
+    }
+}
+
+/// A bound that cannot be a row count says so, rather than being dropped.
+///
+/// The inline sites ignored anything that was not `Rule::integer`, so an
+/// unusable bound became *no bound at all* — the query silently returned every
+/// row.
+#[test]
+fn an_unusable_bound_is_refused_not_dropped() {
+    for cypher in [
+        "MATCH (n) RETURN n LIMIT 'two'",
+        "MATCH (n) RETURN n LIMIT 1.5",
+        "MATCH (n) RETURN n LIMIT -1",
+        "MATCH (n) RETURN n SKIP -1",
+    ] {
+        assert!(parse_query(cypher).is_err(), "accepted `{cypher}`");
+    }
+}
+
+/// A bound that names a variable is refused: it would have to depend on the
+/// rows it is trimming.
+#[test]
+fn a_bound_that_depends_on_a_row_is_refused() {
+    assert!(parse_query("MATCH (n) RETURN n LIMIT n.count").is_err());
+}


### PR DESCRIPTION
Closes #912.

`RETURN n LIMIT toInteger(ceil(1.7))` failed to parse — the grammar accepted an integer literal and nothing else.

**Why folding it at parse time is right, not a shortcut.** Cypher requires the bound not to depend on variables; the TCK scenarios are titled *"…with an expression that does not depend on variables"*. That rule licenses evaluating it **once**, against no row, so `LIMIT toInteger(rand() * 9)` picks one number for the whole query rather than one per row — the specified behaviour. Downstream keeps receiving the `usize` it already expected, so none of the 32 uses of `query.limit` changed.

**The quieter half.** Six parse sites did this inline, each testing for `Rule::integer` and ignoring anything else — so an unusable bound became *no bound at all* and the query returned every row. One `parse_row_count` now, which refuses what it cannot use and keeps the negative-literal message. A test pins that: `LIMIT 'two'`, `LIMIT 1.5`, `LIMIT -1` are refused rather than dropped.

The grammar also tries `expression` **before** `integer` — pest's choice is ordered, so `integer` matched the `1` of `LIMIT 1 + 1` and left `+ 1` unconsumed.

**TCK 3,698 → 3,700**, errored 14 → 12, zero regressions, full workspace suite green (202 suites).