### PR TITLE
A WHERE after a post-WITH OPTIONAL MATCH is a join condition (#978)

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1868,6 +1868,9 @@ impl QueryPlanner {
                 .unwrap_or_default();
             let mut per_match_where: Vec<Option<WhereClause>> = vec![None; stage_matches.len()];
             let mut cross_match_preds: Vec<Expression> = Vec::new();
+            // Predicates that become join conditions on an OPTIONAL MATCH.
+            let mut stage_optional_join_predicates: Vec<Option<Expression>> =
+                vec![None; stage_matches.len()];
 
             // A predicate referring to a leading UNWIND's variable cannot be evaluated
             // during match planning -- the variable is not bound until the Unwind operator
@@ -1883,6 +1886,47 @@ impl QueryPlanner {
                 if pred_vars.iter().any(|v| late_bound.contains(v)) {
                     continue;
                 }
+                // A predicate spanning an OPTIONAL MATCH's own variables and
+                // an outer one is a **join condition**, not a filter above the
+                // join. Cypher scopes the WHERE after an OPTIONAL MATCH to the
+                // optional match, so a row failing it keeps the left side and
+                // nulls the right; filtering above the join deletes the row.
+                //
+                // #667 established this for the pre-WITH decomposition and
+                // this path never inherited it, so
+                // `… WITH r, a1 LIMIT 1 OPTIONAL MATCH (a2)<-[r]-(b2)
+                //  WHERE a1 = a2` returned **no rows** where Cypher returns one
+                // with nulls (#978). The same rule, in the copy that did not
+                // have it.
+                let optional_target = stage_matches.iter().enumerate().find(|(i, mc)| {
+                    if !mc.optional || pred_vars.is_empty() {
+                        return false;
+                    }
+                    let own = &match_var_sets[*i];
+                    let earlier: HashSet<&String> = match_var_sets[..*i]
+                        .iter()
+                        .flat_map(|s| s.iter())
+                        .chain(known_vars.iter())
+                        .collect();
+                    let introduced: HashSet<&String> =
+                        own.iter().filter(|v| !earlier.contains(*v)).collect();
+                    let touches_optional = pred_vars.iter().any(|v| introduced.contains(v));
+                    let touches_outer = pred_vars.iter().any(|v| !introduced.contains(v));
+                    touches_optional && touches_outer
+                });
+                if let Some((i, _)) = optional_target {
+                    stage_optional_join_predicates[i] =
+                        Some(match stage_optional_join_predicates[i].take() {
+                            Some(existing) => Expression::Binary {
+                                left: Box::new(existing),
+                                op: BinaryOp::And,
+                                right: Box::new(pred),
+                            },
+                            None => pred,
+                        });
+                    continue;
+                }
+
                 let target = match_var_sets.iter().position(|match_vars| {
                     pred_vars.is_empty() || pred_vars.iter().all(|v| match_vars.contains(v))
                 });
@@ -1933,7 +1977,14 @@ impl QueryPlanner {
                             if !shared.is_empty() {
                                 if match_clause.optional {
                                     let right_only: Vec<String> = clause_vars.difference(&known_vars).cloned().collect();
-                                    Box::new(LeftOuterJoinOperator::new(existing, match_op, shared.clone(), right_only)) as OperatorBox
+                                    let mut join = LeftOuterJoinOperator::new(
+                                        existing, match_op, shared.clone(), right_only);
+                                    if let Some(pred) =
+                                        stage_optional_join_predicates[match_idx].clone()
+                                    {
+                                        join = join.with_join_predicate(pred);
+                                    }
+                                    Box::new(join) as OperatorBox
                                 } else {
                                     Box::new(JoinOperator::new(existing, match_op, shared.clone())) as OperatorBox
                                 }
@@ -1944,12 +1995,18 @@ impl QueryPlanner {
                                 // then deletes every left row (#954).
                                 let right_only: Vec<String> =
                                     clause_vars.difference(&known_vars).cloned().collect();
-                                Box::new(LeftOuterJoinOperator::new(
+                                let mut join = LeftOuterJoinOperator::new(
                                     existing,
                                     match_op,
                                     Vec::new(),
                                     right_only,
-                                )) as OperatorBox
+                                );
+                                if let Some(pred) =
+                                    stage_optional_join_predicates[match_idx].clone()
+                                {
+                                    join = join.with_join_predicate(pred);
+                                }
+                                Box::new(join) as OperatorBox
                             } else {
                                 Box::new(CartesianProductOperator::new(existing, match_op)) as OperatorBox
                             }

--- a/tests/optional_join_predicate_post_with.rs
+++ b/tests/optional_join_predicate_post_with.rs
@@ -1,0 +1,115 @@
+//! A WHERE after a post-WITH OPTIONAL MATCH is a join condition (#978).
+//!
+//! ```cypher
+//! MATCH (a1)-[r]->()
+//! WITH r, a1 LIMIT 1
+//! OPTIONAL MATCH (a2)<-[r]-(b2)
+//! WHERE a1 = a2
+//! RETURN a1, r, b2, a2
+//! ```
+//!
+//! returned **no rows** where Cypher returns one, with `b2` and `a2` null.
+//!
+//! Cypher scopes the WHERE after an OPTIONAL MATCH to the optional match: a
+//! row failing it keeps the left side and nulls the right. Applied as a filter
+//! *above* the join it deletes the row entirely — which is exactly what #667
+//! established for the pre-WITH decomposition.
+//!
+//! That fix never reached the post-WITH path, which built its
+//! `LeftOuterJoinOperator` without a join predicate at all. The same rule, in
+//! the copy that did not have it.
+
+use samyama::graph::{GraphStore, Label};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn chain() -> GraphStore {
+    let mut store = GraphStore::new();
+    let a = store.create_node_with_labels([Label::new("A")]);
+    let b = store.create_node_with_labels([Label::new("B")]);
+    store.create_edge(a, b, "T").unwrap();
+    store
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"))
+        .records
+        .len()
+}
+
+#[test]
+fn a_failing_predicate_nulls_the_right_side_rather_than_dropping_the_row() {
+    let store = chain();
+    assert_eq!(
+        rows(
+            &store,
+            "MATCH (a1)-[r]->() WITH r, a1 LIMIT 1 \
+             OPTIONAL MATCH (a2)<-[r]-(b2) WHERE a1 = a2 RETURN a1, r, b2, a2",
+        ),
+        1
+    );
+}
+
+#[test]
+fn the_right_side_really_is_null() {
+    // Row count alone would also pass if the predicate were simply ignored.
+    let store = chain();
+    let q = parse_query(
+        "MATCH (a1)-[r]->() WITH r, a1 LIMIT 1 \
+         OPTIONAL MATCH (a2)<-[r]-(b2) WHERE a1 = a2 RETURN a1, b2, a2",
+    )
+    .unwrap();
+    let batch = QueryExecutor::new(&store).execute(&q).unwrap();
+    let rec = &batch.records[0];
+    assert!(rec.get("a1").is_some());
+    for c in ["b2", "a2"] {
+        assert!(
+            matches!(rec.get(c), Some(Value::Null) | None),
+            "{c} should be null: {:?}",
+            rec.get(c)
+        );
+    }
+}
+
+#[test]
+fn a_predicate_that_holds_still_matches() {
+    // The direction a fix that always null-filled would break.
+    let store = chain();
+    let q = parse_query(
+        "MATCH (a1)-[r]->(x) WITH r, a1, x LIMIT 1 \
+         OPTIONAL MATCH (a2)-[r]->(b2) WHERE a1 = a2 RETURN a2, b2",
+    )
+    .unwrap();
+    let batch = QueryExecutor::new(&store).execute(&q).unwrap();
+    assert_eq!(batch.records.len(), 1);
+    assert!(
+        !matches!(batch.records[0].get("a2"), Some(Value::Null) | None),
+        "the predicate holds, so a2 is bound: {:?}",
+        batch.records[0].get("a2")
+    );
+}
+
+#[test]
+fn a_predicate_on_the_optional_clause_alone_still_pushes_down() {
+    // Naming only the optional clause's own variables, it belongs *inside*
+    // that clause where it can anchor the scan — routing it to the join would
+    // cost that. #667's own caveat.
+    let store = chain();
+    assert_eq!(
+        rows(&store, "MATCH (n) WITH n LIMIT 1 OPTIONAL MATCH (b:Nope) WHERE b.x = 1 RETURN n, b"),
+        1
+    );
+}
+
+#[test]
+fn a_pre_with_optional_match_is_unchanged() {
+    // #667's original case, which already worked.
+    let store = chain();
+    assert_eq!(
+        rows(&store, "MATCH (x:A) OPTIONAL MATCH (x)-[:T]->(y) WHERE y.val > 4 RETURN x, y"),
+        1
+    );
+}


### PR DESCRIPTION
Closes #978.

```cypher
MATCH (a1)-[r]->()
WITH r, a1 LIMIT 1
OPTIONAL MATCH (a2)<-[r]-(b2)
WHERE a1 = a2
RETURN a1, r, b2, a2
```

returned **no rows** where Cypher returns one — `(:A), [:T], null, null`.

## Cause

Cypher scopes the WHERE after an OPTIONAL MATCH to the optional match: a row failing it keeps the left side and nulls the right. Applied as a filter *above* the join it deletes the row entirely.

This is precisely what #667 established — and the fix went into the **pre-WITH** decomposition only. The post-WITH stage built its join with no predicate at all:

```rust
Box::new(LeftOuterJoinOperator::new(existing, match_op, shared.clone(), right_only))
```

So the same query behaved differently depending on whether a `WITH` preceded it. The same rule, missing from the copy that did not have it.

## What the fix must not break

- A predicate naming **only** the optional clause's own variables belongs *inside* it, where it can anchor the scan — #667's own caveat, and routing those to the join costs that anchor.
- A predicate that **holds** must still match rather than null-fill.
- `the_right_side_really_is_null` — a row count alone would pass if the predicate were simply ignored.

All three are pinned, along with #667's original pre-WITH case.

## Measured

`MatchWhere6` [5] gained, wrong results 17 → **16**, **zero regressions**.