### PR TITLE
A WHERE predicate's variables are found inside comprehensions too (#948)

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -4246,6 +4246,101 @@ impl QueryPlanner {
                     Self::collect_expression_variables(&wc.predicate, vars);
                 }
             }
+            // Everything else that *contains* expressions.
+            //
+            // These used to fall into `_ => {}`, so a predicate whose only
+            // variables sat inside a comprehension looked **constant** and was
+            // pushed down to the initial scan, where those variables are not
+            // bound yet:
+            //
+            //   MATCH (n)-->(b) WHERE n.name IN [x IN labels(b) | toLower(x)]
+            //   -> VariableNotFound("b")
+            //
+            // Same failure the `ExistsSubquery` arm above was added for, in
+            // every other compound expression (#948). The reasoning there
+            // applies unchanged: over-approximating only ever defers a filter
+            // to a later, still-correct point, while under-approximating
+            // evaluates it too early.
+            Expression::ListExpr(items) => {
+                for e in items {
+                    Self::collect_expression_variables(e, vars);
+                }
+            }
+            Expression::MapExpr(entries) => {
+                for (_, e) in entries {
+                    Self::collect_expression_variables(e, vars);
+                }
+            }
+            Expression::Index { expr, index } => {
+                Self::collect_expression_variables(expr, vars);
+                Self::collect_expression_variables(index, vars);
+            }
+            Expression::ListSlice { expr, start, end } => {
+                Self::collect_expression_variables(expr, vars);
+                for e in start.iter().chain(end.iter()) {
+                    Self::collect_expression_variables(e, vars);
+                }
+            }
+            Expression::Case { operand, when_clauses, else_result } => {
+                for e in operand.iter() {
+                    Self::collect_expression_variables(e, vars);
+                }
+                for (w, t) in when_clauses {
+                    Self::collect_expression_variables(w, vars);
+                    Self::collect_expression_variables(t, vars);
+                }
+                for e in else_result.iter() {
+                    Self::collect_expression_variables(e, vars);
+                }
+            }
+            // The binder cases. Each introduces a variable of its own, which
+            // is *not* an outer dependency -- deferring a predicate on a name
+            // nothing outside ever binds would defer it past every point that
+            // could apply it.
+            Expression::ListComprehension { variable, list_expr, filter, map_expr } => {
+                let mut inner = HashSet::new();
+                Self::collect_expression_variables(list_expr, &mut inner);
+                for e in filter.iter() {
+                    Self::collect_expression_variables(e, &mut inner);
+                }
+                Self::collect_expression_variables(map_expr, &mut inner);
+                inner.remove(variable);
+                vars.extend(inner);
+            }
+            Expression::PredicateFunction { variable, list_expr, predicate, .. } => {
+                let mut inner = HashSet::new();
+                Self::collect_expression_variables(list_expr, &mut inner);
+                Self::collect_expression_variables(predicate, &mut inner);
+                inner.remove(variable);
+                vars.extend(inner);
+            }
+            Expression::Reduce { accumulator, init, variable, list_expr, expression } => {
+                let mut inner = HashSet::new();
+                Self::collect_expression_variables(init, &mut inner);
+                Self::collect_expression_variables(list_expr, &mut inner);
+                Self::collect_expression_variables(expression, &mut inner);
+                inner.remove(accumulator);
+                inner.remove(variable);
+                vars.extend(inner);
+            }
+            Expression::PatternComprehension { pattern, filter, projection } => {
+                // The pattern's own variables are over-approximated as
+                // dependencies, exactly as in the `ExistsSubquery` arm.
+                for path in &pattern.paths {
+                    if let Some(v) = &path.start.variable { vars.insert(v.clone()); }
+                    for seg in &path.segments {
+                        if let Some(v) = &seg.node.variable { vars.insert(v.clone()); }
+                        if let Some(v) = &seg.edge.variable { vars.insert(v.clone()); }
+                    }
+                }
+                for e in filter.iter() {
+                    Self::collect_expression_variables(e, vars);
+                }
+                Self::collect_expression_variables(projection, vars);
+            }
+            Expression::PathVariable(v) => {
+                vars.insert(v.clone());
+            }
             _ => {}
         }
     }

