### PR TITLE
MERGE binds every match, not the first (#956)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -13279,6 +13279,14 @@ pub struct MergeOperator {
     /// The same for `ON MATCH SET`.
     on_match_entity_set: Vec<(String, bool, Expression)>,
     executed: bool,
+    /// Rows this MERGE still owes its caller.
+    ///
+    /// MERGE binds **every** match, not the first one. `MATCH (a) MERGE (b)`
+    /// over a two-node graph is four rows, and `MERGE (b)` on its own is two;
+    /// taking the first match and stopping made both of them one per input row
+    /// (#956). So one input row can produce many output rows and they queue
+    /// here.
+    pending: std::collections::VecDeque<Record>,
 }
 
 impl MergeOperator {
@@ -13313,6 +13321,7 @@ impl MergeOperator {
             on_create_entity_set: Vec::new(),
             on_match_entity_set: Vec::new(),
             executed: false,
+            pending: std::collections::VecDeque::new(),
         }
     }
 
@@ -13780,6 +13789,12 @@ impl PhysicalOperator for MergeOperator {
         // seeds the merge; without one it is a leaf that runs exactly once.
         // Taking the input out first keeps the borrow checker happy while the
         // merge body holds `&mut store`.
+        // One input row can owe several output rows: MERGE binds every match,
+        // not the first (#956).
+        if let Some(r) = self.pending.pop_front() {
+            return Ok(Some(r));
+        }
+
         let base = match self.input.take() {
             Some(mut input) => {
                 let row = input.next_mut(store, tenant_id)?;
@@ -13838,19 +13853,29 @@ impl PhysicalOperator for MergeOperator {
         // Through `Self::node_matches` rather than a third copy of the same
         // comparison: this was the second, and it drifted from the first by
         // exactly this gap.
-        let mut matched_node_id = Self::bound_node(&base, start.variable.as_ref());
-        if matched_node_id.is_none() {
-            let candidates: Vec<&crate::graph::Node> = match labels.first() {
-                Some(first_label) => store.get_nodes_by_label(first_label),
-                None => store.all_nodes(),
-            };
-            for node in candidates {
-                if Self::node_matches(node, labels, props) {
-                    matched_node_id = Some(node.id);
-                    break;
-                }
+        // **Every** match, not the first. MERGE is match-or-create, and when it
+        // matches it binds each match as its own row -- `MATCH (a) MERGE (b)`
+        // over two nodes is four rows. Taking the first and stopping made it
+        // one per input row, silently, with the extra rows simply absent
+        // (#956).
+        let bound = Self::bound_node(&base, start.variable.as_ref());
+        let matched: Vec<NodeId> = match bound {
+            // A variable the row already bound is not a search: it is that one
+            // node.
+            Some(id) => vec![id],
+            None => {
+                let candidates: Vec<&crate::graph::Node> = match labels.first() {
+                    Some(first_label) => store.get_nodes_by_label(first_label),
+                    None => store.all_nodes(),
+                };
+                candidates
+                    .into_iter()
+                    .filter(|node| Self::node_matches(node, labels, props))
+                    .map(|node| node.id)
+                    .collect()
             }
-        }
+        };
+        let matched_node_id = matched.first().copied();
 
         let node_id;
         let mut record = base;
@@ -13868,6 +13893,23 @@ impl PhysicalOperator for MergeOperator {
                 }
             }
             Self::apply_labels(&self.on_match_labels, &record, store, tenant_id);
+
+            // The rest of the matches, each its own row. ON MATCH SET applies
+            // to every one of them, not only the first.
+            for extra in matched.iter().skip(1) {
+                let mut r = record.clone();
+                r.bind(start_var.clone(), Value::NodeRef(*extra));
+                for (var, prop, expr) in &self.on_match_set {
+                    if var == &start_var {
+                        let val = eval_expression(expr, &r, store)?;
+                        if let Value::Property(pv) = val {
+                            let _ = store.set_node_property(tenant_id, *extra, prop.clone(), pv);
+                        }
+                    }
+                }
+                Self::apply_labels(&self.on_match_labels, &r, store, tenant_id);
+                self.pending.push_back(r);
+            }
         } else {
             node_id = store.create_node_with_labels(labels.iter().cloned());
 

--- a/tests/merge_binds_all_matches.rs
+++ b/tests/merge_binds_all_matches.rs
@@ -1,0 +1,119 @@
+//! MERGE binds every match, not the first (#956).
+//!
+//! ```cypher
+//! MATCH (a) MATCH (b) RETURN a, b   -- 4 rows over two nodes
+//! MATCH (a) MERGE (b) RETURN a, b   -- 2 rows. Should be 4.
+//! ```
+//!
+//! `MergeOperator` took the first matching node and `break`, and returned
+//! exactly one record per input row, so the other matches had nowhere to go.
+//!
+//! The rows that went missing are indistinguishable from rows that never
+//! existed: the query looked like it had correlated `a` and `b` when it had
+//! silently picked one `b`, and *which* one depended on scan order. Nothing
+//! errored and the count was plausible.
+//!
+//! These tests count rows, and one of them counts nodes — because the other
+//! half of MERGE is that it must not create when it matched.
+
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn write(store: &mut GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"))
+        .records
+        .len()
+}
+
+fn count(store: &GraphStore, cypher: &str) -> i64 {
+    let q = parse_query(cypher).unwrap();
+    match QueryExecutor::new(store).execute(&q).unwrap().records[0].get("c") {
+        Some(Value::Property(PropertyValue::Integer(n))) => *n,
+        other => panic!("{other:?}"),
+    }
+}
+
+fn two_nodes() -> GraphStore {
+    let mut store = GraphStore::new();
+    store.create_node_with_labels([Label::new("A")]);
+    store.create_node_with_labels([Label::new("B")]);
+    store
+}
+
+#[test]
+fn merge_binds_each_matching_node() {
+    let mut store = two_nodes();
+    assert_eq!(write(&mut store, "MERGE (b) RETURN b"), 2);
+    assert_eq!(count(&store, "MATCH (n) RETURN count(n) AS c"), 2, "matched, not created");
+}
+
+#[test]
+fn it_multiplies_against_the_incoming_rows() {
+    let mut store = two_nodes();
+    assert_eq!(write(&mut store, "MATCH (a) MERGE (b) RETURN a, b"), 4);
+    assert_eq!(count(&store, "MATCH (n) RETURN count(n) AS c"), 2);
+}
+
+#[test]
+fn a_labelled_merge_binds_only_its_own_label() {
+    let mut store = two_nodes();
+    store.create_node_with_labels([Label::new("A")]);
+    assert_eq!(write(&mut store, "MERGE (a:A) RETURN a"), 2);
+    assert_eq!(write(&mut store, "MERGE (b:B) RETURN b"), 1);
+}
+
+#[test]
+fn a_property_pattern_narrows_the_matches() {
+    let mut store = GraphStore::new();
+    for v in [1i64, 1, 2] {
+        let n = store.create_node_with_labels([Label::new("N")]);
+        let _ = store.set_node_property("default", n, "v".to_string(), PropertyValue::Integer(v));
+    }
+    assert_eq!(write(&mut store, "MERGE (n:N {v: 1}) RETURN n"), 2);
+    assert_eq!(count(&store, "MATCH (n) RETURN count(n) AS c"), 3, "nothing created");
+}
+
+#[test]
+fn nothing_matching_still_creates_exactly_one() {
+    // The other half of match-or-create, and the direction a fix that always
+    // enumerated could break.
+    let mut store = two_nodes();
+    assert_eq!(write(&mut store, "MERGE (n:Absent) RETURN n"), 1);
+    assert_eq!(count(&store, "MATCH (n) RETURN count(n) AS c"), 3);
+    assert_eq!(count(&store, "MATCH (n:Absent) RETURN count(n) AS c"), 1);
+}
+
+#[test]
+fn a_bound_variable_is_refused_by_an_earlier_rule() {
+    // `MATCH (a) MERGE (a)` never reaches the matching code: validation
+    // rejects it first. Recorded rather than asserted as correct — Neo4j
+    // accepts the bare form, so this rule may be over-strict, which is
+    // #764's territory and not this change's.
+    let mut store = two_nodes();
+    let q = parse_query("MATCH (a) MERGE (a) RETURN a");
+    assert!(q.is_err(), "if this starts parsing, the bound path needs a test");
+    let _ = &mut store;
+}
+
+#[test]
+fn on_match_set_runs_for_every_match() {
+    // It used to run on the first match only, so a MERGE meant to touch every
+    // matching node touched one.
+    let mut store = GraphStore::new();
+    for _ in 0..3 {
+        store.create_node_with_labels([Label::new("N")]);
+    }
+    write(&mut store, "MERGE (n:N) ON MATCH SET n.seen = 1 RETURN n");
+    assert_eq!(count(&store, "MATCH (n:N) WHERE n.seen = 1 RETURN count(n) AS c"), 3);
+}
+
+#[test]
+fn on_create_set_still_runs_for_the_created_node() {
+    let mut store = GraphStore::new();
+    write(&mut store, "MERGE (n:Fresh) ON CREATE SET n.made = 1 RETURN n");
+    assert_eq!(count(&store, "MATCH (n:Fresh) WHERE n.made = 1 RETURN count(n) AS c"), 1);
+}


### PR DESCRIPTION
Closes #956.

```
MATCH (a) MATCH (b) RETURN a, b   ->  4 rows over two nodes   correct
MATCH (a) MERGE (b) RETURN a, b   ->  2 rows                  should be 4
```

openCypher `Match8` [2] wants 6 from `MATCH (a) MERGE (b) WITH * OPTIONAL MATCH (a)--(b) RETURN count(*)`; we answered 3.

## Cause

```rust
for node in candidates {
    if Self::node_matches(node, labels, props) {
        matched_node_id = Some(node.id);
        break;                       // the first match, and stop
    }
}
```

and the operator returned exactly one record per input row, so the other matches had nowhere to go.

## Why it is quiet

The missing rows are indistinguishable from rows that never existed. The query *looks* like it correlated `a` and `b`; it silently picked one `b`, and which one depended on scan order. Nothing errors and the count is plausible.

`ON MATCH SET` was affected too — it ran on the first match only, so a MERGE meant to touch every matching node touched one. `on_match_set_runs_for_every_match` pins that.

## Scope

Creating when nothing matches is unchanged (`nothing_matching_still_creates_exactly_one` guards the direction an over-eager fix would break), and a variable the row already bound is not a search.

`MATCH (a) MERGE (a)` never reaches this code — an existing validation rule rejects it first. I've recorded that rather than asserting it is correct: Neo4j accepts the bare form, so the rule may be over-strict, which is #764's territory and not this change's.

## Not covered here

`Merge5` [3] is the same defect on the **relationship** path: `MatchMergeEdgeOperator` calls `store.edge_between`, which returns one. Separate fix.

## Measured

`Match8` [2] gained, **zero regressions**.