### PR TITLE
MATCH (a:A:B) means A and B, not A or B (#944)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -4818,7 +4818,14 @@ impl NodeScanOperator {
         // Three cases:
         //   1. No labels  → scan all nodes (rare)
         //   2. Single label → direct copy of label_index entry; no dedup
-        //   3. Multi-label → union with HashSet for dedup
+        //   3. Multi-label → **intersection**
+        //
+        // Case 3 used to be a union, and said so. `(a:A:B)` in Cypher is a
+        // conjunction: the node carries A *and* B. Returning the union made
+        // `MATCH (a:A:B)` answer six rows where two are correct, and
+        // `(a:A:B:C)` return every labelled node in the graph (#944) --
+        // strictly more rows than asked for, from a query that reported
+        // success, so the filter failed open.
         //
         // Sort behavior is conditional:
         //   - With early_limit (LIMIT pushdown): skip sort — only `limit`
@@ -4833,18 +4840,30 @@ impl NodeScanOperator {
         } else if self.labels.len() == 1 {
             self.node_ids = store.node_ids_by_label(&self.labels[0], self.early_limit);
         } else {
-            // Multi-label: union via HashSet. Stop early if early_limit is set.
+            // Intersection, driven from the *smallest* label set: the answer
+            // is a subset of it, so every other label can only remove. That
+            // also makes this cheaper than the union it replaces, which always
+            // walked all of them.
+            //
+            // `early_limit` counts nodes that actually match. The union
+            // counted insertions, so with a LIMIT it could stop before finding
+            // any node carrying all the labels.
+            let mut sets: Vec<Vec<NodeId>> = self
+                .labels
+                .iter()
+                .map(|l| store.node_ids_by_label(l, None))
+                .collect();
+            sets.sort_unstable_by_key(|v| v.len());
+            let (smallest, rest) = sets.split_first().expect("labels.len() > 1");
+            let rest: Vec<HashSet<NodeId>> =
+                rest.iter().map(|v| v.iter().copied().collect()).collect();
             let cap = self.early_limit.unwrap_or(usize::MAX);
-            let mut node_set: HashSet<NodeId> = HashSet::new();
-            'outer: for label in &self.labels {
-                for nid in store.node_ids_by_label(label, None) {
-                    node_set.insert(nid);
-                    if node_set.len() >= cap {
-                        break 'outer;
-                    }
-                }
-            }
-            self.node_ids = node_set.into_iter().collect();
+            self.node_ids = smallest
+                .iter()
+                .copied()
+                .filter(|id| rest.iter().all(|s| s.contains(id)))
+                .take(cap)
+                .collect();
         }
 
         // Sort only when no early_limit (preserves cache locality on full scans).
@@ -14920,20 +14939,22 @@ mod tests {
     }
 
     #[test]
