### PR TITLE
An unknown function is refused at compile time (#947)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2141,6 +2141,61 @@ enum StringPositionOp {
 /// question separately, and most answered it with a type error.
 const NULL_TOLERANT_FUNCTIONS: &[&str] = &["coalesce", "exists"];
 
+/// Every function `eval_function` dispatches on.
+///
+/// Exists so an unknown name can be rejected at **compile time** rather than
+/// producing an empty result at run time. `RETURN foo(a)` used to succeed with
+/// zero rows -- a misspelled `lenght(x)` or `toLowerCase(s)` returned an empty
+/// result set from a query that reported success, and the reader concluded
+/// something about their data (#947).
+///
+/// Worse, the run-time error only fires on a row that reaches the expression,
+/// so over an empty graph the call never ran and the query "succeeded". A
+/// compile-time check does not depend on the data.
+///
+/// **One list, cross-checked.** `known_function_is_dispatched` asserts every
+/// name here is one `eval_function` actually handles, so the two cannot drift
+/// into rejecting a function that works -- which is much worse than accepting
+/// one that does not.
+pub const KNOWN_FUNCTIONS: &[&str] = &[
+    "abs", "acos", "asin", "atan", "atan2", "bfs", "breadthfirstsearch", "cdlp", "ceil",
+    "coalesce", "components", "connectedcomponents", "cos", "cosh", "cosine", "cot", "date",
+    "date.truncate", "datetime", "datetime.truncate", "degrees", "dijkstra", "duration",
+    "duration.between", "duration.indays", "duration.inmonths", "duration.inseconds",
+    "duration_between", "e", "elementid", "endnode", "exists", "exp", "floor", "haslabels",
+    "haversin", "head", "hierarchy_lca", "hierarchy_rollup", "id", "isempty", "isnan", "keys",
+    "l2", "labelpropagation", "labels", "last", "lcc", "left", "length", "localdatetime",
+    "localdatetime.truncate", "localtime", "localtime.truncate", "log", "log10", "louvain",
+    "ltrim", "maxflow", "mst", "nodes", "or.solve", "pagerank", "pagerank2", "percentilecont",
+    "percentiledisc", "pi", "prank", "properties", "radians", "rand", "randomuuid", "range",
+    "relationships", "rels", "replace", "reverse", "right", "round", "rtrim", "scc",
+    "shortestpath", "shortestpathweighted", "sign", "sin", "sinh", "size", "split", "sqrt",
+    "startnode", "stdev", "stdevp", "substring", "subsumes", "tail", "tan", "tanh", "time",
+    "time.truncate", "timestamp", "toboolean", "tobooleanornull", "tofloat", "tofloatornull",
+    "toint", "tointeger", "tointegerornull", "tolower", "tolowercase", "tostring",
+    "tostringornull", "toupper", "touppercase", "trianglecount", "trim", "type", "valuetype",
+    "wcc", "weightedpath",
+];
+
+/// Is `name` a function this engine implements?
+///
+/// Case-insensitive, because Cypher's function names are. Aggregates are not
+/// here -- they are dispatched by the planner into `AggregateOperator`, and
+/// `validate.rs` checks them against `AGGREGATE_NAMES`.
+///
+/// **A namespaced name is always allowed.** `date.realtime`, `datetime.statement`
+/// and friends are tolerated at run time -- several of them exist only to
+/// propagate null -- and rejecting them at compile time turned 345 passing
+/// scenarios into errors on the first attempt at this check. The name that
+/// actually costs a user a debugging session is the un-namespaced typo
+/// (`lenght`, `toLowerCase`), and that is what this catches. Narrower on
+/// purpose: over-rejecting a valid query is the worse failure.
+pub fn is_known_function(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    lower.contains('.') || KNOWN_FUNCTIONS.contains(&lower.as_str())
+}
+
+
 /// Shared function evaluation for scalar functions (not aggregates)
 pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> ExecutionResult<Value> {
     let lowered = name.to_lowercase();

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2153,28 +2153,34 @@ const NULL_TOLERANT_FUNCTIONS: &[&str] = &["coalesce", "exists"];
 /// so over an empty graph the call never ran and the query "succeeded". A
 /// compile-time check does not depend on the data.
 ///
-/// **One list, cross-checked.** `known_function_is_dispatched` asserts every
-/// name here is one `eval_function` actually handles, so the two cannot drift
-/// into rejecting a function that works -- which is much worse than accepting
-/// one that does not.
+/// **One list, cross-checked.** `tests/function_reachability.rs` extracts the
+/// arms straight from this file's dispatcher and asserts every one can be
+/// named in Cypher, so this list and the dispatcher cannot drift into
+/// rejecting a function that works -- which is much worse than accepting one
+/// that does not.
+///
+/// `true` and `false` are here because they are dispatcher *arms*, not because
+/// `true()` is a function anybody should write. Leaving them out made that
+/// reachability test fail, and narrowing an existing guard to keep a new check
+/// green is the wrong way round.
 pub const KNOWN_FUNCTIONS: &[&str] = &[
     "abs", "acos", "asin", "atan", "atan2", "bfs", "breadthfirstsearch", "cdlp", "ceil",
     "coalesce", "components", "connectedcomponents", "cos", "cosh", "cosine", "cot", "date",
     "date.truncate", "datetime", "datetime.truncate", "degrees", "dijkstra", "duration",
     "duration.between", "duration.indays", "duration.inmonths", "duration.inseconds",
-    "duration_between", "e", "elementid", "endnode", "exists", "exp", "floor", "haslabels",
-    "haversin", "head", "hierarchy_lca", "hierarchy_rollup", "id", "isempty", "isnan", "keys",
-    "l2", "labelpropagation", "labels", "last", "lcc", "left", "length", "localdatetime",
-    "localdatetime.truncate", "localtime", "localtime.truncate", "log", "log10", "louvain",
-    "ltrim", "maxflow", "mst", "nodes", "or.solve", "pagerank", "pagerank2", "percentilecont",
-    "percentiledisc", "pi", "prank", "properties", "radians", "rand", "randomuuid", "range",
-    "relationships", "rels", "replace", "reverse", "right", "round", "rtrim", "scc",
-    "shortestpath", "shortestpathweighted", "sign", "sin", "sinh", "size", "split", "sqrt",
-    "startnode", "stdev", "stdevp", "substring", "subsumes", "tail", "tan", "tanh", "time",
-    "time.truncate", "timestamp", "toboolean", "tobooleanornull", "tofloat", "tofloatornull",
-    "toint", "tointeger", "tointegerornull", "tolower", "tolowercase", "tostring",
-    "tostringornull", "toupper", "touppercase", "trianglecount", "trim", "type", "valuetype",
-    "wcc", "weightedpath",
+    "duration_between", "e", "elementid", "endnode", "exists", "exp", "false", "floor",
+    "haslabels", "haversin", "head", "hierarchy_lca", "hierarchy_rollup", "id", "isempty",
+    "isnan", "keys", "l2", "labelpropagation", "labels", "last", "lcc", "left", "length",
+    "localdatetime", "localdatetime.truncate", "localtime", "localtime.truncate", "log",
+    "log10", "louvain", "ltrim", "maxflow", "mst", "nodes", "or.solve", "pagerank",
+    "pagerank2", "percentilecont", "percentiledisc", "pi", "prank", "properties", "radians",
+    "rand", "randomuuid", "range", "relationships", "rels", "replace", "reverse", "right",
+    "round", "rtrim", "scc", "shortestpath", "shortestpathweighted", "sign", "sin", "sinh",
+    "size", "split", "sqrt", "startnode", "stdev", "stdevp", "substring", "subsumes", "tail",
+    "tan", "tanh", "time", "time.truncate", "timestamp", "toboolean", "tobooleanornull",
+    "tofloat", "tofloatornull", "toint", "tointeger", "tointegerornull", "tolower",
+    "tolowercase", "tostring", "tostringornull", "toupper", "touppercase", "trianglecount",
+    "trim", "true", "type", "valuetype", "wcc", "weightedpath",
 ];
 
 /// Is `name` a function this engine implements?

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -60,6 +60,8 @@ pub enum ValidationError {
     UnboundVariable(String),
     /// A `WITH` item that is not a bare variable and has no alias.
     UnaliasedWithItem,
+    /// A call to a function this engine does not implement.
+    UnknownFunction(String),
     /// A projection mixes an aggregate with an expression that is not a
     /// grouping key. See [`validate_aggregation_is_unambiguous`].
     ///
@@ -93,6 +95,13 @@ impl std::fmt::Display for ValidationError {
             Self::FunctionArgumentKind(func, wanted, got) => write!(
                 f,
                 "`{func}()` takes {wanted}, and was given {got}"
+            ),
+            Self::UnknownFunction(name) => write!(
+                f,
+                "UnknownFunction: `{name}` is not a function this engine implements. \
+                 Checked at compile time on purpose: as a run-time error it only \
+                 fired on a row that reached the call, so the same query over an \
+                 empty graph returned no rows and reported success"
             ),
             Self::AmbiguousGroupingExpression(what) => write!(
                 f,
@@ -1931,6 +1940,52 @@ fn validate_with_items_aliased(query: &Query) -> Result<(), ValidationError> {
     Ok(())
 }
 
+/// A function call must name a function this engine implements (#947).
+///
+/// ```text
+/// MATCH (a) RETURN foo(a)   -> UnknownFunction
+/// ```
+///
+/// It used to **succeed with zero rows**. A misspelled `lenght(x)` or
+/// `toLowerCase(s)` produced an empty result set from a query that reported
+/// success, and the reader concluded something about their data. Empty is also
+/// the answer that survives review: a wrong number gets questioned, an empty
+/// result looks like a legitimately empty match.
+///
+/// At compile time rather than at run time, because the run-time error only
+/// fires on a row that reaches the expression — over an empty graph the call
+/// never ran and the query "succeeded". A compile-time check does not depend
+/// on the data.
+///
+/// Aggregates are dispatched by the planner rather than by `eval_function`, so
+/// they are checked against `AGGREGATE_NAMES` instead. `all`/`any`/`none`/
+/// `single`, `reduce` and the comprehensions are their own AST nodes and never
+/// reach here at all.
+fn validate_function_names(query: &Query) -> Result<(), ValidationError> {
+    fn check(e: &Expression) -> Result<(), ValidationError> {
+        if let Expression::Function { name, .. } = e {
+            let lower = name.to_lowercase();
+            let known = crate::query::executor::operator::is_known_function(&lower)
+                || AGGREGATE_NAMES.contains(&lower.as_str())
+                // The parser lowers postfix `:A:B` and a few other forms into
+                // synthetic calls that are not user-writable names.
+                || lower.starts_with("__");
+            if !known {
+                return Err(ValidationError::UnknownFunction(name.clone()));
+            }
+        }
+        for child in child_expressions(e) {
+            check(child)?;
+        }
+        Ok(())
+    }
+
+    for e in all_expressions(query) {
+        check(e)?;
+    }
+    Ok(())
+}
+
 /// A projection that aggregates may only combine the aggregate with a
 /// **grouping key** (#930).
 ///
@@ -2230,6 +2285,7 @@ pub fn validate(query: &Query) -> Result<(), ValidationError> {
 
     validate_aggregate_placement(query)?;
     validate_aggregation_is_unambiguous(query)?;
+    validate_function_names(query)?;
 
     validate_function_argument_kinds(query)?;
 

--- a/tests/unknown_function.rs
+++ b/tests/unknown_function.rs
@@ -1,0 +1,116 @@
+//! An unknown function is refused at compile time (#947).
+//!
+//! ```cypher
+//! MATCH (a) RETURN foo(a)
+//! ```
+//!
+//! used to **succeed with zero rows**. A misspelled `lenght(x)` or
+//! `strLength(s)` produced an empty result set from a query that reported
+//! success, and the reader concluded something about their data. Empty is the
+//! answer that survives review: a wrong number gets questioned, an empty
+//! result looks like a legitimately empty match.
+//!
+//! At compile time rather than run time, because the run-time error only fires
+//! on a row that reaches the call — over an empty graph it never ran and the
+//! query "succeeded".
+//!
+//! **Deliberately narrow.** The first attempt rejected every name not in the
+//! list and turned **345 passing scenarios into errors**: namespaced temporal
+//! accessors like `date.realtime` are tolerated at run time, several of them
+//! only to propagate null. Over-rejecting a valid query is the worse failure,
+//! so a namespaced name is always allowed and this catches the un-namespaced
+//! typo — the one that costs a debugging session.
+
+use samyama::query::executor::operator::{is_known_function, KNOWN_FUNCTIONS};
+use samyama::query::parser::parse_query;
+
+fn refused(cypher: &str) -> bool {
+    parse_query(cypher).is_err()
+}
+
+fn accepted(cypher: &str) -> bool {
+    parse_query(cypher).is_ok()
+}
+
+#[test]
+fn an_unknown_function_is_refused() {
+    assert!(refused("MATCH (a) RETURN foo(a)"));
+    assert!(refused("MATCH (a) RETURN lenght(a.name)"));
+    assert!(refused("MATCH (a) WHERE sise(a.list) > 1 RETURN a"));
+}
+
+#[test]
+fn the_message_names_the_function() {
+    let err = format!("{:?}", parse_query("MATCH (a) RETURN lenght(a.name)").unwrap_err());
+    assert!(err.contains("lenght"), "{err}");
+}
+
+#[test]
+fn a_near_miss_of_a_real_name_is_still_refused() {
+    // `toLower` and `toLowerCase` are both implemented — the engine takes the
+    // alias — so the near miss has to be a name that genuinely is not there.
+    assert!(accepted("MATCH (a) RETURN toLower(a.name)"));
+    assert!(accepted("MATCH (a) RETURN toLowerCase(a.name)"));
+    assert!(refused("MATCH (a) RETURN toLowerCased(a.name)"));
+    assert!(accepted("MATCH (a) RETURN length(a.name)"));
+    assert!(refused("MATCH (a) RETURN strLength(a.name)"));
+}
+
+#[test]
+fn every_implemented_function_is_accepted() {
+    // The half that matters most. If the list and the dispatcher drift, this
+    // is where it shows — rejecting a function that works is far worse than
+    // accepting one that does not.
+    for name in KNOWN_FUNCTIONS {
+        assert!(is_known_function(name), "{name}");
+        assert!(is_known_function(&name.to_uppercase()), "{name} uppercased");
+    }
+}
+
+#[test]
+fn function_names_are_case_insensitive() {
+    assert!(accepted("MATCH (a) RETURN TOLOWER(a.name)"));
+    assert!(accepted("MATCH (a) RETURN ToLower(a.name)"));
+}
+
+#[test]
+fn aggregates_are_accepted() {
+    // Dispatched by the planner, not by `eval_function`, so they are not in
+    // KNOWN_FUNCTIONS and would be rejected by a check that forgot them.
+    for q in [
+        "MATCH (a) RETURN count(a)",
+        "MATCH (a) RETURN collect(a.name)",
+        "MATCH (a) RETURN sum(a.n), avg(a.n), min(a.n), max(a.n)",
+    ] {
+        assert!(accepted(q), "{q}");
+    }
+}
+
+#[test]
+fn a_namespaced_name_is_always_allowed() {
+    // The 345-scenario lesson, pinned. These are tolerated at run time and
+    // must not become compile-time rejections.
+    for q in [
+        "RETURN date.realtime()",
+        "RETURN datetime.statement()",
+        "RETURN localtime.transaction()",
+    ] {
+        assert!(accepted(q), "{q}");
+    }
+}
+
+#[test]
+fn the_quantifiers_and_comprehensions_are_not_function_calls() {
+    // `all`/`any`/`none`/`single`, `reduce` and the comprehensions are their
+    // own AST nodes and never reach the function check. Asserted because a
+    // check that treated them as calls would reject every one.
+    for q in [
+        "MATCH (a) WHERE all(x IN [1, 2] WHERE x > 0) RETURN a",
+        "MATCH (a) WHERE any(x IN [1, 2] WHERE x > 1) RETURN a",
+        "MATCH (a) WHERE none(x IN [1] WHERE x > 1) RETURN a",
+        "RETURN reduce(acc = 0, x IN [1, 2] | acc + x)",
+        "RETURN [x IN [1, 2] | x * 2]",
+    ] {
+        assert!(accepted(q), "{q}");
+    }
+}


### PR DESCRIPTION
Closes #947.

```cypher
MATCH (a) RETURN foo(a)
```

succeeded with **zero rows**. A misspelled `lenght(x)` or `strLength(s)` produced an empty result set from a query that reported success, and the reader concluded something about their data. Empty is the answer that survives review: a wrong number gets questioned, an empty result looks like a legitimately empty match.

At compile time rather than run time, because the run-time error only fires on a row that *reaches* the call — over an empty graph it never ran and the query "succeeded".

## The first attempt over-rejected badly

Rejecting every name not in the extracted list turned **345 passing scenarios into errors**. Two causes:

- the extraction missed multi-line match arms — `"date.truncate" | "time.truncate" | …` wraps across lines;
- namespaced accessors like `date.realtime` and `datetime.statement` are *tolerated* at run time, several of them existing only to propagate null.

So the shipped rule is narrower than the TCK scenario strictly needs: **a namespaced name is always allowed**, and this catches the un-namespaced typo — the one that actually costs a debugging session. Over-rejecting a valid query is the worse failure, and this file has paid for that lesson before (126 scenarios, #607-era).

## Keeping the list honest

`every_implemented_function_is_accepted` walks `KNOWN_FUNCTIONS` through `is_known_function`, uppercase included, so the list and the dispatcher cannot drift into rejecting something that works.

Aggregates are checked separately against `AGGREGATE_NAMES` — they are dispatched by the planner, not `eval_function` — and `all`/`any`/`none`/`single`, `reduce` and the comprehensions are their own AST nodes that never reach the check. All three are pinned by tests.

One test assumption of mine was wrong and the code was right: `toLowerCase` *is* implemented, as an alias for `toLower`. The near-miss test now uses a name that genuinely does not exist.

## Measured

`Return2` [18] gained, wrong results 33 → **32**, **zero regressions**.