### PR TITLE
The TCK harness undoes the Gherkin table's own escaping (#991)

### DIFF
--- a/examples/tck_runner.rs
+++ b/examples/tck_runner.rs
@@ -524,6 +524,55 @@ impl Cursor {
     }
 }
 
+/// Split one Gherkin table row into cells, undoing the table's own escaping.
+///
+/// A cell is not raw text. Gherkin escapes `|` as `\|` inside a cell -- it has
+/// to, since `|` is the delimiter -- and therefore escapes the backslash
+/// itself as `\\`. Both have to be undone before the cell is read as Cypher.
+///
+/// Splitting on a bare `|` and handing the cell straight to `parse_quoted`
+/// skipped that step, with two consequences. A cell containing `\|` was torn
+/// into two cells. And a `\\`, which the table writes for one backslash,
+/// survived as two -- so `Literals6[5]`, whose expected value is
+/// `a\bcn5t'"\//\"'`, was compared against a string with every backslash
+/// doubled and **no engine could pass it**. Neo4j fails it too, which is how
+/// this was found: when every engine loses the same scenario, suspect the
+/// ruler.
+///
+/// Only `\|` and `\\` are handled here, deliberately. `\n` and friends are
+/// Cypher escapes inside the quoted literal and belong to `parse_quoted`;
+/// interpreting them at this layer as well would decode them twice.
+fn split_gherkin_row(line: &str) -> Vec<String> {
+    let inner = line.trim().trim_matches('|');
+    let mut cells = Vec::new();
+    let mut cur = String::new();
+    let mut chars = inner.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => match chars.peek() {
+                Some('|') => {
+                    cur.push('|');
+                    chars.next();
+                }
+                Some('\\') => {
+                    cur.push('\\');
+                    chars.next();
+                }
+                // Left intact for the Cypher layer.
+                _ => cur.push('\\'),
+            },
+            '|' => {
+                cells.push(cur.trim().to_string());
+                cur = String::new();
+            }
+            other => cur.push(other),
+        }
+    }
+    cells.push(cur.trim().to_string());
+    cells
+}
+
+
 fn parse_expected(text: &str) -> Tck {
     let t = text.trim();
     if t.is_empty() {
@@ -974,11 +1023,7 @@ fn parse_feature(path: &Path, text: &str) -> Vec<Scenario> {
 
         // Table row
         if line.starts_with('|') {
-            let cells: Vec<String> = line
-                .trim_matches('|')
-                .split('|')
-                .map(|c| c.trim().to_string())
-                .collect();
+            let cells: Vec<String> = split_gherkin_row(line);
             if pending == Pending::Examples {
                 if let Some((header, rows)) = s.examples.last_mut() {
                     if header.is_empty() {


### PR DESCRIPTION
Closes #991. TCK: closes `Literals6[5]` — **for every engine**, which is the point.

`Literals6[5]` was scored a wrong result for every engine, including Neo4j. When every engine loses the same scenario, suspect the ruler.

## Cause

A Gherkin table cell is not raw text. Gherkin escapes `|` as `\|` inside a cell — it has to, `|` being the delimiter — and therefore escapes the backslash itself as `\\`. The feature file says so in a comment on this very scenario.

The row splitter did neither: it split on a bare `|` and handed each cell straight to `parse_quoted`, so a `\\` — which the table writes for *one* backslash — survived as two. The expected value `a\bcn5t'"\//\"'` was compared against the same string with every backslash doubled. **No engine could pass it.** Our engine had been producing the right answer all along.

The splitter also tore a cell containing `\|` into two cells.

## Scope, deliberately narrow

Only `\|` and `\\` are undone here. `\n` and friends are Cypher escapes inside the quoted literal and belong to `parse_quoted`; interpreting them at this layer too would decode them twice.

That layering is the one an earlier fix in this same file established, where dropping a backslash turned `'Foo\nFoo'` into `FoonFoo` on the expected side — **also found because it scored Neo4j wrong.** Same bug class, same detection method, one layer up.

## Measured on all four engines

| Engine | Before | After |
|---|---|---|
| **Samyama** | 99.6% | **99.7%** |
| Neo4j | 79.4% | **79.5%** |
| Memgraph | 65.9% | 65.9% |
| FalkorDB | 65.7% | 65.7% |

The correction **moves a competitor up**, which is what makes it a ruler fix rather than a score fix. Memgraph and FalkorDB are unchanged — they fail the scenario for their own reasons.

Samyama manifest diff: 1 fixed, **0 regressions**, `evaluated` steady at 3,763.