### PR TITLE
DELETE refuses a node that still has relationships (#946)

### DIFF
--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -133,6 +133,15 @@ pub enum ExecutionError {
     /// exactly like a query reading a property nobody set.
     #[error("{0} was deleted in this query and cannot be read")]
     EntityNotFound(String),
+
+    /// A write refused because it would break an invariant the graph
+    /// guarantees, as distinct from one that is merely wrong.
+    ///
+    /// Its own variant because the caller's response differs: a `TypeError` is
+    /// a bug in the query, while this is the engine declining to do something
+    /// destructive the query did not say it wanted (#946).
+    #[error("Constraint verification failed: {0}")]
+    ConstraintVerificationFailed(String),
 }
 
 pub type ExecutionResult<T> = Result<T, ExecutionError>;

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -12619,6 +12619,32 @@ impl PhysicalOperator for DeleteOperator {
                     for eid in out_edges.into_iter().chain(in_edges) {
                         let _ = store.delete_edge(eid);
                     }
+                } else {
+                    // A plain DELETE must refuse a node that still has
+                    // relationships. `store.delete_node` removes them itself,
+                    // so without this check `DELETE n` silently behaved as
+                    // `DETACH DELETE n` -- the graph stayed consistent and
+                    // relationships the query never mentioned disappeared
+                    // (#946). The whole reason Cypher separates the two is
+                    // that this is a decision the user has to make out loud.
+                    //
+                    // Checked here, not at plan time: `MATCH (a)-[r]->(b)
+                    // DELETE r, a` is legal because the relationship goes
+                    // first, and by this point the node is unconnected. That
+                    // is why edges are deleted before nodes above.
+                    //
+                    // Both directions, or `DELETE b` on `(a)-[r]->(b)` would
+                    // still cascade.
+                    let attached = store.get_outgoing_edges(node_id).len()
+                        + store.get_incoming_edges(node_id).len();
+                    if attached > 0 {
+                        return Err(ExecutionError::ConstraintVerificationFailed(format!(
+                            "Cannot delete node {}, because it still has {} relationship(s). \
+                             Delete them first, or use DETACH DELETE.",
+                            node_id.as_u64(),
+                            attached
+                        )));
+                    }
                 }
                 let _ = store.delete_node(tenant_id, node_id);
             }