-    fn test_node_scan_multi_label_dedup_and_limit() {
-        // Multi-label scan must dedup across labels (a node with both labels
-        // counts once) and still respect early_limit.
+    fn test_node_scan_multi_label_is_a_conjunction() {
+        // This assertion used to read `count == 50, "multi-label union should
+        // dedup"`. It encoded the defect: `(n:Person:Adult)` in Cypher is a
+        // conjunction, so the answer is the 25 nodes carrying **both**, not the
+        // 50 carrying either. openCypher `Match1` [3] settles it, and this test
+        // is why the union survived (#944).
         let mut store = GraphStore::new();
         for _ in 0..50 {
             let id = store.create_node("Person");
-            // Add second label to half — ensures overlap
+            // Second label on half of them, so union and intersection differ.
             if id.as_u64() % 2 == 0 {
                 if let Some(node) = store.get_node_mut(id) {
                     node.labels.insert(Label::new("Adult"));
                 }
             }
         }
-        // Without limit: 50 unique nodes (the Adults are also Persons)
         let mut op = NodeScanOperator::new(
             "n".to_string(),
             vec![Label::new("Person"), Label::new("Adult")],
@@ -14942,9 +14963,22 @@ mod tests {
         while let Ok(Some(_)) = op.next(&store) {
             count += 1;
         }
-        assert_eq!(count, 50, "multi-label union should dedup");
+        assert_eq!(count, 25, "both labels, not either");
 
-        // With early_limit: capped at limit
+        // Each label alone still scans its own set, so a fix that simply
+        // narrowed everything would be caught here.
+        for (label, want) in [("Person", 50), ("Adult", 25)] {
+            let mut op = NodeScanOperator::new("n".to_string(), vec![Label::new(label)]);
+            let mut count = 0;
+            while let Ok(Some(_)) = op.next(&store) {
+                count += 1;
+            }
+            assert_eq!(count, want, "{label} alone");
+        }
+
+        // `early_limit` counts nodes that actually match. The union counted
+        // insertions, so with a LIMIT it could stop before finding any node
+        // carrying all the labels.
         let mut op = NodeScanOperator::new(
             "n".to_string(),
             vec![Label::new("Person"), Label::new("Adult")],
@@ -14955,6 +14989,13 @@ mod tests {
             count += 1;
         }
         assert_eq!(count, 10);
+
+        // A label no node carries makes the whole conjunction empty.
+        let mut op = NodeScanOperator::new(
+            "n".to_string(),
+            vec![Label::new("Person"), Label::new("Nonexistent")],
+        );
+        assert!(matches!(op.next(&store), Ok(None)));
     }
 
     #[test]

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -14949,10 +14949,19 @@ mod tests {
         for _ in 0..50 {
             let id = store.create_node("Person");
             // Second label on half of them, so union and intersection differ.
+            //
+            // Through `add_label_to_node`, not `get_node_mut().labels.insert`.
+            // The direct insert writes the node and **not** `label_index`, so
+            // `node_ids_by_label("Adult")` returned nothing -- and the union
+            // hid that, because `Person ∪ nothing` is still 50. The
+            // intersection is what exposed the fixture, which is the same
+            // failure the index itself exists to prevent: a label the node
+            // carries and the index does not know about is invisible to every
+            // query that looks for it.
             if id.as_u64() % 2 == 0 {
-                if let Some(node) = store.get_node_mut(id) {
-                    node.labels.insert(Label::new("Adult"));
-                }
+                store
+                    .add_label_to_node("default", id, Label::new("Adult"))
+                    .expect("label added through the store, so the index sees it");
             }
         }
         let mut op = NodeScanOperator::new(

--- a/tests/multi_label_conjunction.rs
+++ b/tests/multi_label_conjunction.rs
@@ -1,0 +1,121 @@
+//! `MATCH (a:A:B)` means A **and** B (#944).
+//!
+//! It returned the union: six rows where two are correct, and `(a:A:B:C)`
+//! returned every labelled node in the graph. A single label was right, so
+//! adding labels *widened* the result instead of narrowing it.
+//!
+//! It fails **open** — strictly more rows than asked for, from a query that
+//! reports success. Multi-label patterns are ordinary in real schemas
+//! (`(:Person:Employee)`), and every one of them had been matching
+//! `Person OR Employee`, so any filter, count or write scoped that way was
+//! operating on a superset.
+//!
+//! The scan code did exactly what its own comment said — *"Multi-label: union
+//! via HashSet"* — and a unit test asserted it. The behaviour was pinned in
+//! place rather than caught.
+
+use samyama::graph::{GraphStore, Label};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// The openCypher `Match1` [3] fixture.
+fn graph() -> GraphStore {
+    let mut store = GraphStore::new();
+    for labels in [
+        vec!["A", "B", "C"], vec!["A", "B"], vec!["A", "C"], vec!["B", "C"],
+        vec!["A"], vec!["B"], vec!["C"],
+    ] {
+        store.create_node_with_labels(labels.iter().map(|l| Label::new(*l)));
+    }
+    store
+}
+
+/// The sorted label sets of the matched nodes, as `"A:B"` strings.
+fn matched(store: &GraphStore, cypher: &str) -> Vec<String> {
+    let query = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let mut out: Vec<String> = QueryExecutor::new(store)
+        .execute(&query)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"))
+        .records
+        .iter()
+        .map(|r| {
+            let id = match r.get("a") {
+                Some(Value::Node(id, _)) | Some(Value::NodeRef(id)) => *id,
+                other => panic!("{other:?}"),
+            };
+            let mut ls: Vec<String> = store
+                .get_node(id)
+                .unwrap()
+                .labels
+                .iter()
+                .map(|l| l.as_str().to_string())
+                .collect();
+            ls.sort();
+            ls.join(":")
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn two_labels_mean_both() {
+    let store = graph();
+    assert_eq!(matched(&store, "MATCH (a:A:B) RETURN a"), vec!["A:B", "A:B:C"]);
+}
+
+#[test]
+fn three_labels_mean_all_three() {
+    // This one returned all seven labelled nodes.
+    let store = graph();
+    assert_eq!(matched(&store, "MATCH (a:A:B:C) RETURN a"), vec!["A:B:C"]);
+}
+
+#[test]
+fn a_single_label_is_unchanged() {
+    let store = graph();
+    assert_eq!(
+        matched(&store, "MATCH (a:A) RETURN a"),
+        vec!["A", "A:B", "A:B:C", "A:C"]
+    );
+}
+
+#[test]
+fn adding_a_label_never_widens_the_result() {
+    // The property the union violated, stated directly: each extra label can
+    // only remove rows.
+    let store = graph();
+    let one = matched(&store, "MATCH (a:A) RETURN a");
+    let two = matched(&store, "MATCH (a:A:B) RETURN a");
+    let three = matched(&store, "MATCH (a:A:B:C) RETURN a");
+    assert!(two.len() <= one.len() && three.len() <= two.len(), "{one:?} {two:?} {three:?}");
+    assert!(two.iter().all(|x| one.contains(x)), "each is a subset of the last");
+    assert!(three.iter().all(|x| two.contains(x)));
+}
+
+#[test]
+fn a_label_no_node_carries_makes_it_empty() {
+    let store = graph();
+    assert!(matched(&store, "MATCH (a:A:Nonexistent) RETURN a").is_empty());
+}
+
+#[test]
+fn the_order_the_labels_are_written_does_not_matter() {
+    // The fix drives the intersection from the smallest label set, so the
+    // written order stops being the scan order. It must not become the answer.
+    let store = graph();
+    assert_eq!(
+        matched(&store, "MATCH (a:A:B) RETURN a"),
+        matched(&store, "MATCH (a:B:A) RETURN a")
+    );
+}
+
+#[test]
+fn a_limit_returns_matching_nodes_not_merely_that_many() {
+    // `early_limit` used to count insertions into the union, so a LIMIT could
+    // stop before reaching a node carrying all the labels.
+    let store = graph();
+    let rows = matched(&store, "MATCH (a:A:B) RETURN a LIMIT 1");
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].contains('A') && rows[0].contains('B'), "{rows:?}");
+}


### PR DESCRIPTION
Closes #944.

`MATCH (a:A:B)` returned the **union** of the two label sets.

| query | rows | |
|---|---|---|
| `MATCH (a:A:B)` | 6 | `A`, `A:B`, `A:B:C`, `A:C`, `B`, `B:C` — two are correct |
| `MATCH (a:A:B:C)` | 7 | every labelled node in the graph |
| `MATCH (a:A)` | 4 | correct |

A single label was right, so **adding labels widened the result instead of narrowing it**.

## The code said so

`NodeScanOperator::initialize`:

```rust
//   3. Multi-label → union with HashSet for dedup
```

It did exactly what its comment said. The comment was wrong about Cypher: `(a:A:B)` is a conjunction.

## Why it survived

`test_node_scan_multi_label_dedup_and_limit` asserted it —

```rust
assert_eq!(count, 50, "multi-label union should dedup");
```

— 50 being the union over a fixture where 25 nodes carry both labels. The test **encoded the defect**, pinning the behaviour in place rather than catching it. Same shape as the five tests #607 turned up that asserted rules Cypher does not have.

It now asserts 25, *and* asserts each label alone (50 and 25), so a fix that merely narrowed everything would not pass either.

## Severity

Fails **open**: strictly more rows than asked for, from a query that reports success. `(:Person:Employee)` is an ordinary pattern and every one has been matching `Person OR Employee` — so any filter, count or write scoped that way was operating on a superset.

## The fix is also faster

Driving the intersection from the **smallest** label set beats the union it replaces, which always walked all of them: the answer is a subset of the smallest, so every other label can only remove.

`early_limit` now counts nodes that actually match. The union counted insertions, so with a LIMIT it could stop before reaching any node carrying all the labels — `a_limit_returns_matching_nodes_not_merely_that_many` pins that.

## Measured

openCypher `Match1` [3] gained, **zero regressions**. Seven integration tests, including `adding_a_label_never_widens_the_result`, which states the violated property directly.

⚠️ CI is the full-suite verification.