### PR TITLE
A DELETE finishes before the next clause reads, and no count shortcut skips a write (#993, #994)

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -2485,6 +2485,23 @@ impl QueryPlanner {
                 delete_clause.expressions.clone(),
                 delete_clause.detach,
             ));
+            // ...and the delete is fully applied before anything reads the
+            // graph again. `MATCH (a:A) DELETE a MERGE (a2:A)` matched a node
+            // the DELETE had already removed: rows were pulled one at a time,
+            // so the first row's MERGE ran when only the first node was gone
+            // and matched the second, which was about to be deleted. The
+            // scenario is named for exactly that -- "merges should not be able
+            // to match on deleted nodes" (#994).
+            //
+            // The barrier below materialises the delete's *input*; this one
+            // drains its *output*, which is what makes every deletion happen
+            // before the next clause begins. Both are needed and they solve
+            // opposite halves: #899 stopped a write from un-producing rows the
+            // read had matched, and this stops a later read from seeing rows
+            // the write was about to remove.
+            operator = Box::new(crate::query::executor::operator::EagerOperator::new(
+                operator, 0, None,
+            ));
             true
         } else {
             is_write
@@ -2791,7 +2808,20 @@ impl QueryPlanner {
 
             // Label count cache: O(1) shortcut for MATCH (n:Label) RETURN count(n)
             // Detect: single count aggregate, no group-by, no WHERE, no edges, single MATCH
+            // **No shortcut answers a query that writes.** Each of the three
+            // below replaces the whole plan with a metadata read, discarding
+            // the operator built above -- which is where DELETE, SET, REMOVE,
+            // MERGE and FOREACH live. `MATCH (a:A) DELETE a RETURN count(*)`
+            // therefore returned 2 and **deleted nothing**: a fast, confident
+            // number, and the caller's data still there (#993).
+            //
+            // That is the same rule the inline-property guard below already
+            // states -- the shortcut may only fire when the query says nothing
+            // the metadata cannot express -- and a write is the largest such
+            // thing there is. `is_write` is already computed above and covers
+            // every write clause, so it is the whole condition.
             let use_label_count = has_aggregation
+                && !is_write
                 && aggregates.len() == 1
                 && group_by.is_empty()
                 && matches!(aggregates[0].func, AggregateType::Count)
@@ -2828,6 +2858,7 @@ impl QueryPlanner {
             // Edge type count cache: O(1) shortcut for MATCH ()-[r]->() RETURN type(r), count(r)
             // Detect: one count aggregate, one group-by with type() function, single edge path, no WHERE
             let use_edge_type_count = has_aggregation
+                && !is_write
                 && aggregates.len() == 1
                 && group_by.len() == 1
                 && matches!(aggregates[0].func, AggregateType::Count)
@@ -2876,6 +2907,7 @@ impl QueryPlanner {
                 None
             };
             let use_edge_count = has_aggregation
+                && !is_write
                 && aggregates.len() == 1
                 && group_by.is_empty()
                 && matches!(aggregates[0].func, AggregateType::Count)
@@ -6169,6 +6201,12 @@ impl QueryPlanner {
                         operator, 0, None,
                     ));
                     operator = Box::new(DeleteOperator::new(operator, dc.expressions.clone(), dc.detach));
+                    // The same drain in the clause-pipeline shape (#994). A
+                    // rule applied to one AST shape and not its twin silently
+                    // no-ops for every query written the other way.
+                    operator = Box::new(crate::query::executor::operator::EagerOperator::new(
+                        operator, 0, None,
+                    ));
                 }
                 Clause::Where(w) => {
                     operator = Box::new(FilterOperator::new(operator, w.predicate.clone()));

--- a/tests/count_shortcut_never_skips_a_write.rs
+++ b/tests/count_shortcut_never_skips_a_write.rs
@@ -1,0 +1,85 @@
+//! An O(1) count shortcut may not answer a query that writes (#993).
+//!
+//! ```cypher
+//! MATCH (a:A) DELETE a RETURN count(*) AS n
+//! ```
+//!
+//! returned `n = 2` and **left both nodes in place**.
+//!
+//! `use_label_count` replaces the entire plan with a `LabelCountOperator`
+//! metadata read, discarding the operator tree built above it -- which is
+//! where `DeleteOperator` lives. Its guards checked for a WHERE, a WITH,
+//! multiple MATCHes, segments, inline properties, and `count(x.prop)` versus
+//! `count(*)`. They did not check whether the query *writes*.
+//!
+//! The rule was already written down one guard lower in the same expression:
+//! the shortcut may only fire when the pattern says nothing the metadata
+//! cannot express. A write is the largest such thing there is.
+//!
+//! This is worse than a wrong answer. A wrong answer is at least an answer.
+//! Here the caller asked for a deletion, got a plausible confirmation count
+//! back, and the data is still there -- and the number returned is *correct
+//! for the query as executed*, being the count of rows that matched.
+
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::MutQueryExecutor;
+use samyama::query::parser::parse_query;
+
+fn two_a_nodes() -> GraphStore {
+    let mut store = GraphStore::new();
+    for n in [1i64, 2] {
+        let id = store.create_node_with_labels([Label::new("A")]);
+        store.set_node_property("default", id, "num", PropertyValue::Integer(n)).unwrap();
+    }
+    store
+}
+
+fn run(store: &mut GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"))
+        .records
+        .len()
+}
+
+#[test]
+fn a_delete_with_an_aggregate_return_actually_deletes() {
+    for q in [
+        "MATCH (a:A) DELETE a RETURN count(*) AS n",
+        "MATCH (a:A) DELETE a RETURN count(a) AS n",
+        "MATCH (a:A) DETACH DELETE a RETURN count(*) AS n",
+    ] {
+        let mut store = two_a_nodes();
+        assert_eq!(run(&mut store, q), 1, "{q} should return one aggregate row");
+        assert_eq!(store.node_count(), 0, "{q} reported a count and deleted nothing");
+    }
+}
+
+#[test]
+fn a_set_with_an_aggregate_return_actually_sets() {
+    let mut store = two_a_nodes();
+    run(&mut store, "MATCH (a:A) SET a.num = 9 RETURN count(*) AS n");
+    let all = store.all_nodes();
+    assert!(
+        all.iter().all(|n| n.properties.get("num") == Some(&PropertyValue::Integer(9))),
+        "SET was discarded by the shortcut",
+    );
+}
+
+#[test]
+fn a_remove_with_an_aggregate_return_actually_removes() {
+    let mut store = two_a_nodes();
+    run(&mut store, "MATCH (a:A) REMOVE a.num RETURN count(*) AS n");
+    let all = store.all_nodes();
+    assert!(all.iter().all(|n| n.properties.get("num").is_none()), "REMOVE was discarded");
+}
+
+#[test]
+fn the_shortcut_still_fires_for_a_read() {
+    // The optimisation must survive: a plain count over a label is still the
+    // O(1) metadata read, and still correct.
+    let mut store = two_a_nodes();
+    assert_eq!(run(&mut store, "MATCH (a:A) RETURN count(*) AS n"), 1);
+    assert_eq!(store.node_count(), 2);
+}

--- a/tests/delete_is_applied_before_the_next_clause.rs
+++ b/tests/delete_is_applied_before_the_next_clause.rs
@@ -1,0 +1,77 @@
+//! A DELETE finishes before the next clause reads the graph (#994).
+//!
+//! ```cypher
+//! MATCH (a:A) DELETE a MERGE (a2:A) RETURN a2.num
+//! ```
+//!
+//! over two `:A` nodes returned `2` and `null` where Cypher returns two
+//! nulls. The MERGE matched a node the DELETE had already been asked to
+//! remove.
+//!
+//! Rows were pulled one at a time, so the first row's MERGE ran when only the
+//! first node was gone and matched the second -- which was itself about to be
+//! deleted. The openCypher scenario is named for precisely this: *"merges
+//! should not be able to match on deleted nodes"*.
+//!
+//! There was already an eager barrier *below* the delete, from #899, which
+//! materialises its **input** so a write cannot un-produce rows the read had
+//! already matched. This adds one *above*, draining its **output**. The two
+//! solve opposite halves of the same question and neither implies the other.
+
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn two_a_nodes() -> GraphStore {
+    let mut store = GraphStore::new();
+    for n in [1i64, 2] {
+        let id = store.create_node_with_labels([Label::new("A")]);
+        store.set_node_property("default", id, "num", PropertyValue::Integer(n)).unwrap();
+    }
+    store
+}
+
+fn run(store: &mut GraphStore, cypher: &str) -> Vec<Value> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let r = MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let c = r.columns[0].clone();
+    r.records.iter().map(|rec| rec.get(&c).cloned().unwrap_or(Value::Null)).collect()
+}
+
+#[test]
+fn a_merge_cannot_match_a_node_the_same_query_deleted() {
+    let mut store = two_a_nodes();
+    let got = run(&mut store, "MATCH (a:A) DELETE a MERGE (a2:A) RETURN a2.num");
+    assert_eq!(got.len(), 2, "got {got:?}");
+    assert!(got.iter().all(|v| v.is_null()), "got {got:?}");
+    // +1 created, -2 deleted.
+    assert_eq!(store.node_count(), 1);
+}
+
+#[test]
+fn a_match_after_a_delete_does_not_see_the_deleted_nodes() {
+    let mut store = two_a_nodes();
+    let got = run(&mut store, "MATCH (a:A) DELETE a WITH count(*) AS n MATCH (b:A) RETURN b.num");
+    assert!(got.is_empty(), "got {got:?}");
+}
+
+#[test]
+fn the_delete_still_does_not_un_produce_rows_the_read_matched() {
+    // #899, the barrier on the other side. Deleting the edge must not stop the
+    // second row from being produced.
+    let mut store = GraphStore::new();
+    let a = store.create_node_with_labels([Label::new("A")]);
+    let b = store.create_node_with_labels([Label::new("B")]);
+    store.create_edge(a, b, "R").unwrap();
+    let got = run(&mut store, "MATCH (x)-[r]-(y) DELETE r RETURN count(*) AS n");
+    assert_eq!(format!("{:?}", got[0]).contains("Integer(2)"), true, "got {got:?}");
+}
+
+#[test]
+fn a_plain_delete_still_deletes() {
+    let mut store = two_a_nodes();
+    run(&mut store, "MATCH (a:A) DELETE a RETURN count(*) AS n");
+    assert_eq!(store.node_count(), 0);
+}


### PR DESCRIPTION
Closes #993 and #994. TCK: closes `Merge1[14]`.

Two defects, filed and fixed together because the **control test for one caught the other**.

---

## #994 — a DELETE is not applied before the next clause reads

`MATCH (a:A) DELETE a MERGE (a2:A) RETURN a2.num` over two `:A` nodes returned `2` and `null` where Cypher returns two nulls. Rows were pulled one at a time, so the first row's MERGE ran when only the first node was gone and matched the second — which was itself about to be deleted. The openCypher scenario is named for exactly this: *"merges should not be able to match on deleted nodes"*.

There was already an eager barrier **below** the delete (#899), materialising its *input* so a write cannot un-produce rows the read had already matched. This adds one **above**, draining its *output*. The two solve opposite halves of the same question and neither implies the other:

- **below** — a write must not un-produce rows the read already matched
- **above** — a later read must not see rows the write was about to remove

Added in **both AST shapes**. A rule applied to one and not its twin silently no-ops for every query written the other way.

---

## #993 — a count shortcut answered a query that writes

`MATCH (a:A) DELETE a RETURN count(*) AS n` returned `n = 2` and **left both nodes in place**.

| Query | nodes before → after |
|---|---|
| `MATCH (a:A) DELETE a` | 2 → 0 |
| `… DELETE a RETURN 1 AS n` | 2 → 0 |
| `… DELETE a RETURN a` | 2 → 0 |
| **`… DELETE a RETURN count(*) AS n`** | **2 → 2** |
| **`… DELETE a RETURN count(a) AS n`** | **2 → 2** |
| **`… DETACH DELETE a RETURN count(*) AS n`** | **2 → 2** |

`use_label_count` replaces the **entire plan** with a `LabelCountOperator` metadata read, discarding the operator tree built above it — which is where `DeleteOperator` lives. Its guards checked for a WHERE, a WITH, multiple MATCHes, segments, inline properties, and `count(x.prop)` vs `count(*)`. They did not check whether the query **writes**. `use_edge_count` and `use_edge_type_count` had the same hole, and SET and REMOVE were discarded the same way.

The rule was already written down, one guard lower in the same expression:

> the shortcut may only fire when the pattern says nothing the metadata cannot express

A write is the largest such thing there is. `is_write` is already computed above and covers every write clause, so `&& !is_write` is the whole condition.

### Why this one is worse than a wrong answer

A wrong answer is at least an answer. Here the caller asked for a deletion, got a plausible confirmation count back, and **the data is still there** — and the number returned is *correct for the query as executed*, being the count of rows that matched. Nothing errors, nothing is null, and no layer signals that the delete did not happen.

**The TCK does not cover this shape.** It surfaced only because `a_plain_delete_still_deletes` was written as a *control* for #994 — a test expected to pass either way — and failed on `main`.

---

## Tests

`tests/delete_is_applied_before_the_next_clause.rs` (4) and `tests/count_shortcut_never_skips_a_write.rs` (4):

- a MERGE cannot match a node the same query deleted
- a MATCH after a DELETE does not see the deleted nodes
- **the delete still does not un-produce rows the read matched** — #899's half, unbroken
- a DELETE / SET / REMOVE with an aggregate RETURN actually writes
- **the shortcut still fires for a read** — the O(1) optimisation survives