### PR TITLE
Refresh the README's TCK claim to 99.8%

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ into a public-health trifecta.* [Browse the catalogue →](case_studies)
 
 ## The 30-Second Tour
 
-**Cypher queries** — MATCH, CREATE, MERGE, aggregations, path finding, 30+ functions. **98.8% of the openCypher TCK's evaluated scenarios pass** (3,716 of 3,762, at 96.5% coverage of the 3,897-scenario corpus, measured 2026-08-29); on the same corpus and comparator Neo4j 5 scores 79.5%. That is conformance only — not performance or scale — and the competitor figure is a fixed baseline from one run. See [`docs/CYPHER_COMPATIBILITY.md`](docs/CYPHER_COMPATIBILITY.md) for a per-feature matrix verified by an executable probe, and [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) for the full accounting.
+**Cypher queries** — MATCH, CREATE, MERGE, aggregations, path finding, 30+ functions. **99.8% of the openCypher TCK's evaluated scenarios pass** (3,754 of 3,763, at 96.6% coverage of the 3,897-scenario corpus, measured 2026-08-30); on the same corpus and comparator Neo4j 5 scores 79.5%. That is conformance only — not performance or scale — and the competitor figure is a fixed baseline from one run. See [`docs/CYPHER_COMPATIBILITY.md`](docs/CYPHER_COMPATIBILITY.md) for a per-feature matrix verified by an executable probe, and [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) for the full accounting.
 
 ```cypher
 MATCH (a:Person)-[:KNOWS*1..3]->(b:Person)


### PR DESCRIPTION
3,754 of 3,763 evaluated (96.6% of the 3,897-scenario corpus), measured 2026-08-30 at `b052533`. The claim was 98.8% from 2026-08-29.

## The register moves in the same breath

`claims.py` treats improving past a published number as **staleness in its own right** — *"improving past a published claim still makes the published claim wrong"* — so the README, `harness/claims.json` and the run envelope have to agree, or the H1 gate's condition 6 fails on the next run. Benchmarks-repo PR #36 carries the other two.

## A note on the Neo4j comparator

It stays at **79.5%**, but it is now *produced by the harness* rather than sitting 0.1 point ahead of it.

The figure was published on 2026-08-27, before #991 fixed the expected-side Gherkin unescaping, and the harness at the time produced 79.4%. So the correction **moved the competitor up to meet the published number**, rather than the other way round. Worth stating plainly rather than letting it quietly become true.