### PR TITLE
Refresh the README's TCK claim to the measured number

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ into a public-health trifecta.* [Browse the catalogue →](case_studies)
 
 ## The 30-Second Tour
 
-**Cypher queries** — MATCH, CREATE, MERGE, aggregations, path finding, 30+ functions. **98.3% of the openCypher TCK's evaluated scenarios pass** (3,698 of 3,762, at 96.5% coverage of the 3,897-scenario corpus, measured 2026-08-27); on the same corpus and comparator Neo4j 5 scores 79.5%. That is conformance only — not performance or scale — and the competitor figure is a fixed baseline from one run. See [`docs/CYPHER_COMPATIBILITY.md`](docs/CYPHER_COMPATIBILITY.md) for a per-feature matrix verified by an executable probe, and [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) for the full accounting.
+**Cypher queries** — MATCH, CREATE, MERGE, aggregations, path finding, 30+ functions. **98.8% of the openCypher TCK's evaluated scenarios pass** (3,716 of 3,762, at 96.5% coverage of the 3,897-scenario corpus, measured 2026-08-29); on the same corpus and comparator Neo4j 5 scores 79.5%. That is conformance only — not performance or scale — and the competitor figure is a fixed baseline from one run. See [`docs/CYPHER_COMPATIBILITY.md`](docs/CYPHER_COMPATIBILITY.md) for a per-feature matrix verified by an executable probe, and [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) for the full accounting.
 
 ```cypher
 MATCH (a:Person)-[:KNOWS*1..3]->(b:Person)


### PR DESCRIPTION
98.3% (3,698 of 3,762) → **98.8% (3,716 of 3,762)**, measured 2026-08-29 at `9bd38f5` by `CH-TCK`.

Not a cosmetic bump. `harness/claims.py` reported the old figure as **stale** and failed H1 gate condition 6 over it — which is exactly what that check exists for. Improving past a published claim still makes the published claim wrong, and a number nobody re-checks is the one that drifts.

Wrong results are down to 37 and errors to 9 in the same run.