### PR TITLE
The count fast paths respect a self-loop pattern (#962)

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2757,7 +2757,16 @@ impl QueryPlanner {
                 && !matches!(
                     query.match_clauses[0].pattern.paths[0].segments[0].edge.direction,
                     Direction::Both
-                );
+                )
+                // And distinct endpoints, for the same reason: this count is
+                // also blind to `(n)-[r]->(n)` (#962).
+                && {
+                    let path = &query.match_clauses[0].pattern.paths[0];
+                    match (&path.start.variable, &path.segments[0].node.variable) {
+                        (Some(a), Some(b)) => a != b,
+                        _ => true,
+                    }
+                };
 
             // O(1) count for a single edge type (or all edges): the metadata that already
             // answers `type(r), count(r)` and node label counts can answer this too, but
@@ -2815,7 +2824,24 @@ impl QueryPlanner {
                 && !matches!(
                     query.match_clauses[0].pattern.paths[0].segments[0].edge.direction,
                     Direction::Both
-                );
+                )
+                // And the two endpoints must be *different* variables.
+                // `MATCH (n)-[r]->(n)` asks for self-loops only, and the
+                // store's edge count knows nothing about that constraint --
+                // the fast path answered the **total** edge count, 2 over a
+                // graph with one loop and one ordinary edge, where `RETURN r`
+                // on the same pattern gives one row (#962).
+                //
+                // The same query answering two different numbers depending on
+                // whether it counts is what a fast path has to be checked
+                // against: an optimisation may skip *work*, never a predicate.
+                && {
+                    let path = &query.match_clauses[0].pattern.paths[0];
+                    match (&path.start.variable, &path.segments[0].node.variable) {
+                        (Some(a), Some(b)) => a != b,
+                        _ => true,
+                    }
+                };
 
             if use_edge_count {
                 let edge_type = query.match_clauses[0].pattern.paths[0].segments[0]

--- a/tests/count_fastpath_selfloop.rs
+++ b/tests/count_fastpath_selfloop.rs
@@ -1,0 +1,109 @@
+//! The O(1) count fast paths are blind to a self-loop pattern (#962).
+//!
+//! ```cypher
+//! CREATE (a:A)-[:LOOP]->(a), ()-[:T]->()
+//!
+//! MATCH (n)-[r]->(n) RETURN count(r)   -- answered 2
+//! MATCH (n)-[r]->(n) RETURN r          -- 1 row
+//! ```
+//!
+//! The same query, two different answers, depending on whether it counted.
+//!
+//! `EdgeCountOperator` reads the edge total straight off the store — which is
+//! the point, on a billion-edge graph — but the store knows nothing about
+//! `(n)…(n)`, the constraint that both endpoints are the *same* node. The
+//! guard already excluded undirected patterns and labels and properties; it
+//! did not exclude a repeated endpoint variable.
+//!
+//! An optimisation may skip **work**. It may not skip a **predicate**.
+
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// One self-loop and one ordinary edge, so total and self-loop counts differ.
+fn graph() -> GraphStore {
+    let mut store = GraphStore::new();
+    let a = store.create_node_with_labels([Label::new("A")]);
+    store.create_edge(a, a, "LOOP").unwrap();
+    let x = store.create_node("");
+    let y = store.create_node("");
+    store.create_edge(x, y, "T").unwrap();
+    store
+}
+
+fn count(store: &GraphStore, cypher: &str) -> i64 {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    match QueryExecutor::new(store).execute(&q).unwrap().records[0].get("c") {
+        Some(Value::Property(PropertyValue::Integer(n))) => *n,
+        other => panic!("{cypher}: {other:?}"),
+    }
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    QueryExecutor::new(store).execute(&q).unwrap().records.len()
+}
+
+#[test]
+fn counting_a_self_loop_pattern_agrees_with_returning_it() {
+    // The property that was violated, stated directly: counting a pattern and
+    // listing it must give the same number.
+    let store = graph();
+    assert_eq!(count(&store, "MATCH (n)-[r]->(n) RETURN count(r) AS c"), 1);
+    assert_eq!(rows(&store, "MATCH (n)-[r]->(n) RETURN r"), 1);
+}
+
+#[test]
+fn count_star_over_a_self_loop_pattern_too() {
+    let store = graph();
+    assert_eq!(count(&store, "MATCH (n)-[r]->(n) RETURN count(*) AS c"), 1);
+}
+
+#[test]
+fn a_typed_self_loop_pattern_is_counted_correctly() {
+    let store = graph();
+    assert_eq!(count(&store, "MATCH (n)-[r:LOOP]->(n) RETURN count(r) AS c"), 1);
+    assert_eq!(count(&store, "MATCH (n)-[r:T]->(n) RETURN count(r) AS c"), 0);
+}
+
+#[test]
+fn the_ordinary_fast_path_still_answers_the_total() {
+    // The direction a fix that simply disabled the optimisation would break.
+    // Distinct endpoints, no labels, no properties: still the store's count.
+    let store = graph();
+    assert_eq!(count(&store, "MATCH (a)-[r]->(b) RETURN count(r) AS c"), 2);
+    assert_eq!(count(&store, "MATCH (a)-[r:T]->(b) RETURN count(r) AS c"), 1);
+    assert_eq!(count(&store, "MATCH (a)-[r:LOOP]->(b) RETURN count(r) AS c"), 1);
+}
+
+#[test]
+fn the_fast_path_is_still_chosen_for_the_ordinary_shape() {
+    // Asserted through EXPLAIN, because "the answer is right" would also hold
+    // if the optimisation had been silently switched off everywhere.
+    let store = graph();
+    let q = parse_query("EXPLAIN MATCH (a)-[r]->(b) RETURN count(r) AS c").unwrap();
+    let plan = format!("{:?}", QueryExecutor::new(&store).execute(&q).unwrap().records[0]);
+    assert!(plan.contains("EdgeCount"), "{plan}");
+}
+
+#[test]
+fn the_self_loop_shape_does_not_use_it() {
+    let store = graph();
+    let q = parse_query("EXPLAIN MATCH (n)-[r]->(n) RETURN count(r) AS c").unwrap();
+    let plan = format!("{:?}", QueryExecutor::new(&store).execute(&q).unwrap().records[0]);
+    assert!(!plan.contains("EdgeCount"), "{plan}");
+}
+
+#[test]
+fn grouping_by_type_over_a_self_loop_pattern_is_correct_too() {
+    // The second fast path had the same blind spot.
+    let store = graph();
+    let q = parse_query("MATCH (n)-[r]->(n) RETURN type(r) AS t, count(r) AS c").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&q).unwrap();
+    assert_eq!(batch.records.len(), 1, "{:?}", batch.records);
+    match batch.records[0].get("c") {
+        Some(Value::Property(PropertyValue::Integer(n))) => assert_eq!(*n, 1),
+        other => panic!("{other:?}"),
+    }
+}


### PR DESCRIPTION
Closes #962.

```
MATCH (n)-[r]->(n) RETURN count(r)   ->  2
MATCH (n)-[r]->(n) RETURN r          ->  1 row
```

The same query, two different answers, depending on whether it counts.

## Cause

`EdgeCountOperator` reads the edge total straight off the store — which is the point of it, and why `MATCH (a)-[r]->(b) RETURN count(r)` does not time out on a billion-edge graph (#304).

The store knows nothing about `(n)…(n)`: that both endpoints are the **same node**. The guard already excluded undirected patterns, labels, properties, variable length, WHERE, WITH and ORDER BY — but not a repeated endpoint variable. So the pattern's only real predicate was the one thing the fast path skipped.

**An optimisation may skip work. It may not skip a predicate.**

`EdgeTypeCountOperator` (the `type(r), count(r)` path) had the identical blind spot and gets the same guard.

## Both directions asserted through EXPLAIN

```
MATCH (a)-[r]->(b) RETURN count(r)   ->  EdgeCount (all types)          still fast
MATCH (n)-[r]->(n) RETURN count(r)   ->  Aggregate <- Filter <- Expand
```

Asserting only the answer would also pass if the optimisation had been switched off everywhere — trading a wrong answer for a timeout on a billion-edge graph.

## Measured

`CountingSubgraphMatches1` [9] gained, wrong results 26 → **25**, **zero regressions**.