### PR TITLE
ORDER BY places nodes, relationships and paths (#917)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -8958,17 +8958,17 @@ impl SortOperator {
     /// performed ~2·n·log₂(n) evaluations rather than n. On LDBC IC9 that was
     /// 389,461 rows -> ~14.5 million property resolutions where 389,461 would
     /// do, and `Sort` was 68.6% of the query.
-    fn key_of(&self, record: &Record, store: &GraphStore) -> Vec<PropertyValue> {
+    fn key_of(&self, record: &Record, store: &GraphStore) -> Vec<Value> {
         self.sort_items
             .iter()
             .map(|(expr, _)| {
                 // Errors are folded to Null, which is what the comparator did
                 // before and what ORDER BY over a missing property means.
-                Self::evaluate_expression(expr, record, store)
-                    .unwrap_or(Value::Null)
-                    .as_property()
-                    .cloned()
-                    .unwrap_or(PropertyValue::Null)
+                //
+                // The key is a `Value`, not a `PropertyValue`: going through
+                // `as_property()` turned every node, relationship and path
+                // into `Null` and sorted them all together at the end (#917).
+                Self::evaluate_expression(expr, record, store).unwrap_or(Value::Null)
             })
             .collect()
     }
@@ -8984,21 +8984,18 @@ impl SortOperator {
         sort_items: &[(Expression, bool)],
         record: &Record,
         store: &GraphStore,
-    ) -> Vec<PropertyValue> {
+    ) -> Vec<Value> {
         let mut key = Vec::with_capacity(sort_items.len());
         let mut cursor = readers.iter_mut();
         for (expr, _) in sort_items {
             match expr {
+                // A property is always a `PropertyValue`; the cursor stays.
                 Expression::Property { .. } => {
                     let c = cursor.next().expect("one cursor per property key");
-                    key.push(c.read(record, store));
+                    key.push(Value::Property(c.read(record, store)));
                 }
                 other => key.push(
-                    Self::evaluate_expression(other, record, store)
-                        .unwrap_or(Value::Null)
-                        .as_property()
-                        .cloned()
-                        .unwrap_or(PropertyValue::Null),
+                    Self::evaluate_expression(other, record, store).unwrap_or(Value::Null),
                 ),
             }
         }
@@ -9006,7 +9003,7 @@ impl SortOperator {
     }
 
     /// Compare two precomputed keys under the per-column sort directions.
-    fn cmp_keys(a: &[PropertyValue], b: &[PropertyValue], items: &[(Expression, bool)]) -> std::cmp::Ordering {
+    fn cmp_keys(a: &[Value], b: &[Value], items: &[(Expression, bool)]) -> std::cmp::Ordering {
         for (i, (_, ascending)) in items.iter().enumerate() {
             let (Some(x), Some(y)) = (a.get(i), b.get(i)) else {
                 continue;
@@ -9014,8 +9011,10 @@ impl SortOperator {
             // Cypher's orderability, not the index's: `ORDER BY` puts a
             // string before a number and a list before both, where the `Ord`
             // backing the property index does the opposite. See
-            // `graph::property::cypher_order` for why both orders exist.
-            let ord = crate::graph::property::cypher_order(x, y);
+            // `graph::property::cypher_order` for why both orders exist, and
+            // `record::cypher_order_value` for the entity ranks it cannot
+            // express.
+            let ord = crate::query::executor::record::cypher_order_value(x, y);
             if ord != std::cmp::Ordering::Equal {
                 return if *ascending { ord } else { ord.reverse() };
             }
@@ -9033,7 +9032,7 @@ impl SortOperator {
     /// `ORDER BY … LIMIT`, so any k of a tied set is a valid answer, but two
     /// runs may therefore disagree about *which* — the same latitude the
     /// unstable sort below already takes.
-    fn trim_to(keyed: &mut Vec<(Vec<PropertyValue>, Record)>, k: usize, items: &[(Expression, bool)]) {
+    fn trim_to(keyed: &mut Vec<(Vec<Value>, Record)>, k: usize, items: &[(Expression, bool)]) {
         if k == 0 {
             keyed.clear();
             return;
@@ -9248,7 +9247,7 @@ impl SortOperator {
             })
             .collect();
 
-        let mut keyed: Vec<(Vec<PropertyValue>, Record)> = Vec::new();
+        let mut keyed: Vec<(Vec<Value>, Record)> = Vec::new();
         while let Some(batch) = self.input.next_batch(store, batch_size)? {
             keyed.reserve(batch.records.len());
             for record in batch.records {
@@ -14382,13 +14381,13 @@ impl WithBarrierOperator {
                 for (expr, ascending) in sort_items {
                     let val_a = Self::evaluate_expression(expr, a, store).unwrap_or(Value::Null);
                     let val_b = Self::evaluate_expression(expr, b, store).unwrap_or(Value::Null);
-                    let prop_a = val_a.as_property().unwrap_or(&PropertyValue::Null);
-                    let prop_b = val_b.as_property().unwrap_or(&PropertyValue::Null);
                     // Cypher's orderability, not the property index's — see
                     // `graph::property::cypher_order`. A WITH ... ORDER BY
                     // sorts here rather than in `SortOperator`, so wiring only
-                    // that one left every `WITH` sort on the old order.
-                    let ord = crate::graph::property::cypher_order(prop_a, prop_b);
+                    // that one left every `WITH` sort on the old order — the
+                    // same trap for the entity ranks (#917), which is why both
+                    // sites now call the `Value`-level comparison.
+                    let ord = crate::query::executor::record::cypher_order_value(&val_a, &val_b);
                     if ord != std::cmp::Ordering::Equal {
                         return if *ascending { ord } else { ord.reverse() };
                     }

--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -1307,3 +1307,110 @@ fn temporal_component(v: &PropertyValue, property: &str) -> PropertyValue {
         }
     }
 }
+
+/// Cypher's orderability over `Value`, for `ORDER BY`.
+///
+/// openCypher defines one total order across types, ascending:
+///
+/// ```text
+/// Map < Node < Relationship < List < Path < String < Boolean < Number < NaN < null
+/// ```
+///
+/// [`crate::graph::property::cypher_order`] already implements the part of
+/// that order a `PropertyValue` can express. It cannot express the rest: a
+/// `PropertyValue` holds no node, relationship or path, so sorting through
+/// `as_property()` folded every entity to `Null` (#917). The rows still came
+/// back — the right rows, in fact — with every node, relationship and path
+/// bunched at the null end and indistinguishable from each other and from a
+/// missing value. `ORDER BY` reported success and answered wrongly.
+///
+/// So the comparison has to happen at `Value`, above the property type, and
+/// this function is where the three entity ranks live. Everything it can hand
+/// to `cypher_order` it hands over, so there is still one implementation of
+/// the property half rather than two that drift.
+pub fn cypher_order_value(a: &Value, b: &Value) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+
+    // Ranks are the ascending order above. `Value::List`/`Value::Map` and
+    // their `PropertyValue` spellings are the same type to a query and must
+    // rank the same, or `[1]` and a list of nodes sort into different places.
+    fn rank(v: &Value) -> u8 {
+        match v {
+            Value::Map(_) => 0,
+            Value::Node(..) | Value::NodeRef(_) => 1,
+            Value::Edge(..) | Value::EdgeRef(..) => 2,
+            Value::List(_) => 3,
+            Value::Path { .. } => 4,
+            Value::Null => 9,
+            Value::Property(p) => match p {
+                PropertyValue::Map(_) => 0,
+                PropertyValue::Array(_) | PropertyValue::Vector(_) => 3,
+                PropertyValue::String(_) => 5,
+                PropertyValue::Boolean(_) => 6,
+                PropertyValue::Float(f) if f.is_nan() => 8,
+                PropertyValue::Null => 9,
+                _ => 7,
+            },
+        }
+    }
+
+    let (ra, rb) = (rank(a), rank(b));
+    if ra != rb {
+        return ra.cmp(&rb);
+    }
+
+    match (a, b) {
+        // Both are properties of the same rank: the existing order decides,
+        // including NaN and the element-wise list comparison.
+        (Value::Property(x), Value::Property(y)) => crate::graph::property::cypher_order(x, y),
+        // Element-wise, then by length — the same rule `cypher_order` applies
+        // to `PropertyValue::Array`, restated here because the elements are
+        // `Value`s and may be entities.
+        (Value::List(x), Value::List(y)) => {
+            for (xi, yi) in x.iter().zip(y.iter()) {
+                let c = cypher_order_value(xi, yi);
+                if c != Ordering::Equal {
+                    return c;
+                }
+            }
+            x.len().cmp(&y.len())
+        }
+        // A `Value::Map` against a `PropertyValue::Map`, or a list against an
+        // array: same rank, different spelling. Compare by sorted key, then by
+        // the value under it, so the two spellings interleave.
+        (Value::Map(x), Value::Map(y)) => {
+            let (mut xk, mut yk): (Vec<_>, Vec<_>) =
+                (x.keys().collect(), y.keys().collect());
+            xk.sort();
+            yk.sort();
+            for (kx, ky) in xk.iter().zip(yk.iter()) {
+                let c = kx.cmp(ky);
+                if c != Ordering::Equal {
+                    return c;
+                }
+                let c = cypher_order_value(&x[*kx], &y[*ky]);
+                if c != Ordering::Equal {
+                    return c;
+                }
+            }
+            xk.len().cmp(&yk.len())
+        }
+        // Entities of the same kind. openCypher leaves the order among them
+        // undefined; element id is stable and total, which is what a sort
+        // needs. Two runs over the same graph therefore agree.
+        _ => entity_id(a).cmp(&entity_id(b)),
+    }
+}
+
+fn entity_id(v: &Value) -> (u64, usize) {
+    match v {
+        Value::Node(id, _) | Value::NodeRef(id) => (id.as_u64(), 0),
+        Value::Edge(id, _) | Value::EdgeRef(id, ..) => (id.as_u64(), 0),
+        // A path has no id; length then first node orders it deterministically.
+        Value::Path { nodes, edges } => (
+            nodes.first().map(|n| n.as_u64()).unwrap_or(0),
+            edges.len(),
+        ),
+        _ => (0, 0),
+    }
+}

--- a/tests/order_by_entity_ranks.rs
+++ b/tests/order_by_entity_ranks.rs
@@ -1,0 +1,171 @@
+//! `ORDER BY` places nodes, relationships and paths (#917).
+//!
+//! The sort key was built with `Value::as_property()`. A node, a relationship
+//! and a path have no `PropertyValue`, so each became `PropertyValue::Null` —
+//! and every entity sorted as null: bunched at the end ascending, at the front
+//! descending, indistinguishable from each other and from a genuinely missing
+//! value.
+//!
+//! The query succeeded. The right rows came back, in the wrong order, and
+//! nothing said so.
+//!
+//! openCypher's orderability, ascending:
+//!
+//! ```text
+//! Map < Node < Relationship < List < Path < String < Boolean < Number < NaN < null
+//! ```
+//!
+//! `graph::property::cypher_order` already documented that order in full,
+//! including the three entity ranks — while taking a `PropertyValue`, which
+//! cannot hold any of them. The comparison had to move up to `Value`.
+//!
+//! There are two sort sites: `SortOperator` and a second inside the `WITH`
+//! path. Both are exercised here, because wiring only one is a mistake this
+//! code has already made once.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// One node of each label, one relationship, so a projection can produce a
+/// value of every type the order names.
+fn graph() -> GraphStore {
+    let mut store = GraphStore::new();
+    let a = store.create_node("N");
+    let b = store.create_node("M");
+    store.create_edge(a, b, "REL").unwrap();
+    store
+}
+
+/// A coarse label for what a value *is*, which is all the type ordering cares
+/// about.
+fn kind(v: &Value) -> &'static str {
+    match v {
+        Value::Node(..) | Value::NodeRef(_) => "node",
+        Value::Edge(..) | Value::EdgeRef(..) => "rel",
+        Value::Path { .. } => "path",
+        Value::List(_) | Value::Property(PropertyValue::Array(_)) => "list",
+        Value::Map(_) | Value::Property(PropertyValue::Map(_)) => "map",
+        Value::Property(PropertyValue::String(_)) => "string",
+        Value::Property(PropertyValue::Boolean(_)) => "bool",
+        Value::Property(PropertyValue::Float(f)) if f.is_nan() => "nan",
+        Value::Property(PropertyValue::Integer(_) | PropertyValue::Float(_)) => "number",
+        Value::Null | Value::Property(PropertyValue::Null) => "null",
+        _ => "other",
+    }
+}
+
+fn kinds(store: &GraphStore, cypher: &str) -> Vec<&'static str> {
+    let query = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    QueryExecutor::new(store)
+        .execute(&query)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"))
+        .records
+        .iter()
+        .map(|r| kind(r.get("x").expect("every row projects x")))
+        .collect()
+}
+
+/// Every type openCypher orders, produced in one column in a scrambled order
+/// so the sort has work to do.
+const MIXED: &str = "MATCH (n:N)-[r:REL]->(m:M), p = (n)-[r]->(m) \
+                     WITH [1.5, 'text', n, null, false, {a: 'map'}, ['list'], r, p] AS l \
+                     UNWIND l AS x";
+
+#[test]
+fn ascending_puts_entities_where_cypher_puts_them() {
+    let store = graph();
+    assert_eq!(
+        kinds(&store, &format!("{MIXED} RETURN x ORDER BY x")),
+        vec!["map", "node", "rel", "list", "path", "string", "bool", "number", "null"]
+    );
+}
+
+#[test]
+fn descending_is_the_exact_reverse() {
+    let store = graph();
+    let mut want = kinds(&store, &format!("{MIXED} RETURN x ORDER BY x"));
+    want.reverse();
+    assert_eq!(kinds(&store, &format!("{MIXED} RETURN x ORDER BY x DESC")), want);
+}
+
+#[test]
+fn the_with_path_sorts_the_same_way() {
+    // A second ORDER BY implementation lives in the WITH path. Wiring only
+    // `SortOperator` left every `WITH ... ORDER BY` on the old behaviour once
+    // already, which is why this is asserted rather than assumed.
+    //
+    // The list is built in a WITH before the UNWIND because
+    // `MATCH (n) UNWIND [n] AS x WITH x` raises VariableNotFound("n") -- a
+    // separate defect (#927), unrelated to ordering.
+    let store = graph();
+    assert_eq!(
+        kinds(&store, &format!("{MIXED} WITH x ORDER BY x RETURN x")),
+        kinds(&store, &format!("{MIXED} RETURN x ORDER BY x"))
+    );
+}
+
+#[test]
+fn entities_of_different_kinds_do_not_collapse_together() {
+    // The heart of the bug: a node, a relationship and a path all became null,
+    // so all four of these sorted into one indistinguishable clump at the end.
+    let store = graph();
+    let got = kinds(&store, &format!("{MIXED} RETURN x ORDER BY x"));
+    let tail: Vec<_> = got.iter().rev().take(4).copied().collect();
+    assert_eq!(tail, vec!["null", "number", "bool", "string"]);
+}
+
+#[test]
+fn ordering_by_a_node_is_stable_across_runs() {
+    // openCypher leaves the order among nodes undefined, but a sort still
+    // needs a total order two runs agree on, or `ORDER BY ... LIMIT` returns
+    // different rows each time.
+    let mut store = GraphStore::new();
+    for _ in 0..8 {
+        store.create_node("N");
+    }
+    let q = "MATCH (n:N) RETURN n AS x ORDER BY n";
+    let first = ids(&store, q);
+    assert_eq!(first, ids(&store, q));
+    let mut sorted = first.clone();
+    sorted.sort();
+    assert_eq!(first, sorted, "nodes order by element id");
+}
+
+fn ids(store: &GraphStore, cypher: &str) -> Vec<u64> {
+    let query = parse_query(cypher).unwrap();
+    QueryExecutor::new(store)
+        .execute(&query)
+        .unwrap()
+        .records
+        .iter()
+        .map(|r| match r.get("x") {
+            Some(Value::Node(id, _)) | Some(Value::NodeRef(id)) => id.as_u64(),
+            other => panic!("{other:?}"),
+        })
+        .collect()
+}
+
+#[test]
+fn ordinary_property_ordering_is_unchanged() {
+    let mut store = GraphStore::new();
+    for (i, name) in ["c", "a", "b"].iter().enumerate() {
+        let n = store.create_node("P");
+        let _ = store.set_node_property("default", n, "name".to_string(),
+                                        PropertyValue::String((*name).into()));
+        let _ = store.set_node_property("default", n, "i".to_string(),
+                                        PropertyValue::Integer(i as i64));
+    }
+    let query = parse_query("MATCH (p:P) RETURN p.name AS x ORDER BY p.name").unwrap();
+    let names: Vec<String> = QueryExecutor::new(&store)
+        .execute(&query)
+        .unwrap()
+        .records
+        .iter()
+        .map(|r| match r.get("x") {
+            Some(Value::Property(PropertyValue::String(s))) => s.clone(),
+            other => panic!("{other:?}"),
+        })
+        .collect();
+    assert_eq!(names, vec!["a", "b", "c"]);
+}


### PR DESCRIPTION
Closes #917.

The sort key was built through `Value::as_property()`. A node, a relationship and a path have no `PropertyValue`, so each became `PropertyValue::Null` — **every entity sorted as null**: bunched at the end ascending, at the front descending, indistinguishable from each other and from a genuinely missing value.

The query succeeded. The right rows came back. They were in the wrong order and nothing said so.

## Why the existing comparator could not fix it

`graph::property::cypher_order` already documents openCypher's order in full —

```
Map < Node < Relationship < List < Path < String < Boolean < Number < NaN < null
```

— while taking a `PropertyValue`, which cannot hold a node, a relationship or a path. A doc comment describing an order its own signature makes it unable to implement. This is the `Value` vs `PropertyValue` split again, and forgetting it produces a silent wrong answer rather than a compile error.

So the comparison moves up to `Value`. `cypher_order_value` owns the three entity ranks and hands everything a `PropertyValue` can express back to `cypher_order`, so there is still one implementation of the property half.

## Both sort sites

`SortOperator::cmp_keys` **and** the second ORDER BY inside the `WITH` path. The comment at that second site records that wiring only one has already happened once here, so the test asserts they agree rather than assuming it.

## Ties among entities

Element id. openCypher leaves the order among nodes undefined, but a sort needs *some* total order two runs agree on, or `ORDER BY ... LIMIT` returns different rows each time.

## Measured

pass 3,701 → **3,703**, wrong results 50 → **48**. Two scenarios gained (`ReturnOrderBy1` [11] and [12]), **zero regressions**.

## Tests

Six, including that DESC is the exact reverse of ASC, that the `WITH` path agrees with `SortOperator`, that the four types which used to collapse together no longer do, that node ordering is stable across runs, and that ordinary property ordering is untouched.

The mixed-type list is built in a `WITH` before the `UNWIND` because `MATCH (n) UNWIND [n] AS x WITH x` raises `VariableNotFound("n")` — filed separately as #927, unrelated to ordering.