--- a/tests/delete_connected_node.rs
+++ b/tests/delete_connected_node.rs
@@ -1,0 +1,123 @@
+//! `DELETE` refuses a node that still has relationships (#946).
+//!
+//! ```cypher
+//! CREATE (x:X)
+//! CREATE (x)-[:R]->(), (x)-[:R]->(), (x)-[:R]->()
+//! MATCH (n:X) DELETE n
+//! ```
+//!
+//! succeeded, and took all three relationships with it.
+//!
+//! The store stayed consistent — `delete_node` removes connected edges itself,
+//! so there were never dangling relationships — which is exactly why nothing
+//! complained. What actually happened is that **`DELETE n` silently behaved as
+//! `DETACH DELETE n`**.
+//!
+//! That is destructive by surprise. The reason Cypher separates the two is
+//! that deleting a node's relationships is a decision the user has to make out
+//! loud; a user writing `DELETE n` is relying on the engine to stop them.
+//!
+//! So these tests count relationships, not rows.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) -> Result<(), String> {
+    let query = parse_query(cypher).map_err(|e| format!("{e:?}"))?;
+    let mut ex = MutQueryExecutor::new(store, "default".to_string());
+    ex.execute(&query).map(|_| ()).map_err(|e| format!("{e:?}"))
+}
+
+fn count(store: &GraphStore, cypher: &str) -> i64 {
+    let q = parse_query(cypher).unwrap();
+    match QueryExecutor::new(store).execute(&q).unwrap().records[0].get("c") {
+        Some(Value::Property(PropertyValue::Integer(n))) => *n,
+        other => panic!("{other:?}"),
+    }
+}
+
+fn nodes(store: &GraphStore) -> i64 { count(store, "MATCH (n) RETURN count(n) AS c") }
+fn edges(store: &GraphStore) -> i64 { count(store, "MATCH ()-[r]->() RETURN count(r) AS c") }
+
+/// `(x:X)` with three outgoing `:R` relationships.
+fn hub() -> GraphStore {
+    let mut store = GraphStore::new();
+    let x = store.create_node("X");
+    for _ in 0..3 {
+        let o = store.create_node("");
+        store.create_edge(x, o, "R").unwrap();
+    }
+    store
+}
+
+#[test]
+fn deleting_a_connected_node_is_refused() {
+    let mut store = hub();
+    let err = run(&mut store, "MATCH (n:X) DELETE n").unwrap_err();
+    assert!(err.contains("ConstraintVerificationFailed"), "{err}");
+    // And nothing was destroyed on the way to refusing.
+    assert_eq!(nodes(&store), 4);
+    assert_eq!(edges(&store), 3);
+}
+
+#[test]
+fn the_message_says_what_to_do_instead() {
+    let mut store = hub();
+    let err = run(&mut store, "MATCH (n:X) DELETE n").unwrap_err();
+    assert!(err.contains("DETACH DELETE"), "{err}");
+    assert!(err.contains('3'), "says how many relationships: {err}");
+}
+
+#[test]
+fn detach_delete_still_works() {
+    let mut store = hub();
+    run(&mut store, "MATCH (n:X) DETACH DELETE n").unwrap();
+    assert_eq!(nodes(&store), 3);
+    assert_eq!(edges(&store), 0);
+}
+
+#[test]
+fn an_unconnected_node_deletes_normally() {
+    let mut store = hub();
+    run(&mut store, "MATCH (n) WHERE NOT (n:X) DELETE n").unwrap_err(); // they are connected too
+    let mut store2 = GraphStore::new();
+    store2.create_node("Lonely");
+    run(&mut store2, "MATCH (n:Lonely) DELETE n").unwrap();
+    assert_eq!(nodes(&store2), 0);
+}
+
+#[test]
+fn deleting_the_relationship_first_makes_the_node_deletable() {
+    // The reason the check is at delete time and not at plan time:
+    // `DELETE r, n` is legal because relationships go first, so by the time
+    // the node is reached it is unconnected.
+    let mut store = GraphStore::new();
+    let a = store.create_node("A");
+    let b = store.create_node("B");
+    store.create_edge(a, b, "R").unwrap();
+    run(&mut store, "MATCH (a:A)-[r]->(b:B) DELETE r, a").unwrap();
+    assert_eq!(edges(&store), 0);
+    assert_eq!(nodes(&store), 1, "only b remains");
+}
+
+#[test]
+fn an_incoming_relationship_counts_too() {
+    // Checking only outgoing edges would let `DELETE b` cascade on
+    // `(a)-[r]->(b)`.
+    let mut store = GraphStore::new();
+    let a = store.create_node("A");
+    let b = store.create_node("B");
+    store.create_edge(a, b, "R").unwrap();
+    let err = run(&mut store, "MATCH (b:B) DELETE b").unwrap_err();
+    assert!(err.contains("ConstraintVerificationFailed"), "{err}");
+    assert_eq!(edges(&store), 1);
+}
+
+#[test]
+fn deleting_a_relationship_alone_is_unaffected() {
+    let mut store = hub();
+    run(&mut store, "MATCH ()-[r:R]->() DELETE r").unwrap();
+    assert_eq!(edges(&store), 0);
+    assert_eq!(nodes(&store), 4);
+}


### PR DESCRIPTION
Closes #946.

```cypher
CREATE (x:X)
CREATE (x)-[:R]->(), (x)-[:R]->(), (x)-[:R]->()
MATCH (n:X) DELETE n
```

succeeded, and took all three relationships with it.

## Why nothing complained

The store stayed **consistent**. `delete_node` removes connected edges itself, so there were never dangling relationships and no invariant to trip. What actually happened is that `DELETE n` silently behaved as `DETACH DELETE n`.

That is destructive by surprise, and worse than the error it should have been. The reason Cypher separates the two is that deleting a node's relationships is a decision the user has to make out loud — someone writing `DELETE n` is relying on the engine to stop them.

## Two details

- **Checked at delete time, not plan time.** `MATCH (a)-[r]->(b) DELETE r, a` is legal: the relationship goes first, so by the time the node is reached it is unconnected. Edges were already being deleted before nodes for exactly this reason. `deleting_the_relationship_first_makes_the_node_deletable` pins it.
- **Both directions.** Counting only outgoing edges would let `DELETE b` cascade on `(a)-[r]->(b)`.

## A new error variant

`ConstraintVerificationFailed`, not `TypeError`. The caller's response differs: a type error is a bug in the query, while this is the engine declining to do something destructive the query did not ask for. The message says how many relationships are attached and what to write instead.

## Measured

`Delete1` [7] gained, wrong results 35 → **34**, **zero regressions**. Seven tests, including that nothing is destroyed on the way to refusing, and that `DETACH DELETE` is untouched.