### PR TITLE
Refuse two patterns that can never match (#958)

### DIFF
--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -160,6 +160,15 @@ pub struct Query {
     /// trailing UNWIND deliberately stays after the filter so the cross product is built
     /// from the already-narrowed rows.
     pub unwind_leading: bool,
+    /// A `RETURN *` / `WITH *` that expanded to **no** columns.
+    ///
+    /// Star expansion replaces `*` with the variables in scope, so a star that
+    /// found none leaves an empty projection and nothing downstream can tell
+    /// it apart from a query that projected nothing on purpose. Recorded here
+    /// because validation runs after expansion, and `MATCH () RETURN *` --
+    /// every element anonymous, so the query names no variable -- has to be
+    /// rejected rather than answered with zero rows (#958).
+    pub star_expanded_to_nothing: bool,
     /// MERGE clause (optional)
     pub merge_clause: Option<MergeClause>,
     /// UNION queries (chained via UNION/UNION ALL)
@@ -879,6 +888,7 @@ impl Query {
             extra_unwind_clauses: Vec::new(),
             post_with_unwind_clauses: Vec::new(),
             unwind_leading: false,
+            star_expanded_to_nothing: false,
             merge_clause: None,
             union_queries: Vec::new(),
             explain: false,

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -7559,6 +7559,7 @@ mod tests {
             foreach_clause: None,
             unwind_clause: None,
             unwind_leading: false,
+            star_expanded_to_nothing: false,
             merge_clause: None,
             union_queries: vec![],
             explain: false,

--- a/src/query/star.rs
+++ b/src/query/star.rs
@@ -88,9 +88,10 @@ fn with_output(items: &[ReturnItem]) -> Vec<String> {
 
 /// Replace the `*` item in `items` with one item per name in `scope`,
 /// preserving any other items written alongside it.
-fn expand_into(items: &mut Vec<ReturnItem>, scope: &[String]) {
+/// Returns true when a star was expanded and produced no columns at all.
+fn expand_into(items: &mut Vec<ReturnItem>, scope: &[String]) -> bool {
     if !has_star(items) {
-        return;
+        return false;
     }
 
     // Names the query projects explicitly, wherever they appear relative to
@@ -128,7 +129,9 @@ fn expand_into(items: &mut Vec<ReturnItem>, scope: &[String]) {
             out.push(item);
         }
     }
+    let empty = out.is_empty();
     *items = out;
+    empty
 }
 
 /// Every variable a pattern binds, in written order.
@@ -167,8 +170,9 @@ fn bind_pattern(scope: &mut Vec<String>, pattern: &Pattern) {
 ///
 /// The star is the reason to walk in order: scope is what has been bound so
 /// far, and a `WITH` replaces it (#892).
-fn expand_stars_pipeline(clauses: &mut [Clause]) {
+fn expand_stars_pipeline(clauses: &mut [Clause]) -> bool {
     let mut scope: Vec<String> = Vec::new();
+    let mut empty_star = false;
     for clause in clauses.iter_mut() {
         match clause {
             Clause::Match(mc) => bind_match(&mut scope, std::slice::from_ref(mc)),
@@ -184,13 +188,18 @@ fn expand_stars_pipeline(clauses: &mut [Clause]) {
                 }
             }
             Clause::With(wc) => {
-                expand_into(&mut wc.items, &scope);
+                // A `WITH *` that projects nothing is legal --
+                // `MATCH () CREATE () WITH * CREATE ()` is a TCK scenario that
+                // must pass. Only `RETURN *` with nothing in scope is the
+                // error, so the flag is set at RETURN sites only.
+                let _ = expand_into(&mut wc.items, &scope);
                 scope = with_output(&wc.items);
             }
-            Clause::Return(rc) => expand_into(&mut rc.items, &scope),
+            Clause::Return(rc) => empty_star |= expand_into(&mut rc.items, &scope),
             Clause::Where(_) | Clause::Set(_) | Clause::Remove(_) | Clause::Delete(_) => {}
         }
     }
+    empty_star
 }
 
 /// Expand every `*` in `query`, in place.
@@ -203,7 +212,7 @@ pub fn expand_stars(query: &mut Query) {
     // `return_clause` -- so expanding only one left a literal `*` in the other
     // for whatever reads it next.
     if !query.clauses.is_empty() {
-        expand_stars_pipeline(&mut query.clauses);
+        query.star_expanded_to_nothing |= expand_stars_pipeline(&mut query.clauses);
     }
     if query.needs_clause_pipeline {
         // The parser mirrors the pipeline's RETURN into `return_clause` before
@@ -244,8 +253,9 @@ pub fn expand_stars(query: &mut Query) {
     // A WITH narrows scope to what it projects, so its own `*` is expanded
     // against the scope that reaches it, and everything after sees only its
     // output.
+    let mut empty_star = false;
     let mut apply_with = |wc: &mut WithClause, scope: &mut Vec<String>| {
-        expand_into(&mut wc.items, scope);
+        let _ = expand_into(&mut wc.items, scope);
         *scope = with_output(&wc.items);
     };
 
@@ -273,6 +283,7 @@ pub fn expand_stars(query: &mut Query) {
     }
 
     if let Some(rc) = query.return_clause.as_mut() {
-        expand_into(&mut rc.items, &scope);
+        empty_star |= expand_into(&mut rc.items, &scope);
     }
+    query.star_expanded_to_nothing |= empty_star;
 }

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -62,6 +62,10 @@ pub enum ValidationError {
     UnaliasedWithItem,
     /// A call to a function this engine does not implement.
     UnknownFunction(String),
+    /// `RETURN *` where nothing is in scope.
+    NoVariablesInScope,
+    /// The same relationship variable twice in one pattern.
+    RelationshipUniquenessViolation(String),
     /// A projection mixes an aggregate with an expression that is not a
     /// grouping key. See [`validate_aggregation_is_unambiguous`].
     ///
@@ -102,6 +106,20 @@ impl std::fmt::Display for ValidationError {
                  Checked at compile time on purpose: as a run-time error it only \
                  fired on a row that reached the call, so the same query over an \
                  empty graph returned no rows and reported success"
+            ),
+            Self::NoVariablesInScope => write!(
+                f,
+                "NoVariablesInScope: `RETURN *` has nothing to return. Every \
+                 pattern element here is anonymous, so the query names no \
+                 variable — `MATCH () RETURN *` asks for all of nothing, which \
+                 is a query nobody meant to write"
+            ),
+            Self::RelationshipUniquenessViolation(var) => write!(
+                f,
+                "RelationshipUniquenessViolation: `{var}` appears twice in one \
+                 pattern. Cypher matches relationships edge-distinctly, so a \
+                 single pattern cannot traverse the same relationship twice — \
+                 the pattern can never match, whatever the graph holds"
             ),
             Self::AmbiguousGroupingExpression(what) => write!(
                 f,
@@ -1940,6 +1958,80 @@ fn validate_with_items_aliased(query: &Query) -> Result<(), ValidationError> {
     Ok(())
 }
 
+/// `RETURN *` must have something to return (#958).
+///
+/// ```text
+/// MATCH () RETURN *   -> NoVariablesInScope
+/// ```
+///
+/// Every element of that pattern is anonymous, so the query names no
+/// variable and `*` expands to nothing. We answered zero rows: a query
+/// asking for all of nothing, reported as a successful empty match.
+///
+/// Only when the expansion finds nothing at all. `MATCH (n) RETURN *` is
+/// fine, and so is any query that binds one variable anywhere.
+///
+/// `RETURN` only. A `WITH *` that projects nothing is legal --
+/// `MATCH () CREATE () WITH * CREATE ()` is a scenario that must pass, and
+/// flagging it too broke two of them.
+///
+/// The flag is set during expansion because validation runs after it: by the
+/// time this sees the query the `*` has already become zero columns, which is
+/// indistinguishable from a projection that was empty on purpose.
+fn validate_star_has_scope(query: &Query) -> Result<(), ValidationError> {
+    if query.star_expanded_to_nothing {
+        return Err(ValidationError::NoVariablesInScope);
+    }
+    Ok(())
+}
+
+/// A relationship variable may appear once per pattern (#958).
+///
+/// ```text
+/// MATCH (a)-[r]->()-[r]->(a) RETURN r   -> RelationshipUniquenessViolation
+/// ```
+///
+/// Cypher matches relationships edge-distinctly: one pattern cannot traverse
+/// the same relationship twice, so this pattern can never match whatever the
+/// graph holds. We ran it and returned zero rows -- true, and indistinguishable
+/// from a graph that simply has no such shape.
+///
+/// Per *path*, not per query: `MATCH (a)-[r]->(b) MATCH (c)-[r]->(d)` is a
+/// different rule (the second clause re-uses a bound relationship, which is
+/// legal and means the same edge).
+fn validate_relationship_uniqueness(query: &Query) -> Result<(), ValidationError> {
+    use crate::query::ast::{Clause, Pattern};
+
+    fn check(pattern: &Pattern) -> Result<(), ValidationError> {
+        for path in &pattern.paths {
+            let mut seen: HashSet<&String> = HashSet::new();
+            for seg in &path.segments {
+                if let Some(v) = &seg.edge.variable {
+                    if !seen.insert(v) {
+                        return Err(ValidationError::RelationshipUniquenessViolation(v.clone()));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    for mc in &query.match_clauses {
+        check(&mc.pattern)?;
+    }
+    for c in &query.clauses {
+        match c {
+            Clause::Match(mc) => check(&mc.pattern)?,
+            Clause::Create(cc) => check(&cc.pattern)?,
+            _ => {}
+        }
+    }
+    if let Some(cc) = &query.create_clause {
+        check(&cc.pattern)?;
+    }
+    Ok(())
+}
+
 /// A function call must name a function this engine implements (#947).
 ///
 /// ```text
@@ -2286,6 +2378,8 @@ pub fn validate(query: &Query) -> Result<(), ValidationError> {
     validate_aggregate_placement(query)?;
     validate_aggregation_is_unambiguous(query)?;
     validate_function_names(query)?;
+    validate_star_has_scope(query)?;
+    validate_relationship_uniqueness(query)?;
 
     validate_function_argument_kinds(query)?;
 

--- a/tests/pattern_and_star_validation.rs
+++ b/tests/pattern_and_star_validation.rs
@@ -1,0 +1,82 @@
+//! Two compile-time rules the engine was missing (#958).
+//!
+//! ```cypher
+//! MATCH (a)-[r]->()-[r]->(a) RETURN r   -- RelationshipUniquenessViolation
+//! MATCH () RETURN *                     -- NoVariablesInScope
+//! ```
+//!
+//! Both used to **succeed with zero rows**. The first can never match whatever
+//! the graph holds — Cypher traverses relationships edge-distinctly, so one
+//! pattern cannot use the same relationship twice — and an empty result is
+//! indistinguishable from a graph that simply lacks the shape. The second asks
+//! for all of nothing.
+//!
+//! The `RETURN *` rule needed a flag set during star expansion, because
+//! validation runs *after* it: by then the `*` has become zero columns, which
+//! looks exactly like a projection that was empty on purpose.
+
+use samyama::query::parser::parse_query;
+
+fn refused(cypher: &str) -> bool {
+    parse_query(cypher).is_err()
+}
+
+fn accepted(cypher: &str) -> bool {
+    parse_query(cypher).is_ok()
+}
+
+#[test]
+fn a_relationship_variable_twice_in_one_pattern_is_refused() {
+    assert!(refused("MATCH (a)-[r]->()-[r]->(a) RETURN r"));
+    assert!(refused("MATCH (a)-[r]->(b)-[r]->(c) RETURN a"));
+}
+
+#[test]
+fn the_message_names_the_relationship() {
+    let err = format!("{:?}", parse_query("MATCH (a)-[r]->()-[r]->(a) RETURN r").unwrap_err());
+    assert!(err.contains('r'), "{err}");
+}
+
+#[test]
+fn distinct_relationship_variables_are_fine() {
+    assert!(accepted("MATCH (a)-[r1]->()-[r2]->(a) RETURN r1, r2"));
+    assert!(accepted("MATCH (a)-[r]->(b) RETURN r"));
+}
+
+#[test]
+fn the_same_name_in_two_patterns_is_a_different_rule() {
+    // `MATCH (a)-[r]->(b) MATCH (c)-[r]->(d)` re-uses a *bound* relationship,
+    // which is legal and means the same edge. The rule is per path, not per
+    // query, and conflating them would reject valid Cypher.
+    assert!(accepted("MATCH (a)-[r]->(b) MATCH (c)-[r]->(d) RETURN r"));
+    assert!(accepted("MATCH (a)-[r]->(b), (c)-[r2]->(d) RETURN r, r2"));
+}
+
+#[test]
+fn return_star_with_nothing_in_scope_is_refused() {
+    assert!(refused("MATCH () RETURN *"));
+}
+
+#[test]
+fn return_star_with_something_in_scope_is_fine() {
+    assert!(accepted("MATCH (n) RETURN *"));
+    assert!(accepted("MATCH ()-[r]->() RETURN *"));
+    assert!(accepted("MATCH p = ()-->() RETURN *"));
+    assert!(accepted("UNWIND [1, 2] AS x RETURN *"));
+    assert!(accepted("CREATE (n) RETURN *"));
+}
+
+#[test]
+fn a_with_star_that_projects_nothing_is_legal() {
+    // Only RETURN is the error. Flagging WITH too broke two TCK scenarios that
+    // must pass, which is how this rule found its own edge.
+    assert!(accepted("MATCH () CREATE () WITH * CREATE ()"));
+    assert!(accepted("MATCH () CREATE () WITH * MATCH () CREATE ()"));
+}
+
+#[test]
+fn an_explicit_projection_beside_a_star_keeps_it_alive() {
+    // `RETURN *, 1` projects something even when the star finds nothing, so it
+    // is not the error the rule is about.
+    assert!(accepted("MATCH (n) RETURN *, 1 AS one"));
+}


### PR DESCRIPTION
Closes #958.

```cypher
MATCH (a)-[r]->()-[r]->(a) RETURN r   -- succeeded, 0 rows
MATCH () RETURN *                     -- succeeded, 0 rows
```

## Relationship uniqueness

Cypher traverses relationships edge-distinctly, so one pattern cannot use the same relationship twice. That pattern **can never match, whatever the graph holds** — and an empty result is indistinguishable from a graph that simply lacks the shape, so the user goes looking at their data.

Per **path**, not per query: `MATCH (a)-[r]->(b) MATCH (c)-[r]->(d)` re-uses a *bound* relationship, which is legal and means the same edge. `the_same_name_in_two_patterns_is_a_different_rule` guards that, because conflating them would reject valid Cypher.

## RETURN * with nothing in scope

Every element is anonymous, so the query names no variable and `*` expands to nothing.

The awkward part: validation runs **after** star expansion, so by the time it sees the query the `*` has already become zero columns — indistinguishable from a projection that was empty on purpose. The fact is recorded during expansion on a query flag, the way the AST already carries `unwind_leading`.

**RETURN only.** A `WITH *` that projects nothing is legal — `MATCH () CREATE () WITH * CREATE ()` is a scenario that must pass. My first attempt flagged WITH too and broke it and `Create3` [3]; the failure-manifest diff caught it, the pass count alone would not have (it read +2/−2).

## Measured

`Match3` [29] and `Return7` [2] gained, wrong results 29 → **27**, **zero regressions**. Eight tests, five of which pin the shapes that must stay accepted.