### PR TITLE
Duration arithmetic carries its nanoseconds, and a date keeps whole days (#1001)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -226,6 +226,43 @@ pub(crate) mod statement_clock {
 }
 
 
+/// Build a `Duration` with `nanos` carried into `seconds`.
+///
+/// `nanos` is a sub-second remainder in `0..1_000_000_000`, and every producer
+/// of a `Duration` has to leave it that way. `duration()` already does -- it
+/// combines seconds and nanos into one i128 total before splitting (#814) --
+/// but duration *arithmetic* added the fields straight across, so adding a
+/// duration to itself gave `nanos: 1000000006` and rendered as
+/// `P25Y10M58DT67H56M26.1000000006S` where openCypher says
+/// `...M27.000000006S`: one second short, with the missing second sitting
+/// unrendered inside the nanoseconds field (#1001).
+///
+/// Months and days are *not* carried into each other or into seconds. Cypher
+/// keeps the three groups separate on purpose -- a month is not 30 days and a
+/// day is not always 86,400 seconds across a DST boundary -- so normalising
+/// them would change answers rather than tidy them.
+///
+/// `i128` for the same reason `duration()` uses it: the nanosecond product
+/// overflows `i64` past roughly 292 years.
+fn normalized_duration(months: i64, days: i64, seconds: i128, nanos: i128) -> PropertyValue {
+    let total = seconds * 1_000_000_000 + nanos;
+    // Truncating division, exactly as `duration()` does -- **not** floor
+    // division. The two differ only for a negative total, and the difference
+    // is not academic: flooring gives `{seconds: -1, nanos: 999_999_999}`,
+    // which is the same instant but which the renderer, reading the sign off
+    // each field, prints as `PT-1.999999999S` instead of `PT-0.000000001S`.
+    // The representation carries the sign in `nanos`, and a normaliser that
+    // does not follow that convention produces a correct value that renders
+    // wrong.
+    PropertyValue::Duration {
+        months,
+        days,
+        seconds: (total / 1_000_000_000) as i64,
+        nanos: (total % 1_000_000_000) as i32,
+    }
+}
+
+
 /// Shared binary operator evaluation used by Project, Aggregate, and Sort operators
 fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<Value> {
     // Identity comparison for the three entity kinds (Cypher: n1 = n2, r1 = r2,
@@ -509,7 +546,8 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
             // Duration + Duration
             (PropertyValue::Duration { months: m1, days: d1, seconds: s1, nanos: n1 },
              PropertyValue::Duration { months: m2, days: d2, seconds: s2, nanos: n2 }) => {
-                PropertyValue::Duration { months: m1 + m2, days: d1 + d2, seconds: s1 + s2, nanos: n1 + n2 }
+                normalized_duration(m1 + m2, d1 + d2, *s1 as i128 + *s2 as i128,
+                                    *n1 as i128 + *n2 as i128)
             }
             // Cypher null propagation: any arithmetic with a null operand is null,
             // not an error. Without this, `p.a + p.missing` aborts the whole query --
@@ -556,7 +594,8 @@ fn eval_binary_op(op: &BinaryOp, left: Value, right: Value) -> ExecutionResult<V
             // Duration - Duration
             (PropertyValue::Duration { months: m1, days: d1, seconds: s1, nanos: n1 },
              PropertyValue::Duration { months: m2, days: d2, seconds: s2, nanos: n2 }) => {
-                PropertyValue::Duration { months: m1 - m2, days: d1 - d2, seconds: s1 - s2, nanos: n1 - n2 }
+                normalized_duration(m1 - m2, d1 - d2, *s1 as i128 - *s2 as i128,
+                                    *n1 as i128 - *n2 as i128)
             }
             (PropertyValue::Null, _) | (_, PropertyValue::Null) => PropertyValue::Null,
             _ => return Err(ExecutionError::TypeError("Sub requires numeric operands".to_string())),
@@ -4066,7 +4105,21 @@ fn shift_temporal(
     // (#853).
     let drop_date_part = matches!(v, PropertyValue::LocalTime(_) | PropertyValue::Time { .. });
     let exact = if drop_sub_day {
-        days as i128 * 86_400 * 1_000_000_000
+        // Only the *sub-day remainder* is dropped, not the whole seconds
+        // field. A duration's seconds can hold entire days -- `P25Y10M58D` +
+        // `T67H56M27S` is 67 hours, nearly three days of them -- and those days
+        // are calendar days a date can move by. Discarding the field wholesale
+        // lost them: `date('1984-10-11') + duration({...})` answered 1997-10-10
+        // where openCypher says 1997-10-11, and the subtraction missed by a day
+        // the other way (#1001).
+        //
+        // The whole days come out by truncation toward zero, which is what
+        // keeps #817 intact: there, `days: -14` with a `+15h49m` remainder
+        // yields zero whole days, so `days` stays -14 rather than becoming the
+        // -13 that combining and then truncating produced.
+        let whole_days_in_seconds =
+            (seconds as i128 * 1_000_000_000 + nanos as i128) / (86_400 * 1_000_000_000);
+        (days as i128 + whole_days_in_seconds) * 86_400 * 1_000_000_000
     } else if drop_date_part {
         seconds as i128 * 1_000_000_000 + nanos as i128
     } else {

--- a/tests/duration_arithmetic_normalisation.rs
+++ b/tests/duration_arithmetic_normalisation.rs
@@ -1,0 +1,91 @@
+//! Duration arithmetic carries its nanoseconds, and a date keeps the whole
+//! days inside a duration's seconds (#1001).
+//!
+//! Two bugs, both silent, both off by exactly one unit.
+//!
+//! 1. `Duration + Duration` and `Duration - Duration` added the fields
+//!    straight across, so adding a duration to itself produced
+//!    `nanos: 1000000006` and rendered `…M26.1000000006S` where openCypher
+//!    says `…M27.000000006S`. The whole second was not lost — it was sitting
+//!    unrendered inside the nanoseconds field. `duration()` itself has always
+//!    normalised (#814); only the arithmetic did not.
+//!
+//! 2. `shift_temporal` drops a duration's sub-day part for a `Date` (#817),
+//!    but dropped the entire `seconds` field with it. A duration's seconds can
+//!    hold whole days — `T67H56M27S` is nearly three — and those are calendar
+//!    days a date can move by.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+
+const D: &str = "duration({years: 12.5, months: 5.5, days: 14.5, hours: 16.5, \
+                 minutes: 12.5, seconds: 70.5, nanoseconds: 3})";
+
+fn text(cypher: &str) -> String {
+    let store = GraphStore::new();
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let r = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let c = r.columns[0].clone();
+    let v = format!("{:?}", r.records[0].get(&c));
+    let a = v.find('"').expect("a string result");
+    let b = v.rfind('"').unwrap();
+    v[a + 1..b].to_string()
+}
+
+#[test]
+fn adding_a_duration_to_itself_carries_the_nanoseconds() {
+    assert_eq!(text(&format!("RETURN toString({D} + {D}) AS a")),
+               "P25Y10M58DT67H56M27.000000006S");
+}
+
+#[test]
+fn subtracting_a_duration_from_itself_is_zero() {
+    assert_eq!(text(&format!("RETURN toString({D} - {D}) AS a")), "PT0S");
+}
+
+#[test]
+fn a_negative_sub_second_duration_keeps_its_sign_in_the_nanoseconds() {
+    // The representation carries the sign in `nanos`, not as a borrow from
+    // seconds. A normaliser using floor division gives `{seconds: -1,
+    // nanos: 999999999}` -- the same instant, printed as `PT-1.999999999S`.
+    // A correct value that renders wrong.
+    assert_eq!(text("RETURN toString(duration({nanoseconds: -1}) + duration({seconds: 0})) AS a"),
+               "PT-0.000000001S");
+    assert_eq!(text("RETURN toString(duration({seconds: 1}) - duration({nanoseconds: 1})) AS a"),
+               "PT0.999999999S");
+}
+
+#[test]
+fn months_and_days_are_not_merged_into_each_other() {
+    // Cypher keeps the three groups separate on purpose: a month is not 30
+    // days, and a day is not always 86,400 seconds across a DST boundary.
+    // Normalising them would change answers rather than tidy them.
+    assert_eq!(text("RETURN toString(duration({months: 1}) + duration({days: 1})) AS a"), "P1M1D");
+}
+
+#[test]
+fn a_date_moves_by_the_whole_days_inside_the_seconds() {
+    assert_eq!(text(&format!("RETURN toString(date('1984-10-11') + {D}) AS a")), "1997-10-11");
+    assert_eq!(text(&format!("RETURN toString(date('1984-10-11') - {D}) AS a")), "1971-10-12");
+}
+
+#[test]
+fn a_sub_day_remainder_is_still_dropped_by_a_date() {
+    // #817's rule, which this must not break: `days: -14` with a `+15h49m`
+    // remainder stays -14, rather than combining to -13.34 and truncating to
+    // -13. Fifteen hours is less than a day, so it yields zero whole days.
+    assert_eq!(
+        text("RETURN toString(date('1984-10-11') - duration({days: 14, hours: -15, minutes: -49})) AS a"),
+        text("RETURN toString(date('1984-10-11') - duration({days: 14})) AS a"),
+    );
+}
+
+#[test]
+fn an_ordinary_date_plus_days_is_unaffected() {
+    assert_eq!(text("RETURN toString(date('1984-10-11') + duration({days: 1})) AS a"), "1984-10-12");
+    assert_eq!(text("RETURN toString(date('1984-10-11') + duration({hours: 23})) AS a"), "1984-10-11");
+    assert_eq!(text("RETURN toString(date('1984-10-11') + duration({hours: 25})) AS a"), "1984-10-12");
+}


### PR DESCRIPTION
Closes #1001. TCK: closes `Temporal8[1]` and `Temporal8[6]`.

Two bugs, both silent, both off by exactly one unit.

## 1. `nanos` was not normalised on add or subtract

| | |
|---|---|
| openCypher | `P25Y10M58DT67H56M27.000000006S` |
| Samyama | `P25Y10M58DT67H56M26.1000000006S` |

`nanos` is a sub-second remainder in `0..1_000_000_000`. `duration()` maintains that — it combines seconds and nanos into one `i128` total before splitting (#814) — but `Duration + Duration` and `Duration - Duration` added the fields **straight across**, producing `nanos: 1000000006`.

The whole second was not lost; it was sitting unrendered inside the nanoseconds field. The months, days and hours were **already exactly right**, which is what made it hard to see.

### The sign convention, which caught me out

The representation carries the sign in `nanos` via **truncating** division, not as a borrow from seconds. Normalising with *floor* division instead gives `{seconds: -1, nanos: 999999999}` — the same instant, but the renderer reads the sign off each field and prints `PT-1.999999999S` where openCypher says `PT-0.000000001S`.

A correct value that renders wrong. My first attempt did exactly that, and a probe caught it before the TCK ran.

## 2. A date dropped whole days along with the sub-day remainder

| | `+` | `−` |
|---|---|---|
| openCypher | `1997-10-11` | `1971-10-12` |
| Samyama | `1997-10-10` | `1971-10-13` |

Off by one in **opposite directions** — the signature of a dropped magnitude rather than an offset error.

`shift_temporal` sets `drop_sub_day` for a `Date` and then discarded the entire `seconds` field. But a duration's seconds can hold whole **days** — `T67H56M27S` is nearly three of them — and those are calendar days a date can legitimately move by. Only the sub-day *remainder* should go.

**#817's rule is preserved and asserted**: `days: -14` with a `+15h49m` remainder must stay `-14` rather than combining and truncating to `-13`. Extracting whole days by truncation toward zero satisfies both, since 15h49m yields zero whole days.

## Tests

`tests/duration_arithmetic_normalisation.rs` — 7 cases:

- adding a duration to itself carries the nanoseconds
- subtracting a duration from itself is `PT0S`
- **a negative sub-second duration keeps its sign in the nanoseconds** — the floor-vs-truncate trap
- **months and days are not merged into each other** — Cypher keeps the groups separate on purpose; a month is not 30 days
- a date moves by the whole days inside the seconds
- **a sub-day remainder is still dropped by a date** — #817, unbroken
- an ordinary date plus days/hours is unaffected (23h → same day, 25h → next)

All 56 existing temporal tests pass.

## TCK

3,763 evaluated → **3,756 pass (99.8%)**, 3 wrong, 4 errored. Manifest diff: 2 fixed, **0 regressions**.

## Context

Found while establishing what the temporal gap actually is, after ADR-037 wrongly claimed the `Duration` type did not exist (corrected in #1000). It exists and is largely right; these are the completeness bugs inside it.