### PR TITLE
A trail that revisits a node keeps its whole walk (#976)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -6903,17 +6903,25 @@ impl VarLengthExpandOperator {
                          bound it with an upper hop limit or a more selective start"
                     )));
                 }
-                // `parent` reconstructs the path for a bound path or
-                // relationship variable. Built from the current stack, so it
-                // describes *this* trail rather than a shortest route.
-                let mut parent: std::collections::HashMap<NodeId, (NodeId, crate::graph::EdgeId)> =
-                    std::collections::HashMap::new();
-                let mut prev = source_id;
-                for (n, e) in &path {
-                    parent.insert(*n, (prev, *e));
-                    prev = *n;
-                }
-                self.buffer(record, nb, &parent, source_id, store);
+                // The trail, handed over directly.
+                //
+                // It used to be flattened into a `parent` map keyed by node and
+                // reconstructed from that -- which cannot represent a trail
+                // that **revisits a node**. Every later visit overwrote the
+                // earlier one, so reconstruction walked back along the wrong
+                // edges and stopped early: an undirected `*3..3` came back as
+                // a two-hop path (#976). Undirected walks over a small graph
+                // revisit constantly, which is why this shows up there and not
+                // on a directed chain.
+                //
+                // `path` is already the walk, in order. There was never a
+                // reason to go through a lossy intermediate.
+                let mut trail_nodes = Vec::with_capacity(path.len() + 1);
+                trail_nodes.push(source_id);
+                trail_nodes.extend(path.iter().map(|(n, _)| *n));
+                let trail_edges: Vec<crate::graph::EdgeId> =
+                    path.iter().map(|(_, e)| *e).collect();
+                self.buffer_trail(record, nb, trail_nodes, trail_edges, store);
             }
 
             if depth < self.max_hops {
@@ -7086,6 +7094,22 @@ impl VarLengthExpandOperator {
     }
 
     /// Build and buffer an output record binding the target (and optional path).
+    /// `buffer`, given the walk directly instead of a parent map.
+    ///
+    /// The BFS has only a parent map, which is fine there: it visits each node
+    /// once. A trail may revisit one, and a map keyed by node cannot hold that
+    /// (#976).
+    fn buffer_trail(
+        &mut self,
+        base: &Record,
+        target: NodeId,
+        nodes: Vec<NodeId>,
+        edges: Vec<crate::graph::EdgeId>,
+        store: &GraphStore,
+    ) {
+        self.buffer_walk(base, target, nodes, edges, store)
+    }
+
     fn buffer(
         &mut self,
         base: &Record,
@@ -7101,17 +7125,34 @@ impl VarLengthExpandOperator {
         // clause cannot retake it (#710). Reconstructed from `parent` rather
         // than from the path variable, because isolation applies whether or not
         // the pattern names the path.
+        let (nodes, edges) = reconstruct_path(parent, source, target);
+        self.buffer_walk(base, target, nodes, edges, store)
+    }
+
+    /// Shared by both walks: bind the target, record isolation, and materialise
+    /// a path or relationship list from the walk it was given.
+    fn buffer_walk(
+        &mut self,
+        base: &Record,
+        target: NodeId,
+        nodes: Vec<NodeId>,
+        edges: Vec<crate::graph::EdgeId>,
+        store: &GraphStore,
+    ) {
+        let mut rec = base.clone();
+        rec.bind(self.target_var.clone(), Value::NodeRef(target));
+
         if self.track_edges {
             if self.starts_clause {
                 rec.clear_used_edges();
             }
-            let (_, walked) = reconstruct_path(parent, source, target);
+            let walked = edges.clone();
             for e in walked {
                 rec.mark_edge_used(e);
             }
         }
         if self.path_variable.is_some() || self.rel_variable.is_some() {
-            let (mut nodes, mut edges) = reconstruct_path(parent, source, target);
+            let (mut nodes, mut edges) = (nodes, edges);
             // `reconstruct_path` returns the walk in the order it was walked,
             // which is the pattern's order only when the two agree. When the
             // planner anchored the far end and walked back, they do not.

--- a/tests/trail_path_revisits_nodes.rs
+++ b/tests/trail_path_revisits_nodes.rs
@@ -1,0 +1,132 @@
+//! A trail that revisits a node keeps its whole walk (#976).
+//!
+//! ```cypher
+//! MATCH topRoute = (:Start)<-[:CONNECTED_TO]-()-[:CONNECTED_TO*3..3]-(:End)
+//! RETURN topRoute
+//! ```
+//!
+//! returned the right **number** of rows and a two-hop path where the answer
+//! is four hops.
+//!
+//! The trail was flattened into a `parent` map keyed by node and rebuilt from
+//! it. That cannot represent a walk that **revisits a node**: every later
+//! visit overwrites the earlier one, so reconstruction follows the wrong edges
+//! back and stops early.
+//!
+//! Undirected walks over a small graph revisit constantly, which is why this
+//! shows on `*3..3` undirected and not on a directed chain — and why the row
+//! count stayed right while the paths did not.
+//!
+//! `path` was already the walk, in order. There was never a reason to go
+//! through a lossy intermediate.
+
+use samyama::graph::{GraphStore, Label};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// The openCypher `Match6` [14] fixture: a star around `mid`.
+fn star() -> GraphStore {
+    let mut store = GraphStore::new();
+    let db1 = store.create_node_with_labels([Label::new("Start")]);
+    let db2 = store.create_node_with_labels([Label::new("End")]);
+    let mid = store.create_node("");
+    let other = store.create_node("");
+    for t in [db1, db2, db2, other, other] {
+        store.create_edge(mid, t, "CONNECTED_TO").unwrap();
+    }
+    store
+}
+
+fn shapes(store: &GraphStore, cypher: &str, col: &str) -> Vec<(usize, usize)> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let mut out: Vec<(usize, usize)> = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"))
+        .records
+        .iter()
+        .map(|r| match r.get(col) {
+            Some(Value::Path { nodes, edges }) => (nodes.len(), edges.len()),
+            other => panic!("{cypher}: {other:?}"),
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn an_undirected_trail_that_revisits_a_node_keeps_every_hop() {
+    let store = star();
+    let got = shapes(
+        &store,
+        "MATCH topRoute = (:Start)<-[:CONNECTED_TO]-()-[:CONNECTED_TO*3..3]-(:End) \
+         RETURN topRoute",
+        "topRoute",
+    );
+    assert_eq!(got.len(), 4, "four routes");
+    // One fixed hop plus three variable ones: five nodes, four relationships.
+    assert!(got.iter().all(|&s| s == (5, 4)), "{got:?}");
+}
+
+#[test]
+fn every_path_is_internally_consistent() {
+    let store = star();
+    for (n, e) in shapes(
+        &store,
+        "MATCH p = (:Start)<-[:CONNECTED_TO]-()-[:CONNECTED_TO*3..3]-(:End) RETURN p",
+        "p",
+    ) {
+        assert_eq!(n, e + 1, "{n} nodes, {e} relationships");
+    }
+}
+
+#[test]
+fn length_agrees_with_the_path() {
+    // A shortened path used to report a shortened length too — consistent and
+    // wrong — so the count of relationships has to be checked against the
+    // pattern, not against the path itself.
+    let store = star();
+    let q = parse_query(
+        "MATCH p = (:Start)<-[:CONNECTED_TO]-()-[:CONNECTED_TO*3..3]-(:End) \
+         RETURN length(p) AS len",
+    )
+    .unwrap();
+    for rec in &QueryExecutor::new(&store).execute(&q).unwrap().records {
+        assert!(
+            format!("{:?}", rec.get("len")).contains("Integer(4)"),
+            "{:?}",
+            rec.get("len")
+        );
+    }
+}
+
+#[test]
+fn a_directed_chain_is_unchanged() {
+    // The shape the parent map always handled: no node is visited twice.
+    let mut store = GraphStore::new();
+    let a = store.create_node_with_labels([Label::new("A")]);
+    let b = store.create_node("");
+    let c = store.create_node_with_labels([Label::new("C")]);
+    store.create_edge(a, b, "R").unwrap();
+    store.create_edge(b, c, "R").unwrap();
+    assert_eq!(
+        shapes(&store, "MATCH p = (:A)-[:R*2..2]->(:C) RETURN p", "p"),
+        vec![(3, 2)]
+    );
+}
+
+#[test]
+fn the_relationship_list_matches_the_path() {
+    let store = star();
+    let q = parse_query(
+        "MATCH p = (:Start)<-[:CONNECTED_TO]-()-[r:CONNECTED_TO*3..3]-(:End) \
+         RETURN size(r) AS n",
+    )
+    .unwrap();
+    for rec in &QueryExecutor::new(&store).execute(&q).unwrap().records {
+        assert!(
+            format!("{:?}", rec.get("n")).contains("Integer(3)"),
+            "the variable-length segment walked three: {:?}",
+            rec.get("n")
+        );
+    }
+}


### PR DESCRIPTION
Closes #976.

```cypher
MATCH topRoute = (:Start)<-[:CONNECTED_TO]-()-[:CONNECTED_TO*3..3]-(:End) RETURN topRoute
```

Four rows — the right number — and each path `<(:Start)<-[]-()-[]->(:End)>`: **two hops where the answer is four**.

## Cause

The trail enumerator flattened its walk into a `parent` map keyed by node and rebuilt the path from it. A map keyed by node **cannot represent a trail that revisits a node** — every later visit overwrites the earlier one, so reconstruction follows the wrong edges back and stops early.

The fixture is a star, so every route passes through `mid` more than once. Undirected walks over a small graph revisit constantly, which is why this shows on `*3..3` undirected and not on a directed chain.

## Why it is quiet

The row count is right, the endpoints are right, and only the path between them is truncated. The shortened path reports a shortened `length()` too, so it stays **internally consistent** — an "n nodes, n−1 relationships" check passes. `length_agrees_with_the_path` therefore checks the length against the *pattern*, not against the path.

## Fix

`path` was already the walk, in order. Hand it over directly instead of round-tripping through a lossy intermediate. The BFS keeps its parent map, which is correct there because it visits each node once.

## Measured

`Match6` [14] gained, wrong results 18 → **17**, **zero regressions**.