### PR TITLE
An aggregate inside a list predicate is hoisted, not handed to the scalar evaluator (#997)

### DIFF
--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -249,6 +249,47 @@ fn extract_agg_inner(
                 map_expr: map_expr.clone(),
             }
         }
+        // `ALL(ok IN collect(x) WHERE ok)`. The same class as the collection
+        // literal above, in the sibling that fix did not reach: the aggregate
+        // sits in the *list* a predicate iterates, so leaving it here handed
+        // `collect` to the scalar evaluator and produced "Unknown function:
+        // collect" — the identical error #670 was raised for, one variant
+        // over (#997).
+        //
+        // The predicate itself is left alone, for the same reason a
+        // comprehension's body is: it runs once per element with the loop
+        // variable bound, so an aggregate there is a different question and
+        // must not be silently hoisted out of the loop.
+        Expression::PredicateFunction { name, variable, list_expr, predicate } => {
+            Expression::PredicateFunction {
+                name: name.clone(),
+                variable: variable.clone(),
+                list_expr: Box::new(extract_agg_inner(list_expr, counter, aggs)),
+                predicate: predicate.clone(),
+            }
+        }
+        // `reduce(t = 0, x IN collect(n.v) | t + x)`. The seed and the list are
+        // evaluated once, so both hoist; the body is per-element and does not.
+        Expression::Reduce { accumulator, init, variable, list_expr, expression } => {
+            Expression::Reduce {
+                accumulator: accumulator.clone(),
+                init: Box::new(extract_agg_inner(init, counter, aggs)),
+                variable: variable.clone(),
+                list_expr: Box::new(extract_agg_inner(list_expr, counter, aggs)),
+                expression: expression.clone(),
+            }
+        }
+        // `collect(x)[0]`, `collect(x)[1..3]` — structurally the same as the
+        // binary arm above, and missed for the same reason.
+        Expression::Index { expr, index } => Expression::Index {
+            expr: Box::new(extract_agg_inner(expr, counter, aggs)),
+            index: Box::new(extract_agg_inner(index, counter, aggs)),
+        },
+        Expression::ListSlice { expr, start, end } => Expression::ListSlice {
+            expr: Box::new(extract_agg_inner(expr, counter, aggs)),
+            start: start.as_ref().map(|e| Box::new(extract_agg_inner(e, counter, aggs))),
+            end: end.as_ref().map(|e| Box::new(extract_agg_inner(e, counter, aggs))),
+        },
         // Leaf expressions and others — no aggregates possible
         other => other.clone(),
     }
@@ -433,6 +474,38 @@ fn expression_has_aggregate(expr: &Expression) -> bool {
             expression_has_aggregate(left) || expression_has_aggregate(right)
         }
         Expression::Unary { expr, .. } => expression_has_aggregate(expr),
+        // The detector has to agree with `extract_agg_inner` above, arm for
+        // arm. It decides whether an `AggregateOperator` is planned at all,
+        // so a shape the extractor can rewrite but this cannot see is never
+        // given the chance (#997).
+        //
+        // Loop bodies are excluded on both sides for the same reason.
+        Expression::Case { operand, when_clauses, else_result } => {
+            operand.as_ref().is_some_and(|e| expression_has_aggregate(e))
+                || when_clauses.iter().any(|(c, t)| {
+                    expression_has_aggregate(c) || expression_has_aggregate(t)
+                })
+                || else_result.as_ref().is_some_and(|e| expression_has_aggregate(e))
+        }
+        Expression::ListExpr(items) => items.iter().any(expression_has_aggregate),
+        Expression::MapExpr(entries) => {
+            entries.iter().any(|(_, e)| expression_has_aggregate(e))
+        }
+        Expression::ListComprehension { list_expr, .. }
+        | Expression::PredicateFunction { list_expr, .. } => {
+            expression_has_aggregate(list_expr)
+        }
+        Expression::Reduce { init, list_expr, .. } => {
+            expression_has_aggregate(init) || expression_has_aggregate(list_expr)
+        }
+        Expression::Index { expr, index } => {
+            expression_has_aggregate(expr) || expression_has_aggregate(index)
+        }
+        Expression::ListSlice { expr, start, end } => {
+            expression_has_aggregate(expr)
+                || start.as_ref().is_some_and(|e| expression_has_aggregate(e))
+                || end.as_ref().is_some_and(|e| expression_has_aggregate(e))
+        }
         _ => false,
     }
 }

