### PR TITLE
Keep the join when an OPTIONAL MATCH carries a join predicate (#982)

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1541,7 +1541,20 @@ impl QueryPlanner {
             // predicate is part of the optional pattern, so a row failing it
             // must still emit nulls, and a filter above the expand would
             // delete exactly that row.
-            if operator.is_some() && per_match_where[match_idx].is_none() {
+            //
+            // `per_match_where` is not the only place that `WHERE` can land.
+            // A predicate spanning the optional side and an outer variable --
+            // `OPTIONAL MATCH (b)-[r2]-(c) WHERE r <> r2` -- is classified as
+            // a *join* predicate above, which leaves `per_match_where` empty.
+            // Checking only `per_match_where` let exactly those clauses push
+            // down, and the pushdown has nowhere to put a join predicate, so
+            // it was dropped: `r <> r2` stopped being applied at all and the
+            // relationship a row was matched on came back as its own
+            // `r2` (#982). Both stores have to be empty to push down.
+            if operator.is_some()
+                && per_match_where[match_idx].is_none()
+                && optional_join_predicates[match_idx].is_none()
+            {
                 if let Some(null_vars) =
                     Self::optional_pushdown_vars(match_clause, &known_vars)
                 {

--- a/tests/optional_join_predicate_pushdown.rs
+++ b/tests/optional_join_predicate_pushdown.rs
@@ -1,0 +1,82 @@
+//! A join predicate must block the OPTIONAL MATCH pushdown (#982).
+//!
+//! ```cypher
+//! MATCH (a)-[r {name: 'r1'}]-(b)
+//! OPTIONAL MATCH (b)-[r2]-(c)
+//! WHERE r <> r2
+//! RETURN a, b, c
+//! ```
+//!
+//! returned **3** rows where Cypher returns 2. The extra row was the one where
+//! `r2` *is* `r` — the relationship the outer MATCH came in on, walked back the
+//! other way. `r <> r2` exists precisely to exclude it.
+//!
+//! #726 pushes a single-segment OPTIONAL MATCH into an expand instead of a
+//! join, and guarded that on the clause having no WHERE. But a predicate
+//! spanning the optional side and an outer variable is classified as a *join*
+//! predicate (#667), not a per-clause WHERE, so it leaves `per_match_where`
+//! empty and the guard waved it through. The expand has nowhere to put a join
+//! predicate, so `r <> r2` was not applied anywhere — a row count that is too
+//! large by exactly the rows the predicate was written to remove.
+
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// `(a)-[r1]->(b)-[r2]->(c)`, the two edges distinguishable by name.
+fn chain() -> GraphStore {
+    let mut store = GraphStore::new();
+    let a = store.create_node_with_labels([Label::new("A")]);
+    let b = store.create_node_with_labels([Label::new("B")]);
+    let c = store.create_node_with_labels([Label::new("C")]);
+    let e1 = store.create_edge(a, b, "T").unwrap();
+    let e2 = store.create_edge(b, c, "T").unwrap();
+    store.set_edge_property(e1, "name", PropertyValue::String("r1".into())).unwrap();
+    store.set_edge_property(e2, "name", PropertyValue::String("r2".into())).unwrap();
+    store
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> Vec<Vec<Value>> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let r = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let cols = r.columns.clone();
+    r.records
+        .iter()
+        .map(|rec| cols.iter().map(|c| rec.get(c).cloned().unwrap_or(Value::Null)).collect())
+        .collect()
+}
+
+#[test]
+fn the_predicate_excludes_the_relationship_matched_on() {
+    let store = chain();
+    let got = rows(
+        &store,
+        "MATCH (a)-[r {name: 'r1'}]-(b) OPTIONAL MATCH (b)-[r2]-(c) WHERE r <> r2 RETURN a, b, c",
+    );
+    // (a)-[r1]-(b) matches both directions. From b, the only other edge is r2
+    // to c; from a there is none, so that row nulls c.
+    assert_eq!(got.len(), 2, "got {got:?}");
+}
+
+#[test]
+fn a_row_with_no_surviving_match_still_emits_nulls() {
+    let store = chain();
+    let got = rows(
+        &store,
+        "MATCH (a)-[r {name: 'r2'}]->(b) OPTIONAL MATCH (b)-[r2]-(c) WHERE r <> r2 RETURN a, c",
+    );
+    // b is the far end (node c of the chain) and has only the one edge, which
+    // the predicate removes. OPTIONAL MATCH keeps the row and nulls `c`.
+    assert_eq!(got.len(), 1, "got {got:?}");
+    assert_eq!(got[0][1], Value::Null, "c should be null: {got:?}");
+}
+
+#[test]
+fn an_optional_match_with_no_predicate_still_pushes_down() {
+    let store = chain();
+    // The #726 pushdown must survive: no WHERE, so nothing to lose.
+    let got = rows(&store, "MATCH (a)-[r {name: 'r1'}]-(b) OPTIONAL MATCH (b)-[r2]-(c) RETURN a, b, c");
+    assert_eq!(got.len(), 3, "got {got:?}");
+}


### PR DESCRIPTION
Closes #982.

`MATCH (a)-[r {name: 'r1'}]-(b) OPTIONAL MATCH (b)-[r2]-(c) WHERE r <> r2 RETURN a, b, c` returned **3** rows where Cypher returns 2. The extra row is the one where `r2` *is* `r` — the relationship the outer MATCH came in on, walked back the other way. `r <> r2` exists precisely to exclude it.

## Cause

#726 pushes a single-segment `OPTIONAL MATCH` down into an expand instead of planning a join, and guarded that on the clause having no `WHERE`:

> A `WHERE` on the clause keeps the join: in `OPTIONAL MATCH` the predicate is part of the optional pattern, so a row failing it must still emit nulls, and a filter above the expand would delete exactly that row.

The reasoning is right; the check is incomplete. `per_match_where` is not the only place a `WHERE` can land. A predicate spanning the optional side *and* an outer variable is classified as a **join** predicate (#667) and stored in `optional_join_predicates`, which leaves `per_match_where` empty. So the guard passed for exactly the clauses it was written to catch, the pushdown fired, and — since an expand has nowhere to put a join predicate — `r <> r2` was silently dropped.

`EXPLAIN` showed it plainly: a chained `Expand` with no `LeftOuterJoin` and no trace of the predicate anywhere in the plan.

## Fix

Require both stores to be empty before pushing down.

## Why it was quiet

Every row returned was individually correct and every value in it was real; the count was merely too large, by precisely the rows the predicate existed to remove. There is no error, no null, and nothing a caller could distinguish from a query that legitimately matched three times.

## Tests

`tests/optional_join_predicate_pushdown.rs` — three cases, verified to fail before the fix (2 of 3) and pass after:

- the predicate excludes the relationship matched on
- a row with no surviving match still emits nulls rather than vanishing
- **an OPTIONAL MATCH with no predicate still pushes down** — #726's 422 ms → 0.02 ms is untouched

All 42 existing OPTIONAL MATCH tests across 7 files pass.

TCK: closes Match7[11].