### PR TITLE
min() and max() use Cypher's orderability (#960)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -7634,12 +7634,30 @@ impl AggregatorState {
             // directions: while null sorted smallest it won every min(), and once ordering
             // was corrected so null sorts greatest (#369) it would have won every max().
             // Neither is a comparator problem; the accumulator simply must not see nulls.
+            // Cypher's orderability, not `PropertyValue`'s derived `Ord`.
+            //
+            // That `Ord` backs the B-tree property index and orders Boolean,
+            // Number, String, ..., Array, Map, Null; Cypher orders
+            // Map < List < String < Boolean < Number < null. Over mixed input
+            // the two disagree about which value is smallest, so
+            // `min([1, 'a', [1,2], 0.2, 'b'])` answered `0.2` where openCypher
+            // answers `[1, 2]`, and `max` answered the list where the answer
+            // is `1` (#960).
+            //
+            // `graph::property::cypher_order` is the comparator ORDER BY uses.
+            // Both orders exist on purpose and neither can be dropped -- see
+            // its doc comment -- so the fix is for each caller to ask for the
+            // one it means.
             AggregatorState::Min(curr) => {
                 if let Some(prop) = value.as_property() {
                     if matches!(prop, PropertyValue::Null) {
                         return;
                     }
-                    if curr.is_none() || prop < curr.as_ref().unwrap() {
+                    let smaller = curr.as_ref().is_none_or(|c| {
+                        crate::graph::property::cypher_order(prop, c)
+                            == std::cmp::Ordering::Less
+                    });
+                    if smaller {
                         *curr = Some(prop.clone());
                     }
                 }
@@ -7649,7 +7667,11 @@ impl AggregatorState {
                     if matches!(prop, PropertyValue::Null) {
                         return;
                     }
-                    if curr.is_none() || prop > curr.as_ref().unwrap() {
+                    let larger = curr.as_ref().is_none_or(|c| {
+                        crate::graph::property::cypher_order(prop, c)
+                            == std::cmp::Ordering::Greater
+                    });
+                    if larger {
                         *curr = Some(prop.clone());
                     }
                 }
@@ -7717,16 +7739,26 @@ impl AggregatorState {
                 *sum += bs;
                 *count += bc;
             }
+            // The same comparator as the accumulator above, or a parallel
+            // aggregation would answer differently from a sequential one.
             (AggregatorState::Min(a), AggregatorState::Min(b)) => {
                 if let Some(b) = b {
-                    if a.is_none() || &b < a.as_ref().unwrap() {
+                    let smaller = a.as_ref().is_none_or(|c| {
+                        crate::graph::property::cypher_order(&b, c)
+                            == std::cmp::Ordering::Less
+                    });
+                    if smaller {
                         *a = Some(b);
                     }
                 }
             }
             (AggregatorState::Max(a), AggregatorState::Max(b)) => {
                 if let Some(b) = b {
-                    if a.is_none() || &b > a.as_ref().unwrap() {
+                    let larger = a.as_ref().is_none_or(|c| {
+                        crate::graph::property::cypher_order(&b, c)
+                            == std::cmp::Ordering::Greater
+                    });
+                    if larger {
                         *a = Some(b);
                     }
                 }

--- a/tests/minmax_orderability.rs
+++ b/tests/minmax_orderability.rs
@@ -1,0 +1,132 @@
+//! `min()` and `max()` use Cypher's orderability (#960).
+//!
+//! ```cypher
+//! UNWIND [1, 'a', null, [1, 2], 0.2, 'b'] AS x RETURN max(x), min(x)
+//! ```
+//!
+//! answered `max = [1, 2]` and `min = 0.2`, where openCypher answers
+//! `max = 1` and `min = [1, 2]`.
+//!
+//! They compared with `PropertyValue`'s derived `Ord`, which is the **index**
+//! order — Boolean, Number, String, …, Array, Map, Null — and exists to back
+//! the B-tree property index, where the only requirement is that numbers
+//! compare numerically across `Integer` and `Float`.
+//!
+//! Cypher's orderability is a different total order:
+//! `Map < List < String < Boolean < Number < null`. Over mixed input the two
+//! disagree about which value is smallest.
+//!
+//! Both orders exist on purpose and neither can be dropped — see
+//! `graph::property::cypher_order`'s doc comment — so the fix is for each
+//! caller to ask for the one it means.
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn one(store: &GraphStore, cypher: &str, col: &str) -> String {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let batch = QueryExecutor::new(store).execute(&q).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    format!("{:?}", batch.records[0].get(col))
+}
+
+#[test]
+fn max_over_mixed_types_is_the_number() {
+    let store = GraphStore::new();
+    let got = one(
+        &store,
+        "UNWIND [1, 'a', null, [1, 2], 0.2, 'b'] AS x RETURN max(x) AS m",
+        "m",
+    );
+    assert!(got.contains("Integer(1)"), "expected 1, got {got}");
+}
+
+#[test]
+fn min_over_mixed_types_is_the_list() {
+    let store = GraphStore::new();
+    let got = one(
+        &store,
+        "UNWIND [1, 'a', null, [1, 2], 0.2, 'b'] AS x RETURN min(x) AS m",
+        "m",
+    );
+    assert!(got.contains("Array"), "expected the list, got {got}");
+}
+
+#[test]
+fn numbers_alone_still_compare_numerically() {
+    // The half the index order got right, and the half a careless fix would
+    // break: within one type nothing about the ordering changes.
+    let store = GraphStore::new();
+    for (q, want) in [
+        ("UNWIND [3, 1, 2] AS x RETURN min(x) AS m", "Integer(1)"),
+        ("UNWIND [3, 1, 2] AS x RETURN max(x) AS m", "Integer(3)"),
+        ("UNWIND [1, 0.5, 2] AS x RETURN min(x) AS m", "Float(0.5)"),
+    ] {
+        let got = one(&store, q, "m");
+        assert!(got.contains(want), "{q}: expected {want}, got {got}");
+    }
+}
+
+#[test]
+fn strings_alone_still_compare_lexically() {
+    let store = GraphStore::new();
+    let got = one(&store, "UNWIND ['b', 'a', 'c'] AS x RETURN min(x) AS m", "m");
+    assert!(got.contains("\"a\""), "{got}");
+}
+
+#[test]
+fn nulls_are_ignored_not_compared() {
+    // Aggregates ignore nulls. Comparing them broke min and max in opposite
+    // directions once already: null sorted smallest won every min, and once
+    // ordering put null greatest it would have won every max.
+    let store = GraphStore::new();
+    for (q, want) in [
+        ("UNWIND [null, 2, null, 1] AS x RETURN min(x) AS m", "Integer(1)"),
+        ("UNWIND [null, 2, null, 1] AS x RETURN max(x) AS m", "Integer(2)"),
+    ] {
+        let got = one(&store, q, "m");
+        assert!(got.contains(want), "{q}: expected {want}, got {got}");
+    }
+}
+
+#[test]
+fn all_null_input_gives_null() {
+    let store = GraphStore::new();
+    let got = one(&store, "UNWIND [null, null] AS x RETURN min(x) AS m", "m");
+    assert!(got.contains("Null") || got == "None", "{got}");
+}
+
+#[test]
+fn a_string_beats_a_list_and_a_number_beats_a_string() {
+    // The order stated directly, one pair at a time, so a future change that
+    // reorders two adjacent ranks is caught rather than absorbed.
+    let store = GraphStore::new();
+    let cases = [
+        ("UNWIND [[1], 'a'] AS x RETURN max(x) AS m", "\"a\""),
+        ("UNWIND [[1], 'a'] AS x RETURN min(x) AS m", "Array"),
+        ("UNWIND ['a', 1] AS x RETURN max(x) AS m", "Integer(1)"),
+        ("UNWIND ['a', 1] AS x RETURN min(x) AS m", "\"a\""),
+        ("UNWIND [true, 1] AS x RETURN max(x) AS m", "Integer(1)"),
+    ];
+    for (q, want) in cases {
+        let got = one(&store, q, "m");
+        assert!(got.contains(want), "{q}: expected {want}, got {got}");
+    }
+}
+
+#[test]
+fn min_and_max_over_a_property_are_unchanged() {
+    // The overwhelmingly common case: one type, read from the graph.
+    let mut store = GraphStore::new();
+    for v in [5i64, 1, 9] {
+        let n = store.create_node("N");
+        let _ = store.set_node_property("default", n, "v".to_string(), PropertyValue::Integer(v));
+    }
+    let q = parse_query("MATCH (n:N) RETURN min(n.v) AS lo, max(n.v) AS hi").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&q).unwrap();
+    let get = |c: &str| match batch.records[0].get(c) {
+        Some(Value::Property(PropertyValue::Integer(n))) => *n,
+        other => panic!("{c}: {other:?}"),
+    };
+    assert_eq!((get("lo"), get("hi")), (1, 9));
+}


### PR DESCRIPTION
Closes #960.

```cypher
UNWIND [1, 'a', null, [1, 2], 0.2, 'b'] AS x RETURN max(x), min(x)
```

| | max | min |
|---|---|---|
| expected | **1** | **[1, 2]** |
| we answered | [1, 2] | 0.2 |

Effectively swapped: we picked the list for `max` and a number for `min`.

## Cause

`min`/`max` compared with `PropertyValue`'s derived `Ord` — the **index** order (Boolean, Number, String, …, Array, Map, Null), which exists to back the B-tree property index where the only requirement is that numbers compare numerically across `Integer` and `Float`.

Cypher's orderability is a different total order: `Map < List < String < Boolean < Number < null`. Over mixed input the two disagree about which value is smallest.

`graph::property::cypher_order` already implements the right one — it is what `ORDER BY` uses, and its doc comment is explicit that both orders exist on purpose and neither can be dropped:

> Reusing the index order for `ORDER BY` sorted strings after numbers and lists after both. […] Do not "unify" them.

So the fix is not to change either order; it is for each caller to ask for the one it means.

## The merge path too

`AggregatorState`'s merge — used when partial aggregates are combined — had the same two comparisons. Fixing only the accumulator would make a **parallel aggregation answer differently from a sequential one**, which is the kind of difference that shows up only under load.

## Measured

`Aggregation2` [11] and [12] gained, wrong results 27 → **26**, **zero regressions**.

Eight tests, including that numbers alone still compare numerically and strings lexically — the half the index order got right and a careless fix would break — and one that states the cross-type order a pair at a time, so reordering two adjacent ranks is caught rather than absorbed.