### PR TITLE
`+` concatenates a list whichever way the list was written (#986)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -293,6 +293,64 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
         return Ok(Value::Property(PropertyValue::Null));
     }
 
+    // Concatenation, at the `Value` level, before either side is narrowed to a
+    // `PropertyValue`.
+    //
+    // A list has two spellings: `Value::Property(PropertyValue::Array)`, which
+    // the parser folds a literal into, and `Value::List`, which an expression
+    // builds because a `PropertyValue` cannot hold an entity. `+` only
+    // understood the first, so `[1,2] + [3]` worked and
+    // `[a.list2[1], a.list2[0]] + a.list` raised "Binary op requires property
+    // values" -- the same operator, on the same kind of thing, decided by how
+    // the list happened to be written (#986).
+    //
+    // Doing it here rather than after narrowing also keeps a list of nodes
+    // concatenable, which narrowing would have destroyed.
+    if matches!(op, BinaryOp::Add) {
+        let as_items = |v: &Value| -> Option<Vec<Value>> {
+            match v {
+                Value::List(items) => Some(items.clone()),
+                Value::Property(PropertyValue::Array(items)) => {
+                    Some(items.iter().cloned().map(Value::Property).collect())
+                }
+                _ => None,
+            }
+        };
+        // ...and hand back the *narrower* spelling whenever it fits. Returning
+        // `Value::List` unconditionally was correct arithmetic and a
+        // regression anyway: `IN` and slicing read the `Array` spelling, so
+        // `[1]+[2] IN [3]+[4]` and `… + […][1..3]` broke -- the mirror image
+        // of the bug being fixed. A list of properties concatenates to a list
+        // of properties; only an entity forces the wider spelling.
+        let narrow = |items: Vec<Value>| -> Value {
+            let props: Option<Vec<PropertyValue>> =
+                items.iter().map(|v| v.as_property().cloned()).collect();
+            match props {
+                Some(p) => Value::Property(PropertyValue::Array(p)),
+                None => Value::List(items),
+            }
+        };
+        match (as_items(&left), as_items(&right)) {
+            (Some(mut a), Some(b)) => {
+                a.extend(b);
+                return Ok(narrow(a));
+            }
+            // Cypher appends a non-list to a list and prepends one to a list.
+            // Null is not appended: `[1] + null` is null, which the narrowing
+            // below already yields, so it must not be caught here.
+            (Some(mut a), None) if !right.is_null() => {
+                a.push(right);
+                return Ok(narrow(a));
+            }
+            (None, Some(b)) if !left.is_null() => {
+                let mut out = vec![left];
+                out.extend(b);
+                return Ok(narrow(out));
+            }
+            _ => {}
+        }
+    }
+
     let left_prop = match left {
         Value::Property(p) => p,
         Value::Null => PropertyValue::Null,

--- a/tests/list_concatenation_spellings.rs
+++ b/tests/list_concatenation_spellings.rs
@@ -1,0 +1,158 @@
+//! `+` concatenates a list whichever way the list was written (#986).
+//!
+//! ```cypher
+//! MATCH (a)
+//! WITH a ORDER BY [a.list2[1], a.list2[0], a.list[1]] + a.list + a.list2 DESC
+//!   LIMIT 3
+//! RETURN a
+//! ```
+//!
+//! raised `TypeError("Binary op requires property values")` while
+//! `RETURN [1,2] + [3]` worked. The same operator, on the same kind of thing,
+//! decided by how the list happened to be written.
+//!
+//! A list has two spellings. The parser folds a *literal* into
+//! `Value::Property(PropertyValue::Array)`; an expression builds
+//! `Value::List`, because a `PropertyValue` cannot hold an entity. `+`
+//! understood only the first.
+//!
+//! The failure was invisible from the row count. `SortOperator::key_of` folds
+//! an evaluation error to `Null`, so every key compared equal and the rows
+//! came back in insertion order -- and the TCK's *ascending* scenario expects
+//! a set that insertion order happens to satisfy, so it passed while nothing
+//! was being sorted at all. Only the descending twin failed. See #987.
+
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn graph() -> GraphStore {
+    let mut store = GraphStore::new();
+    for (l, list, list2) in [
+        ("A", vec![2, -2], vec![3, -2]),
+        ("B", vec![1, 2], vec![2, -2]),
+        ("C", vec![300, 0], vec![1, -2]),
+        ("D", vec![1, -20], vec![4, -2]),
+        ("E", vec![2, -2, 100], vec![5, -2]),
+    ] {
+        let n = store.create_node_with_labels([Label::new(l)]);
+        let arr = |v: &Vec<i64>| {
+            PropertyValue::Array(v.iter().map(|x| PropertyValue::Integer(*x)).collect())
+        };
+        store.set_node_property("default", n, "list", arr(&list)).unwrap();
+        store.set_node_property("default", n, "list2", arr(&list2)).unwrap();
+    }
+    store
+}
+
+fn one_col(store: &GraphStore, cypher: &str) -> Vec<Value> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let r = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let c = r.columns[0].clone();
+    r.records.iter().map(|rec| rec.get(&c).cloned().unwrap_or(Value::Null)).collect()
+}
+
+/// The label of each row, for readable assertions.
+fn labels(store: &GraphStore, cypher: &str) -> Vec<String> {
+    one_col(store, cypher)
+        .iter()
+        .map(|v| format!("{v:?}"))
+        .map(|s| {
+            let i = s.find("String(\"").expect("a label");
+            s[i + 8..i + 9].to_string()
+        })
+        .collect()
+}
+
+const KEY: &str = "[a.list2[1], a.list2[0], a.list[1]] + a.list + a.list2";
+
+#[test]
+fn a_list_built_from_expressions_concatenates() {
+    let store = graph();
+    let got = one_col(&store, &format!("MATCH (a) RETURN {KEY} AS k"));
+    assert_eq!(got.len(), 5);
+    // A's key: [-2,3,-2] + [2,-2] + [3,-2]
+    let a = format!("{:?}", got[0]);
+    assert_eq!(a.matches("Integer(").count(), 7, "got {a}");
+}
+
+#[test]
+fn descending_orders_by_the_key_rather_than_by_nothing() {
+    let store = graph();
+    assert_eq!(
+        labels(&store, &format!(
+            "MATCH (a) WITH a ORDER BY {KEY} DESC LIMIT 3 RETURN labels(a) AS l")),
+        ["E", "D", "A"],
+    );
+}
+
+#[test]
+fn ascending_still_agrees_and_now_for_the_right_reason() {
+    let store = graph();
+    // This is the scenario that passed while nothing was sorted: insertion
+    // order A,B,C is the same *set* as the expected C,B,A. Asserting the
+    // sequence, not the set, is what makes it a real check.
+    assert_eq!(
+        labels(&store, &format!(
+            "MATCH (a) WITH a ORDER BY {KEY} ASC LIMIT 3 RETURN labels(a) AS l")),
+        ["C", "B", "A"],
+    );
+}
+
+#[test]
+fn a_literal_list_still_concatenates() {
+    let store = graph();
+    let got = one_col(&store, "RETURN [1,2] + [3] AS c");
+    assert_eq!(format!("{:?}", got[0]).matches("Integer(").count(), 3);
+}
+
+#[test]
+fn a_value_is_appended_and_prepended() {
+    let store = graph();
+    for (q, n) in [("RETURN [1,2] + 3 AS c", 3), ("RETURN 1 + [2,3] AS c", 3)] {
+        let got = one_col(&store, q);
+        assert_eq!(format!("{:?}", got[0]).matches("Integer(").count(), n, "{q}");
+    }
+}
+
+#[test]
+fn null_is_not_appended_to_a_list() {
+    let store = graph();
+    // `[1] + null` is null in Cypher, not a two-element list. The append arm
+    // must not catch it.
+    let got = one_col(&store, "RETURN [1, 2] + null AS c");
+    assert!(got[0].is_null(), "got {:?}", got[0]);
+}
+
+#[test]
+fn a_list_of_nodes_concatenates_without_being_flattened_to_properties() {
+    let store = graph();
+    // The reason `Value::List` exists: a `PropertyValue` cannot hold an
+    // entity. Concatenating at the `Value` level keeps them; narrowing first
+    // would have destroyed them.
+    let got = one_col(&store, "MATCH (a) WITH collect(a) AS ns RETURN ns + ns AS c");
+    let s = format!("{:?}", got[0]);
+    assert_eq!(s.matches("NodeRef").count() + s.matches("Node(").count(), 10, "got {s}");
+}
+
+#[test]
+fn the_result_keeps_the_narrow_spelling_so_in_and_slicing_still_read_it() {
+    let store = graph();
+    // Returning `Value::List` unconditionally was correct arithmetic and a
+    // regression anyway: `IN` and slicing read the `Array` spelling, so
+    // `[1]+[2] IN [3]+[4]` and `[…] + [...][1..3]` broke -- the mirror image
+    // of the bug this file fixes. Precedence3[3], [4] and [5].
+    for (q, want) in [
+        ("RETURN [1]+[2] IN [3]+[4] AS a", "Boolean(false)"),
+        ("RETURN [1]+2 IN [3]+4 AS a", "Boolean(false)"),
+        ("RETURN [1]+[2] IN [3]+[[1,2]] AS a", "Boolean(true)"),
+    ] {
+        let got = one_col(&store, q);
+        assert!(format!("{:?}", got[0]).contains(want), "{q}: got {:?}", got[0]);
+    }
+    // A slice of a concatenation is still sliceable.
+    let got = one_col(&store, "RETURN ([1,2,3] + [4,5])[1..3] AS a");
+    assert_eq!(format!("{:?}", got[0]).matches("Integer(").count(), 2, "got {:?}", got[0]);
+}


