### PR TITLE
A zero-length named path survives a WITH (#964)

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1748,6 +1748,42 @@ impl QueryPlanner {
             }
         }
 
+        // `MATCH p = (a)` binds `p` to a path of one node and no relationships.
+        //
+        // A named path is bound by the expand that walks it, so a pattern with
+        // no segments had no expand and nothing bound `p`: `MATCH p = (a)
+        // RETURN p` parsed and then failed with VariableNotFound. The
+        // zero-length path is the one case where there is nothing to walk, and
+        // it is exactly the case the walking code cannot reach (#909).
+        //
+        // **Below the WITH barriers**, not above them. Bound above, the
+        // barrier never saw `p` and projected a null for it, so
+        // `MATCH p = (a) WITH p RETURN p` answered `null` where
+        // `MATCH p = (a) RETURN p` answered the path -- the variable existed
+        // right up until something asked the WITH to carry it (#964).
+        //
+        // `named_path_handles` already produces the right handle for a
+        // segment-less path -- it is what MERGE uses -- so this is the same
+        // description, bound by the same operator.
+        {
+            let mut zero_length: Vec<(String, Vec<String>, Vec<String>)> = Vec::new();
+            for mc in &query.match_clauses {
+                for path in &mc.pattern.paths {
+                    if path.segments.is_empty() && path.path_variable.is_some() {
+                        let single = crate::query::ast::Pattern { paths: vec![path.clone()] };
+                        zero_length.extend(named_path_handles(&single));
+                    }
+                }
+            }
+            if !zero_length.is_empty() {
+                if let Some(op) = operator.take() {
+                    operator = Some(Box::new(
+                        crate::query::executor::operator::BindPathOperator::new(op, zero_length),
+                    ));
+                }
+            }
+        }
+
         // 1b. Build ordered list of WITH stages, then apply barriers + post-WITH matches in sequence.
         // extra_with_stages contains earlier WITH stages; query.with_clause is the last one.
         // Each stage: (with_clause, unwind, post_match_clauses, post_where_clause)
