### PR TITLE
A malformed \u escape is a compile-time error (#989)

### DIFF
--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -848,10 +848,16 @@ fn unescape_name(raw: &str) -> String {
 ///
 /// An unrecognised escape yields the escaped character itself (`\\q` -> `q`), which keeps
 /// Windows-style paths and regex fragments from turning into a parse error.
-fn unescape_string_literal(literal: &str) -> String {
+///
+/// `\\u` is the exception, because it is not unrecognised: openCypher defines it as
+/// exactly four hex digits, so `'\\uH'` is a malformed *known* escape rather than an
+/// unknown one, and the spec asks for `InvalidUnicodeLiteral` at compile time. It used
+/// to fall back to the unknown-escape rule and yield the string `"uH"` -- a query that
+/// should not compile instead returning a plausible value nobody wrote (#989).
+fn unescape_string_literal(literal: &str) -> ParseResult<String> {
     let inner = &literal[1..literal.len() - 1];
     if !inner.contains('\\') {
-        return inner.to_string();
+        return Ok(inner.to_string());
     }
 
     let mut out = String::with_capacity(inner.len());
@@ -871,14 +877,23 @@ fn unescape_string_literal(literal: &str) -> String {
             Some('\\') => out.push('\\'),
             Some('\'') => out.push('\''),
             Some('"') => out.push('"'),
-            // \uXXXX, as in openCypher
+            // \uXXXX, as in openCypher. Exactly four hex digits: fewer, or a
+            // non-hex digit among them, is a malformed literal and not a
+            // string. `take(4)` yields whatever is left at the end of the
+            // input, so the length is checked rather than assumed.
             Some('u') => {
                 let hex: String = chars.by_ref().take(4).collect();
-                match u32::from_str_radix(&hex, 16).ok().and_then(char::from_u32) {
-                    Some(decoded) => out.push(decoded),
+                let decoded = if hex.len() == 4 && hex.chars().all(|c| c.is_ascii_hexdigit()) {
+                    u32::from_str_radix(&hex, 16).ok().and_then(char::from_u32)
+                } else {
+                    None
+                };
+                match decoded {
+                    Some(c) => out.push(c),
                     None => {
-                        out.push('u');
-                        out.push_str(&hex);
+                        return Err(ParseError::SemanticError(format!(
+                            "InvalidUnicodeLiteral: `\\u{hex}` is not four hex digits"
+                        )))
                     }
                 }
             }
@@ -886,7 +901,7 @@ fn unescape_string_literal(literal: &str) -> String {
             None => out.push('\\'),
         }
     }
-    out
+    Ok(out)
 }
 
 fn parse_match_statement_partial(pair: pest::iterators::Pair<Rule>, query: &mut Query) -> ParseResult<()> {
@@ -1854,7 +1869,7 @@ fn parse_value(pair: pest::iterators::Pair<Rule>) -> ParseResult<PropertyValue> 
                 return Ok(PropertyValue::Float(val));
             }
             Rule::string => {
-                return Ok(PropertyValue::String(unescape_string_literal(inner.as_str())));
+                return Ok(PropertyValue::String(unescape_string_literal(inner.as_str())?));
             }
             Rule::list => {
                 // `Vector` is the embedding type -- f32 throughout. Treating *any*
@@ -1895,7 +1910,7 @@ fn parse_value(pair: pest::iterators::Pair<Rule>) -> ParseResult<PropertyValue> 
                             match part.as_rule() {
                                 Rule::property_key => key = unescape_name(part.as_str()),
                                 Rule::string => {
-                                    key = unescape_string_literal(part.as_str());
+                                    key = unescape_string_literal(part.as_str())?;
                                 }
                                 Rule::value => val = parse_value(part)?,
                                 _ => {}
@@ -2441,7 +2456,7 @@ fn parse_primary(pair: pest::iterators::Pair<Rule>) -> ParseResult<Expression> {
                         match part.as_rule() {
                             Rule::property_key => key = unescape_name(part.as_str()),
                             Rule::string => {
-                                key = unescape_string_literal(part.as_str());
+                                key = unescape_string_literal(part.as_str())?;
                             }
                             Rule::expression => value = Some(parse_expression(part)?),
                             _ => {}

--- a/tests/invalid_unicode_literal.rs
+++ b/tests/invalid_unicode_literal.rs
@@ -1,0 +1,71 @@
+//! A malformed `\u` escape is a compile-time error (#989).
+//!
+//! ```cypher
+//! RETURN '\uH'
+//! ```
+//!
+//! returned the string `"uH"`. openCypher asks for `InvalidUnicodeLiteral` at
+//! compile time -- a query that should not compile was instead answering with
+//! a plausible value nobody wrote.
+//!
+//! The unknown-escape fallback (`\q` -> `q`) is deliberate and stays: it keeps
+//! Windows paths and regex fragments from becoming parse errors. But `\u` is
+//! not unknown. openCypher *defines* it as exactly four hex digits, so a
+//! malformed `\u` is a broken known escape rather than an unrecognised one,
+//! and the two want opposite treatment.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+
+fn value(cypher: &str) -> Result<String, String> {
+    let store = GraphStore::new();
+    let q = parse_query(cypher).map_err(|e| e.to_string())?;
+    let r = QueryExecutor::new(&store).execute(&q).map_err(|e| format!("{e:?}"))?;
+    let c = r.columns[0].clone();
+    Ok(format!("{:?}", r.records[0].get(&c)))
+}
+
+#[test]
+fn a_non_hex_unicode_escape_is_rejected() {
+    let e = value(r#"RETURN '\uH'"#).unwrap_err();
+    assert!(e.contains("InvalidUnicodeLiteral"), "got {e}");
+}
+
+#[test]
+fn a_short_unicode_escape_is_rejected() {
+    // `take(4)` yields whatever is left at the end of the input, so the length
+    // has to be checked rather than assumed -- `\u00` would otherwise decode
+    // as U+0000.
+    let e = value(r#"RETURN '\u00'"#).unwrap_err();
+    assert!(e.contains("InvalidUnicodeLiteral"), "got {e}");
+}
+
+#[test]
+fn a_well_formed_unicode_escape_still_decodes() {
+    assert!(value(r#"RETURN '\u0041' AS a"#).unwrap().contains("\"A\""));
+}
+
+#[test]
+fn an_unknown_escape_is_still_tolerated() {
+    // The fallback this rule must not swallow.
+    assert!(value(r#"RETURN '\q' AS a"#).unwrap().contains("\"q\""));
+}
+
+#[test]
+fn a_backslash_u_that_is_not_an_escape_needs_escaping() {
+    // Deliberate behaviour change, and the one with real blast radius:
+    // `'C:\users'` used to yield `C:users` and is now an error, because `\u`
+    // followed by `sers` is a malformed unicode escape. That is what
+    // openCypher specifies, and what a reference implementation does -- the
+    // path has to be written `'C:\\users'`.
+    assert!(value(r#"RETURN 'C:\users' AS p"#).is_err());
+    assert!(value(r#"RETURN 'C:\\users' AS p"#).unwrap().contains("C:"));
+}
+
+#[test]
+fn the_escaped_characters_scenario_round_trips() {
+    // Literals6[5]. Every pair here is `\\` or `\'`, so no single `\u` arises.
+    let got = value(r#"RETURN 'a\\bcn5t\'"\\//\\"\'' AS literal"#).unwrap();
+    assert!(got.contains(r#"a\\bcn5t'\"\\//\\\"'"#), "got {got}");
+}


### PR DESCRIPTION
Closes #989. TCK: closes `Literals6[13]`.

`RETURN '\uH'` returned the string `"uH"`. openCypher asks for `InvalidUnicodeLiteral` at compile time — a query that should not compile was instead answering with a plausible value nobody wrote.

## Cause

`unescape_string_literal` has a deliberate unknown-escape fallback (`\q` → `q`) so Windows paths and regex fragments don't become parse errors. A `\uXXXX` that failed to decode fell into that same fallback and emitted `u` plus whatever it had consumed.

But `\u` is **not** an unknown escape. openCypher defines it as exactly four hex digits, so a malformed `\u` is a *broken known* escape rather than an *unrecognised* one — and the two want opposite treatment.

`chars.take(4)` also yields whatever is left at end of input, so `'\u00'` decoded as U+0000 rather than failing. The length is now checked rather than assumed.

## Behaviour change worth flagging

This reaches beyond the malformed case. **`'C:\users'` used to yield `C:users` and is now an error**, because `\u` followed by `sers` is a malformed unicode escape. That is what openCypher specifies and what a reference implementation does — the path must be written `'C:\\users'` — but it will affect existing queries.

That is exactly why this was measured with a **full TCK manifest diff** rather than a spot check.

## TCK

3,763 evaluated → **3,751 pass (99.7%)**, 7 wrong, 5 errored. Manifest diff: **1 fixed, 0 regressions**.

## Tests

`tests/invalid_unicode_literal.rs` — 6 cases:

- a non-hex `\u` escape is rejected
- **a short `\u` escape is rejected** — the `take(4)`-at-end-of-input case
- a well-formed `\u0041` still decodes
- **an unknown escape is still tolerated** — the fallback this must not swallow
- **a backslash-u that is not an escape needs escaping** — pins the `'C:\users'` change deliberately
- the `Literals6[5]` escaped-characters string round-trips