### PR TITLE
Setting a property to null removes it (#952)

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -1385,6 +1385,19 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         self.invalidate_statistics_cache();
         let key_str = key.into();
         let val = value.into();
+        // Setting a property to null **removes** it. Cypher has no stored
+        // null: `CREATE ({missing: null})` creates a node with no `missing`
+        // key at all, so `keys(n)` and `properties(n)` must not report one.
+        //
+        // At the store rather than at each writer. The SET operator already
+        // did this for itself, so `SET n.b = null` was right while
+        // `CREATE ({b: null})` stored a `Null` and `'b' IN keys(n)` answered
+        // true (#952) -- the engine disagreeing with itself across two paths
+        // to the same state.
+        if matches!(val, PropertyValue::Null) {
+            self.remove_node_property(node_id, &key_str);
+            return Ok(());
+        }
         let idx = node_id.as_u64() as usize;
 
         // Enforce unique constraints on the write path. The constraint registry, the
@@ -1500,6 +1513,11 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         self.invalidate_statistics_cache();
         let key_str = key.into();
         let val = value.into();
+        // Null removes, as on the node path above (#952).
+        if matches!(val, PropertyValue::Null) {
+            self.remove_edge_property(edge_id, &key_str);
+            return Ok(());
+        }
         let idx = edge_id.as_u64() as usize;
 
         // Apply the mutation to the live stores first so the snapshot below
@@ -2042,8 +2060,18 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
     /// DS-07c: Set a property on an edge via sparse map
     pub fn set_edge_property_sparse(&mut self, edge_id: EdgeId, key: impl Into<String>, value: impl Into<PropertyValue>) {
         self.invalidate_statistics_cache();
+        let key = key.into();
+        let value = value.into();
+        // Null removes, as on the other two property setters (#952). This is
+        // the one CREATE and MERGE use for relationships, so without it
+        // `CREATE ()-[:R {p: null}]->()` stored a key Cypher says is not
+        // there.
+        if matches!(value, PropertyValue::Null) {
+            self.remove_edge_property(edge_id, &key);
+            return;
+        }
         let props = self.edge_properties.entry(edge_id).or_insert_with(PropertyMap::new);
-        props.insert(key.into(), value.into());
+        props.insert(key, value);
     }
 
     /// Check if an edge exists

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -1395,6 +1395,15 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         // true (#952) -- the engine disagreeing with itself across two paths
         // to the same state.
         if matches!(val, PropertyValue::Null) {
+            // Still checked for existence. The early return skipped the
+            // `NodeNotFound` the non-null path raises, so setting a property
+            // to null on a node that does not exist silently succeeded --
+            // caught by `test_set_node_property`, which uses exactly that
+            // case. A removal is still a write, and a write to nothing is
+            // still an error.
+            if self.get_node(node_id).is_none() {
+                return Err(GraphError::NodeNotFound(node_id));
+            }
             self.remove_node_property(node_id, &key_str);
             return Ok(());
         }
@@ -1513,8 +1522,12 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         self.invalidate_statistics_cache();
         let key_str = key.into();
         let val = value.into();
-        // Null removes, as on the node path above (#952).
+        // Null removes, as on the node path above (#952) -- and, as there,
+        // a write to an edge that does not exist is still an error.
         if matches!(val, PropertyValue::Null) {
+            if self.get_edge(edge_id).is_none() {
+                return Err(GraphError::EdgeNotFound(edge_id));
+            }
             self.remove_edge_property(edge_id, &key_str);
             return Ok(());
         }

--- a/tests/null_property_removes.rs
+++ b/tests/null_property_removes.rs
@@ -1,0 +1,134 @@
+//! Setting a property to null removes it (#952).
+//!
+//! Cypher has no stored null. `CREATE ({missing: null})` creates a node with
+//! no `missing` key at all, so `keys(n)` must not report one.
+//!
+//! The engine already knew this on **one** path: `SET n.b = null` removed the
+//! property correctly, while `CREATE ({b: null})` stored a `Null` and
+//! `'b' IN keys(n)` answered true. Two paths to the same state that disagreed
+//! — and `properties(n)` handed back a map containing an explicit `Null`,
+//! which is not a value Cypher can produce any other way.
+//!
+//! Fixed at the store rather than at each writer: there are twenty-odd call
+//! sites across CREATE, MERGE, SET, FOREACH and the algorithm writers, and
+//! fixing them one at a time is how the next one gets missed.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+}
+
+/// `keys(n)` for the single node, sorted.
+fn keys(store: &GraphStore, cypher: &str) -> Vec<String> {
+    let q = parse_query(cypher).unwrap();
+    let batch = QueryExecutor::new(store).execute(&q).unwrap();
+    let mut out = match batch.records[0].get("k") {
+        Some(Value::Property(PropertyValue::Array(items))) => items
+            .iter()
+            .map(|p| match p {
+                PropertyValue::String(s) => s.clone(),
+                other => panic!("{other:?}"),
+            })
+            .collect::<Vec<_>>(),
+        other => panic!("{other:?}"),
+    };
+    out.sort();
+    out
+}
+
+#[test]
+fn create_does_not_store_a_null_property() {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE ({exists: 42, missing: null})");
+    assert_eq!(keys(&store, "MATCH (n) RETURN keys(n) AS k"), vec!["exists"]);
+}
+
+#[test]
+fn properties_does_not_report_it_either() {
+    // The map used to come back containing an explicit `Null`, which Cypher
+    // cannot produce any other way.
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE ({exists: 42, missing: null})");
+    let q = parse_query("MATCH (n) RETURN properties(n) AS k").unwrap();
+    match QueryExecutor::new(&store).execute(&q).unwrap().records[0].get("k") {
+        Some(Value::Property(PropertyValue::Map(m))) => {
+            assert_eq!(m.len(), 1, "{m:?}");
+            assert!(m.contains_key("exists"));
+        }
+        other => panic!("{other:?}"),
+    }
+}
+
+#[test]
+fn membership_in_keys_answers_false() {
+    // The scenario as written: three questions, one about a null property.
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE ({exists: 42, missing: null})");
+    let q = parse_query(
+        "MATCH (n) RETURN 'exists' IN keys(n) AS a, 'missing' IN keys(n) AS b, \
+         'missingToo' IN keys(n) AS c",
+    )
+    .unwrap();
+    let batch = QueryExecutor::new(&store).execute(&q).unwrap();
+    let got: Vec<bool> = ["a", "b", "c"]
+        .iter()
+        .map(|c| match batch.records[0].get(c) {
+            Some(Value::Property(PropertyValue::Boolean(v))) => *v,
+            other => panic!("{c}: {other:?}"),
+        })
+        .collect();
+    assert_eq!(got, vec![true, false, false]);
+}
+
+#[test]
+fn set_to_null_still_removes() {
+    // The path that was already right, pinned so the store-level change did
+    // not disturb it.
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE ({a: 1, b: 2})");
+    run(&mut store, "MATCH (n) SET n.b = null");
+    assert_eq!(keys(&store, "MATCH (n) RETURN keys(n) AS k"), vec!["a"]);
+}
+
+#[test]
+fn a_relationship_property_behaves_the_same() {
+    // Relationships go through a different setter, which is why fixing the
+    // node path alone would have left half the bug in place.
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE ()-[:R {kept: 1, dropped: null}]->()");
+    assert_eq!(
+        keys(&store, "MATCH ()-[r]->() RETURN keys(r) AS k"),
+        vec!["kept"]
+    );
+}
+
+#[test]
+fn merge_does_not_store_one_either() {
+    let mut store = GraphStore::new();
+    run(&mut store, "MERGE ({id: 1, absent: null})");
+    assert_eq!(keys(&store, "MATCH (n) RETURN keys(n) AS k"), vec!["id"]);
+}
+
+#[test]
+fn ordinary_properties_are_untouched() {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE ({a: 1, b: 'two', c: true, d: 3.5})");
+    assert_eq!(
+        keys(&store, "MATCH (n) RETURN keys(n) AS k"),
+        vec!["a", "b", "c", "d"]
+    );
+}
+
+#[test]
+fn setting_null_over_an_existing_value_removes_it() {
+    let mut store = GraphStore::new();
+    run(&mut store, "CREATE ({a: 1, b: 2})");
+    run(&mut store, "MATCH (n) SET n.a = null, n.b = 3");
+    assert_eq!(keys(&store, "MATCH (n) RETURN keys(n) AS k"), vec!["b"]);
+}


### PR DESCRIPTION
Closes #952.

`CREATE ({exists: 42, missing: null})` stored the null:

| | `'exists' IN keys(n)` | `'missing' IN keys(n)` |
|---|---|---|
| expected | true | **false** |
| we answered | true | **true** |

`properties(n)` also handed back a map containing an explicit `Null` — a value Cypher cannot produce any other way.

## The engine already knew the rule, on one path

```
CREATE ({a: 1, b: null})              ->  keys(n) = ['a', 'b']   ✗
CREATE ({a: 1, b: 2}); SET n.b = null ->  keys(n) = ['a']        ✓
```

`SET` was right and `CREATE` was not — two paths to the same state that disagreed.

## Fixed at the store

`set_node_property`, `set_edge_property` and `set_edge_property_sparse` now treat a null as a removal, rather than patching each writer. There are twenty-odd call sites across CREATE, MERGE, SET, FOREACH and the algorithm writers; fixing them one at a time is how the next one gets missed.

Relationships go through a *different* setter — `set_edge_property_sparse` is what CREATE and MERGE use — so a node-only fix would have left half the bug in place. `a_relationship_property_behaves_the_same` pins that.

## Beyond keys()

`properties()`, `exists(n.p)` and `n.p IS NOT NULL` all ask whether a property is present. A node created with an explicitly-null property looked like it had one, and reading it returned null — indistinguishable from a property nobody set, which is the whole distinction Cypher removes by not storing nulls.

## Measured

`Graph8` [8] gained, wrong results 33 → **32**, **zero regressions**.