### PR TITLE
A bound relationship list drives a var-length segment (#984)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -6645,6 +6645,134 @@ impl VarLengthExpandOperator {
         })
     }
 
+    /// Is this segment's relationship variable already bound to a list?
+    ///
+    /// Only a *list* counts. A relationship variable bound to a single
+    /// relationship is a different question -- and an error the validator
+    /// still rejects -- so this must not fire on one.
+    fn walk_is_bound(&self, record: &Record) -> bool {
+        let Some(rv) = self.rel_variable.as_ref() else { return false };
+        matches!(
+            record.get(rv),
+            Some(Value::List(_)) | Some(Value::Property(PropertyValue::Array(_)))
+        )
+    }
+
+    /// Verify the one path `rs` names, and emit it if it is legal.
+    ///
+    /// Everything the search would enforce is enforced here too, because a
+    /// pattern does not stop meaning what it says when its walk is handed to
+    /// it: the length bounds, the type filter, the inline property filter,
+    /// relationship isomorphism, and the direction each edge is traversed in.
+    /// Leaving any of them out would make the bound form quietly more
+    /// permissive than the searched form -- the same query, two answers.
+    fn walk_bound_list(&mut self, record: &Record, store: &GraphStore) -> ExecutionResult<()> {
+        let Some(rv) = self.rel_variable.clone() else { return Ok(()) };
+        let source_val = record
+            .get(&self.source_var)
+            .ok_or_else(|| ExecutionError::VariableNotFound(self.source_var.clone()))?;
+        if matches!(source_val, Value::Null)
+            || matches!(source_val.as_property(), Some(PropertyValue::Null))
+        {
+            return Ok(());
+        }
+        let source_id = source_val.node_id().ok_or_else(|| {
+            ExecutionError::TypeError(format!("{} is not a node", self.source_var))
+        })?;
+
+        let ids: Vec<crate::graph::EdgeId> = match record.get(&rv) {
+            Some(Value::List(items)) => items.iter().filter_map(|v| v.edge_id()).collect(),
+            // A list that reached here as a property array cannot hold an
+            // entity (see `Value` vs `PropertyValue`), so it can never name a
+            // relationship. An empty walk is the honest reading.
+            Some(Value::Property(PropertyValue::Array(_))) => Vec::new(),
+            _ => return Ok(()),
+        };
+        // A non-relationship somewhere in the list means the list is not a
+        // walk. Matching nothing is right; matching the prefix that happened
+        // to be relationships is not.
+        let named = match record.get(&rv) {
+            Some(Value::List(items)) => items.len(),
+            _ => 0,
+        };
+        if ids.len() != named || ids.len() < self.min_hops || ids.len() > self.max_hops {
+            return Ok(());
+        }
+
+        self.ensure_type_ids(store);
+        let mut at = source_id;
+        let mut nodes = vec![at];
+        let mut seen: Vec<crate::graph::EdgeId> = Vec::with_capacity(ids.len());
+        for eid in &ids {
+            // Relationship isomorphism inside the list itself: a walk that
+            // reuses an edge is not a walk, whether a BFS built it or a WITH
+            // did.
+            if seen.contains(eid) {
+                return Ok(());
+            }
+            let Some(edge) = store.get_edge(*eid) else { return Ok(()) };
+            if !self.edge_types.is_empty()
+                && !self.edge_types.iter().any(|t| t.as_str() == edge.edge_type.as_str())
+            {
+                return Ok(());
+            }
+            if !self.edge_props_ok(*eid, store) {
+                return Ok(());
+            }
+            // Where this edge lands, given where we stand and which way the
+            // pattern lets us cross it. `Both` may be crossed either way; the
+            // directed forms may not, and an edge that does not touch `at` at
+            // all fails whichever direction is written.
+            let next = match self.direction {
+                Direction::Outgoing if edge.source == at => edge.target,
+                Direction::Incoming if edge.target == at => edge.source,
+                Direction::Both if edge.source == at => edge.target,
+                Direction::Both if edge.target == at => edge.source,
+                _ => return Ok(()),
+            };
+            seen.push(*eid);
+            at = next;
+            nodes.push(at);
+        }
+
+        // An edge this clause already walked is not available to this segment
+        // (#710), exactly as in the searched form.
+        if self.track_edges && !self.starts_clause {
+            let used = record.used_edge_slice();
+            if ids.iter().any(|e| used.contains(e)) {
+                return Ok(());
+            }
+        }
+        // A bound target must be the node the walk actually reaches.
+        if let Some(bound) = record.get(&self.target_var).and_then(|v| v.node_id()) {
+            if bound != at {
+                return Ok(());
+            }
+        }
+        if let Some(pinned) = self.pinned_target {
+            if pinned != at {
+                return Ok(());
+            }
+        }
+        if !self.target_labels.is_empty() {
+            let ok = store.get_node(at).is_some_and(|n| {
+                self.target_labels.iter().all(|l| n.labels.contains(l))
+            });
+            if !ok {
+                return Ok(());
+            }
+        }
+        // `buffer_walk` rebinds `rs` from `edges`, which is the same list it
+        // was given -- so the binding survives unchanged, which is what the
+        // pattern asks for. `reversed_walk` does not apply: the list is
+        // already in the pattern's order.
+        let base = record.clone();
+        let reversed = std::mem::replace(&mut self.reversed_walk, false);
+        self.buffer_walk(&base, at, nodes, ids, store);
+        self.reversed_walk = reversed;
+        Ok(())
+    }
+
     pub fn with_rel_variable(mut self, var: String) -> Self {
         self.rel_variable = Some(var);
         self
@@ -6968,6 +7096,15 @@ impl VarLengthExpandOperator {
     /// BFS from the source bound in `record`, buffering one output record per
     /// distinct reachable target in `[min_hops, max_hops]`.
     fn expand_from(&mut self, record: &Record, store: &GraphStore) -> ExecutionResult<()> {
+        // `MATCH (first)-[rs*]->(second)` where `rs` is *already bound* to a
+        // list of relationships is not a search at all. openCypher reads it as
+        // "the walk is exactly `rs`", so there is one candidate path and the
+        // only question is whether it is legal. Running the BFS here would
+        // rebind `rs` to whatever it found and answer a different question
+        // (#984).
+        if self.walk_is_bound(record) {
+            return self.walk_bound_list(record, store);
+        }
         let source_val = record
             .get(&self.source_var)
             .ok_or_else(|| ExecutionError::VariableNotFound(self.source_var.clone()))?;

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -2894,7 +2894,18 @@ pub fn validate(query: &Query) -> Result<(), ValidationError> {
                         check(&path.start.variable)?;
                         for seg in &path.segments {
                             check(&seg.node.variable)?;
-                            check(&seg.edge.variable)?;
+                            // ...but *not* a var-length segment's variable. A
+                            // list is exactly what `[rs*]` binds, so
+                            // `WITH [r1, r2] AS rs MATCH (a)-[rs*]->(b)` is
+                            // legal openCypher and means "the walk is
+                            // precisely `rs`". The rule below is about a
+                            // single-hop `[rs]`, where a list genuinely is
+                            // not a relationship; applied to the var-length
+                            // form it rejected three TCK scenarios outright
+                            // (#984).
+                            if seg.edge.length.is_none() {
+                                check(&seg.edge.variable)?;
+                            }
                         }
                     }
                 }
@@ -2937,7 +2948,14 @@ pub fn validate(query: &Query) -> Result<(), ValidationError> {
                     check(&path.start.variable)?;
                     for seg in &path.segments {
                         check(&seg.node.variable)?;
-                        check(&seg.edge.variable)?;
+                        // The same var-length exemption as the pipeline copy
+                        // above. `MATCH ... WITH ... MATCH` is the by-kind
+                        // shape, and it is the shape all three affected TCK
+                        // scenarios are written in, so fixing only the
+                        // pipeline copy would have changed nothing at all.
+                        if seg.edge.length.is_none() {
+                            check(&seg.edge.variable)?;
+                        }
                     }
                 }
             }

--- a/tests/bound_relationship_list_varlength.rs
+++ b/tests/bound_relationship_list_varlength.rs
@@ -1,0 +1,144 @@
+//! A bound relationship list drives a var-length segment (#984).
+//!
+//! ```cypher
+//! MATCH ()-[r1]->()-[r2]->()
+//! WITH [r1, r2] AS rs LIMIT 1
+//! MATCH (first)-[rs*]->(second)
+//! RETURN first, second
+//! ```
+//!
+//! failed outright with *"`rs` is bound to a collection and cannot be used as
+//! a node or relationship in a pattern"*.
+//!
+//! That rule (#654) is correct for a single-hop `[rs]` -- a list is not a
+//! relationship -- but a var-length segment binds a *list* of relationships,
+//! so a list is exactly the right type. openCypher reads `[rs*]` with `rs`
+//! bound as "the walk is precisely `rs`": one candidate path, and the only
+//! question is whether it is legal.
+//!
+//! Two things had to change together. Narrowing the rule alone would have
+//! turned the error into a wrong answer, because `VarLengthExpandOperator`
+//! only ever *wrote* its relationship variable -- it would have searched, then
+//! rebound `rs` to whatever it found, answering a different question quietly.
+
+use samyama::graph::{GraphStore, Label};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+/// `(a:A)-[:Y]->(b:B)-[:Y]->(c:C)`, the TCK's graph.
+fn chain() -> GraphStore {
+    let mut store = GraphStore::new();
+    let a = store.create_node_with_labels([Label::new("A")]);
+    let b = store.create_node_with_labels([Label::new("B")]);
+    let c = store.create_node_with_labels([Label::new("C")]);
+    store.create_edge(a, b, "Y").unwrap();
+    store.create_edge(b, c, "Y").unwrap();
+    store
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> Vec<Vec<Value>> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let r = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let cols = r.columns.clone();
+    r.records
+        .iter()
+        .map(|rec| cols.iter().map(|c| rec.get(c).cloned().unwrap_or(Value::Null)).collect())
+        .collect()
+}
+
+fn labels(v: &Value, store: &GraphStore) -> Vec<String> {
+    let id = v.node_id().expect("a node");
+    let mut l: Vec<String> = store.get_node(id).unwrap().labels.iter()
+        .map(|x| x.as_str().to_string()).collect();
+    l.sort();
+    l
+}
+
+#[test]
+fn the_walk_is_exactly_the_bound_list() {
+    let store = chain();
+    let got = rows(&store,
+        "MATCH ()-[r1]->()-[r2]->() WITH [r1, r2] AS rs LIMIT 1 \
+         MATCH (first)-[rs*]->(second) RETURN first, second");
+    assert_eq!(got.len(), 1, "got {got:?}");
+    assert_eq!(labels(&got[0][0], &store), ["A"]);
+    assert_eq!(labels(&got[0][1], &store), ["C"]);
+}
+
+#[test]
+fn it_agrees_with_bound_endpoints() {
+    let store = chain();
+    let got = rows(&store,
+        "MATCH (a)-[r1]->()-[r2]->(b) WITH [r1, r2] AS rs, a AS first, b AS second LIMIT 1 \
+         MATCH (first)-[rs*]->(second) RETURN first, second");
+    assert_eq!(got.len(), 1, "got {got:?}");
+    assert_eq!(labels(&got[0][1], &store), ["C"]);
+}
+
+#[test]
+fn endpoints_bound_the_wrong_way_round_match_nothing() {
+    let store = chain();
+    // `first` is the far end and `second` the near one, so the walk would have
+    // to run against every edge's direction. Cypher answers no rows -- not the
+    // path reversed, and not an error.
+    let got = rows(&store,
+        "MATCH (a)-[r1]->()-[r2]->(b) WITH [r1, r2] AS rs, a AS second, b AS first LIMIT 1 \
+         MATCH (first)-[rs*]->(second) RETURN first, second");
+    assert!(got.is_empty(), "got {got:?}");
+}
+
+#[test]
+fn the_list_is_not_rebound_by_the_match() {
+    let store = chain();
+    // The failure this guards is silent: search, then overwrite `rs` with what
+    // was found. The row count would be right and `rs` would be wrong.
+    let got = rows(&store,
+        "MATCH ()-[r1]->()-[r2]->() WITH [r1, r2] AS rs LIMIT 1 \
+         MATCH (f)-[rs*]->(s) RETURN size(rs) AS n");
+    assert_eq!(got.len(), 1, "got {got:?}");
+    assert_eq!(format!("{:?}", got[0][0]).contains("Integer(2)"), true, "got {got:?}");
+}
+
+#[test]
+fn a_length_bound_the_list_violates_matches_nothing() {
+    let store = chain();
+    for pattern in ["[rs*3..]", "[rs*..1]"] {
+        let q = format!(
+            "MATCH ()-[r1]->()-[r2]->() WITH [r1, r2] AS rs LIMIT 1 \
+             MATCH (f)-{pattern}->(s) RETURN f");
+        assert!(rows(&store, &q).is_empty(), "{pattern} should match nothing");
+    }
+}
+
+#[test]
+fn a_type_filter_the_list_violates_matches_nothing() {
+    let store = chain();
+    let got = rows(&store,
+        "MATCH ()-[r1]->()-[r2]->() WITH [r1, r2] AS rs LIMIT 1 \
+         MATCH (f)-[rs:NOPE*]->(s) RETURN f");
+    assert!(got.is_empty(), "got {got:?}");
+}
+
+#[test]
+fn a_single_hop_bound_to_a_list_is_still_an_error() {
+    // #654's rule is untouched where it was right: a list is not one
+    // relationship.
+    let store = chain();
+    let q = "MATCH ()-[r1]->() WITH [r1] AS rs LIMIT 1 MATCH (f)-[rs]->(s) RETURN f";
+    let parsed = parse_query(q);
+    let failed = parsed.is_err()
+        || QueryExecutor::new(&store).execute(&parsed.unwrap()).is_err();
+    assert!(failed, "a single-hop segment bound to a list must still be rejected");
+}
+
+#[test]
+fn a_node_bound_to_a_list_is_still_an_error() {
+    let store = chain();
+    let q = "MATCH (n) WITH [n] AS us LIMIT 1 MATCH (us)-->(m) RETURN m";
+    let parsed = parse_query(q);
+    let failed = parsed.is_err()
+        || QueryExecutor::new(&store).execute(&parsed.unwrap()).is_err();
+    assert!(failed, "a node bound to a list must still be rejected");
+}


### PR DESCRIPTION
Closes #984. TCK: closes Match4[8], Match9[6], Match9[7].

`MATCH ()-[r1]->()-[r2]->() WITH [r1, r2] AS rs LIMIT 1 MATCH (first)-[rs*]->(second)` failed outright — *"`rs` is bound to a collection and cannot be used as a node or relationship in a pattern"*.

#654's rule is right for a single-hop `[rs]`, where a list genuinely is not a relationship. A **var-length** segment binds a *list* of relationships, so for `[rs*]` a list is exactly the right type, and openCypher reads the bound form as *"the walk is precisely `rs`"* — one candidate path, and the only question is whether it is legal.

## Two halves, and they had to land together

Narrowing the validation alone would have turned the error into a **wrong answer**. `VarLengthExpandOperator` only ever *wrote* its relationship variable — it would have searched from `first`, found whatever it found, and rebound `rs` to that. A plausible row count, a real answer to a different question, and nothing to signal the difference. Strictly worse than the error.

So `expand_from` now recognises a bound walk and **verifies** it rather than searching. Everything the search enforces is enforced on the given walk too, because a pattern does not stop meaning what it says when its walk is handed to it:

- length bounds (`*3..`, `*..1`)
- the type filter
- inline edge properties
- relationship isomorphism *within the list*
- a bound or pinned target, and target labels
- edges an earlier segment of the clause already used (#710)
- the direction each edge is crossed in

Leaving any of them out would make the bound form quietly more permissive than the searched form — one query, two answers.

## Both AST shapes

The rule exists twice in `validate.rs`. All three scenarios are written `MATCH … WITH … MATCH`, which is the **by-kind** shape, so patching only the clause-pipeline copy would have changed nothing at all.

## Tests

`tests/bound_relationship_list_varlength.rs` — 8 cases:

- the walk is exactly the bound list
- it agrees with bound endpoints
- endpoints bound the wrong way round match nothing (not the path reversed, not an error)
- **the list is not rebound by the MATCH** — the silent failure this guards
- a length bound the list violates matches nothing
- a type filter the list violates matches nothing
- **a single-hop segment bound to a list is still an error** — #654 untouched where it was right
- **a node bound to a list is still an error**

51 existing var-length and collection-literal tests across 6 files pass.