### PR DESCRIPTION
Closes #986. TCK: closes both `WithOrderBy2[10]` outlines (`DESC`, `DESCENDING`).

```cypher
RETURN [1,2] + [3]                                   -- worked
MATCH (a) RETURN [a.list2[1], a.list2[0]] + a.list   -- TypeError
```

> `Binary op requires property values`

The same operator, on the same kind of thing, decided by how the list happened to be written.

## Cause

A list has **two spellings**. The parser folds a literal into `Value::Property(PropertyValue::Array)`; an expression builds `Value::List`, because a `PropertyValue` cannot hold an entity. `eval_binary_op` narrowed both operands to `PropertyValue` before doing anything, so `Value::List` fell straight through to the error arm.

Concatenation now happens at the `Value` level, *before* narrowing — which also keeps a list of nodes concatenable, since narrowing first would have destroyed the case `Value::List` exists for.

## The regression the manifest caught

My first attempt returned `Value::List` unconditionally. Correct arithmetic, and a regression anyway: `IN` and slicing read the `Array` spelling, so `[1]+[2] IN [3]+[4]` and `(…)[1..3]` broke — **the mirror image of the bug being fixed** — taking out `Precedence3[3]`, `[4]` and `[5]`.

The headline moved from **10 wrong results to 9** and read as an improvement. Only the failure-manifest diff showed three scenarios had gone the other way.

The result now keeps the narrow spelling whenever every element fits it, and widens only for an entity.

## How this hid (filed as #987)

`SortOperator::key_of` folds an evaluation error to `Null`. So every sort key compared equal and the rows came back in insertion order — right count, right contents, no error.

`WithOrderBy2[9]` (ascending) expects `{C, B, A}` **in any order** under `LIMIT 3`, and unsorted insertion order is `A, B, C` — the same set. **The ascending scenario passed while nothing was being sorted at all.** Only its descending twin, expecting `{E, D, A}`, could ever have failed.

## Tests

`tests/list_concatenation_spellings.rs` — 8 cases, including the two that guard the regression above:

- a list built from expressions concatenates
- descending orders by the key rather than by nothing
- **ascending still agrees, and now for the right reason** — asserts the *sequence*, not the set, which is what makes it a real check
- a literal list still concatenates; a value is appended and prepended
- `null` is not appended (`[1] + null` is null, not a two-element list)
- **a list of nodes concatenates without being flattened to properties**
- **the result keeps the narrow spelling so `IN` and slicing still read it**

## TCK

3,763 evaluated → **3,750 pass (99.7%)**, 8 wrong, 5 errored. Manifest diff: 2 fixed, **0 regressions**.