--- a/tests/aggregate_inside_a_list_predicate.rs
+++ b/tests/aggregate_inside_a_list_predicate.rs
@@ -1,0 +1,111 @@
+//! An aggregate inside a list predicate is hoisted, not handed to the scalar
+//! evaluator (#997).
+//!
+//! ```cypher
+//! UNWIND [true, true] AS x RETURN ALL(ok IN collect(x) WHERE ok) AS okay
+//! ```
+//!
+//! failed with `Unknown function: collect` — an error naming one of Cypher's
+//! most ordinary functions. `collect(x)` works as a top-level aggregate and
+//! works through a `WITH`; it failed only inside the list a predicate
+//! iterates.
+//!
+//! `extract_agg_inner` hoists nested aggregates into the `AggregateOperator`.
+//! It handled `Function`, `Binary`, `Unary`, `Case`, `ListExpr`, `MapExpr` and
+//! `ListComprehension`, and fell through everything else. `PredicateFunction`
+//! is the sibling that fix (#670) did not reach, and so are `Reduce`, `Index`
+//! and `ListSlice`.
+//!
+//! `expression_has_aggregate` had the same missing arms, and it is the one
+//! that decides whether an `AggregateOperator` is planned at all — so fixing
+//! only the extractor leaves a shape it can rewrite but is never asked to.
+//! Both walkers have to agree arm for arm.
+
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn nums() -> GraphStore {
+    let mut store = GraphStore::new();
+    for n in [1i64, 2, 3] {
+        let id = store.create_node_with_labels([Label::new("N")]);
+        store.set_node_property("default", id, "v", PropertyValue::Integer(n)).unwrap();
+    }
+    store
+}
+
+fn one(store: &GraphStore, cypher: &str) -> Value {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let r = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let c = r.columns[0].clone();
+    r.records[0].get(&c).cloned().unwrap_or(Value::Null)
+}
+
+#[test]
+fn all_over_a_collect_is_planned_as_an_aggregate() {
+    let store = nums();
+    assert!(format!("{:?}", one(&store, "UNWIND [true, true] AS x RETURN ALL(ok IN collect(x) WHERE ok) AS okay"))
+        .contains("Boolean(true)"));
+}
+
+#[test]
+fn the_other_three_predicates_too() {
+    let store = nums();
+    for (q, want) in [
+        ("MATCH (n:N) RETURN ANY(v IN collect(n.v) WHERE v = 2) AS r", "Boolean(true)"),
+        ("MATCH (n:N) RETURN NONE(v IN collect(n.v) WHERE v > 9) AS r", "Boolean(true)"),
+        ("MATCH (n:N) RETURN SINGLE(v IN collect(n.v) WHERE v = 3) AS r", "Boolean(true)"),
+    ] {
+        assert!(format!("{:?}", one(&store, q)).contains(want), "{q}");
+    }
+}
+
+#[test]
+fn reduce_hoists_its_seed_and_its_list() {
+    let store = nums();
+    let got = one(&store, "MATCH (n:N) RETURN reduce(t = 0, v IN collect(n.v) | t + v) AS total");
+    assert!(format!("{got:?}").contains("Integer(6)"), "got {got:?}");
+}
+
+#[test]
+fn indexing_and_slicing_an_aggregate() {
+    let store = nums();
+    assert!(format!("{:?}", one(&store, "MATCH (n:N) RETURN collect(n.v)[0] AS r")).contains("Integer(1)"));
+    let sliced = one(&store, "MATCH (n:N) RETURN collect(n.v)[0..2] AS r");
+    assert_eq!(format!("{sliced:?}").matches("Integer(").count(), 2, "got {sliced:?}");
+}
+
+#[test]
+fn a_loop_body_is_left_alone() {
+    // The body runs once per element with the loop variable bound, so an
+    // aggregate there is a different question and must not be hoisted out of
+    // the loop. Only the *list* is rewritten.
+    let store = nums();
+    let got = one(&store, "MATCH (n:N) RETURN [v IN collect(n.v) WHERE v > 1 | v * 2] AS r");
+    assert_eq!(format!("{got:?}").matches("Integer(").count(), 2, "got {got:?}");
+}
+
+#[test]
+fn a_predicate_over_an_ordinary_list_still_works() {
+    let store = nums();
+    assert!(format!("{:?}", one(&store, "RETURN ALL(x IN [1,2,3] WHERE x > 0) AS r")).contains("Boolean(true)"));
+    assert!(format!("{:?}", one(&store, "UNWIND [1,2] AS x WITH collect(x) AS c RETURN ALL(v IN c WHERE v > 0) AS r"))
+        .contains("Boolean(true)"));
+}
+
+#[test]
+fn the_full_tck_shape() {
+    // List11[3]. `range()` was correct throughout; the failure was the final
+    // `ALL(ok IN collect(...) WHERE ok)`.
+    let store = nums();
+    let got = one(&store,
+        "WITH 0 AS start, [1, 2, 500, 1000, 1500] AS stopList, \
+         [-1000, -3, -2, -1, 1, 2, 3, 1000] AS stepList \
+         UNWIND stopList AS stop UNWIND stepList AS step \
+         WITH start, stop, step, range(start, stop, step) AS list \
+         WITH start, stop, step, list, sign(stop-start) <> sign(step) AS empty \
+         RETURN ALL(ok IN collect((size(list) = 0) = empty) WHERE ok) AS okay");
+    assert!(format!("{got:?}").contains("Boolean(true)"), "got {got:?}");
+}


