### PR TITLE
A label test on a relationship is a type test (#914)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2626,7 +2626,8 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
         }
         // `n:A:B` as a value, produced by the parser's postfix label check.
         // True when the node carries *every* named label; null when the
-        // subject is null, following Cypher's three-valued logic.
+        // subject is null, following Cypher's three-valued logic. On a
+        // relationship the same syntax is a type test -- see below.
         "haslabels" => {
             let wanted: Vec<String> = match &args[1] {
                 Value::Property(PropertyValue::Array(items)) => items
@@ -2638,6 +2639,23 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     .collect(),
                 _ => return Err(ExecutionError::TypeError("hasLabels expects a label list".into())),
             };
+            // On a relationship, `r:T` is a **type** test, and Cypher allows
+            // it: `MATCH ()-[r]->() RETURN r:T2` asks whether this
+            // relationship is a T2. We raised a TypeError and killed the query
+            // (#914).
+            //
+            // A relationship has exactly one type, so a multi-label test is
+            // false rather than an error -- `r:A:B` asks for something no
+            // relationship can be, which is a question with an answer.
+            let edge_type = match &args[0] {
+                Value::Edge(_, e) => Some(e.edge_type.as_str().to_string()),
+                Value::EdgeRef(_, _, _, ty) => Some(ty.as_str().to_string()),
+                _ => None,
+            };
+            if let Some(ty) = edge_type {
+                let matches = wanted.len() == 1 && wanted[0] == ty;
+                return Ok(Value::Property(PropertyValue::Boolean(matches)));
+            }
             let node = match &args[0] {
                 Value::Node(_, n) => Some((**n).clone()),
                 Value::NodeRef(id) => {
@@ -2651,7 +2669,7 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                 }
                 _ => {
                     return Err(ExecutionError::TypeError(
-                        "a label test requires a node".to_string(),
+                        "a label test requires a node or a relationship".to_string(),
                     ))
                 }
             };

--- a/tests/relationship_type_test.rs
+++ b/tests/relationship_type_test.rs
@@ -1,0 +1,97 @@
+//! `r:T` on a relationship is a **type** test (#914).
+//!
+//! `MATCH ()-[r]->() RETURN r:T2` raised `TypeError("a label test requires a
+//! node")` and killed the whole query. The parser turns postfix `:A:B` into a
+//! `hasLabels` call regardless of what the subject is, and `hasLabels` only
+//! knew about nodes.
+//!
+//! Cypher asks the question of relationships too, where it means "is this a
+//! T2?". A relationship has exactly one type, so `r:A:B` is a question about
+//! something no relationship can be — that is `false`, not an error. The
+//! distinction matters because the error form takes the *entire* query down,
+//! including the rows that had nothing to do with the test.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn graph() -> GraphStore {
+    let mut store = GraphStore::new();
+    let a = store.create_node("A");
+    let b = store.create_node("B");
+    store.create_edge(a, b, "T1").unwrap();
+    store.create_edge(a, b, "T2").unwrap();
+    store
+}
+
+fn bools(store: &GraphStore, cypher: &str) -> Vec<Option<bool>> {
+    let query = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let batch = QueryExecutor::new(store)
+        .execute(&query)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let mut out: Vec<Option<bool>> = batch
+        .records
+        .iter()
+        .map(|r| match r.get("result") {
+            Some(Value::Property(PropertyValue::Boolean(b))) => Some(*b),
+            Some(Value::Property(PropertyValue::Null)) | Some(Value::Null) | None => None,
+            other => panic!("{cypher}: {other:?}"),
+        })
+        .collect();
+    out.sort_by_key(|b| (b.is_none(), *b));
+    out
+}
+
+#[test]
+fn a_type_test_answers_true_for_the_matching_type() {
+    let store = graph();
+    assert_eq!(
+        bools(&store, "MATCH ()-[r:T2]->() RETURN r:T2 AS result"),
+        vec![Some(true)]
+    );
+}
+
+#[test]
+fn a_type_test_answers_per_row_without_failing_the_query() {
+    let store = graph();
+    // Both relationships are returned; the T1 row answers false rather than
+    // aborting the query the T2 row would have succeeded in.
+    assert_eq!(
+        bools(&store, "MATCH ()-[r]->() RETURN r:T2 AS result"),
+        vec![Some(false), Some(true)]
+    );
+}
+
+#[test]
+fn a_relationship_cannot_carry_two_types() {
+    let store = graph();
+    assert_eq!(
+        bools(&store, "MATCH ()-[r]->() RETURN r:T1:T2 AS result"),
+        vec![Some(false), Some(false)]
+    );
+}
+
+#[test]
+fn a_label_test_on_a_node_is_unchanged() {
+    let store = graph();
+    assert_eq!(
+        bools(&store, "MATCH (n) RETURN n:A AS result"),
+        vec![Some(false), Some(true)]
+    );
+}
+
+#[test]
+fn a_label_test_on_null_is_null() {
+    let store = graph();
+    assert_eq!(
+        bools(&store, "MATCH (n) WITH n LIMIT 1 RETURN null:A AS result"),
+        vec![None]
+    );
+}
+
+#[test]
+fn a_type_test_on_a_number_is_still_an_error() {
+    let store = graph();
+    let query = parse_query("MATCH (n) RETURN 1:A AS result").unwrap();
+    assert!(QueryExecutor::new(&store).execute(&query).is_err());
+}


### PR DESCRIPTION
Closes #914.

`MATCH ()-[r]->() RETURN r:T2` raised `TypeError("a label test requires a node")` and failed the entire query. openCypher TCK `Graph5` [2].

The parser turns postfix `:A:B` into a `hasLabels` call whatever the subject is; `hasLabels` matched `Node`, `NodeRef`, `Null`, then a catch-all `TypeError`. A relationship landed in the catch-all.

On a relationship this is a **type** test, and the answer is per-row — in `MATCH ()-[r]->() RETURN r:T2` some rows are true and some false — so erroring does not lose one value, it loses the rows that would have said true. A relationship carries exactly one type, so `r:A:B` is `false` rather than an error: a well-formed question with a negative answer.

`null:A` stays `null`; `1:A` stays a `TypeError`.

## Measured

openCypher TCK 2024.3, outline-expanded corpus, 3,762 evaluated: pass 3,700 → **3,701**, errored 12 → **11**, wrong results unchanged at 50. Failure-manifest diff shows exactly one scenario gained and **zero** regressions.

Six tests in `tests/relationship_type_test.rs`, including that the node and null paths are unchanged.