### PR TITLE
Two equal lists are equal (#925)

### DIFF
--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -169,6 +169,32 @@ impl PartialEq for Value {
             // Path
             (Value::Path { nodes: n1, edges: e1 }, Value::Path { nodes: n2, edges: e2 }) => n1 == n2 && e1 == e2,
             (Value::Null, Value::Null) => true,
+            // Lists and maps had no arm at all, so they fell to `_ => false`
+            // and **no two lists were ever equal** -- `[] == []` included, and
+            // `a == a` with it, for a type that also implements `Eq` (#925).
+            //
+            // Nothing errored. `GROUP BY` a list simply never merged two
+            // groups and `DISTINCT` never removed a duplicate, so a query
+            // returned one row too many with every row individually right.
+            (Value::List(a), Value::List(b)) => a == b,
+            (Value::Map(a), Value::Map(b)) => a == b,
+            // The two spellings of one list. `PropertyValue::Array` cannot
+            // hold a node, so a list of relationships has to be a
+            // `Value::List` while a list read from a property is an `Array` --
+            // and a query that groups over both is mixing spellings, not
+            // types. Same for maps.
+            (Value::List(a), Value::Property(PropertyValue::Array(b)))
+            | (Value::Property(PropertyValue::Array(b)), Value::List(a)) => {
+                a.len() == b.len()
+                    && a.iter().zip(b).all(|(x, y)| *x == Value::Property(y.clone()))
+            }
+            (Value::Map(a), Value::Property(PropertyValue::Map(b)))
+            | (Value::Property(PropertyValue::Map(b)), Value::Map(a)) => {
+                a.len() == b.len()
+                    && a.iter().all(|(k, v)| {
+                        b.get(k).is_some_and(|w| *v == Value::Property(w.clone()))
+                    })
+            }
             _ => false,
         }
     }