--- a/tests/comprehension_variable_scope.rs
+++ b/tests/comprehension_variable_scope.rs
@@ -1,0 +1,131 @@
+//! A WHERE predicate's variables are found inside comprehensions too (#948).
+//!
+//! ```cypher
+//! MATCH (n)-->(b)
+//! WHERE n.name IN [x IN labels(b) | toLower(x)]
+//! RETURN b
+//! ```
+//!
+//! raised `VariableNotFound("b")`.
+//!
+//! `Planner::collect_expression_variables` decides *where* a WHERE conjunct
+//! can be evaluated. It handled `Variable`, `Property`, `Binary`, `Unary`,
+//! `Function` and `ExistsSubquery`, then `_ => {}`. So a predicate whose only
+//! variables live inside a comprehension reported **no** variables, looked
+//! constant, and was pushed to the initial scan — before the expansion that
+//! binds `b`.
+//!
+//! That is the bug the `ExistsSubquery` arm was added for, left in place for
+//! every other compound expression. Its comment already gives the rule:
+//! over-approximating only defers a filter to a later, still-correct point,
+//! while under-approximating evaluates it too early.
+//!
+//! `VariableNotFound` is the loud failure. The quiet one is a predicate that
+//! happens to reference a variable bound early enough to evaluate, but whose
+//! meaning depends on a later binding — it filters on the wrong thing and
+//! returns a plausible number of rows.
+
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+
+/// `(a:A {name: 'c'})-[:T]->(:B)` and `-[:T]->(:C)`.
+fn graph() -> GraphStore {
+    let mut store = GraphStore::new();
+    let a = store.create_node("A");
+    let _ = store.set_node_property("default", a, "name".to_string(),
+                                    PropertyValue::String("c".into()));
+    let _ = store.set_node_property("default", a, "n".to_string(), PropertyValue::Integer(2));
+    for label in ["B", "C"] {
+        let t = store.create_node_with_labels([Label::new(label)]);
+        let _ = store.set_node_property("default", t, "n".to_string(), PropertyValue::Integer(2));
+        store.create_edge(a, t, "T").unwrap();
+    }
+    store
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> usize {
+    let query = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    QueryExecutor::new(store)
+        .execute(&query)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"))
+        .records
+        .len()
+}
+
+#[test]
+fn a_list_comprehension_in_a_where_sees_the_expanded_variable() {
+    let store = graph();
+    assert_eq!(
+        rows(&store, "MATCH (n)-->(b) WHERE n.name IN [x IN labels(b) | toLower(x)] RETURN b"),
+        1
+    );
+}
+
+#[test]
+fn a_quantifier_in_a_where_sees_it_too() {
+    // `all`/`any`/`none`/`single` are `PredicateFunction`, a separate variant
+    // that fell into the same catch-all.
+    let store = graph();
+    assert_eq!(
+        rows(&store, "MATCH (n)-->(b) WHERE any(x IN labels(b) WHERE x = 'B') RETURN b"),
+        1
+    );
+    assert_eq!(
+        rows(&store, "MATCH (n)-->(b) WHERE none(x IN labels(b) WHERE x = 'B') RETURN b"),
+        1
+    );
+}
+
+#[test]
+fn a_case_expression_in_a_where_sees_it_too() {
+    let store = graph();
+    assert_eq!(
+        rows(&store, "MATCH (n)-->(b) WHERE (CASE WHEN b:B THEN 1 ELSE 0 END) = 1 RETURN b"),
+        1
+    );
+}
+
+#[test]
+fn a_list_literal_in_a_where_sees_it_too() {
+    let store = graph();
+    assert_eq!(
+        rows(&store, "MATCH (n)-->(b) WHERE size([b, n]) = 2 RETURN b"),
+        2
+    );
+}
+
+#[test]
+fn reduce_in_a_where_sees_it_too() {
+    let store = graph();
+    assert_eq!(
+        rows(&store, "MATCH (n)-->(b) WHERE reduce(acc = 0, x IN labels(b) | acc + 1) = 1 RETURN b"),
+        2
+    );
+}
+
+#[test]
+fn the_comprehensions_own_variable_is_not_an_outer_dependency() {
+    // `x` is bound by the comprehension. Treating it as a dependency would
+    // defer the predicate past every point that could apply it, so a query
+    // referencing nothing else must still run.
+    let store = graph();
+    assert_eq!(
+        rows(&store, "MATCH (n) WHERE any(x IN [1, 2] WHERE x = 1) RETURN n"),
+        3
+    );
+    assert_eq!(
+        rows(&store, "MATCH (n) WHERE size([x IN [1, 2, 3] | x * 2]) = 3 RETURN n"),
+        3
+    );
+}
+
+#[test]
+fn an_ordinary_pushed_predicate_still_filters() {
+    // The half that must not regress: a predicate naming only the scanned
+    // variable is still pushed down, and still narrows.
+    let store = graph();
+    assert_eq!(rows(&store, "MATCH (n) WHERE n.name = 'c' RETURN n"), 1);
+    assert_eq!(rows(&store, "MATCH (n)-->(b) WHERE n.name = 'c' RETURN b"), 2);
+    assert_eq!(rows(&store, "MATCH (n)-->(b) WHERE n.name = 'zzz' RETURN b"), 0);
+}


### PR DESCRIPTION
Closes #948.

```cypher
MATCH (n)-->(b)
WHERE n.name IN [x IN labels(b) | toLower(x)]
RETURN b
```

```
VariableNotFound("b")
```

## Cause

`collect_expression_variables` decides *where* a WHERE conjunct can be evaluated. It handled `Variable`, `Property`, `Binary`, `Unary`, `Function` and `ExistsSubquery` — and then `_ => {}`.

So a predicate whose only variables live inside a comprehension reported **no variables at all**. It looked constant, and the decomposition pushed it to the initial scan, before the expansion that binds `b`.

## This is the bug the ExistsSubquery arm was added for

That arm's own comment states the rule:

> Reporting no variables (the previous behaviour) made this predicate look constant, so it was applied at the initial scan — before the expansion that binds `b`. […] over-approximates […] That only ever defers the filter to a later, still-correct point, never evaluates it too early.

The fix went into one variant and the catch-all left every other compound expression in the same state: pattern comprehensions, `all`/`any`/`none`/`single`, `reduce`, `CASE`, list and map literals, indexing, slicing.

## The quiet half

`VariableNotFound` is the loud failure. The one that does not announce itself is a predicate that happens to name a variable bound early enough to evaluate, but whose *meaning* depends on a later binding — it filters on the wrong thing and returns a plausible row count.

## Binders

The four constructs that introduce a variable — list comprehension, predicate function, `reduce`, pattern comprehension — collect from their sub-expressions and then **remove** the name they bind. Deferring a predicate on a name nothing outside ever binds would defer it past every point that could apply it; `the_comprehensions_own_variable_is_not_an_outer_dependency` pins that.

## Measured

`List12` [6] gained, errored 9 → **8**, **zero regressions**. Seven tests, one per construct, plus `an_ordinary_pushed_predicate_still_filters` so the pushdown that makes scans selective is not quietly disabled.