### PR TITLE
ORDER BY and WHERE after a WITH see the scope in front of the projection (#970, #972)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2141,6 +2141,62 @@ enum StringPositionOp {
 /// question separately, and most answered it with a type error.
 const NULL_TOLERANT_FUNCTIONS: &[&str] = &["coalesce", "exists"];
 
+/// Every variable name an expression reads.
+///
+/// Names only -- `a.num` contributes `a` -- because that is what a record is
+/// keyed on. Used to decide which pre-projection bindings a `WITH ... ORDER BY`
+/// has to carry (#970).
+fn collect_expression_names(expr: &Expression, out: &mut HashSet<String>) {
+    match expr {
+        Expression::Variable(v) | Expression::PathVariable(v) => {
+            out.insert(v.clone());
+        }
+        Expression::Property { variable, .. } => {
+            out.insert(variable.clone());
+        }
+        Expression::Binary { left, right, .. } => {
+            collect_expression_names(left, out);
+            collect_expression_names(right, out);
+        }
+        Expression::Unary { expr, .. } => collect_expression_names(expr, out),
+        Expression::Function { args, .. } => {
+            for a in args {
+                collect_expression_names(a, out);
+            }
+        }
+        Expression::ListExpr(items) => {
+            for e in items {
+                collect_expression_names(e, out);
+            }
+        }
+        Expression::MapExpr(entries) => {
+            for (_, e) in entries {
+                collect_expression_names(e, out);
+            }
+        }
+        Expression::Index { expr, index } => {
+            collect_expression_names(expr, out);
+            collect_expression_names(index, out);
+        }
+        Expression::ListSlice { expr, start, end } => {
+            collect_expression_names(expr, out);
+            for e in start.iter().chain(end.iter()) {
+                collect_expression_names(e, out);
+            }
+        }
+        Expression::Case { operand, when_clauses, else_result } => {
+            for e in operand.iter().chain(else_result.iter()) {
+                collect_expression_names(e, out);
+            }
+            for (w, t) in when_clauses {
+                collect_expression_names(w, out);
+                collect_expression_names(t, out);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Every function `eval_function` dispatches on.
 ///
 /// Exists so an unknown name can be rejected at **compile time** rather than
@@ -7868,6 +7924,7 @@ impl AggregateOperator {
             executed: false,
         }
     }
+
 
     fn evaluate_expression(expr: &Expression, record: &Record, store: &GraphStore) -> ExecutionResult<Value> {
         match expr {
@@ -14509,6 +14566,59 @@ impl WithBarrierOperator {
         }
     }
 
+    /// Bindings a sort expression names that the projection did not carry.
+    ///
+    /// `WITH a, a.num2 % 3 AS mod ORDER BY sum` sorts by `sum`, projected by
+    /// an *earlier* WITH and not by this one. Cypher allows that: ORDER BY
+    /// after a WITH sees the projected aliases **and** the scope in front of
+    /// it. Sorting the projected rows alone evaluated `sum` to null on every
+    /// row, so the order was whatever the input order happened to be and the
+    /// LIMIT then kept the wrong three (#970).
+    ///
+    /// Copied under a private prefix rather than bound plainly, so a carried
+    /// name cannot collide with something the projection produced or leak into
+    /// the rows the next clause sees.
+    const CARRY: &'static str = "__orderby_carry_";
+
+    fn carry_sort_scope(&self, from: &Record, into: &mut Record) {
+        if self.sort_items.is_empty() {
+            return;
+        }
+        for (expr, _) in &self.sort_items {
+            let mut names = HashSet::new();
+            collect_expression_names(expr, &mut names);
+            for name in names {
+                if into.get(&name).is_none() {
+                    if let Some(v) = from.get(&name) {
+                        into.bind(format!("{}{}", Self::CARRY, name), v.clone());
+                    }
+                }
+            }
+        }
+    }
+
+
+    /// Evaluate a sort expression against a projected row, falling back to the
+    /// pre-projection bindings `carry_sort_scope` copied in.
+    fn eval_sort_key(expr: &Expression, record: &Record, store: &GraphStore) -> Value {
+        match Self::evaluate_expression(expr, record, store) {
+            Ok(Value::Null) | Err(_) => {}
+            Ok(v) => return v,
+        }
+        let mut names = HashSet::new();
+        collect_expression_names(expr, &mut names);
+        if names.is_empty() {
+            return Value::Null;
+        }
+        let mut widened = record.clone();
+        for name in names {
+            if let Some(v) = record.get(&format!("{}{}", Self::CARRY, name)) {
+                widened.bind(name, v.clone());
+            }
+        }
+        Self::evaluate_expression(expr, &widened, store).unwrap_or(Value::Null)
+    }
+
     fn evaluate_expression(expr: &Expression, record: &Record, store: &GraphStore) -> ExecutionResult<Value> {
         match expr {
             // Delegates rather than adding a sixth copy of this logic; the
@@ -14623,6 +14733,7 @@ impl WithBarrierOperator {
                     let value = Self::evaluate_expression(expr, &intermediate, store)?;
                     new_record.bind(alias.clone(), value);
                 }
+                self.carry_sort_scope(&intermediate, &mut new_record);
                 projected.push(new_record);
             }
             projected
@@ -14652,6 +14763,7 @@ impl WithBarrierOperator {
                         let value = Self::evaluate_expression(expr, &record, store)?;
                         new_record.bind(alias.clone(), value);
                     }
+                    self.carry_sort_scope(&record, &mut new_record);
                     records.push(new_record);
                     if let Some(c) = cap {
                         if records.len() >= c {
@@ -14689,8 +14801,10 @@ impl WithBarrierOperator {
             let sort_items = &self.sort_items;
             output_records.sort_by(|a, b| {
                 for (expr, ascending) in sort_items {
-                    let val_a = Self::evaluate_expression(expr, a, store).unwrap_or(Value::Null);
-                    let val_b = Self::evaluate_expression(expr, b, store).unwrap_or(Value::Null);
+                    // The projected name wins; the carried pre-projection
+                    // binding answers for anything the projection dropped.
+                    let val_a = Self::eval_sort_key(expr, a, store);
+                    let val_b = Self::eval_sort_key(expr, b, store);
                     // Cypher's orderability, not the property index's — see
                     // `graph::property::cypher_order`. A WITH ... ORDER BY
                     // sorts here rather than in `SortOperator`, so wiring only
@@ -14704,6 +14818,15 @@ impl WithBarrierOperator {
                 }
                 std::cmp::Ordering::Equal
             });
+        }
+
+        // The carried pre-projection bindings are the sort's business only.
+        // Left in place they would appear as columns and, worse, re-enter
+        // scope for the next clause under a name it never projected.
+        if !self.sort_items.is_empty() {
+            for record in output_records.iter_mut() {
+                record.retain_bindings(|k| !k.starts_with(Self::CARRY));
+            }
         }
 
         // Apply SKIP

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -14566,14 +14566,19 @@ impl WithBarrierOperator {
         }
     }
 
-    /// Bindings a sort expression names that the projection did not carry.
+    /// Bindings the ORDER BY or WHERE names that the projection did not carry.
     ///
     /// `WITH a, a.num2 % 3 AS mod ORDER BY sum` sorts by `sum`, projected by
-    /// an *earlier* WITH and not by this one. Cypher allows that: ORDER BY
-    /// after a WITH sees the projected aliases **and** the scope in front of
-    /// it. Sorting the projected rows alone evaluated `sum` to null on every
-    /// row, so the order was whatever the input order happened to be and the
-    /// LIMIT then kept the wrong three (#970).
+    /// an *earlier* WITH and not by this one. Cypher allows that: after a
+    /// WITH, both ORDER BY and WHERE see the projected aliases **and** the
+    /// scope in front of them. Evaluating against the projected rows alone
+    /// made `sum` null on every row, so the order was whatever the input order
+    /// happened to be and the LIMIT then kept the wrong three (#970).
+    ///
+    /// The WHERE has the identical shape:
+    /// `WITH a.name2 AS name WHERE name = 'B' OR a.name2 = 'C'` filters on
+    /// both, and `a` is gone by then, so the second disjunct was always false
+    /// and the row it should have kept was dropped.
     ///
     /// Copied under a private prefix rather than bound plainly, so a carried
     /// name cannot collide with something the projection produced or leak into
@@ -14581,10 +14586,15 @@ impl WithBarrierOperator {
     const CARRY: &'static str = "__orderby_carry_";
 
     fn carry_sort_scope(&self, from: &Record, into: &mut Record) {
-        if self.sort_items.is_empty() {
+        if self.sort_items.is_empty() && self.where_predicate.is_none() {
             return;
         }
-        for (expr, _) in &self.sort_items {
+        for expr in self
+            .sort_items
+            .iter()
+            .map(|(e, _)| e)
+            .chain(self.where_predicate.iter())
+        {
             let mut names = HashSet::new();
             collect_expression_names(expr, &mut names);
             for name in names {
@@ -14598,25 +14608,28 @@ impl WithBarrierOperator {
     }
 
 
-    /// Evaluate a sort expression against a projected row, falling back to the
-    /// pre-projection bindings `carry_sort_scope` copied in.
+    /// Evaluate an ORDER BY or WHERE expression against a projected row,
+    /// widened with the pre-projection bindings `carry_sort_scope` copied in.
+    ///
+    /// Widened **always**, not only when the projected row yields null. A
+    /// predicate over a name the projection dropped does not have to evaluate
+    /// to null to be wrong: `name = 'B' OR a.name2 = 'C'` with `a` gone gives
+    /// a perfectly ordinary `false`, and a fallback keyed on null never fires.
+    ///
+    /// The projected alias still wins, because `carry_sort_scope` only copies
+    /// a name the projection did not already bind.
     fn eval_sort_key(expr: &Expression, record: &Record, store: &GraphStore) -> Value {
-        match Self::evaluate_expression(expr, record, store) {
-            Ok(Value::Null) | Err(_) => {}
-            Ok(v) => return v,
-        }
         let mut names = HashSet::new();
         collect_expression_names(expr, &mut names);
-        if names.is_empty() {
-            return Value::Null;
-        }
-        let mut widened = record.clone();
+        let mut widened: Option<Record> = None;
         for name in names {
             if let Some(v) = record.get(&format!("{}{}", Self::CARRY, name)) {
-                widened.bind(name, v.clone());
+                let v = v.clone();
+                widened.get_or_insert_with(|| record.clone()).bind(name, v);
             }
         }
-        Self::evaluate_expression(expr, &widened, store).unwrap_or(Value::Null)
+        let target = widened.as_ref().unwrap_or(record);
+        Self::evaluate_expression(expr, target, store).unwrap_or(Value::Null)
     }
 
     fn evaluate_expression(expr: &Expression, record: &Record, store: &GraphStore) -> ExecutionResult<Value> {
@@ -14778,11 +14791,12 @@ impl WithBarrierOperator {
         // Apply WHERE filter (if present in WITH ... WHERE ...)
         if let Some(ref predicate) = self.where_predicate {
             output_records.retain(|record| {
-                match Self::evaluate_expression(predicate, record, store) {
-                    Ok(Value::Property(PropertyValue::Boolean(b))) => b,
-                    Ok(Value::Null) | Ok(Value::Property(PropertyValue::Null)) => false,
-                    _ => false,
-                }
+                // Through the same widening as the sort: a WITH's WHERE sees
+                // the projected aliases *and* the scope in front of them.
+                matches!(
+                    Self::eval_sort_key(predicate, record, store),
+                    Value::Property(PropertyValue::Boolean(true))
+                )
             });
         }
 
@@ -14823,7 +14837,7 @@ impl WithBarrierOperator {
         // The carried pre-projection bindings are the sort's business only.
         // Left in place they would appear as columns and, worse, re-enter
         // scope for the next clause under a name it never projected.
-        if !self.sort_items.is_empty() {
+        if !self.sort_items.is_empty() || self.where_predicate.is_some() {
             for record in output_records.iter_mut() {
                 record.retain_bindings(|k| !k.starts_with(Self::CARRY));
             }

--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -330,6 +330,15 @@ impl Record {
     }
 
     /// All bindings, in binding order.
+    /// Drop every binding whose name the predicate rejects.
+    ///
+    /// Used to strip the private bindings a `WITH ... ORDER BY` carries for
+    /// the sort: they must not become columns, and must not re-enter scope for
+    /// the next clause under a name it never projected (#970).
+    pub fn retain_bindings(&mut self, keep: impl Fn(&str) -> bool) {
+        self.bindings.retain(|(k, _)| keep(k));
+    }
+
     pub fn bindings(&self) -> &[(Arc<str>, Value)] {
         &self.bindings
     }

--- a/tests/order_by_preprojection_scope.rs
+++ b/tests/order_by_preprojection_scope.rs
@@ -131,3 +131,85 @@ fn order_by_a_property_of_a_projected_node_still_works() {
         vec![1, 3]
     );
 }
+
+// ---------------------------------------------------------------------------
+// A WITH's WHERE has the identical scope rule.
+//
+//   WITH a.name2 AS name WHERE name = 'B' OR a.name2 = 'C'
+//
+// filters on the projected alias *and* on `a`, which the projection dropped.
+// With `a` gone the second disjunct was an ordinary `false` — not a null — so
+// a fallback keyed on null would never have fired. That is why the widening is
+// unconditional.
+
+fn named() -> GraphStore {
+    let mut store = GraphStore::new();
+    for v in ["A", "B", "C"] {
+        let n = store.create_node("");
+        let _ = store.set_node_property(
+            "default", n, "name2".to_string(), PropertyValue::String(v.into()));
+    }
+    store
+}
+
+fn strings(store: &GraphStore, cypher: &str, col: &str) -> Vec<String> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let mut out: Vec<String> = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"))
+        .records
+        .iter()
+        .map(|r| match r.get(col) {
+            Some(Value::Property(PropertyValue::String(s))) => s.clone(),
+            other => panic!("{col}: {other:?}"),
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn a_with_where_sees_both_scopes() {
+    let store = named();
+    assert_eq!(
+        strings(
+            &store,
+            "MATCH (a) WITH a.name2 AS name WHERE name = \"B\" OR a.name2 = \"C\" RETURN *",
+            "name",
+        ),
+        vec!["B", "C"]
+    );
+}
+
+#[test]
+fn a_with_where_on_the_alias_alone_is_unchanged() {
+    let store = named();
+    assert_eq!(
+        strings(&store, "MATCH (a) WITH a.name2 AS name WHERE name = \"B\" RETURN *", "name"),
+        vec!["B"]
+    );
+}
+
+#[test]
+fn a_with_where_that_matches_nothing_still_returns_nothing() {
+    // The direction an unconditional widening could break: a predicate that
+    // is legitimately false everywhere must stay false.
+    let store = named();
+    let q = parse_query("MATCH (a) WITH a.name2 AS name WHERE name = \"Z\" RETURN *").unwrap();
+    assert_eq!(QueryExecutor::new(&store).execute(&q).unwrap().records.len(), 0);
+}
+
+#[test]
+fn the_projected_alias_shadows_the_carried_name() {
+    // `name` is projected from `a.name2`; a carried `a` must not change what
+    // `name` means.
+    let store = named();
+    assert_eq!(
+        strings(
+            &store,
+            "MATCH (a) WITH a.name2 AS name WHERE name <> \"A\" AND a.name2 <> \"C\" RETURN *",
+            "name",
+        ),
+        vec!["B"]
+    );
+}

--- a/tests/order_by_preprojection_scope.rs
+++ b/tests/order_by_preprojection_scope.rs
@@ -1,0 +1,133 @@
+//! `WITH … ORDER BY` sees the scope in front of the projection (#970).
+//!
+//! ```cypher
+//! MATCH (a:A)
+//! WITH a, a.num + a.num2 AS sum
+//! WITH a, a.num2 % 3 AS mod
+//!   ORDER BY sum
+//!   LIMIT 3
+//! RETURN a, mod
+//! ```
+//!
+//! `sum` is projected by the *first* WITH and not by the second, and Cypher
+//! allows the ORDER BY to name it: after a WITH, ORDER BY sees the projected
+//! aliases **and** the scope in front of them.
+//!
+//! Sorting the projected rows alone evaluated `sum` to null on every row, so
+//! the order was whatever the input order happened to be — and the `LIMIT 3`
+//! then kept the wrong three. Nothing errored; the query returned three rows
+//! that looked entirely plausible.
+//!
+//! The pre-projection bindings the sort needs are carried under a private
+//! prefix and stripped before the rows leave, so they cannot become columns or
+//! re-enter scope for the next clause.
+
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// The openCypher `WithOrderBy4` [8] fixture.
+fn graph() -> GraphStore {
+    let mut store = GraphStore::new();
+    for (num, num2) in [(1i64, 4i64), (5, 2), (9, 0), (3, 3), (7, 1)] {
+        let n = store.create_node_with_labels([Label::new("A")]);
+        let _ = store.set_node_property("default", n, "num".to_string(), PropertyValue::Integer(num));
+        let _ = store.set_node_property("default", n, "num2".to_string(), PropertyValue::Integer(num2));
+    }
+    store
+}
+
+fn column(store: &GraphStore, cypher: &str, col: &str) -> Vec<i64> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"))
+        .records
+        .iter()
+        .map(|r| match r.get(col) {
+            Some(Value::Property(PropertyValue::Integer(n))) => *n,
+            other => panic!("{col}: {other:?}"),
+        })
+        .collect()
+}
+
+#[test]
+fn order_by_can_name_a_variable_the_projection_dropped() {
+    // sums are 5, 7, 9, 6, 8; the three smallest are 5, 6, 7 -> num 1, 3, 5.
+    let store = graph();
+    let got = column(
+        &store,
+        "MATCH (a:A) WITH a, a.num + a.num2 AS sum \
+         WITH a, a.num2 % 3 AS mod ORDER BY sum LIMIT 3 RETURN a.num AS n",
+        "n",
+    );
+    assert_eq!(got, vec![1, 3, 5]);
+}
+
+#[test]
+fn the_projected_alias_still_wins() {
+    // `mod` exists only in the projection. Sorting by it must use it, not
+    // anything carried in.
+    let store = graph();
+    let got = column(
+        &store,
+        "MATCH (a:A) WITH a, a.num2 % 3 AS mod ORDER BY mod, a.num RETURN a.num AS n",
+        "n",
+    );
+    assert_eq!(got, vec![3, 9, 1, 7, 5]);
+}
+
+#[test]
+fn the_carried_bindings_do_not_become_columns() {
+    // They are the sort's business only. Left in place they would appear as
+    // extra columns in the result.
+    let store = graph();
+    let q = parse_query(
+        "MATCH (a:A) WITH a, a.num + a.num2 AS sum \
+         WITH a.num2 % 3 AS mod ORDER BY sum LIMIT 1 RETURN mod",
+    )
+    .unwrap();
+    let batch = QueryExecutor::new(&store).execute(&q).unwrap();
+    for (name, _) in batch.records[0].bindings() {
+        assert!(!name.starts_with("__orderby_carry_"), "{name} leaked");
+    }
+}
+
+#[test]
+fn the_carried_bindings_do_not_re_enter_scope() {
+    // The worse failure: a name the next clause never projected coming back
+    // into scope. Referencing `sum` after the second WITH must not resolve.
+    let store = graph();
+    let q = parse_query(
+        "MATCH (a:A) WITH a, a.num + a.num2 AS sum \
+         WITH a.num2 % 3 AS mod ORDER BY sum RETURN mod, sum",
+    )
+    .expect("this parses; scope is decided at run time here");
+    let err = QueryExecutor::new(&store).execute(&q).unwrap_err();
+    assert!(
+        format!("{err:?}").contains("sum"),
+        "`sum` must stay out of scope after the second WITH, got {err:?}"
+    );
+}
+
+#[test]
+fn an_ordinary_order_by_on_a_projected_value_is_unchanged() {
+    let store = graph();
+    assert_eq!(
+        column(&store, "MATCH (a:A) WITH a.num AS n ORDER BY n RETURN n", "n"),
+        vec![1, 3, 5, 7, 9]
+    );
+    assert_eq!(
+        column(&store, "MATCH (a:A) WITH a.num AS n ORDER BY n DESC RETURN n", "n"),
+        vec![9, 7, 5, 3, 1]
+    );
+}
+
+#[test]
+fn order_by_a_property_of_a_projected_node_still_works() {
+    let store = graph();
+    assert_eq!(
+        column(&store, "MATCH (a:A) WITH a ORDER BY a.num LIMIT 2 RETURN a.num AS n", "n"),
+        vec![1, 3]
+    );
+}


### PR DESCRIPTION
Closes #970.

```cypher
MATCH (a:A)
WITH a, a.num + a.num2 AS sum
WITH a, a.num2 % 3 AS mod
  ORDER BY sum
  LIMIT 3
RETURN a, mod
```

`sum` is projected by the **first** WITH and not by the second. Cypher allows the ORDER BY to name it: after a WITH, ORDER BY sees the projected aliases *and* the scope in front of them.

Sorting the projected rows alone evaluated `sum` to null on every row, so the order became whatever the input order happened to be — and the `LIMIT 3` kept the wrong three.

## Why it is quiet

Nothing errors. Three rows come back, right shape, entirely plausible. **The LIMIT is what turns a wrong order into wrong rows**; without it the same bug returns the right set in an arbitrary sequence, which is easy to mistake for "ORDER BY over a null is unspecified".

## Fix

Carry the pre-projection bindings the sort names under a private prefix, strip them before the rows leave. Two things that has to get right, both tested:

- **the projected alias wins** — `ORDER BY mod` uses the projection's `mod`, not anything carried;
- **carried names must not leak** — not as columns, and not back into scope for the next clause. `RETURN sum` after the second WITH still fails with `VariableNotFound`.

## Measured

`WithOrderBy4` [8] gained, wrong results 22 → **21**, **zero regressions**.

---

## Also closes #972 — the WHERE half

```cypher
MATCH (a) WITH a.name2 AS name WHERE name = 'B' OR a.name2 = 'C' RETURN *
```

returned only `'B'`. Same rule, same carried bindings.

**This is what made the widening unconditional.** My first version widened only when the projected row evaluated to *null*. That fixed the ORDER BY and did nothing here: with `a` gone, `a.name2 = 'C'` is an ordinary `false`, not a null, so the fallback never fired.

A predicate does not have to be null to be wrong. Widening always is safe because the carried bindings only ever include names the projection did not itself bind, so the projected alias still shadows them — `the_projected_alias_shadows_the_carried_name` pins that, and `a_with_where_that_matches_nothing_still_returns_nothing` pins the direction an over-eager widening would break.

`WithOrderBy4` [8] **and** `WithWhere7` [3] gained; wrong results 22 → **20**, zero regressions.
