### PR TITLE
CREATE reuses the variables a WITH projected (#940)

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2199,14 +2199,47 @@ impl QueryPlanner {
             // still reported success.
             let mut matched_vars: std::collections::HashSet<String> =
                 std::collections::HashSet::new();
-            for mc in &query.match_clauses {
-                for path in &mc.pattern.paths {
-                    if let Some(v) = &path.start.variable {
+            // A WITH re-scopes: what it projects is all that exists after it,
+            // under the names it gives them. Reading the MATCH clauses instead
+            // meant `MATCH (n) WITH n AS a CREATE (a)-[:T]->(b)` did not
+            // recognise `a` and created a *fresh* node for it, so a query that
+            // should add one node added two and returned the new blank one
+            // where the caller expected the matched one (#940).
+            //
+            // Only the last WITH matters here: this CREATE runs after all of
+            // them, and each stage's scope replaces the one before it.
+            let scoping_with = query
+                .with_clause
+                .as_ref()
+                .or_else(|| query.extra_with_stages.last().map(|(wc, ..)| wc));
+            if let Some(wc) = scoping_with {
+                for item in &wc.items {
+                    if let Some(alias) = &item.alias {
+                        matched_vars.insert(alias.clone());
+                    } else if let Expression::Variable(v) = &item.expression {
                         matched_vars.insert(v.clone());
                     }
-                    for seg in &path.segments {
-                        if let Some(v) = &seg.node.variable {
+                }
+                // A MATCH written after the WITH binds on top of what it
+                // projected.
+                let split = query
+                    .with_split_index
+                    .unwrap_or(query.match_clauses.len());
+                for mc in &query.match_clauses[split..] {
+                    for v in Self::clause_variables(&mc.pattern) {
+                        matched_vars.insert(v);
+                    }
+                }
+            } else {
+                for mc in &query.match_clauses {
+                    for path in &mc.pattern.paths {
+                        if let Some(v) = &path.start.variable {
                             matched_vars.insert(v.clone());
+                        }
+                        for seg in &path.segments {
+                            if let Some(v) = &seg.node.variable {
+                                matched_vars.insert(v.clone());
+                            }
                         }
                     }
                 }

--- a/tests/create_after_with.rs
+++ b/tests/create_after_with.rs
@@ -1,0 +1,110 @@
+//! CREATE reuses the variables a WITH projected (#940).
+//!
+//! ```cypher
+//! MATCH (n) MATCH (m) WITH n AS a, m AS b CREATE (a)-[:T]->(b) RETURN a, b
+//! ```
+//!
+//! answered `(), ()` — two **fresh blank nodes** — where the existing node was
+//! expected twice. Without the WITH the same query reuses the bound variables
+//! correctly.
+//!
+//! A WITH re-scopes: what it projects is all that exists after it, under the
+//! names it gives them. The by-kind planning path built its "already bound"
+//! set from `query.match_clauses` alone, so `a` appeared in no match clause and
+//! CREATE classified it as new.
+//!
+//! The clause-pipeline path always got this right, which is the two-AST-shapes
+//! split again — and this query parses into the by-kind fields. So these tests
+//! count **nodes**, not rows: the defect is a write, and a query that returns
+//! plausible-looking rows while adding two nodes it should not is the failure
+//! worth pinning.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn one_node() -> GraphStore {
+    let mut store = GraphStore::new();
+    let n = store.create_node("");
+    let _ = store.set_node_property("default", n, "num".to_string(), PropertyValue::Integer(1));
+    store
+}
+
+fn count(store: &GraphStore, cypher: &str) -> i64 {
+    let q = parse_query(cypher).unwrap();
+    match QueryExecutor::new(store).execute(&q).unwrap().records[0].get("c") {
+        Some(Value::Property(PropertyValue::Integer(n))) => *n,
+        other => panic!("{other:?}"),
+    }
+}
+
+fn nodes(store: &GraphStore) -> i64 {
+    count(store, "MATCH (n) RETURN count(n) AS c")
+}
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let mut ex = MutQueryExecutor::new(store, "default".to_string());
+    ex.execute(&q).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+}
+
+#[test]
+fn an_aliased_variable_is_reused_not_recreated() {
+    let mut store = one_node();
+    run(&mut store, "MATCH (n) MATCH (m) WITH n AS a, m AS b CREATE (a)-[:T]->(b) RETURN a, b");
+    assert_eq!(nodes(&store), 1, "only the relationship is new");
+    assert_eq!(count(&store, "MATCH ()-[r:T]->() RETURN count(r) AS c"), 1);
+}
+
+#[test]
+fn only_the_genuinely_new_node_is_created() {
+    let mut store = one_node();
+    run(&mut store, "MATCH (n) WITH n AS a CREATE (a)-[:T]->(x) RETURN a");
+    assert_eq!(nodes(&store), 2, "`x` is new, `a` is not");
+}
+
+#[test]
+fn the_returned_node_is_the_matched_one() {
+    // The half that silently corrupts a follow-on write: the query returned
+    // the blank node it had just made, so anything downstream operated on the
+    // wrong node.
+    let mut store = one_node();
+    let q = parse_query("MATCH (n) WITH n AS a CREATE (a)-[:T]->(x) RETURN a.num AS c").unwrap();
+    let mut ex = MutQueryExecutor::new(&mut store, "default".to_string());
+    let batch = ex.execute(&q).unwrap();
+    match batch.records[0].get("c") {
+        Some(Value::Property(PropertyValue::Integer(n))) => assert_eq!(*n, 1),
+        other => panic!("expected the matched node's num, got {other:?}"),
+    }
+}
+
+#[test]
+fn an_unaliased_pass_through_is_reused_too() {
+    let mut store = one_node();
+    run(&mut store, "MATCH (n) WITH n CREATE (n)-[:T]->(x) RETURN n");
+    assert_eq!(nodes(&store), 2);
+}
+
+#[test]
+fn a_name_the_with_dropped_is_a_new_node() {
+    // The other side of re-scoping, and the reason the fix reads the WITH
+    // rather than adding its names to the match variables: `m` is not
+    // projected, so it is out of scope and CREATE (m) makes a fresh node.
+    let mut store = one_node();
+    run(&mut store, "MATCH (n) MATCH (m) WITH n AS a CREATE (a)-[:T]->(m) RETURN a");
+    assert_eq!(nodes(&store), 2);
+}
+
+#[test]
+fn create_without_a_with_is_unchanged() {
+    let mut store = one_node();
+    run(&mut store, "MATCH (n) MATCH (m) CREATE (n)-[:T]->(m) RETURN n, m");
+    assert_eq!(nodes(&store), 1);
+}
+
+#[test]
+fn a_match_after_the_with_still_binds() {
+    let mut store = one_node();
+    run(&mut store, "MATCH (n) WITH n AS a MATCH (b) CREATE (a)-[:T]->(b) RETURN a");
+    assert_eq!(nodes(&store), 1, "both ends were already bound");
+}


### PR DESCRIPTION
Closes #940.

```cypher
MATCH (n) MATCH (m) WITH n AS a, m AS b CREATE (a)-[:T]->(b) RETURN a, b
```

answered `(), ()` — two **fresh blank nodes** — where the existing node was expected twice.

| query | nodes before → after |
|---|---|
| `MATCH (n) MATCH (m) CREATE (n)-[:T]->(m)` | 1 → 1 ✅ |
| `… WITH n AS a, m AS b CREATE (a)-[:T]->(b)` | 1 → **3** ❌ |
| `MATCH (n) WITH n AS a CREATE (a)-[:T]->(x)` | 1 → **3** (should be 2) ❌ |

## Cause

A WITH **re-scopes**: what it projects is all that exists after it, under the names it gives them. The by-kind planning path built its "already bound" set from `query.match_clauses` alone, so `a` appeared in no match clause and CREATE classified it as new.

The clause-pipeline path has always recomputed `bound` from the WITH's projected names. This is the two-AST-shapes split again — a rule applied in one representation does nothing in the other — and this query parses into the by-kind fields.

## It is a write bug

Two nodes created that should not be, on every execution, and the *blank* ones returned where the caller expected the matched ones — so a follow-on write lands on the wrong node. `the_returned_node_is_the_matched_one` pins that half.

The tests count **nodes**, not rows, for the same reason.

## Scope

Taken from the last WITH (the CREATE runs after all of them; each stage replaces the one before), plus anything a MATCH written after it binds. `a_name_the_with_dropped_is_a_new_node` pins the other direction: a variable the WITH did *not* project is out of scope, and `CREATE (m)` must still make a fresh node — which is why the fix reads the WITH rather than adding its names to the match variables.

## Measured

pass 3,714 → **3,716**, wrong results 39 → **37**, **zero regressions**.

⚠️ CI is the full-suite verification; vm-1 is running the SF10 benchmark.