### PR TITLE
A property is a scalar or a list of scalars (#975)

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -750,6 +750,31 @@ pub struct GraphStore {
     statistics_cache: std::sync::RwLock<Option<std::sync::Arc<GraphStatistics>>>,
 }
 
+
+/// Can this value be a property?
+///
+/// A property is a scalar or a list of scalars. A **map inside a list** is
+/// neither, at any depth: `SET a.maplist = [{num: 1}]` stored an
+/// `Array([Map(..)])`, which `properties(a)` hands back and no Cypher
+/// expression can build (#975).
+///
+/// A bare map is left alone. Storing one is a documented extension (NDS-08,
+/// nested map properties) rather than an accident, and withdrawing it is a
+/// separate decision.
+///
+/// Checked here rather than at each writer because there are four separate
+/// value converters -- CREATE's, MERGE's, SET's, and the shared
+/// `storable_property` -- and inline literal properties go through none of
+/// them.
+pub fn property_is_storable(p: &PropertyValue) -> bool {
+    match p {
+        PropertyValue::Array(items) => items
+            .iter()
+            .all(|i| !matches!(i, PropertyValue::Map(_)) && property_is_storable(i)),
+        _ => true,
+    }
+}
+
 impl GraphStore {
     /// Create a new empty graph store
     pub fn new() -> Self {
@@ -1394,6 +1419,12 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         // `CREATE ({b: null})` stored a `Null` and `'b' IN keys(n)` answered
         // true (#952) -- the engine disagreeing with itself across two paths
         // to the same state.
+        if !property_is_storable(&val) {
+            return Err(GraphError::ConstraintViolation(format!(
+                "InvalidPropertyType: `{key_str}` cannot hold a map inside a list. \
+                 A property is a scalar or a list of scalars."
+            )));
+        }
         if matches!(val, PropertyValue::Null) {
             // Still checked for existence. The early return skipped the
             // `NodeNotFound` the non-null path raises, so setting a property
@@ -1522,6 +1553,11 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         self.invalidate_statistics_cache();
         let key_str = key.into();
         let val = value.into();
+        if !property_is_storable(&val) {
+            return Err(GraphError::ConstraintViolation(format!(
+                "InvalidPropertyType: `{key_str}` cannot hold a map inside a list."
+            )));
+        }
         // Null removes, as on the node path above (#952) -- and, as there,
         // a write to an edge that does not exist is still an error.
         if matches!(val, PropertyValue::Null) {

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3915,14 +3915,45 @@ fn zone_aligned_instants(a: &PropertyValue, b: &PropertyValue) -> Option<(i128, 
 /// disagreement is theirs to keep.
 fn storable_property(v: &Value) -> Option<PropertyValue> {
     match v {
+        // A list literal reaches here already folded into an `Array`, so the
+        // element check has to look *inside* it: `[{num: 1}]` arrives as
+        // `Array([Map(..)])` and was stored whole, giving a node a property no
+        // Cypher expression can produce (#975).
+        Value::Property(p) if !property_is_storable(p) => None,
         Value::Property(p) => Some(p.clone()),
+        // A list built in the query rather than folded by the parser. Each
+        // element is checked as a *list element*, which is stricter than as a
+        // property in its own right: a bare map may be stored (NDS-08), a map
+        // inside a list may not.
         Value::List(items) => items
             .iter()
-            .map(storable_property)
+            .map(|i| match i {
+                Value::Property(PropertyValue::Map(_)) | Value::Map(_) => None,
+                other => storable_property(other),
+            })
             .collect::<Option<Vec<_>>>()
             .map(PropertyValue::Array),
         // A property can hold neither an entity nor a map.
         _ => None,
+    }
+}
+
+/// Can this value be a property?
+///
+/// A property is a scalar or a list of scalars. A **map** is neither, at any
+/// depth: `SET a.maplist = [{num: 1}]` must raise a TypeError rather than
+/// storing something `properties(a)` can hand back but no query can build.
+///
+/// A bare map is left alone here. Storing one is a documented extension
+/// (NDS-08, nested map properties) rather than an accident, and turning that
+/// off is a decision this fix is not entitled to make; the TCK scenario is
+/// about a list *containing* one.
+fn property_is_storable(p: &PropertyValue) -> bool {
+    match p {
+        PropertyValue::Array(items) => items
+            .iter()
+            .all(|i| !matches!(i, PropertyValue::Map(_)) && property_is_storable(i)),
+        _ => true,
     }
 }
 
@@ -13071,6 +13102,22 @@ impl PhysicalOperator for SetPropertyOperator {
                 };
                 (var.clone(), prop.clone(), val)
             }).collect();
+
+            // A property is a scalar or a list of scalars. `SET a.maplist =
+            // [{num: 1}]` stored an `Array([Map(..)])` -- something
+            // `properties(a)` hands back and no Cypher expression can build
+            // (#975). SET has its own value conversion, a fourth copy of this
+            // logic, so the shared `storable_property` never saw it; the check
+            // is applied to the result instead, which covers whichever
+            // converter produced it.
+            for (_, prop, val) in &evaluated {
+                if !property_is_storable(val) {
+                    return Err(ExecutionError::TypeError(format!(
+                        "InvalidPropertyType: `{prop}` cannot hold a map inside a list. \
+                         A property is a scalar or a list of scalars."
+                    )));
+                }
+            }
 
             // Apply mutations via store methods (syncs columnar + row + index)
             for (var, prop, val) in &evaluated {

--- a/tests/property_type_validation.rs
+++ b/tests/property_type_validation.rs
@@ -1,0 +1,78 @@
+//! A property is a scalar or a list of scalars (#975).
+//!
+//! ```cypher
+//! CREATE (a) SET a.maplist = [{num: 1}]
+//! ```
+//!
+//! succeeded, storing an `Array([Map(..)])` — something `properties(a)` hands
+//! back and no Cypher expression can build. openCypher wants
+//! `TypeError: InvalidPropertyType`.
+//!
+//! SET has its **own** value conversion, a fourth copy of the same logic, so
+//! the shared `storable_property` never saw the value. The check is applied to
+//! the result instead, which covers whichever converter produced it.
+//!
+//! A **bare** map is deliberately left alone: storing one is a documented
+//! extension (NDS-08, nested map properties) rather than an accident, and
+//! turning that off is not this fix's decision. The scenario is about a list
+//! *containing* one.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::MutQueryExecutor;
+use samyama::query::parser::parse_query;
+
+fn run(cypher: &str) -> Result<(), String> {
+    let mut store = GraphStore::new();
+    let q = parse_query(cypher).map_err(|e| format!("parse: {e:?}"))?;
+    MutQueryExecutor::new(&mut store, "default".to_string())
+        .execute(&q)
+        .map(|_| ())
+        .map_err(|e| format!("{e:?}"))
+}
+
+#[test]
+fn a_list_of_maps_is_refused_by_set() {
+    let err = run("CREATE (a) SET a.maplist = [{num: 1}]").unwrap_err();
+    assert!(err.contains("TypeError"), "{err}");
+}
+
+#[test]
+fn the_message_names_the_property() {
+    let err = run("CREATE (a) SET a.maplist = [{num: 1}]").unwrap_err();
+    assert!(err.contains("maplist"), "{err}");
+}
+
+#[test]
+fn a_list_of_maps_is_refused_by_create_and_merge() {
+    // The shared converter covers these; asserted so a future refactor cannot
+    // fix one path and leave the others.
+    assert!(run("CREATE ({maplist: [{num: 1}]})").is_err());
+    assert!(run("MERGE ({maplist: [{num: 1}]})").is_err());
+}
+
+#[test]
+fn a_nested_list_of_maps_is_refused_too() {
+    assert!(run("CREATE (a) SET a.x = [[{num: 1}]]").is_err());
+}
+
+#[test]
+fn a_list_of_scalars_is_fine() {
+    run("CREATE (a) SET a.ok = [1, 2, 3]").unwrap();
+    run("CREATE (a) SET a.ok = ['a', 'b']").unwrap();
+    run("CREATE (a) SET a.ok = [1.5, true]").unwrap();
+    run("CREATE (a) SET a.ok = []").unwrap();
+}
+
+#[test]
+fn a_bare_map_is_left_alone() {
+    // Not part of this fix. If storing one is ever withdrawn that is a
+    // separate, deliberate decision — this test records which side of the line
+    // it is on today.
+    run("CREATE (a) SET a.m = {num: 1}").unwrap();
+}
+
+#[test]
+fn ordinary_scalar_properties_are_unaffected() {
+    run("CREATE (a) SET a.n = 1, a.s = 'x', a.b = true, a.f = 1.5").unwrap();
+    run("CREATE (a) SET a.gone = null").unwrap();
+}


### PR DESCRIPTION
Closes #975.

```cypher
CREATE (a) SET a.maplist = [{num: 1}]
```

succeeded, storing an `Array([Map(..)])` — something `properties(a)` hands back and no Cypher expression can build. openCypher wants `TypeError: InvalidPropertyType`.

## Checked in the store, not at the writers

There are **four** separate value converters — CREATE's, MERGE's, SET's, and the shared `storable_property` — and inline literal properties (`CREATE ({maplist: [{num: 1}]})`) go through none of them.

I patched the shared converter, then SET's copy, and `a_list_of_maps_is_refused_by_create_and_merge` still failed. One guard on the write path covers all of them.

## A bare map is left alone

Storing one is a documented extension (NDS-08, nested map properties) rather than an accident, and withdrawing it is a separate decision. The scenario is about a list *containing* one. `a_bare_map_is_left_alone` records which side of that line today's behaviour is on, so a future change to it is deliberate.

## Measured

`Set1` [10] gained, wrong results 18 → **17**, **zero regressions**.