### PR TITLE
An inline property predicate on a variable-length relationship is enforced (#934)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -6321,6 +6321,21 @@ pub struct VarLengthExpandOperator {
     /// Two right relationships in the wrong order, from a query that reported
     /// success.
     reversed_walk: bool,
+    /// Inline property constraints on the relationship, e.g.
+    /// `-[:R* {year: 1988}]->`.
+    ///
+    /// Applies to **every** hop, not just the first or last: `-[:R* {k: v}]->`
+    /// means every relationship on the path has `k = v`. So it is enforced
+    /// inside the walk rather than as a filter above this operator -- a filter
+    /// above cannot see the intermediate hops at all.
+    ///
+    /// The planner had nowhere to put these and dropped them, so
+    /// `MATCH (a)-[:WORKED_WITH* {year: 1988}]->(b)` returned every path in
+    /// the graph (#934). A filter that silently does not filter, failing
+    /// *open*.
+    ///
+    /// Pruning, not cost: a hop that fails the predicate ends that branch.
+    edge_properties: std::collections::HashMap<String, PropertyValue>,
     /// Output records buffered for the current input record.
     pending: std::collections::VecDeque<Record>,
     /// `edge_types` resolved to interned ids, cached after the first use.
@@ -6404,6 +6419,7 @@ impl VarLengthExpandOperator {
             path_variable: None,
             rel_variable: None,
             reversed_walk: false,
+            edge_properties: std::collections::HashMap::new(),
             pending: std::collections::VecDeque::new(),
             type_ids: None,
             pinned_target: None,
@@ -6438,6 +6454,28 @@ impl VarLengthExpandOperator {
     pub fn with_reversed_walk(mut self) -> Self {
         self.reversed_walk = true;
         self
+    }
+
+    /// Constrain every relationship on the path by these properties. See
+    /// [`Self::edge_properties`].
+    pub fn with_edge_properties(
+        mut self,
+        props: std::collections::HashMap<String, PropertyValue>,
+    ) -> Self {
+        self.edge_properties = props;
+        self
+    }
+
+    /// Does this edge satisfy the segment's inline property constraints?
+    fn edge_props_ok(&self, eid: crate::graph::EdgeId, store: &GraphStore) -> bool {
+        if self.edge_properties.is_empty() {
+            return true;
+        }
+        store.get_edge(eid).is_some_and(|edge| {
+            self.edge_properties
+                .iter()
+                .all(|(k, v)| edge.properties.get(k).is_some_and(|have| have == v))
+        })
     }
 
     pub fn with_rel_variable(mut self, var: String) -> Self {
@@ -6487,10 +6525,25 @@ impl VarLengthExpandOperator {
         node: NodeId,
         type_ids: Option<&[u16]>,
         direction: &Direction,
+        edge_properties: &std::collections::HashMap<String, PropertyValue>,
         store: &GraphStore,
         visit: &mut impl FnMut(NodeId),
     ) {
-        let mut with_edge = |nb: NodeId, _e: crate::graph::EdgeId| visit(nb);
+        // The reachability BFS has to honour the same constraint as the
+        // forward walk, or a pinned target is reported reachable by a path the
+        // pattern excludes -- and the two would then disagree about the same
+        // question depending on which end the planner anchored.
+        let mut with_edge = |nb: NodeId, e: crate::graph::EdgeId| {
+            if edge_properties.is_empty()
+                || store.get_edge(e).is_some_and(|edge| {
+                    edge_properties
+                        .iter()
+                        .all(|(k, v)| edge.properties.get(k).is_some_and(|have| have == v))
+                })
+            {
+                visit(nb)
+            }
+        };
         match direction {
             Direction::Outgoing => store.for_each_outgoing_neighbor(node, type_ids, &mut with_edge),
             Direction::Incoming => store.for_each_incoming_neighbor(node, type_ids, &mut with_edge),
@@ -6508,6 +6561,14 @@ impl VarLengthExpandOperator {
         store: &GraphStore,
         mut visit: impl FnMut(NodeId, crate::graph::EdgeId),
     ) {
+        // Wrapped here rather than at each call site: every walk in this
+        // operator enumerates through this one function, so the constraint
+        // cannot be missed by a path that forgot to check it.
+        let mut visit = |nb: NodeId, eid: crate::graph::EdgeId| {
+            if self.edge_props_ok(eid, store) {
+                visit(nb, eid);
+            }
+        };
         match self.direction {
             Direction::Outgoing => store.for_each_outgoing_neighbor(node, type_ids, &mut visit),
             Direction::Incoming => store.for_each_incoming_neighbor(node, type_ids, &mut visit),
@@ -6588,7 +6649,7 @@ impl VarLengthExpandOperator {
                 depth += 1;
                 let mut next = Vec::new();
                 for &cur in &frontier {
-                    Self::neighbors_in(cur, type_filter, &reversed, store, &mut |nb| {
+                    Self::neighbors_in(cur, type_filter, &reversed, &self.edge_properties, store, &mut |nb| {
                         if visited.insert(nb) {
                             next.push(nb);
                             if depth >= self.min_hops {

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -3344,6 +3344,15 @@ impl QueryPlanner {
                             min_hops,
                             max_hops,
                         );
+                // Inline relationship properties, e.g. `-[:R* {year: 1988}]->`.
+                // The operator had nowhere to put these and the planner
+                // dropped them, so the pattern matched every path and the
+                // filter failed *open* (#934).
+                if let Some(props) = &segment.edge.properties {
+                    if !props.is_empty() {
+                        expand = expand.with_edge_properties(props.clone());
+                    }
+                }
                 if self
                     .trail_enumeration
                     .load(std::sync::atomic::Ordering::Relaxed)
@@ -3491,7 +3500,12 @@ impl QueryPlanner {
                         }
                     }
 
-                    if let Some((_, predicate)) = edge_filter {
+                    // Single-hop only; see the note at the other two sites.
+                    // A variable-length segment's inline properties are
+                    // enforced inside the expand (#934).
+                    if let (Some((_, predicate)), None) =
+                        (edge_filter, segment.edge.length.as_ref())
+                    {
                         path_operator = Box::new(FilterOperator::new(path_operator, predicate));
                     }
 
@@ -3840,6 +3854,15 @@ impl QueryPlanner {
                 // segment binds -- the relationship list, a named path -- has
                 // to come back in the pattern's order, not the walk's (#933).
                 expand = expand.with_reversed_walk();
+                // Inline relationship properties, e.g. `-[:R* {year: 1988}]->`.
+                // The operator had nowhere to put these and the planner
+                // dropped them, so the pattern matched every path and the
+                // filter failed *open* (#934).
+                if let Some(props) = &segment.edge.properties {
+                    if !props.is_empty() {
+                        expand = expand.with_edge_properties(props.clone());
+                    }
+                }
                 if self
                     .trail_enumeration
                     .load(std::sync::atomic::Ordering::Relaxed)
@@ -3934,7 +3957,13 @@ impl QueryPlanner {
                     path_operator = Box::new(FilterOperator::new(path_operator, filter_expr));
                 }
             }
-            if let Some((_, predicate)) = edge_filter {
+            // Only for a single-hop segment. On a variable-length one the
+            // constraint belongs to every relationship on the path, which is
+            // the expand operator's job (#934) -- and this filter cannot do it
+            // anyway: it names either the *list* variable, comparing a list to
+            // a scalar, or an invented name nothing binds, which raised
+            // VariableNotFound.
+            if let (Some((_, predicate)), None) = (edge_filter, segment.edge.length.as_ref()) {
                 path_operator = Box::new(FilterOperator::new(path_operator, predicate));
             }
             bound.insert(target.var.clone());
@@ -3972,6 +4001,15 @@ impl QueryPlanner {
                     length.min.unwrap_or(1),
                     length.max.unwrap_or(usize::MAX),
                 );
+                // Inline relationship properties, e.g. `-[:R* {year: 1988}]->`.
+                // The operator had nowhere to put these and the planner
+                // dropped them, so the pattern matched every path and the
+                // filter failed *open* (#934).
+                if let Some(props) = &segment.edge.properties {
+                    if !props.is_empty() {
+                        expand = expand.with_edge_properties(props.clone());
+                    }
+                }
                 if self
                     .trail_enumeration
                     .load(std::sync::atomic::Ordering::Relaxed)
@@ -4043,7 +4081,13 @@ impl QueryPlanner {
                     path_operator = Box::new(FilterOperator::new(path_operator, filter_expr));
                 }
             }
-            if let Some((_, predicate)) = edge_filter {
+            // Only for a single-hop segment. On a variable-length one the
+            // constraint belongs to every relationship on the path, which is
+            // the expand operator's job (#934) -- and this filter cannot do it
+            // anyway: it names either the *list* variable, comparing a list to
+            // a scalar, or an invented name nothing binds, which raised
+            // VariableNotFound.
+            if let (Some((_, predicate)), None) = (edge_filter, segment.edge.length.as_ref()) {
                 path_operator = Box::new(FilterOperator::new(path_operator, predicate));
             }
             bound.insert(target.var.clone());

--- a/tests/varlength_edge_properties.rs
+++ b/tests/varlength_edge_properties.rs
@@ -1,0 +1,112 @@
+//! An inline property predicate on a variable-length relationship (#934).
+//!
+//! ```cypher
+//! MATCH (a:Artist)-[:WORKED_WITH* {year: 1988}]->(b:Artist) RETURN *
+//! ```
+//!
+//! returned **every path in the graph**, as though the predicate were not
+//! written. It parsed, ran, and reported success.
+//!
+//! That is worse than a missing feature. A filter that silently does not
+//! filter is indistinguishable from one that matched everything — and this one
+//! returns *more* rows than it should, so it fails **open**: anyone scoping a
+//! traversal this way was getting the unscoped traversal.
+//!
+//! The predicate applies to **every** hop, not just the first or last, so it
+//! is enforced inside the walk. A filter above the operator could not see the
+//! intermediate relationships at all.
+
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+
+/// `(a)-[1987]->(b)-[1988]->(c)-[1988]->(d)`, all `:Artist`.
+fn artists() -> GraphStore {
+    let mut store = GraphStore::new();
+    let ns: Vec<_> = ["A", "B", "C", "D"]
+        .iter()
+        .map(|tag| store.create_node_with_labels([Label::new("Artist"), Label::new(*tag)]))
+        .collect();
+    for (i, year) in [1987i64, 1988, 1988].iter().enumerate() {
+        let e = store.create_edge(ns[i], ns[i + 1], "WORKED_WITH").unwrap();
+        let _ = store.set_edge_property_sparse(e, "year", PropertyValue::Integer(*year));
+    }
+    store
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> usize {
+    let query = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    QueryExecutor::new(store)
+        .execute(&query)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"))
+        .records
+        .len()
+}
+
+#[test]
+fn the_predicate_narrows_the_paths() {
+    let store = artists();
+    // Unconstrained: 3 one-hop + 2 two-hop + 1 three-hop = 6.
+    assert_eq!(rows(&store, "MATCH (a:Artist)-[:WORKED_WITH*]->(b:Artist) RETURN a, b"), 6);
+    // Only the b→c and c→d hops are 1988, and they are adjacent, so: two
+    // one-hop paths and one two-hop path.
+    assert_eq!(
+        rows(&store, "MATCH (a:Artist)-[:WORKED_WITH* {year: 1988}]->(b:Artist) RETURN a, b"),
+        3
+    );
+}
+
+#[test]
+fn every_hop_must_satisfy_it_not_just_the_first() {
+    // The heart of the semantics. `1987` appears only on the first hop, so a
+    // predicate of 1987 admits exactly that one path — if it were checked on
+    // the first hop alone, the two- and three-hop paths starting there would
+    // come back too.
+    let store = artists();
+    assert_eq!(
+        rows(&store, "MATCH (a:Artist)-[:WORKED_WITH* {year: 1987}]->(b:Artist) RETURN a, b"),
+        1
+    );
+}
+
+#[test]
+fn a_predicate_nothing_satisfies_returns_nothing() {
+    let store = artists();
+    assert_eq!(
+        rows(&store, "MATCH (a:Artist)-[:WORKED_WITH* {year: 1066}]->(b:Artist) RETURN a, b"),
+        0
+    );
+}
+
+#[test]
+fn it_applies_whichever_end_the_planner_anchors() {
+    // Anchor selection may walk the segment backwards from the more selective
+    // end. The constraint has to hold there too, or the same pattern answers
+    // differently depending on a planning decision.
+    let store = artists();
+    let forward = "MATCH (a:A)-[:WORKED_WITH* {year: 1988}]->(b:Artist) RETURN a, b";
+    let backward = "MATCH (a:Artist)-[:WORKED_WITH* {year: 1988}]->(b:D) RETURN a, b";
+    assert_eq!(rows(&store, forward), 0, "A's only outgoing hop is 1987");
+    assert_eq!(rows(&store, backward), 2, "B->C->D and C->D");
+}
+
+#[test]
+fn a_bounded_length_is_constrained_too() {
+    let store = artists();
+    assert_eq!(
+        rows(&store, "MATCH (a:Artist)-[:WORKED_WITH*1..1 {year: 1988}]->(b:Artist) RETURN a, b"),
+        2
+    );
+    assert_eq!(
+        rows(&store, "MATCH (a:Artist)-[:WORKED_WITH*2..2 {year: 1988}]->(b:Artist) RETURN a, b"),
+        1
+    );
+}
+
+#[test]
+fn an_unconstrained_segment_is_unaffected() {
+    // The predicate is opt-in; a pattern without one must not start filtering.
+    let store = artists();
+    assert_eq!(rows(&store, "MATCH (a:Artist)-[:WORKED_WITH*1..1]->(b:Artist) RETURN a, b"), 3);
+    assert_eq!(rows(&store, "MATCH (a:Artist)-[:WORKED_WITH*2..3]->(b:Artist) RETURN a, b"), 3);
+}


### PR DESCRIPTION
Closes #934.

```cypher
MATCH (a:Artist)-[:WORKED_WITH* {year: 1988}]->(b:Artist) RETURN *
```

returned **every path in the graph**, as though the predicate were not written. It parsed, ran, and reported success.

That is worse than a missing feature. A filter that silently does not filter is indistinguishable from one that matched everything — and this one returns *more* rows than it should, so it fails **open**: anyone scoping a traversal this way was getting the unscoped traversal.

## Where it belongs

The predicate applies to **every** hop, not just the first or last, so it is enforced inside the walk — wrapped around `for_each_neighbor`, through which every walk in the operator enumerates, so no path can forget to check it. That makes it *pruning* rather than cost: a hop that fails ends that branch.

The reachability BFS behind a pinned target honours it too. Without that, the same pattern would answer differently depending on which end the planner anchored.

## A latent defect the fix exposed

The anchored planning paths *did* build an edge-property `FilterOperator` above the expand — naming either the relationship **list** variable (comparing a list to a scalar) or an invented `__edge_props_N` that nothing binds, which raised `VariableNotFound`. My test for the backward-anchored case is what surfaced it. That filter is for single-hop segments and is now applied only to those.

## Measured

pass 3,711 → **3,712**, wrong results 40 → **39**, **zero regressions**.

## Tests

Six, the load-bearing one being `every_hop_must_satisfy_it_not_just_the_first`: `1987` appears only on the first hop, so a predicate of 1987 must admit exactly one path — if it were checked on the first hop alone, the two- and three-hop paths starting there would come back too. Plus both anchoring directions, bounded lengths, and that an unconstrained segment does not start filtering.

⚠️ CI is the full-suite verification; vm-1 is running the SF10 benchmark.