### PR TITLE
The release tag is blocked by CH-REGRESS (H1 gate condition 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,13 @@ jobs:
         # from a pre-existing one.
         run: ./scripts/check_thread_determinism.sh /tmp/openCypher/tck/features
 
+      - name: The release gate refuses for three reasons, not one
+        # It is the missing and the stale verdict that actually happen, and
+        # both look like "nothing is wrong" to a check that only compares a
+        # status string. This runs in CI because a gate nobody tests is a gate
+        # nobody can rely on at the moment it matters.
+        run: python3 scripts/test_check_release_gate.py
+
       - name: LINT-RATCHET — the clippy warning count may not rise
         # A ceiling, not a clean-tree gate: the debt stops growing while what
         # to do about the existing 769 stays open (#487).

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -70,6 +70,23 @@ jobs:
           echo "version=$WS_VERSION" >> "$GITHUB_OUTPUT"
           echo "new=true" >> "$GITHUB_OUTPUT"
 
+      # spec 19 §2 condition 3: CH-REGRESS green on its own nightly bare-metal
+      # run **and blocking the release tag**. See scripts/check_release_gate.py
+      # for why the verdict lives on its own branch and why missing and stale
+      # block the tag exactly as red does.
+      - name: CH-REGRESS must be green and recent before a tag is cut
+        if: steps.check.outputs.new == 'true'
+        shell: bash
+        run: |
+          set -uo pipefail
+          if ! git fetch origin release-gate --depth=1 2>/dev/null; then
+            echo "::error::no release-gate branch — the nightly has never published a verdict"
+            exit 1
+          fi
+          git show FETCH_HEAD:RELEASE-GATE.json > RELEASE-GATE.json
+          cat RELEASE-GATE.json
+          python3 scripts/check_release_gate.py RELEASE-GATE.json
+
       - name: Tag and publish the GitHub Release
         if: steps.check.outputs.new == 'true'
         env:

--- a/scripts/check_release_gate.py
+++ b/scripts/check_release_gate.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Refuse to cut a release tag unless CH-REGRESS vouched for this build.
+
+spec 19 §2 condition 3: CH-REGRESS green on its own nightly bare-metal run
+**and blocking the release tag**. The evidence lives in
+`samyama-graph-competitor-benchmarks`, which the tag workflow cannot read, so
+the nightly on the fixed host publishes its verdict to this repo's
+`release-gate` branch and this script reads it from there.
+
+A verdict is a fact about a run, not about a commit, which is why it lives on
+its own branch rather than on main: otherwise every nightly would be a
+source-code change.
+
+**Missing and stale block the tag exactly as red does.** "We could not tell" is
+not "it is fine" -- treating those as the same thing is the failure the whole
+harness is built to avoid, and a release is the last place to start.
+
+    python3 scripts/check_release_gate.py RELEASE-GATE.json [--max-age-days 3]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("verdict", type=Path)
+    ap.add_argument("--max-age-days", type=int, default=3,
+                    help="older than this and the nightly is not running")
+    a = ap.parse_args()
+
+    if not a.verdict.exists():
+        print(f"::error::no {a.verdict}. The nightly "
+              f"(harness/nightly/ch-regress-nightly.sh in the benchmarks repo) "
+              f"publishes CH-REGRESS's verdict to the release-gate branch; "
+              f"without it nothing has vouched for this build's latency.")
+        return 1
+
+    try:
+        g = json.loads(a.verdict.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        print(f"::error::{a.verdict} is not readable JSON: {e}")
+        return 1
+
+    try:
+        measured = datetime.fromisoformat(str(g["measured_at"]).replace("Z", "+00:00"))
+    except (KeyError, ValueError) as e:
+        print(f"::error::{a.verdict} has no usable measured_at: {e}")
+        return 1
+
+    age = (datetime.now(timezone.utc) - measured).days
+    if age > a.max_age_days:
+        print(f"::error::the CH-REGRESS verdict is {age} days old "
+              f"(limit {a.max_age_days}) — the nightly has not run. "
+              f"A gate with gaps nobody notices is not a gate.")
+        return 1
+
+    if g.get("status") != "pass":
+        print(f"::error::CH-REGRESS is {g.get('status')!r}: {g.get('note')}")
+        return 1
+
+    print(f"CH-REGRESS pass, {age}d old, host {g.get('host')!r}, "
+          f"engine {g.get('engine_commit')}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_release_gate.py
+++ b/scripts/test_check_release_gate.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""The release gate must refuse for *three* reasons, not one.
+
+A gate that only rejects a red verdict is not a gate. The two cases that
+actually happen are the nightly having stopped (stale) and never having run
+(missing), and both look exactly like "nothing is wrong" if the check only
+compares a status string.
+
+Run: python3 scripts/test_check_release_gate.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+CHECK = HERE / "check_release_gate.py"
+
+
+def run(verdict: dict | None, name: str = "RELEASE-GATE.json") -> int:
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / name
+        if verdict is not None:
+            p.write_text(json.dumps(verdict))
+        return subprocess.run(
+            [sys.executable, str(CHECK), str(p)], capture_output=True, text=True
+        ).returncode
+
+
+def stamp(days_ago: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+CASES = [
+    ("a fresh pass lets the tag through", 0,
+     {"status": "pass", "measured_at": stamp(0), "host": "vm-1"}),
+    ("a fresh fail blocks", 1,
+     {"status": "fail", "measured_at": stamp(0), "note": "IC6 3.2x slower"}),
+    # The nightly stopped a week ago. Nothing is red; nothing has looked.
+    ("a stale pass blocks", 1,
+     {"status": "pass", "measured_at": stamp(9), "host": "vm-1"}),
+    ("an unmeasured verdict blocks", 1,
+     {"status": "unmeasured", "measured_at": stamp(0)}),
+    # The nightly has never run, or the branch is gone.
+    ("a missing verdict blocks", 1, None),
+    ("a verdict with no measured_at blocks", 1, {"status": "pass"}),
+    ("three days is inside the window", 0,
+     {"status": "pass", "measured_at": stamp(3), "host": "vm-1"}),
+    ("four days is not", 1,
+     {"status": "pass", "measured_at": stamp(4), "host": "vm-1"}),
+]
+
+if __name__ == "__main__":
+    ok = True
+    for name, want, verdict in CASES:
+        got = run(verdict)
+        good = got == want
+        ok &= good
+        print(f"{'ok  ' if good else 'FAIL'} {name}"
+              + ("" if good else f"  -- wanted rc={want}, got rc={got}"))
+    print("\nPASS" if ok else "\nFAIL")
+    sys.exit(0 if ok else 1)


### PR DESCRIPTION
Spec 19 §2 condition 3 asks for CH-REGRESS green on its nightly bare-metal run **and blocking the release tag**. The second half was a sentence in the gate's *to close* text — nothing stopped a tag being cut with no latency evidence behind it, which is the shape of requirement that stays unmet because nothing is looking at it.

## How the two repos are connected

The evidence lives in `samyama-graph-competitor-benchmarks`, which this workflow cannot read. So the nightly on the fixed host reduces its CH-REGRESS envelope to a small verdict and pushes it to this repo's **`release-gate` branch**; `scripts/check_release_gate.py` reads it there before `tag-release.yml` is allowed to tag.

Its own branch rather than main, deliberately: a verdict is a fact about a *run*, not about a commit. On main every nightly would be a source-code change.

## Missing and stale block exactly as red does

The two failures that actually happen are a nightly that stopped and one that never ran. Both look like "nothing is wrong" to a check that only compares a status string. "We could not tell" is not "it is fine" — treating those as the same thing is the failure the whole harness exists to prevent, and a release is the last place to start.

The verdict is published by the nightly **whatever the outcome**, for the same reason: a nightly that publishes only its successes turns a red run into a stale one and makes the two indistinguishable downstream.

## Tests

`scripts/test_check_release_gate.py`, eight cases, run in CI:

```
ok   a fresh pass lets the tag through
ok   a fresh fail blocks
ok   a stale pass blocks
ok   an unmeasured verdict blocks
ok   a missing verdict blocks
ok   a verdict with no measured_at blocks
ok   three days is inside the window
ok   four days is not
```

A gate nobody tests is a gate nobody can rely on at the moment it matters.

## The other half

The nightly itself — runner script, systemd user timer, verdict publisher, and the `gate.py` change that now checks all three clauses of condition 3 instead of one and a half — is in the benchmarks repo.