### PR TITLE
A variable-length relationship list is in pattern order (#933)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -6308,6 +6308,19 @@ pub struct VarLengthExpandOperator {
     /// The pattern's own name for the relationships traversed, bound to a
     /// list of them (#652).
     rel_variable: Option<String>,
+    /// This segment is being walked against the direction it was written in.
+    ///
+    /// The planner may anchor a variable-length segment at whichever end is
+    /// more selective and walk back along it -- `(a)-[:R*1..2]->(b)` read from
+    /// `b` is `(b)<-[:R*1..2]-(a)`, and the pairs are identical. The *order* of
+    /// what it collects is not: the walk produces relationships starting from
+    /// the anchor, and `r` must list them in the pattern's direction.
+    ///
+    /// `MATCH (a)-[r:REL*2..2]->(b:End) RETURN r` anchored on `b:End` and
+    /// answered `[{num: 2}, {num: 1}]` where the graph reads 1 then 2 (#933).
+    /// Two right relationships in the wrong order, from a query that reported
+    /// success.
+    reversed_walk: bool,
     /// Output records buffered for the current input record.
     pending: std::collections::VecDeque<Record>,
     /// `edge_types` resolved to interned ids, cached after the first use.
@@ -6390,6 +6403,7 @@ impl VarLengthExpandOperator {
             max_hops,
             path_variable: None,
             rel_variable: None,
+            reversed_walk: false,
             pending: std::collections::VecDeque::new(),
             type_ids: None,
             pinned_target: None,
@@ -6418,6 +6432,14 @@ impl VarLengthExpandOperator {
     /// hop. The variable was simply dropped, so the query failed with
     /// "Variable not found: r" -- the traversal was right and its own name for
     /// what it traversed did not exist (#652).
+    /// Mark this segment as walked against its written direction, so a bound
+    /// path or relationship list is emitted in the pattern's order rather than
+    /// the walk's. See [`Self::reversed_walk`].
+    pub fn with_reversed_walk(mut self) -> Self {
+        self.reversed_walk = true;
+        self
+    }
+
     pub fn with_rel_variable(mut self, var: String) -> Self {
         self.rel_variable = Some(var);
         self
@@ -6892,7 +6914,14 @@ impl VarLengthExpandOperator {
             }
         }
         if self.path_variable.is_some() || self.rel_variable.is_some() {
-            let (nodes, edges) = reconstruct_path(parent, source, target);
+            let (mut nodes, mut edges) = reconstruct_path(parent, source, target);
+            // `reconstruct_path` returns the walk in the order it was walked,
+            // which is the pattern's order only when the two agree. When the
+            // planner anchored the far end and walked back, they do not.
+            if self.reversed_walk {
+                nodes.reverse();
+                edges.reverse();
+            }
             if let Some(ref rv) = self.rel_variable {
                 // A list of relationships, not of ids: `r` is the same kind of
                 // thing a single-hop `[r]` binds, one per hop.

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -3776,6 +3776,10 @@ impl QueryPlanner {
                     length.min.unwrap_or(1),
                     length.max.unwrap_or(usize::MAX),
                 );
+                // Walked against the written direction, so anything this
+                // segment binds -- the relationship list, a named path -- has
+                // to come back in the pattern's order, not the walk's (#933).
+                expand = expand.with_reversed_walk();
                 if self
                     .trail_enumeration
                     .load(std::sync::atomic::Ordering::Relaxed)

--- a/tests/varlength_list_order.rs
+++ b/tests/varlength_list_order.rs
@@ -1,0 +1,133 @@
+//! A variable-length relationship list is in pattern order (#933).
+//!
+//! ```cypher
+//! CREATE (a:A)-[:REL {num: 1}]->(b:B)-[:REL {num: 2}]->(e:End)
+//! MATCH (a)-[r:REL*2..2]->(b:End) RETURN r
+//! ```
+//!
+//! answered `[{num: 2}, {num: 1}]`. Two correct relationships in the wrong
+//! order, from a query that reported success — so `r[0]` was the last hop.
+//!
+//! The planner may anchor a variable-length segment at whichever end is more
+//! selective and walk back along it: `(a)-[:R*1..2]->(b)` read from `b` is
+//! `(b)<-[:R*1..2]-(a)`, and the *pairs* are identical. That reversal is worth
+//! a great deal — it is why LDBC IC6 starts at the tag that selects seven
+//! rather than expanding 400,257 rows. What is not identical is the **order**
+//! of what the walk collects.
+//!
+//! The pattern here has a label on the far end and none on the near one, which
+//! is exactly what makes anchor selection flip it. Tests that only ever walk
+//! forwards never see this.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// `(a:A)-[:REL {num: 1}]->(b:B)-[:REL {num: 2}]->(e:End)`
+fn chain() -> GraphStore {
+    let mut store = GraphStore::new();
+    let a = store.create_node("A");
+    let b = store.create_node("B");
+    let e = store.create_node("End");
+    for (src, dst, num) in [(a, b, 1i64), (b, e, 2)] {
+        let eid = store.create_edge(src, dst, "REL").unwrap();
+        let _ = store.set_edge_property_sparse(eid, "num", PropertyValue::Integer(num));
+    }
+    store
+}
+
+/// The `num` of each relationship in the list bound to `col`, in order.
+fn nums(store: &GraphStore, cypher: &str, col: &str) -> Vec<i64> {
+    let query = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let batch = QueryExecutor::new(store)
+        .execute(&query)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let rec = batch.records.first().unwrap_or_else(|| panic!("{cypher}: no rows"));
+    let items = match rec.get(col) {
+        Some(Value::List(items)) => items.clone(),
+        other => panic!("{cypher}: {other:?}"),
+    };
+    items
+        .iter()
+        .map(|v| {
+            let id = match v {
+                Value::Edge(id, _) | Value::EdgeRef(id, ..) => *id,
+                other => panic!("{other:?}"),
+            };
+            let edge = store.get_edge(id).expect("edge in store");
+            match edge.properties.get("num") {
+                Some(PropertyValue::Integer(n)) => *n,
+                other => panic!("{other:?}"),
+            }
+        })
+        .collect()
+}
+
+#[test]
+fn the_list_reads_in_the_pattern_direction_when_the_far_end_is_anchored() {
+    // `b:End` is labelled and the near end is not, so the planner anchors
+    // there and walks backwards. The list must still read 1, 2.
+    let store = chain();
+    assert_eq!(nums(&store, "MATCH (a)-[r:REL*2..2]->(b:End) RETURN r", "r"), vec![1, 2]);
+}
+
+#[test]
+fn the_list_reads_in_the_pattern_direction_when_the_near_end_is_anchored() {
+    // The same walk in the direction it is written. This one always worked,
+    // and is asserted so a fix cannot trade one direction for the other.
+    let store = chain();
+    assert_eq!(nums(&store, "MATCH (a:A)-[r:REL*2..2]->(b) RETURN r", "r"), vec![1, 2]);
+}
+
+#[test]
+fn a_named_path_carries_its_relationships_in_the_same_order() {
+    let store = chain();
+    assert_eq!(
+        nums(&store, "MATCH p = (a)-[:REL*2..2]->(b:End) RETURN relationships(p) AS r", "r"),
+        vec![1, 2]
+    );
+}
+
+#[test]
+fn the_path_nodes_run_from_the_start_of_the_pattern() {
+    let store = chain();
+    let query = parse_query("MATCH p = (a)-[:REL*2..2]->(b:End) RETURN nodes(p) AS n").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&query).unwrap();
+    let labels: Vec<String> = match batch.records[0].get("n") {
+        Some(Value::List(items)) => items
+            .iter()
+            .map(|v| {
+                let id = match v {
+                    Value::Node(id, _) | Value::NodeRef(id) => *id,
+                    other => panic!("{other:?}"),
+                };
+                let node = store.get_node(id).unwrap();
+                let mut ls: Vec<String> = node.labels.iter().map(|l| l.as_str().to_string()).collect();
+                ls.sort();
+                ls.join(":")
+            })
+            .collect(),
+        other => panic!("{other:?}"),
+    };
+    assert_eq!(labels, vec!["A", "B", "End"]);
+}
+
+#[test]
+fn a_single_hop_is_unaffected() {
+    let store = chain();
+    assert_eq!(nums(&store, "MATCH (a)-[r:REL*1..1]->(b:B) RETURN r", "r"), vec![1]);
+}
+
+#[test]
+fn the_pairs_are_the_same_whichever_end_is_anchored() {
+    // The reversal is only about ordering. If it ever changed *which* rows
+    // come back, that would be a far worse bug than the one being fixed.
+    let store = chain();
+    let count = |q: &str| {
+        let query = parse_query(q).unwrap();
+        QueryExecutor::new(&store).execute(&query).unwrap().records.len()
+    };
+    assert_eq!(count("MATCH (a)-[r:REL*2..2]->(b:End) RETURN r"), 1);
+    assert_eq!(count("MATCH (a:A)-[r:REL*2..2]->(b) RETURN r"), 1);
+    assert_eq!(count("MATCH (a)-[r:REL*1..2]->(b) RETURN r"), 3);
+}


### PR DESCRIPTION
Closes #933.

```cypher
CREATE (a:A)-[:REL {num: 1}]->(b:B)-[:REL {num: 2}]->(e:End)
MATCH (a)-[r:REL*2..2]->(b:End) RETURN r
```

answered `[[:REL {num: 2}], [:REL {num: 1}]]`. Two correct relationships in the wrong order, from a query that reported success — `r[0]` was the last hop, and `relationships(p)` read backwards.

## The reversal is deliberate; the ordering was not

The planner may anchor a variable-length segment at whichever end is more selective and walk back along it. `(a)-[:R*1..2]->(b)` read from `b` is `(b)<-[:R*1..2]-(a)` and the *pairs* are identical. That is worth a great deal: before it, LDBC IC6 always started at the person and expanded to 400,257 rows instead of starting at the tag that selects seven.

What is **not** identical is the order of what the walk collects. `reconstruct_path` returns the trail in the order walked, which matches the pattern only when the two agree.

This pattern has a label on the far end (`b:End`) and none on the near one — precisely what makes anchor selection flip it. A test that only ever walks forwards never sees this, which is why the forward case is now asserted too.

## Measured

pass 3,711 → **3,712**, wrong results 40 → **39**, **zero regressions**.

## Tests

Six, including both anchoring directions, `relationships(p)` and `nodes(p)` on a named path, and — the one that matters most — that the **row counts are identical from either end**. If a fix for an ordering bug ever changed *which* rows come back, that would be far worse than the bug.

⚠️ CI is the full-suite verification; vm-1 is running the SF10 benchmark. Not merging until green.