### PR TITLE
A path has no properties, and {} is still a rebinding (#980)

### DIFF
--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -66,6 +66,8 @@ pub enum ValidationError {
     MergeNullProperty(String),
     /// A bare node pattern used as a predicate.
     InvalidPredicatePattern,
+    /// A property read from a path variable.
+    PropertyOnPath(String),
     /// `RETURN *` where nothing is in scope.
     NoVariablesInScope,
     /// The same relationship variable twice in one pattern.
@@ -124,6 +126,12 @@ impl std::fmt::Display for ValidationError {
                  `WHERE (n)` asks whether a node exists that is already bound, \
                  which is always true; the pattern shorthand needs a relationship, \
                  as in `WHERE (n)-->()`"
+            ),
+            Self::PropertyOnPath(var) => write!(
+                f,
+                "InvalidArgumentType: `{var}` is a path, and a path has no \
+                 properties. `length({var})`, `nodes({var})` and \
+                 `relationships({var})` are what a path answers"
             ),
             Self::NoVariablesInScope => write!(
                 f,
@@ -1976,6 +1984,62 @@ fn validate_with_items_aliased(query: &Query) -> Result<(), ValidationError> {
     Ok(())
 }
 
+/// A path has no properties (#980).
+///
+/// ```text
+/// MATCH r = (n)-[*]->() WHERE r.name = 'apa'   -> InvalidArgumentType
+/// ```
+///
+/// `r` is a path. Reading `r.name` is not a question a path can answer, and
+/// we answered zero rows -- indistinguishable from a graph where nothing has
+/// that name.
+///
+/// Only for variables a pattern binds *as a path*. The kind map is the same
+/// one `validate_variable_kinds` builds, so a name that binds a node keeps
+/// answering property reads.
+fn validate_no_property_on_path(query: &Query) -> Result<(), ValidationError> {
+    use crate::query::ast::Clause;
+
+    let mut kinds: std::collections::HashMap<String, EntityKind> =
+        std::collections::HashMap::new();
+    for mc in &query.match_clauses {
+        let _ = note_pattern_kinds(&mut kinds, &mc.pattern);
+    }
+    for c in &query.clauses {
+        if let Clause::Match(mc) = c {
+            let _ = note_pattern_kinds(&mut kinds, &mc.pattern);
+        }
+    }
+    let paths: std::collections::HashSet<&String> = kinds
+        .iter()
+        .filter(|(_, k)| matches!(k, EntityKind::Path))
+        .map(|(v, _)| v)
+        .collect();
+    if paths.is_empty() {
+        return Ok(());
+    }
+
+    fn check(
+        e: &Expression,
+        paths: &std::collections::HashSet<&String>,
+    ) -> Result<(), ValidationError> {
+        if let Expression::Property { variable, .. } = e {
+            if paths.contains(variable) {
+                return Err(ValidationError::PropertyOnPath(variable.clone()));
+            }
+        }
+        for child in child_expressions(e) {
+            check(child, paths)?;
+        }
+        Ok(())
+    }
+
+    for e in all_expressions(query) {
+        check(e, &paths)?;
+    }
+    Ok(())
+}
+
 /// A MERGE pattern may not carry a literal null property (#973).
 ///
 /// ```text
@@ -2532,6 +2596,7 @@ pub fn validate(query: &Query) -> Result<(), ValidationError> {
     validate_function_names(query)?;
     validate_star_has_scope(query)?;
     validate_merge_null_properties(query)?;
+    validate_no_property_on_path(query)?;
     validate_predicate_patterns(query)?;
     validate_relationship_uniqueness(query)?;
 
@@ -2701,9 +2766,17 @@ pub fn validate(query: &Query) -> Result<(), ValidationError> {
                 let bound = &bound;
                 let mut check = |np: &crate::query::ast::NodePattern| -> Result<(), ValidationError> {
                     if let Some(v) = &np.variable {
+                        // A property map counts even when it is **empty**.
+                        // `CREATE (n:Foo) CREATE (n {})-[:OWNS]->(:Dog)` is a
+                        // rebinding attempt Cypher rejects, and treating `{}`
+                        // as "adds nothing" accepted it and created the
+                        // relationship anyway (#980). Writing braces at all is
+                        // the tell; a bare re-mention has `properties: None`
+                        // and stays legal, which is how
+                        // `CREATE (a)-[:R]->(b)` works.
                         let adds_something = !np.labels.is_empty()
-                            || np.properties.as_ref().is_some_and(|p| !p.is_empty())
-                            || np.property_exprs.as_ref().is_some_and(|p| !p.is_empty());
+                            || np.properties.is_some()
+                            || np.property_exprs.is_some();
                         if bound.contains(v) && adds_something {
                             return Err(if merge {
                                 ValidationError::MergeOnBoundVariable(v.clone())

--- a/tests/path_property_and_rebind.rs
+++ b/tests/path_property_and_rebind.rs
@@ -1,0 +1,90 @@
+//! A path has no properties, and `{}` is still a rebinding (#980).
+//!
+//! ```cypher
+//! MATCH r = (n)-[*]->() WHERE r.name = 'apa' RETURN r   -- InvalidArgumentType
+//! CREATE (n:Foo) CREATE (n {})-[:OWNS]->(:Dog)          -- VariableAlreadyBound
+//! ```
+//!
+//! Both succeeded with zero rows.
+//!
+//! `r.name` on a path is not a question a path can answer, and an empty result
+//! is indistinguishable from a graph where nothing has that name.
+//!
+//! `CREATE (n {})` on a bound `n` is a rebinding attempt. The existing rule
+//! asked whether the pattern "adds something" and read an **empty** property
+//! map as adding nothing, so it accepted the query and created the
+//! relationship. Writing braces at all is the tell — a bare re-mention has no
+//! property map, which is how `CREATE (a)-[:R]->(b)` stays legal.
+
+use samyama::query::parser::parse_query;
+
+fn refused(cypher: &str) -> bool {
+    parse_query(cypher).is_err()
+}
+
+fn accepted(cypher: &str) -> bool {
+    parse_query(cypher).is_ok()
+}
+
+#[test]
+fn a_property_read_on_a_path_is_refused() {
+    assert!(refused("MATCH (n) MATCH r = (n)-[*]->() WHERE r.name = 'apa' RETURN r"));
+    assert!(refused("MATCH p = (a)-->(b) RETURN p.x"));
+}
+
+#[test]
+fn the_message_names_the_path_and_what_to_use() {
+    let err = format!(
+        "{:?}",
+        parse_query("MATCH p = (a)-->(b) RETURN p.x").unwrap_err()
+    );
+    assert!(err.contains('p'), "{err}");
+    assert!(err.contains("length") || err.contains("nodes"), "{err}");
+}
+
+#[test]
+fn the_path_functions_are_still_fine() {
+    for q in [
+        "MATCH p = (a)-->(b) RETURN length(p)",
+        "MATCH p = (a)-->(b) RETURN nodes(p)",
+        "MATCH p = (a)-->(b) RETURN relationships(p)",
+        "MATCH p = (a)-->(b) RETURN p",
+    ] {
+        assert!(accepted(q), "{q}");
+    }
+}
+
+#[test]
+fn a_property_read_on_a_node_or_relationship_is_unaffected() {
+    // The rule keys on the variable binding a *path*, so ordinary reads have
+    // to keep working — most of the corpus is these.
+    for q in [
+        "MATCH (n) RETURN n.x",
+        "MATCH ()-[r]->() RETURN r.x",
+        "MATCH p = (a)-[r]->(b) RETURN a.x, r.y, b.z",
+    ] {
+        assert!(accepted(q), "{q}");
+    }
+}
+
+#[test]
+fn an_empty_property_map_on_a_bound_variable_is_refused() {
+    assert!(refused("CREATE (n:Foo) CREATE (n {})-[:OWNS]->(:Dog)"));
+    assert!(refused("MATCH (n) CREATE (n {})-[:R]->(:X)"));
+}
+
+#[test]
+fn a_bare_re_mention_stays_legal() {
+    // How an edge between existing nodes is written, and the idiom every TCK
+    // fixture uses. No property map, so nothing is being rebound.
+    assert!(accepted("CREATE (a), (b), (a)-[:R]->(b)"));
+    assert!(accepted("MATCH (a), (b) CREATE (a)-[:R]->(b)"));
+}
+
+#[test]
+fn a_non_empty_property_map_was_already_refused() {
+    // The case the old rule did catch, pinned so the widening did not narrow
+    // anything by accident.
+    assert!(refused("CREATE (n:Foo) CREATE (n {x: 1})-[:R]->(:X)"));
+    assert!(refused("CREATE (n:Foo) CREATE (n:Bar)-[:R]->(:X)"));
+}


### PR DESCRIPTION
Closes #980.

```cypher
MATCH r = (n)-[*]->() WHERE r.name = 'apa' RETURN r   -- succeeded, 0 rows
CREATE (n:Foo) CREATE (n {})-[:OWNS]->(:Dog)          -- succeeded, created it
```

## A property read on a path

`length(r)`, `nodes(r)` and `relationships(r)` are what a path answers. `r.name` returned null on every row, filtering everything out — indistinguishable from a graph where nothing has that name.

The kind map `validate_variable_kinds` already builds knows which variables bind paths, so this is a lookup rather than new machinery, and property reads on nodes and relationships are untouched.

## An empty property map

The rebinding rule already existed — `CREATE (n {x: 1})` and `CREATE (n:Bar)` on a bound `n` are both refused — but it asked whether the pattern *adds something* and read `{}` as adding nothing:

```rust
|| np.properties.as_ref().is_some_and(|p| !p.is_empty())
```

Writing braces at all is the tell. A bare re-mention has `properties: None`, which is how `CREATE (a)-[:R]->(b)` and the `CREATE (a), (b), (a)-[:R]->(b)` idiom every TCK fixture uses stay legal — `a_bare_re_mention_stays_legal` pins that.

## Measured

`MatchWhere1` [14] and `Create1` [19] gained, wrong results 13 → **11**, **zero regressions**. Pass rate **99.5%**.