@@ -177,21 +203,61 @@ impl PartialEq for Value {
 impl Eq for Value {}
 
 impl Hash for Value {
+    /// Hash **canonically**, not per variant.
+    ///
+    /// `Eq` treats `Value::List` and `Value::Property(Array)` as the same
+    /// list, and `Value::Map` and `Value::Property(Map)` as the same map, so
+    /// the two spellings have to reach the same hash or the `Hash`/`Eq`
+    /// contract is broken and a HashMap loses entries it holds.
+    ///
+    /// That is why a list is hashed here rather than delegating to its
+    /// elements' `Hash`: the elements are `PropertyValue` on one side and
+    /// `Value` on the other, and only hashing each element *as the `Value` it
+    /// is equal to* makes the two agree.
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Use semantic tags so NodeRef and Node hash the same
         match self {
             Value::Node(id, _) | Value::NodeRef(id) => { 0u8.hash(state); id.hash(state); }
             Value::Edge(id, _) | Value::EdgeRef(id, ..) => { 1u8.hash(state); id.hash(state); }
+            // A property that is a list or a map hashes as the list or map it
+            // is, not as "a property".
+            Value::Property(PropertyValue::Array(items)) => {
+                5u8.hash(state);
+                items.len().hash(state);
+                for item in items { Value::Property(item.clone()).hash(state); }
+            }
+            Value::Property(PropertyValue::Map(entries)) => {
+                hash_map_entries(state, entries.iter().map(|(k, v)| (k, Value::Property(v.clone()))));
+            }
             Value::Property(p) => { 2u8.hash(state); p.hash(state); }
             Value::Path { nodes, edges } => { 3u8.hash(state); nodes.hash(state); edges.hash(state); }
-            Value::List(items) => { 5u8.hash(state); items.hash(state); }
+            Value::List(items) => {
+                5u8.hash(state);
+                items.len().hash(state);
+                for item in items { item.hash(state); }
+            }
             Value::Map(entries) => {
-                6u8.hash(state);
-                for (k, v) in entries { k.hash(state); v.hash(state); }
+                hash_map_entries(state, entries.iter().map(|(k, v)| (k, v.clone())));
             }
             Value::Null => { 4u8.hash(state); }
         }
     }
+}
+
+/// Hash a map's entries in key order.
+///
+/// `Value::Map` is a `BTreeMap` and `PropertyValue::Map` is a `HashMap`, whose
+/// iteration order is not stable between runs let alone between the two types.
+/// Sorting by key is what makes one hash of the other possible at all.
+fn hash_map_entries<'a, H: Hasher>(
+    state: &mut H,
+    entries: impl Iterator<Item = (&'a String, Value)>,
+) {
+    6u8.hash(state);
+    let mut pairs: Vec<(&String, Value)> = entries.collect();
+    pairs.sort_by(|a, b| a.0.cmp(b.0));
+    pairs.len().hash(state);
+    for (k, v) in pairs { k.hash(state); v.hash(state); }
 }
 
 impl Record {

--- a/tests/list_equality.rs
+++ b/tests/list_equality.rs
@@ -1,0 +1,161 @@
+//! Two equal lists are equal (#925).
+//!
+//! `PartialEq for Value` matched every variant except `List` and `Map`, which
+//! fell through to `_ => false`. So `[] == []` was false, `[1,2] == [1,2]` was
+//! false, and `a == a` was false for a type that also implements `Eq`.
+//!
+//! Nothing errored. `GROUP BY` over a list never merged two groups and
+//! `DISTINCT` never removed a duplicate, so a query returned one row too many
+//! with every row individually correct — which no caller can detect.
+//!
+//! The hash is what hid it: `Hash for Value` *did* handle both variants, so
+//! two equal lists landed in the same bucket, were compared, found unequal,
+//! and stored twice. A missing hash would have been loud.
+//!
+//! These tests exercise the behaviour through queries rather than through
+//! `==` directly, because the defect was only visible in grouping and
+//! deduplication and a unit test on the operator would not have run either.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn rows(store: &GraphStore, cypher: &str) -> usize {
+    let query = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    QueryExecutor::new(store)
+        .execute(&query)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"))
+        .records
+        .len()
+}
+
+/// A chain a-b-c-d, so `p = (a)-[*0..3]->(x)` yields four paths.
+fn chain() -> GraphStore {
+    let mut store = GraphStore::new();
+    let a = store.create_node("Root");
+    let b = store.create_node("N");
+    let c = store.create_node("N");
+    let d = store.create_node("N");
+    store.create_edge(a, b, "R").unwrap();
+    store.create_edge(b, c, "R").unwrap();
+    store.create_edge(c, d, "R").unwrap();
+    store
+}
+
+#[test]
+fn two_empty_lists_group_as_one() {
+    let store = chain();
+    // The zero-length path has `relationships(p) = []`; the one-hop path has
+    // one relationship, whose `tail` is also `[]`. Two paths, one group.
+    // Before the fix this answered 2.
+    assert_eq!(
+        rows(&store, "MATCH p = (:Root)-[*0..1]->(x) \
+                      WITH tail(relationships(p)) AS rs, count(*) AS c RETURN rs, c"),
+        1
+    );
+}
+
+#[test]
+fn equal_lists_of_relationships_group_as_one() {
+    let store = chain();
+    // Four paths of length 0..3; their tails are [], [], [r2] and [r2, r3] —
+    // three distinct groups.
+    assert_eq!(
+        rows(&store, "MATCH p = (:Root)-[*0..3]->(x) \
+                      WITH tail(relationships(p)) AS rs, count(*) AS c RETURN rs, c"),
+        3
+    );
+}
+
+#[test]
+fn distinct_removes_a_duplicate_list() {
+    let store = chain();
+    assert_eq!(
+        rows(&store, "MATCH p = (:Root)-[*0..1]->(x) \
+                      RETURN DISTINCT tail(relationships(p)) AS rs"),
+        1
+    );
+}
+
+#[test]
+fn distinct_keeps_lists_that_differ() {
+    let store = chain();
+    assert_eq!(
+        rows(&store, "UNWIND [[1, 2], [1, 2], [2, 1], []] AS l RETURN DISTINCT l"),
+        3
+    );
+}
+
+#[test]
+fn distinct_deduplicates_maps() {
+    let store = chain();
+    assert_eq!(
+        rows(&store, "UNWIND [{a: 1}, {a: 1}, {a: 2}] AS m RETURN DISTINCT m"),
+        2
+    );
+}
+
+#[test]
+fn a_map_is_not_equal_to_a_map_with_an_extra_key() {
+    let store = chain();
+    assert_eq!(
+        rows(&store, "UNWIND [{a: 1}, {a: 1, b: 2}] AS m RETURN DISTINCT m"),
+        2
+    );
+}
+
+/// The two spellings of one list must group together, or a query that reads
+/// one list from a property and builds another in the query splits them.
+#[test]
+fn a_stored_list_and_a_built_list_are_the_same_list() {
+    let mut store = GraphStore::new();
+    let n = store.create_node("N");
+    let _ = store.set_node_property(
+        "default",
+        n,
+        "xs".to_string(),
+        PropertyValue::Array(vec![PropertyValue::Integer(1), PropertyValue::Integer(2)]),
+    );
+    assert_eq!(
+        rows(&store, "MATCH (n:N) UNWIND [n.xs, [1, 2]] AS l RETURN DISTINCT l"),
+        1
+    );
+}
+
+/// Equality is only half of it: a HashMap consults the hash first, so the two
+/// spellings must also hash alike or grouping loses entries it holds.
+#[test]
+fn the_two_spellings_hash_alike() {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    fn h(v: &Value) -> u64 {
+        let mut s = DefaultHasher::new();
+        v.hash(&mut s);
+        s.finish()
+    }
+
+    let built = Value::List(vec![
+        Value::Property(PropertyValue::Integer(1)),
+        Value::Property(PropertyValue::Integer(2)),
+    ]);
+    let stored = Value::Property(PropertyValue::Array(vec![
+        PropertyValue::Integer(1),
+        PropertyValue::Integer(2),
+    ]));
+    assert_eq!(built, stored, "equal");
+    assert_eq!(h(&built), h(&stored), "and therefore hashed alike");
+
+    // A different list must not be forced to collide just to satisfy the above.
+    let other = Value::List(vec![Value::Property(PropertyValue::Integer(1))]);
+    assert_ne!(built, other);
+}
+
+/// `Eq` promises reflexivity, and lists were the counter-example.
+#[test]
+fn a_list_equals_itself() {
+    let empty = Value::List(vec![]);
+    assert_eq!(empty, empty.clone());
+    let one = Value::List(vec![Value::Property(PropertyValue::String("x".into()))]);
+    assert_eq!(one, one.clone());
+}


