### PR TITLE
Two temporal completeness fixes: datetime.fromepoch*, and ISO 8601's alternative duration notation (#1003, #1005)

### DIFF
--- a/docs/ADR/ADR-037-bolt-protocol-feasibility.md
+++ b/docs/ADR/ADR-037-bolt-protocol-feasibility.md
@@ -37,7 +37,7 @@
 > | Scenario | Actual cause |
 > |---|---|
 > | `Temporal8[1]`, `[6]` | `nanos` not normalised — `nanos: 1000000006` should carry a second, giving `…M27.000000006S` where we render `…M26.1000000006S` |
-> | `Temporal2[7]` | a malformed duration string is silently accepted as a zero duration |
+> | `Temporal2[7]` | ~~a malformed duration string is silently accepted as a zero duration~~ — **restated 2026-08-30**: the string is *valid*. `'P2012-02-02T14:37:21.545'` is ISO 8601's alternative duration notation, spelling the components as a date and a clock; the unit scanner cannot read it and returned zero |
 > | `Temporal10[9]`, `[10]` | extended-year date literals (`-999999999-01-01`); `duration.between` itself is correct |
 > | `Temporal3[10]` ×2 | datetime *selection* semantics; the zone handling underneath is correct |
 > | `Temporal1[11]` | `datetime.fromepoch` / `datetime.fromepochmillis` not implemented |

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -4532,6 +4532,77 @@ fn add_duration_to_datetime(dt_millis: i64, months: i64, days: i64, seconds: i64
     }
 }
 
+/// ISO 8601's alternative duration form: `P<date>T<time>`, where the date is
+/// `YYYY-MM-DD` (or `YYYYMMDD`) and the time is `hh:mm:ss[.fff]` (or `hhmmss`).
+///
+/// Returns `None` when the input is not in that shape, so the unit scanner
+/// keeps every string it already handled. The two forms are mutually
+/// exclusive -- one has unit letters and the other has separators -- so a
+/// shape test is enough to route between them and neither needs to know about
+/// the other.
+///
+/// The fields are durations, not calendar positions: the year field may exceed
+/// any real year and the month field is a count of months, so no date
+/// validation applies.
+fn parse_extended_duration(date_part: &str, time_part: &str) -> Option<Value> {
+    /// `a-b-c` with every field all digits, or one run of `n` digits split
+    /// into fixed-width fields.
+    fn fields(s: &str, widths: [usize; 3]) -> Option<[i128; 3]> {
+        let parts: Vec<&str> = if s.contains('-') || s.contains(':') {
+            s.split(|c| c == '-' || c == ':').collect()
+        } else {
+            if s.len() != widths.iter().sum::<usize>() {
+                return None;
+            }
+            let (a, b) = s.split_at(widths[0]);
+            let (b, c) = b.split_at(widths[1]);
+            vec![a, b, c]
+        };
+        if parts.len() != 3 || parts.iter().any(|p| p.is_empty() || !p.bytes().all(|b| b.is_ascii_digit())) {
+            return None;
+        }
+        let mut out = [0i128; 3];
+        for (i, p) in parts.iter().enumerate() {
+            out[i] = p.parse::<i128>().ok()?;
+        }
+        Some(out)
+    }
+
+    // A fraction is allowed only on the seconds, and only in the time half.
+    let (time_head, frac) = match time_part.split_once(|c| c == '.' || c == ',') {
+        Some((h, f)) if f.bytes().all(|b| b.is_ascii_digit()) && !f.is_empty() => (h, f),
+        Some(_) => return None,
+        None => (time_part, ""),
+    };
+
+    let [years, months_f, days] = fields(date_part, [4, 2, 2])?;
+    let [hours, minutes, seconds] = if time_head.is_empty() {
+        [0, 0, 0]
+    } else {
+        fields(time_head, [2, 2, 2])?
+    };
+    // A bare date with no `T` is ambiguous against the unit form only in ways
+    // the digit test already excludes, but an empty date is not a duration.
+    if date_part.is_empty() {
+        return None;
+    }
+
+    const NPS: i128 = 1_000_000_000;
+    let mut nanos = frac
+        .chars()
+        .chain(std::iter::repeat('0'))
+        .take(9)
+        .fold(0i128, |acc, c| acc * 10 + c.to_digit(10).unwrap_or(0) as i128);
+    nanos += (hours * 3600 + minutes * 60 + seconds) * NPS;
+
+    Some(Value::Property(PropertyValue::Duration {
+        months: (years * 12 + months_f) as i64,
+        days: days as i64,
+        seconds: (nanos / NPS) as i64,
+        nanos: (nanos % NPS) as i32,
+    }))
+}
+
 /// Parse ISO 8601 duration string (e.g. "P1Y2M3DT4H5M6S")
 /// Parse an ISO-8601 duration, with **per-component signs** (#853).
 ///