@@ -2004,24 +2040,6 @@ impl QueryPlanner {
         // `named_path_handles` already produces the right handle for a
         // segment-less path -- it is what MERGE uses -- so this is the same
         // description, bound by the same operator.
-        {
-            let mut zero_length: Vec<(String, Vec<String>, Vec<String>)> = Vec::new();
-            for mc in &query.match_clauses {
-                for path in &mc.pattern.paths {
-                    if path.segments.is_empty() && path.path_variable.is_some() {
-                        let single = crate::query::ast::Pattern { paths: vec![path.clone()] };
-                        zero_length.extend(named_path_handles(&single));
-                    }
-                }
-            }
-            if !zero_length.is_empty() {
-                operator = Box::new(crate::query::executor::operator::BindPathOperator::new(
-                    operator,
-                    zero_length,
-                ));
-            }
-        }
-
         // A *leading* UNWIND is planned before the WITH barriers, above, so that
         // a following WITH has its variable bound. It still lands below the
         // WHERE, which is what `UNWIND [1,2] AS x MATCH (p) WHERE p.n = x`

--- a/tests/path_through_with.rs
+++ b/tests/path_through_with.rs
@@ -1,0 +1,90 @@
+//! A zero-length named path survives a WITH (#964).
+//!
+//! ```cypher
+//! MATCH p = (a) RETURN p            -- <()>
+//! MATCH p = (a) WITH p RETURN p     -- null
+//! ```
+//!
+//! The variable existed right up until something asked the WITH to carry it.
+//!
+//! `MATCH p = (a)` has no segments, so no expand walks it and nothing binds
+//! `p`; #909 added a `BindPathOperator` for exactly that case. It was inserted
+//! **above** the WITH barriers, so the barrier never saw `p` and projected a
+//! null for it. Moving it below is the whole fix.
+
+use samyama::graph::{GraphStore, Label};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn path_of(store: &GraphStore, cypher: &str, col: &str) -> (usize, usize) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let batch = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    match batch.records[0].get(col) {
+        Some(Value::Path { nodes, edges }) => (nodes.len(), edges.len()),
+        other => panic!("{cypher}: expected a path, got {other:?}"),
+    }
+}
+
+fn one_node() -> GraphStore {
+    let mut store = GraphStore::new();
+    store.create_node("");
+    store
+}
+
+#[test]
+fn a_zero_length_path_survives_a_with() {
+    let store = one_node();
+    assert_eq!(path_of(&store, "MATCH p = (a) WITH p RETURN p", "p"), (1, 0));
+}
+
+#[test]
+fn it_still_works_without_a_with() {
+    // #909's own case, pinned: moving the operator must not lose it.
+    let store = one_node();
+    assert_eq!(path_of(&store, "MATCH p = (a) RETURN p", "p"), (1, 0));
+}
+
+#[test]
+fn it_survives_an_aliasing_with() {
+    let store = one_node();
+    assert_eq!(path_of(&store, "MATCH p = (a) WITH p AS q RETURN q", "q"), (1, 0));
+}
+
+#[test]
+fn it_survives_a_with_star() {
+    let store = one_node();
+    assert_eq!(path_of(&store, "MATCH p = (a) WITH * RETURN p", "p"), (1, 0));
+}
+
+#[test]
+fn a_path_with_segments_is_unaffected() {
+    // The ordinary case, bound by the expand that walks it.
+    let mut store = GraphStore::new();
+    let a = store.create_node_with_labels([Label::new("A")]);
+    let b = store.create_node_with_labels([Label::new("B")]);
+    store.create_edge(a, b, "R").unwrap();
+    assert_eq!(path_of(&store, "MATCH p = (:A)-[:R]->(:B) RETURN p", "p"), (2, 1));
+    assert_eq!(path_of(&store, "MATCH p = (:A)-[:R]->(:B) WITH p RETURN p", "p"), (2, 1));
+}
+
+#[test]
+fn the_path_functions_read_it_after_a_with() {
+    // A null would have made these answer 0 and null rather than failing, so
+    // the projection alone is not enough to pin the fix.
+    let store = one_node();
+    let q = parse_query("MATCH p = (a) WITH p RETURN length(p) AS len, nodes(p) AS ns").unwrap();
+    let batch = QueryExecutor::new(&store).execute(&q).unwrap();
+    let rec = &batch.records[0];
+    assert!(
+        format!("{:?}", rec.get("len")).contains("Integer(0)"),
+        "{:?}",
+        rec.get("len")
+    );
+    match rec.get("ns") {
+        Some(Value::List(v)) => assert_eq!(v.len(), 1),
+        Some(Value::Property(samyama::graph::PropertyValue::Array(v))) => assert_eq!(v.len(), 1),
+        other => panic!("{other:?}"),
+    }
+}


### PR DESCRIPTION
Closes #964.

```cypher
MATCH p = (a) RETURN p          -- <()>
MATCH p = (a) WITH p RETURN p   -- null
```

The variable existed right up until something asked the WITH to carry it.

## Cause

`MATCH p = (a)` has no segments, so no expand walks it and nothing binds `p`. #909 added a `BindPathOperator` for exactly that case — the zero-length path is the one shape the walking code cannot reach.

It was inserted **above** the WITH barriers:

```
BindPath (p)          <- binds p here
  WithBarrier (p)     <- projects p, not bound yet -> null
    ...matches
```

No error, because a WITH projecting a variable it cannot resolve yields null rather than failing.

## Fix

Move the bind **below** the barriers, where the match output still is. The operator and its handles are unchanged.

## Why projecting it is not enough to pin

`length(p)` over a null answers 0 and `nodes(p)` answers null — both plausible. `the_path_functions_read_it_after_a_with` reads the path through those as well, or a regression comes back looking like an ordinary empty result.

## Measured

`With1` [4] gained, wrong results 26 → **25**, **zero regressions**.