### PR DESCRIPTION
Closes #997. TCK: closes `List11[3]`.

```cypher
UNWIND [true, true] AS x RETURN ALL(ok IN collect(x) WHERE ok) AS okay
```

> `RuntimeError("Unknown function: collect")`

An error naming one of Cypher's most ordinary functions. `collect(x)` works as a top-level aggregate and works through a `WITH` — it failed only inside the list a predicate iterates.

## Cause

`extract_agg_inner` hoists nested aggregates into the `AggregateOperator`. It handled `Function`, `Binary`, `Unary`, `Case`, `ListExpr`, `MapExpr` and `ListComprehension`, then fell through everything else to `other => other.clone()`.

`PredicateFunction` (`all`/`any`/`none`/`single`) is the sibling that the earlier fix did not reach. So are `Reduce`, `Index` and `ListSlice` — `collect(x)[0]` had the same problem.

The comment on the `ListExpr` arm already describes this failure exactly, for the *previous* variant:

> Not recursing here left those to the scalar evaluator, which has no aggregate handling, so they failed with "Unknown function: collect" — an error naming one of Cypher's most ordinary functions (#670).

**Same error, same cause, one variant over.** A recursive walker that enumerates variants grows a new hole every time a variant is added, so this enumerates the class rather than the case in front of it.

## Two halves, both needed

`expression_has_aggregate` had the *same* missing arms — and it is the one that decides whether an `AggregateOperator` is planned at all. Fixing only the extractor leaves a shape it can rewrite but is never asked to. The two walkers now agree arm for arm.

**Loop bodies are excluded on both sides.** A comprehension's map expression and a predicate's filter run once per element with the loop variable bound, so an aggregate there is a different question and must not be silently hoisted out of the loop. Only the *list* is rewritten.

## Tests

`tests/aggregate_inside_a_list_predicate.rs` — 7 cases:

- `ALL` over a `collect` is planned as an aggregate
- `ANY` / `NONE` / `SINGLE` too
- `reduce` hoists its seed **and** its list
- indexing and slicing an aggregate
- **a loop body is left alone** — the exclusion, asserted rather than assumed
- a predicate over an ordinary list still works, with and without a `WITH`
- **the full `List11[3]` shape** end to end

## TCK

3,763 evaluated → **3,754 pass (99.8%)**, 5 wrong, 4 errored. Manifest diff: 1 fixed, **0 regressions**.