@@ -4557,6 +4628,19 @@ fn parse_iso_duration(s: &str) -> ExecutionResult<Value> {
         Some(idx) => (&rest[..idx], &rest[idx + 1..]),
         None => (rest, ""),
     };
+
+    // ISO 8601's *alternative* duration form, which spells the components as a
+    // date and a clock rather than with unit letters:
+    //
+    //     P2012-02-02T14:37:21.545   ==   P2012Y2M2DT14H37M21.545S
+    //
+    // The unit scanner below cannot read it -- there are no units to read, and
+    // its `-` handling is a per-component sign, so the separators looked like
+    // signs on empty numbers and the whole string scanned to zero. `duration()`
+    // returned `PT0S` for a perfectly valid duration, with no error (#1005).
+    if let Some(v) = parse_extended_duration(date_part, time_part) {
+        return Ok(v);
+    }
 
     const NPS: i128 = 1_000_000_000;
     // A mean Gregorian month is exactly 2,629,746 seconds (#829).

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2319,7 +2319,8 @@ fn collect_expression_names(expr: &Expression, out: &mut HashSet<String>) {
 pub const KNOWN_FUNCTIONS: &[&str] = &[
     "abs", "acos", "asin", "atan", "atan2", "bfs", "breadthfirstsearch", "cdlp", "ceil",
     "coalesce", "components", "connectedcomponents", "cos", "cosh", "cosine", "cot", "date",
-    "date.truncate", "datetime", "datetime.truncate", "degrees", "dijkstra", "duration",
+    "date.truncate", "datetime", "datetime.fromepoch", "datetime.fromepochmillis",
+    "datetime.truncate", "degrees", "dijkstra", "duration",
     "duration.between", "duration.indays", "duration.inmonths", "duration.inseconds",
     "duration_between", "e", "elementid", "endnode", "exists", "exp", "false", "floor",
     "haslabels", "haversin", "head", "hierarchy_lca", "hierarchy_rollup", "id", "isempty",
@@ -3489,6 +3490,43 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
         // `<type>.truncate(unit, value, map)` for all five namespaces (#769).
         // The namespace names the *result* type, so `date.truncate` over a
         // datetime returns a Date.
+        // `datetime.fromepoch(seconds, nanoseconds)` and
+        // `datetime.fromepochmillis(millis)`. Both name an instant in UTC, so
+        // the result is a `ZonedDateTime` at offset 0 with no zone id --
+        // an epoch has no locality to attach.
+        //
+        // Nanoseconds are carried whole rather than folded into the seconds:
+        // `datetime.fromepoch(416779, 999999999)` is
+        // 1970-01-05T19:46:19.999999999Z, which no millisecond-based
+        // representation can express (#1003).
+        "datetime.fromepoch" | "datetime.fromepochmillis" => {
+            let want = if lowered == "datetime.fromepoch" { 2 } else { 1 };
+            if args.len() != want {
+                return Err(ExecutionError::RuntimeError(format!(
+                    "{name}() requires {want} argument(s)"
+                )));
+            }
+            let (secs, nanos) = if want == 2 {
+                (extract_int(&args[0])?, extract_int(&args[1])?)
+            } else {
+                let millis = extract_int(&args[0])?;
+                // `div_euclid`, not `/`: a negative epoch millisecond is a real
+                // instant before 1970, and truncating toward zero would place
+                // it in the wrong second with a negative nanosecond remainder.
+                (millis.div_euclid(1_000), millis.rem_euclid(1_000) * 1_000_000)
+            };
+            if !(0..1_000_000_000).contains(&nanos) {
+                return Err(ExecutionError::RuntimeError(
+                    "nanoseconds must be in 0..1000000000".to_string(),
+                ));
+            }
+            Ok(Value::Property(PropertyValue::ZonedDateTime {
+                secs,
+                nanos: nanos as u32,
+                offset_seconds: 0,
+                zone: None,
+            }))
+        }
         "date.truncate" | "time.truncate" | "localtime.truncate"
         | "localdatetime.truncate" | "datetime.truncate" => {
             if args.len() < 2 {

--- a/tests/datetime_from_epoch.rs
+++ b/tests/datetime_from_epoch.rs
@@ -1,0 +1,75 @@
+//! `datetime.fromepoch` and `datetime.fromepochmillis` (#1003).
+//!
+//! ```cypher
+//! RETURN datetime.fromepoch(416779, 999999999),
+//!        datetime.fromepochmillis(237821673987)
+//! ```
+//!
+//! failed with `Unknown function`. Both name an instant in UTC, so the result
+//! is a `ZonedDateTime` at offset 0 with no zone id -- an epoch has no
+//! locality to attach.
+//!
+//! Nanoseconds are carried whole rather than folded into the seconds:
+//! `datetime.fromepoch(416779, 999999999)` is `1970-01-05T19:46:19.999999999Z`,
+//! which no millisecond-based representation can express at all.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+
+fn text(cypher: &str) -> String {
+    let store = GraphStore::new();
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let r = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let c = r.columns[0].clone();
+    let v = format!("{:?}", r.records[0].get(&c));
+    let a = v.find('"').expect("a string result");
+    v[a + 1..v.rfind('"').unwrap()].to_string()
+}
+
+fn fails(cypher: &str) -> bool {
+    let store = GraphStore::new();
+    match parse_query(cypher) {
+        Err(_) => true,
+        Ok(q) => QueryExecutor::new(&store).execute(&q).is_err(),
+    }
+}
+
+#[test]
+fn from_epoch_keeps_nanosecond_precision() {
+    assert_eq!(text("RETURN toString(datetime.fromepoch(416779, 999999999)) AS d"),
+               "1970-01-05T19:46:19.999999999Z");
+}
+
+#[test]
+fn from_epoch_millis() {
+    assert_eq!(text("RETURN toString(datetime.fromepochmillis(237821673987)) AS d"),
+               "1977-07-15T13:34:33.987Z");
+}
+
+#[test]
+fn a_negative_epoch_millisecond_is_an_instant_before_1970() {
+    // `div_euclid`, not `/`. Truncating toward zero would put -1ms in second
+    // zero with a negative nanosecond remainder, which is not a time.
+    assert_eq!(text("RETURN toString(datetime.fromepochmillis(-1)) AS d"),
+               "1969-12-31T23:59:59.999Z");
+}
+
+#[test]
+fn the_epoch_itself() {
+    assert_eq!(text("RETURN toString(datetime.fromepoch(0, 0)) AS d"), "1970-01-01T00:00Z");
+}
+
+#[test]
+fn a_nanosecond_outside_its_range_is_refused() {
+    assert!(fails("RETURN datetime.fromepoch(0, 1000000000)"));
+    assert!(fails("RETURN datetime.fromepoch(0, -1)"));
+}
+
+#[test]
+fn the_wrong_arity_is_refused() {
+    assert!(fails("RETURN datetime.fromepoch(0)"));
+    assert!(fails("RETURN datetime.fromepochmillis(0, 0)"));
+}

--- a/tests/duration_extended_iso_form.rs
+++ b/tests/duration_extended_iso_form.rs
@@ -1,0 +1,84 @@
+//! ISO 8601's alternative duration form (#1005).
+//!
+//! ```cypher
+//! RETURN duration('P2012-02-02T14:37:21.545')
+//! ```
+//!
+//! returned `PT0S`. The string is **valid** — it is ISO 8601's alternative
+//! duration notation, which spells the components as a date and a clock rather
+//! than with unit letters, and openCypher expects `P2012Y2M2DT14H37M21.545S`.
+//!
+//! The unit scanner could not read it: there are no units to read, and its `-`
+//! handling is a *per-component sign*, so the date separators looked like signs
+//! on empty numbers and the whole string scanned to zero. A valid duration
+//! became a zero duration with no error.
+//!
+//! The two notations are mutually exclusive — one has unit letters, the other
+//! has separators — so a shape test routes between them and neither parser
+//! needs to know about the other.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+
+fn text(cypher: &str) -> String {
+    let store = GraphStore::new();
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let r = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let c = r.columns[0].clone();
+    let v = format!("{:?}", r.records[0].get(&c));
+    let a = v.find('"').expect("a string result");
+    v[a + 1..v.rfind('"').unwrap()].to_string()
+}
+
+fn dur(s: &str) -> String {
+    text(&format!("RETURN toString(duration('{s}')) AS d"))
+}
+
+#[test]
+fn the_extended_form_parses() {
+    assert_eq!(dur("P2012-02-02T14:37:21.545"), "P2012Y2M2DT14H37M21.545S");
+}
+
+#[test]
+fn the_basic_extended_form_parses_too() {
+    // The same notation without separators.
+    assert_eq!(dur("P20120202T143721.545"), "P2012Y2M2DT14H37M21.545S");
+}
+
+#[test]
+fn it_agrees_with_the_unit_form() {
+    assert_eq!(dur("P2012-02-02T14:37:21.545"), dur("P2012Y2M2DT14H37M21.545S"));
+}
+
+#[test]
+fn the_fields_are_durations_not_calendar_positions() {
+    // A month field is a count of months, not a month of the year, so no date
+    // validation applies and the year may exceed any real year.
+    assert_eq!(dur("P0001-13-01T00:00:00"), "P2Y1M1D");
+}
+
+#[test]
+fn every_unit_form_case_is_untouched() {
+    // Temporal2[7]'s other six examples, which the shape test must not divert.
+    for (input, want) in [
+        ("P14DT16H12M", "P14DT16H12M"),
+        ("P5M1.5D", "P5M1DT12H"),
+        ("P0.75M", "P22DT19H51M49.5S"),
+        ("PT0.75M", "PT45S"),
+        ("P2.5W", "P17DT12H"),
+        ("P12Y5M14DT16H12M70S", "P12Y5M14DT16H13M10S"),
+    ] {
+        assert_eq!(dur(input), want, "{input}");
+    }
+}
+
+#[test]
+fn a_per_component_sign_still_works() {
+    // #853: a `-` in the unit form is a sign, and `duration(toString(d)) = d`
+    // must hold for a mixed-sign duration. The shape test must not read that
+    // `-` as a date separator.
+    assert_eq!(dur("P1DT-0.001S"), "P1DT-0.001S");
+}


### PR DESCRIPTION
Closes #1003 and #1005. TCK: closes `Temporal1[11]` and `Temporal2[7]`.

Two of the five completeness gaps enumerated when ADR-037's claim that the temporal *types* were missing was corrected (#1000). The types are there; these are holes inside them.

*(This PR grew a second commit after review was requested — the description covers both rather than leaving the first one's text standing.)*

---

## #1003 — `datetime.fromepoch` and `datetime.fromepochmillis` were not implemented

```cypher
RETURN datetime.fromepoch(416779, 999999999) AS d1,
       datetime.fromepochmillis(237821673987) AS d2
```

failed with `Unknown function`. openCypher expects `'1970-01-05T19:46:19.999999999Z'` and `'1977-07-15T13:34:33.987Z'`.

Both name an instant in **UTC**, so the result is a `ZonedDateTime` at offset 0 with **no zone id** — an epoch has no locality to attach. Nanoseconds are carried whole rather than folded into the seconds: `…19.999999999Z` is not expressible in any millisecond-based representation.

**`fromepochmillis` splits with `div_euclid`/`rem_euclid`, not `/` and `%`.** A negative epoch millisecond is a real instant before 1970; truncating toward zero would place it in second zero with a *negative* nanosecond remainder, which is not a time. `datetime.fromepochmillis(-1)` is `1969-12-31T23:59:59.999Z`, and it is asserted.

## #1005 — `duration()` returned `PT0S` for a valid duration

```cypher
RETURN duration('P2012-02-02T14:37:21.545')
```

returned `PT0S`. The string is **valid** — ISO 8601's alternative duration notation, spelling the components as a date and a clock rather than with unit letters. openCypher expects `P2012Y2M2DT14H37M21.545S`.

`parse_iso_duration` is a unit scanner. There are no units to read here, and its `-` handling is a **per-component sign** (#853), so the date separators looked like signs sitting on empty numbers and the whole string scanned to zero. **A valid duration became a zero duration with no error.**

The two notations are mutually exclusive — one has unit letters, the other separators — so a shape test routes between them and neither parser needs to know about the other. Both spellings are accepted: separated (`P2012-02-02T14:37:21.545`) and basic (`P20120202T143721.545`).

The fields are **durations, not calendar positions** — the year field may exceed any real year, the month field is a count of months — so no date validation applies, and that is asserted rather than left implied.

## A line of the ADR-037 correction is restated

When that correction enumerated the temporal gaps, I described `Temporal2[7]` as *"a malformed duration string is silently accepted as a zero duration"*. **The "malformed" half was wrong**: the string is well-formed and we failed to parse it. The correction is annotated in place rather than edited — the same treatment as the claim it corrects.

## Tests

- `tests/datetime_from_epoch.rs` (6): nanosecond precision, the millis form, **the negative epoch**, the epoch itself, a nanosecond outside `0..1e9` refused, wrong arity refused.
- `tests/duration_extended_iso_form.rs` (6): both extended spellings, agreement with the unit form, **fields are durations not calendar positions** (`P0001-13-01T00:00:00` → `P2Y1M1D`), **all six unit-form examples from `Temporal2[7]` untouched**, and **#853's mixed-sign `P1DT-0.001S` round-trip** — which the shape test must not read as a date separator.

## TCK

3,763 evaluated → **3,758 pass (99.9%)**, 2 wrong, 3 errored. Manifest diff across both commits: **2 fixed, 0 regressions**.