### PR DESCRIPTION
Closes #925.

`PartialEq for Value` matched every variant except `List` and `Map`, which fell to `_ => false`. So `[] == []` was **false**, `[1,2] == [1,2]` was false, and `a == a` was false — for a type that also implements `Eq`, whose whole promise is reflexivity.

## What it did

Nothing errored. Grouping and deduplication both compare, so `GROUP BY` over a list never merged two groups and `DISTINCT` never removed a duplicate. The query came back with **one row too many and every row individually correct**, which no caller can detect.

openCypher `Quantifier1/2/3/4` [9] each returned 16 rows where 15 are right: sixteen paths leave the anchor, two of them have `tail(relationships(p)) = []`, and those two are one group. `With5` [2] is the same fault through `DISTINCT`.

## The hash is what hid it

`Hash for Value` *did* handle both variants. So two equal lists landed in the same bucket, were compared, found unequal, and stored separately. A missing hash would have been loud.

## The two spellings

The same fix closes a second gap: `Value::List(Vec<Value>)` and `Value::Property(PropertyValue::Array(Vec<PropertyValue>))` are both "a list" to a query. `PropertyValue::Array` cannot hold a node, so a list of relationships *must* be a `Value::List` while a list read from a property is an `Array` — a query grouping over both is mixing spellings, not types.

Bridging them in `Eq` forces the hash to bridge them too, so hashing is now **canonical rather than per-variant**: a list hashes its elements as the `Value`s they are equal to, and map entries hash in key order because one side is a `BTreeMap` and the other a `HashMap` whose iteration order is not stable between runs.

## Measured

| | before | after |
|---|---|---|
| pass | 3,701 | **3,706** |
| wrong result | 50 | **45** |
| errored | 11 | 11 |

Five scenarios gained, **zero regressions** by failure-manifest diff.

## Tests

Nine in `tests/list_equality.rs`, driven through queries rather than through `==`, because the defect was only ever visible in grouping and deduplication. Including that the two spellings both compare equal *and* hash alike — equality alone would have left a HashMap losing entries it holds.