### PR TITLE
MERGE with an undirected relationship pattern matches either way (#938)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -11364,8 +11364,13 @@ impl PhysicalOperator for MatchCreateEdgeOperator {
 /// Checks if edge exists between bound endpoints before creating.
 pub struct MatchMergeEdgeOperator {
     input: OperatorBox,
-    /// (source_var, target_var, edge_type, properties, edge_var)
-    edges_to_merge: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>)>,
+    /// (source_var, target_var, edge_type, properties, edge_var, undirected)
+    ///
+    /// `undirected` is `-[r:T]-`, which matches a relationship either way
+    /// round. It used to be dropped, so this operator looked only for
+    /// `source -> target` and MERGE created a duplicate beside an existing
+    /// `target -> source` (#938).
+    edges_to_merge: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>, bool)>,
     on_create_set: Vec<(String, String, Expression)>,
     on_match_set: Vec<(String, String, Expression)>,
     /// Whole-entity `ON CREATE`/`ON MATCH SET`; see `MergeOperator` (#874).
@@ -11379,7 +11384,7 @@ pub struct MatchMergeEdgeOperator {
 impl MatchMergeEdgeOperator {
     pub fn new(
         input: OperatorBox,
-        edges_to_merge: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>)>,
+        edges_to_merge: Vec<(String, String, EdgeType, HashMap<String, PropertyValue>, Option<String>, bool)>,
         on_create_set: Vec<(String, String, Expression)>,
         on_match_set: Vec<(String, String, Expression)>,
     ) -> Self {
@@ -11420,7 +11425,9 @@ impl PhysicalOperator for MatchMergeEdgeOperator {
     fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
         if !self.done {
             while let Some(record) = self.input.next_mut(store, tenant_id)? {
-                for (source_var, target_var, edge_type, properties, edge_var) in &self.edges_to_merge {
+                for (source_var, target_var, edge_type, properties, edge_var, undirected) in
+                    &self.edges_to_merge
+                {
                     let source_id = match record.get(source_var).and_then(|v| v.node_id()) {
                         Some(id) => id,
                         None => continue,
@@ -11430,8 +11437,17 @@ impl PhysicalOperator for MatchMergeEdgeOperator {
                         None => continue,
                     };
 
-                    // Check if edge already exists
-                    let existing = store.edge_between(source_id, target_id, Some(edge_type));
+                    // Does one already exist? For `-[r:T]-`, either way round;
+                    // the pattern's own direction is preferred when both do.
+                    let existing = store
+                        .edge_between(source_id, target_id, Some(edge_type))
+                        .or_else(|| {
+                            if *undirected {
+                                store.edge_between(target_id, source_id, Some(edge_type))
+                            } else {
+                                None
+                            }
+                        });
 
                     let mut result_record = record.clone();
 
@@ -13222,8 +13238,13 @@ impl MergeOperator {
     ) -> ExecutionResult<Option<Record>> {
         // Flatten the path into nodes and the relationships between them.
         let mut pattern_nodes: Vec<&crate::query::ast::NodePattern> = vec![&path.start];
-        // (from_index, to_index, type, properties, variable)
-        let mut pattern_rels: Vec<(usize, usize, EdgeType, HashMap<String, PropertyValue>, Option<String>)> = Vec::new();
+        // (from_index, to_index, type, properties, variable, undirected)
+        //
+        // `undirected` is carried because `Direction::Both` used to be folded
+        // into `Outgoing` here, so `MERGE (a)-[r:KNOWS]-(b)` only ever looked
+        // for `a -> b`. An existing `b -> a` did not match and MERGE created a
+        // second relationship beside it (#938).
+        let mut pattern_rels: Vec<(usize, usize, EdgeType, HashMap<String, PropertyValue>, Option<String>, bool)> = Vec::new();
         for segment in &path.segments {
             pattern_nodes.push(&segment.node);
             let to = pattern_nodes.len() - 1;
@@ -13245,7 +13266,11 @@ impl MergeOperator {
                 Direction::Incoming => (to, from),
                 Direction::Outgoing | Direction::Both => (from, to),
             };
-            pattern_rels.push((a, b, edge_type, props, segment.edge.variable.clone()));
+            // An undirected pattern *creates* left-to-right, which is why the
+            // orientation above is still (from, to) for `Both`. Only matching
+            // has to look both ways.
+            let undirected = matches!(segment.edge.direction, Direction::Both);
+            pattern_rels.push((a, b, edge_type, props, segment.edge.variable.clone(), undirected));
         }
 
         // Candidate node ids per pattern position.
@@ -13329,9 +13354,9 @@ impl MergeOperator {
             // (a)-[r:R]->(b) RETURN r` failed with VariableNotFound and a named
             // path had nothing to build from (#903).
             let mut matched_edges: Vec<crate::graph::types::EdgeId> = Vec::with_capacity(pattern_rels.len());
-            for (from, to, ty, props, var) in &pattern_rels {
+            for (from, to, ty, props, var, undirected) in &pattern_rels {
                 let Some(edge_id) =
-                    Self::merge_edge_match(store, assignment[*from], assignment[*to], ty, props)
+                    Self::merge_edge_match(store, assignment[*from], assignment[*to], ty, props, *undirected)
                 else {
                     continue;
                 };
@@ -13386,7 +13411,7 @@ impl MergeOperator {
             created.push(node_id);
         }
         let mut created_edges: Vec<crate::graph::types::EdgeId> = Vec::with_capacity(pattern_rels.len());
-        for (from, to, edge_type, props, var) in &pattern_rels {
+        for (from, to, edge_type, props, var, _undirected) in &pattern_rels {
             let edge_id = store
                 .create_edge(created[*from], created[*to], edge_type.clone())
                 .map_err(|e| ExecutionError::GraphError(e.to_string()))?;
@@ -13427,35 +13452,50 @@ self.apply_sets(&sets, &record, store, tenant_id)?;
     /// endpoints only, so `MERGE (a)-[:R {k: 1}]->(b)` matched a bare `:R`
     /// edge, bound nothing, and left the graph without the property the query
     /// asked for (#903).
+    /// The existing relationship a MERGE pattern segment matches, if any.
+    ///
+    /// `undirected` comes from `-[r:T]-`, where the pattern matches a
+    /// relationship in *either* direction. Folding that into "outgoing" meant
+    /// an existing `b -> a` never matched `MERGE (a)-[r:T]-(b)` and MERGE
+    /// created a second relationship beside it (#938) -- a duplicate write
+    /// from a clause whose entire purpose is not to write when the thing is
+    /// already there.
     fn merge_edge_match(
         store: &GraphStore,
         src: NodeId,
         dst: NodeId,
         ty: &EdgeType,
         props: &HashMap<String, PropertyValue>,
+        undirected: bool,
     ) -> Option<crate::graph::types::EdgeId> {
-        store
-            .get_outgoing_edge_targets(src)
-            .iter()
-            .find(|(eid, _s, t, et)| {
-                if *t != dst || et != ty {
-                    return false;
-                }
-                if props.is_empty() {
-                    return true;
-                }
-                store.get_edge(*eid).is_some_and(|edge| {
+        let props_ok = |eid: crate::graph::types::EdgeId| {
+            props.is_empty()
+                || store.get_edge(eid).is_some_and(|edge| {
                     props
                         .iter()
                         .all(|(k, v)| edge.properties.get(k).is_some_and(|have| have == v))
                 })
-            })
+        };
+        let forward = store
+            .get_outgoing_edge_targets(src)
+            .iter()
+            .find(|(eid, _s, t, et)| *t == dst && et == ty && props_ok(*eid))
+            .map(|(eid, ..)| *eid);
+        if forward.is_some() || !undirected {
+            return forward;
+        }
+        // The other way round. Checked second so a relationship written in the
+        // pattern's own direction is preferred when both exist.
+        store
+            .get_outgoing_edge_targets(dst)
+            .iter()
+            .find(|(eid, _s, t, et)| *t == src && et == ty && props_ok(*eid))
             .map(|(eid, ..)| *eid)
     }
 
     fn search(
         candidates: &[Vec<NodeId>],
-        rels: &[(usize, usize, EdgeType, HashMap<String, PropertyValue>, Option<String>)],
+        rels: &[(usize, usize, EdgeType, HashMap<String, PropertyValue>, Option<String>, bool)],
         store: &GraphStore,
         assignment: &mut Vec<NodeId>,
     ) -> Option<Vec<NodeId>> {
@@ -13470,11 +13510,11 @@ self.apply_sets(&sets, &record, store, tenant_id)?;
             }
             assignment.push(cand);
             // Check every relationship whose endpoints are now both assigned.
-            let ok = rels.iter().all(|(from, to, ty, props, _v)| {
+            let ok = rels.iter().all(|(from, to, ty, props, _v, undirected)| {
                 if *from > i || *to > i {
                     return true;
                 }
-                Self::merge_edge_match(store, assignment[*from], assignment[*to], ty, props)
+                Self::merge_edge_match(store, assignment[*from], assignment[*to], ty, props, *undirected)
                     .is_some()
             });
             if ok {

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2460,7 +2460,20 @@ impl QueryPlanner {
                     }
 
                     if let (Some(src), Some(tgt)) = (&current_var, &target_var) {
-                        edges_to_merge.push((src.clone(), tgt.clone(), edge_type, edge_props, edge_var));
+                        // `-[r:T]-` matches a relationship either way round.
+                        // Without this the operator only ever looked for
+                        // `src -> tgt`, so an existing `tgt -> src` did not
+                        // match and MERGE wrote a duplicate beside it (#938).
+                        let undirected =
+                            matches!(edge.direction, crate::query::ast::Direction::Both);
+                        edges_to_merge.push((
+                            src.clone(),
+                            tgt.clone(),
+                            edge_type,
+                            edge_props,
+                            edge_var,
+                            undirected,
+                        ));
                     }
                     current_var = target_var;
                 }

--- a/tests/merge_undirected.rs
+++ b/tests/merge_undirected.rs
@@ -1,0 +1,119 @@
+//! MERGE with an undirected relationship pattern (#938).
+//!
+//! ```cypher
+//! MATCH (a {id: 2})--(b {id: 1})
+//! MERGE (a)-[r:KNOWS]-(b)
+//! ```
+//!
+//! `-[r:T]-` matches a relationship either way round. Both MERGE paths folded
+//! `Direction::Both` into `Outgoing`, so an existing `b -> a` did not match and
+//! MERGE wrote a second relationship beside it.
+//!
+//! That is worse than a wrong row. MERGE exists so that a write does *not*
+//! happen when the thing is already there; an undirected MERGE against a graph
+//! whose relationships run the other way accumulates a duplicate on every run.
+//! The TCK scenario asserts "no side effects" for exactly this reason, so these
+//! tests count relationships rather than rows.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let query = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let mut ex = MutQueryExecutor::new(store, "default".to_string());
+    ex.execute(&query).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+}
+
+fn edge_count(store: &GraphStore) -> i64 {
+    let query = parse_query("MATCH ()-[r]->() RETURN count(r) AS c").unwrap();
+    match QueryExecutor::new(store).execute(&query).unwrap().records[0].get("c") {
+        Some(Value::Property(PropertyValue::Integer(n))) => *n,
+        other => panic!("{other:?}"),
+    }
+}
+
+/// `a -[:KNOWS]-> b`, and `b` is the one carrying the lower id.
+fn pair() -> (GraphStore, samyama::graph::NodeId, samyama::graph::NodeId) {
+    let mut store = GraphStore::new();
+    let a = store.create_node("N");
+    let b = store.create_node("N");
+    let _ = store.set_node_property("default", a, "id".to_string(), PropertyValue::Integer(2));
+    let _ = store.set_node_property("default", b, "id".to_string(), PropertyValue::Integer(1));
+    let e = store.create_edge(a, b, "KNOWS").unwrap();
+    let _ = store.set_edge_property_sparse(e, "name", PropertyValue::String("ab".into()));
+    (store, a, b)
+}
+
+#[test]
+fn an_undirected_merge_matches_a_relationship_written_the_other_way() {
+    // The existing edge is a -> b; the MERGE is written b -[r]- a. Directional
+    // matching misses it and creates a second one.
+    let (mut store, ..) = pair();
+    assert_eq!(edge_count(&store), 1);
+    run(&mut store, "MATCH (a {id: 1}), (b {id: 2}) MERGE (a)-[r:KNOWS]-(b)");
+    assert_eq!(edge_count(&store), 1, "matched, not created");
+}
+
+#[test]
+fn it_is_idempotent_across_runs() {
+    // The failure mode that matters: one duplicate per run, forever.
+    let (mut store, ..) = pair();
+    for _ in 0..3 {
+        run(&mut store, "MATCH (a {id: 1}), (b {id: 2}) MERGE (a)-[r:KNOWS]-(b)");
+    }
+    assert_eq!(edge_count(&store), 1);
+}
+
+#[test]
+fn a_directed_merge_still_respects_direction() {
+    // The fix must not make MERGE undirected everywhere: `->` against an edge
+    // running the other way is genuinely absent and must be created.
+    let (mut store, ..) = pair();
+    run(&mut store, "MATCH (a {id: 1}), (b {id: 2}) MERGE (a)-[r:KNOWS]->(b)");
+    assert_eq!(edge_count(&store), 2, "b -> a did not exist");
+}
+
+#[test]
+fn an_undirected_merge_still_creates_when_nothing_matches() {
+    let mut store = GraphStore::new();
+    let a = store.create_node("N");
+    let b = store.create_node("N");
+    let _ = store.set_node_property("default", a, "id".to_string(), PropertyValue::Integer(1));
+    let _ = store.set_node_property("default", b, "id".to_string(), PropertyValue::Integer(2));
+    assert_eq!(edge_count(&store), 0);
+    run(&mut store, "MATCH (a {id: 1}), (b {id: 2}) MERGE (a)-[r:KNOWS]-(b)");
+    assert_eq!(edge_count(&store), 1);
+    // And created in the pattern's written direction, which is what Cypher
+    // does for an undirected MERGE.
+    let q = parse_query("MATCH (a {id: 1})-[r:KNOWS]->(b {id: 2}) RETURN count(r) AS c").unwrap();
+    match QueryExecutor::new(&store).execute(&q).unwrap().records[0].get("c") {
+        Some(Value::Property(PropertyValue::Integer(n))) => assert_eq!(*n, 1),
+        other => panic!("{other:?}"),
+    }
+}
+
+#[test]
+fn the_matched_relationship_keeps_its_properties() {
+    // The symptom that exposed this: the created duplicate came back as a bare
+    // `[:KNOWS]` beside the real one.
+    let (mut store, ..) = pair();
+    run(&mut store, "MATCH (a {id: 1}), (b {id: 2}) MERGE (a)-[r:KNOWS]-(b)");
+    let q = parse_query("MATCH ()-[r:KNOWS]->() RETURN r.name AS n").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&q).unwrap();
+    assert_eq!(batch.records.len(), 1);
+    match batch.records[0].get("n") {
+        Some(Value::Property(PropertyValue::String(s))) => assert_eq!(s, "ab"),
+        other => panic!("{other:?}"),
+    }
+}
+
+#[test]
+fn an_unbound_undirected_merge_also_matches_either_way() {
+    // The other MERGE path: endpoints not bound by an earlier MATCH, so the
+    // whole pattern is searched for. Both paths had the same defect and a fix
+    // to one would not have reached the other.
+    let (mut store, ..) = pair();
+    run(&mut store, "MERGE ({id: 1})-[r:KNOWS]-({id: 2})");
+    assert_eq!(edge_count(&store), 1);
+}


### PR DESCRIPTION
Closes #938.

```cypher
MATCH (a {id: 2})--(b {id: 1})
MERGE (a)-[r:KNOWS]-(b)
RETURN r
```

against a graph whose matching relationship runs `b -> a` returned the existing one for the first row and a **freshly created** bare `[:KNOWS]` for the second. The TCK scenario asserts *no side effects*; we wrote one.

## Two paths, same conflation

`-[r:T]-` matches a relationship either way round. Both MERGE paths folded `Direction::Both` into `Outgoing`:

- `MergeOperator::merge_path` — `merge_edge_match` scanned only `get_outgoing_edge_targets(src)`.
- `MatchMergeEdgeOperator` — the path taken when both endpoints are already bound, which is this scenario — kept no direction at all and called the directional `store.edge_between`.

I fixed the first one and the TCK **did not move**, which is what sent me looking for the second. Both are fixed and both are tested; a fix to one alone would have left the pass count identical either way.

## Why it is worse than a wrong row

MERGE exists so that a write does *not* happen when the thing is already there. An undirected MERGE against a graph whose relationships run the other way accumulates **one duplicate per run, forever**. `it_is_idempotent_across_runs` is the test that matters here.

## Scope

Matching looks both ways. **Creating** stays left-to-right — what Cypher does for an undirected pattern — so `a_directed_merge_still_respects_direction` and `an_undirected_merge_still_creates_when_nothing_matches` pin that the fix did not make MERGE undirected everywhere. When relationships exist in both directions the pattern's own is preferred, so the choice is deterministic.

## Measured

pass 3,713 → **3,714**, wrong results 40 → **39**, **zero regressions**.

⚠️ CI is the full-suite verification; vm-1 is running the SF10 benchmark.