### PR TITLE
MERGE binds every matching relationship (#968)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -11639,21 +11639,42 @@ impl PhysicalOperator for MatchMergeEdgeOperator {
                         None => continue,
                     };
 
-                    // Does one already exist? For `-[r:T]-`, either way round;
-                    // the pattern's own direction is preferred when both do.
-                    let existing = store
-                        .edge_between(source_id, target_id, Some(edge_type))
-                        .or_else(|| {
-                            if *undirected {
-                                store.edge_between(target_id, source_id, Some(edge_type))
-                            } else {
-                                None
-                            }
+                    // **Every** existing match, not the first. MERGE is
+                    // match-or-create, and when it matches it binds each match
+                    // as its own row: over two `:TYPE` relationships between
+                    // the same pair, `MERGE (a)-[r:TYPE]->(b) RETURN count(r)`
+                    // is 2, and taking one made it 1 (#968). The node half of
+                    // the same defect was #956.
+                    //
+                    // For `-[r:T]-`, either way round; the pattern's own
+                    // direction comes first, so when relationships exist both
+                    // ways the order is deterministic.
+                    let mut existing_all =
+                        store.edges_between(source_id, target_id, Some(edge_type));
+                    if *undirected {
+                        existing_all
+                            .extend(store.edges_between(target_id, source_id, Some(edge_type)));
+                    }
+                    // The pattern's inline properties narrow what counts as a
+                    // match. `edges_between` knows only the endpoints and the
+                    // type, so without this `MERGE (a)-[r:T {k: v}]->(b)`
+                    // matched a relationship with the wrong `k` and created
+                    // nothing -- and, once every match was emitted rather than
+                    // the first, returned it as an extra row.
+                    if !properties.is_empty() {
+                        existing_all.retain(|eid| {
+                            store.get_edge(*eid).is_some_and(|e| {
+                                properties.iter().all(|(k, v)| {
+                                    e.properties.get(k).is_some_and(|have| have == v)
+                                })
+                            })
                         });
+                    }
 
-                    let mut result_record = record.clone();
-
-                    if let Some(edge_id) = existing {
+                    for edge_id in &existing_all {
+                        let edge_id = *edge_id;
+                        let mut result_record = record.clone();
+                        {
                         // Edge exists — apply ON MATCH SET
                         for (var, prop, expr) in &self.on_match_set {
                             if edge_var.as_deref() == Some(var) || var == "_edge" {
@@ -11689,8 +11710,13 @@ impl PhysicalOperator for MatchMergeEdgeOperator {
                                 result_record.bind(ev.clone(), Value::Edge(edge_id, Box::new(edge.clone())));
                             }
                         }
-                    } else {
-                        // Edge doesn't exist — create it + apply ON CREATE SET
+                        }
+                            self.results.push(result_record);
+                    }
+
+                    let mut result_record = record.clone();
+                    if existing_all.is_empty() {
+                        // Nothing matched — create it + apply ON CREATE SET
                         let edge_id = store.create_edge(source_id, target_id, edge_type.clone())
                             .map_err(|e| ExecutionError::GraphError(e.to_string()))?;
 
@@ -11733,8 +11759,12 @@ impl PhysicalOperator for MatchMergeEdgeOperator {
                                 result_record.bind(ev.clone(), Value::Edge(edge_id, Box::new(edge.clone())));
                             }
                         }
+                        // Inside the branch. Left outside, a pattern that
+                        // *matched* also pushed this bare record, with the
+                        // relationship variable unbound -- VariableNotFound at
+                        // read time, and an extra row before that.
+                        self.results.push(result_record);
                     }
-                    self.results.push(result_record);
                 }
             }
             self.done = true;

--- a/tests/merge_binds_all_matches.rs
+++ b/tests/merge_binds_all_matches.rs
@@ -117,3 +117,65 @@ fn on_create_set_still_runs_for_the_created_node() {
     write(&mut store, "MERGE (n:Fresh) ON CREATE SET n.made = 1 RETURN n");
     assert_eq!(count(&store, "MATCH (n:Fresh) WHERE n.made = 1 RETURN count(n) AS c"), 1);
 }
+
+// ---------------------------------------------------------------------------
+// The relationship half of the same defect (#968).
+//
+// `MatchMergeEdgeOperator` called `store.edge_between`, which returns one, so
+// `MERGE (a)-[r:TYPE]->(b)` over two existing `:TYPE` relationships between
+// the same pair bound one and `count(r)` answered 1 where openCypher says 2.
+
+fn pair_with_two_edges() -> GraphStore {
+    let mut store = GraphStore::new();
+    let a = store.create_node_with_labels([Label::new("A")]);
+    let b = store.create_node_with_labels([Label::new("B")]);
+    store.create_edge(a, b, "TYPE").unwrap();
+    store.create_edge(a, b, "TYPE").unwrap();
+    store
+}
+
+#[test]
+fn merge_binds_each_matching_relationship() {
+    let mut store = pair_with_two_edges();
+    assert_eq!(
+        write(&mut store, "MATCH (a:A), (b:B) MERGE (a)-[r:TYPE]->(b) RETURN r"),
+        2
+    );
+    assert_eq!(
+        count(&store, "MATCH ()-[r:TYPE]->() RETURN count(r) AS c"),
+        2,
+        "matched, not created"
+    );
+}
+
+#[test]
+fn an_inline_property_narrows_which_relationships_match() {
+    // `edges_between` knows only the endpoints and the type. Without filtering
+    // on the pattern's properties, emitting every match returns relationships
+    // the pattern excludes — the failure this fix's first attempt produced.
+    let mut store = GraphStore::new();
+    let a = store.create_node_with_labels([Label::new("A")]);
+    let b = store.create_node_with_labels([Label::new("B")]);
+    for v in [1i64, 2] {
+        let e = store.create_edge(a, b, "TYPE").unwrap();
+        let _ = store.set_edge_property_sparse(e, "k", PropertyValue::Integer(v));
+    }
+    assert_eq!(
+        write(&mut store, "MATCH (a:A), (b:B) MERGE (a)-[r:TYPE {k: 1}]->(b) RETURN r"),
+        1
+    );
+    assert_eq!(count(&store, "MATCH ()-[r:TYPE]->() RETURN count(r) AS c"), 2);
+}
+
+#[test]
+fn a_relationship_merge_that_matches_nothing_still_creates_one() {
+    let mut store = GraphStore::new();
+    let a = store.create_node_with_labels([Label::new("A")]);
+    let b = store.create_node_with_labels([Label::new("B")]);
+    let _ = (a, b);
+    assert_eq!(
+        write(&mut store, "MATCH (a:A), (b:B) MERGE (a)-[r:TYPE]->(b) RETURN r"),
+        1
+    );
+    assert_eq!(count(&store, "MATCH ()-[r:TYPE]->() RETURN count(r) AS c"), 1);
+}


### PR DESCRIPTION
Closes #968. The relationship half of #956.

```cypher
CREATE (a:A), (b:B)
CREATE (a)-[:TYPE]->(b)
CREATE (a)-[:TYPE]->(b)

MATCH (a:A), (b:B) MERGE (a)-[r:TYPE]->(b) RETURN count(r)
```

expects **2** with no side effects; we answered 1. `MatchMergeEdgeOperator` called `store.edge_between`, which returns one.

## Two things the fix has to get right

I found both by breaking them. The first attempt fixed `Merge5` [3] and broke [5], [12], [13] and [15]:

- **Inline properties still narrow the match.** `edges_between` knows only the endpoints and the type, so `MERGE (a)-[r:T {k: 1}]->(b)` matched a relationship with the wrong `k`. With a single match that was invisible; emitting every match turned it into an extra row.
- **The create branch's record must not also be pushed when something matched.** Left outside the branch it appended a bare record with the relationship variable unbound — `VariableNotFound("r")` at read time, and an extra row before that.

The failure-manifest diff caught both. The pass count moved **+1** while four scenarios broke.

## Measured

`Merge5` [3] gained, wrong results 24 → **23**, **zero regressions**. Three new tests including `an_inline_property_narrows_which_relationships_match`, which is the shape the first attempt got wrong.