### PR TITLE
A named zone's offset is resolved at the selected date (#1006)

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -3330,7 +3330,23 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                         // is the neighbouring behaviour (#809).
                         None => match map.get("datetime").or_else(|| map.get("time")) {
                             Some(PropertyValue::ZonedDateTime { offset_seconds, zone, .. }) => {
-                                (*offset_seconds, zone.clone())
+                                // The *zone* is inherited; its **offset is not**.
+                                // A named zone has no single offset, and the
+                                // selection has just moved the date --
+                                // `{date: <a March date>, time: <an October
+                                // datetime in Europe/Stockholm>}` is a summer
+                                // date, so the answer is +02:00 and not the
+                                // source's wintertime +01:00. Copying the
+                                // offset carried a value derived from a date
+                                // that is no longer the date (#1006).
+                                match zone {
+                                    Some(name) => {
+                                        let sp = tmp::parse_timezone_spec(name)?;
+                                        (tmp::resolve_offset(&sp, d as i64, t)?, zone.clone())
+                                    }
+                                    // A bare offset has no date to depend on.
+                                    None => (*offset_seconds, None),
+                                }
                             }
                             Some(PropertyValue::Time { offset_seconds, .. }) => (*offset_seconds, None),
                             _ => (0, None),
@@ -3346,14 +3362,26 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
                     // zoned source the same reading is an instant, and treating
                     // it as local time shifts every value by the difference
                     // between the two offsets (#809).
-                    let source_offset = map
-                        .get("datetime")
-                        .or_else(|| map.get("time"))
-                        .and_then(|v| match v {
-                            PropertyValue::ZonedDateTime { offset_seconds, .. }
-                            | PropertyValue::Time { offset_seconds, .. } => Some(*offset_seconds),
-                            _ => None,
-                        });
+                    //
+                    // The source's offset is **re-resolved at the selected
+                    // date** for the same reason the inherited one above is: a
+                    // named zone's offset is a function of the date, and the
+                    // selection has moved it. Reading the stored +01:00 of an
+                    // October value while placing it on a March date undid the
+                    // wrong hour and landed the instant one hour out (#1006).
+                    let source_offset = match map.get("datetime").or_else(|| map.get("time")) {
+                        Some(PropertyValue::ZonedDateTime { offset_seconds, zone, .. }) => {
+                            match zone {
+                                Some(name) => {
+                                    let sp = tmp::parse_timezone_spec(name)?;
+                                    Some(tmp::resolve_offset(&sp, d as i64, t)?)
+                                }
+                                None => Some(*offset_seconds),
+                            }
+                        }
+                        Some(PropertyValue::Time { offset_seconds, .. }) => Some(*offset_seconds),
+                        _ => None,
+                    };
                     // The components describe local time; store the instant.
                     let utc_secs = match source_offset {
                         // A re-zoning: the reading is already the source's wall

--- a/tests/zone_offset_resolved_at_selected_date.rs
+++ b/tests/zone_offset_resolved_at_selected_date.rs
@@ -1,0 +1,89 @@
+//! A named zone's offset is resolved at the *selected* date (#1006).
+//!
+//! ```cypher
+//! WITH localdatetime({year: 1984, week: 10, dayOfWeek: 3, hour: 12, ...}) AS otherDate,
+//!      datetime({year: 1984, month: 10, day: 11, hour: 12,
+//!                timezone: 'Europe/Stockholm'}) AS otherTime
+//! RETURN datetime({date: otherDate, time: otherTime, day: 28, second: 42})
+//! ```
+//!
+//! answered `…+01:00[Europe/Stockholm]` where openCypher says `…+02:00`.
+//! The date, the time, the `second` override and the zone *name* were all
+//! right. Only the offset was wrong.
+//!
+//! A named zone has **no single offset** -- its offset is a function of the
+//! date. The source is in October, when Stockholm is `+01:00`; the selection
+//! moves the value to 28 March, when Stockholm is `+02:00`. The selection
+//! inherited the zone and *copied its stored offset*, which is a value derived
+//! from a date that is no longer the date.
+//!
+//! Two sites had it. The inherited-zone path, and the source offset used by
+//! #809's re-zoning conversion -- where undoing `+01:00` instead of `+02:00`
+//! lands the instant an hour out. Fixing one leaves the other wrong, and the
+//! two failing TCK outlines are exactly one of each.
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+
+const BINDINGS: &str = "WITH localdatetime({year: 1984, week: 10, dayOfWeek: 3, hour: 12, \
+     minute: 31, second: 14, millisecond: 645}) AS otherDate, \
+     datetime({year: 1984, month: 10, day: 11, hour: 12, timezone: 'Europe/Stockholm'}) AS otherTime ";
+
+fn text(cypher: &str) -> String {
+    let store = GraphStore::new();
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let r = QueryExecutor::new(&store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let c = r.columns[0].clone();
+    let v = format!("{:?}", r.records[0].get(&c));
+    let a = v.find('"').expect("a string result");
+    v[a + 1..v.rfind('"').unwrap()].to_string()
+}
+
+fn select(expr: &str) -> String {
+    text(&format!("{BINDINGS} RETURN toString(datetime({expr})) AS d"))
+}
+
+#[test]
+fn an_inherited_zone_takes_the_offset_of_the_selected_date() {
+    // 28 March 1984 is summer time in Stockholm; 11 October is not.
+    assert_eq!(select("{date: otherDate, time: otherTime, day: 28, second: 42}"),
+               "1984-03-28T12:00:42+02:00[Europe/Stockholm]");
+}
+
+#[test]
+fn a_rezoning_converts_from_the_selected_dates_offset() {
+    // 12:00+02:00 is 10:00 UTC, which is 00:00 in Honolulu. Undoing the
+    // source's stored +01:00 instead would give 01:00.
+    assert_eq!(
+        select("{date: otherDate, time: otherTime, day: 28, second: 42, timezone: 'Pacific/Honolulu'}"),
+        "1984-03-28T00:00:42-10:00[Pacific/Honolulu]");
+}
+
+#[test]
+fn a_selection_that_stays_in_winter_is_unchanged() {
+    // The control: when the selected date is on the same side of the DST
+    // boundary as the source, re-resolving and copying agree.
+    assert_eq!(select("{date: otherDate, time: otherTime, month: 12, day: 11}"),
+               "1984-12-11T12:00+01:00[Europe/Stockholm]");
+}
+
+#[test]
+fn a_zoned_source_with_no_selection_keeps_its_own_zone() {
+    // #809: defaulting to UTC re-labelled the value. Still true.
+    assert_eq!(text("RETURN toString(datetime({datetime: datetime({year: 1984, month: 10, \
+                     day: 11, hour: 12, timezone: 'Europe/Stockholm'})})) AS d"),
+               "1984-10-11T12:00+01:00[Europe/Stockholm]");
+}
+
+#[test]
+fn a_bare_offset_has_no_date_to_depend_on() {
+    // A `+05:00` is not a zone and must be copied unchanged whatever the date.
+    assert_eq!(
+        text("WITH time({hour: 12, minute: 31, second: 14, timezone: '+01:00'}) AS t, \
+              date({year: 1984, month: 3, day: 28}) AS d \
+              RETURN toString(datetime({date: d, time: t})) AS r"),
+        "1984-03-28T12:31:14+01:00");
+}


### PR DESCRIPTION
Closes #1006. TCK: closes both remaining `Temporal3[10]` outlines — and with them, **`wrong result` reaches 0.**

```cypher
datetime({date: <a March date>, time: <an October datetime in Europe/Stockholm>,
          day: 28, second: 42})
```

| | |
|---|---|
| openCypher | `1984-03-28T12:00:42**+02:00**[Europe/Stockholm]` |
| Samyama | `1984-03-28T12:00:42**+01:00**[Europe/Stockholm]` |

The date, the time, the `second` override and the zone **name** were all right. Only the offset was wrong.

## Cause

A named zone has **no single offset** — its offset is a function of the date. The source is in October, when Stockholm is `+01:00`; the selection moves the value to 28 March, when Stockholm is `+02:00` (summer time began 25 March 1984).

The selection inherited the zone and **copied its stored offset** — a value derived from a date that is no longer the date.

## Two sites, and fixing one leaves the other wrong

1. **The inherited-zone path**, when the map names no target zone.
2. **The source offset that #809's re-zoning conversion undoes.** With `timezone: 'Pacific/Honolulu'` the result was `01:00:42` rather than `00:00:42`, because undoing `+01:00` instead of `+02:00` lands the instant an hour out.

The two failing outlines are **exactly one of each**, which is what made it worth looking for a second site rather than stopping at the first.

A bare offset has no date to depend on and is still copied unchanged.

## Tests

`tests/zone_offset_resolved_at_selected_date.rs` — 5 cases:

- an inherited zone takes the offset of the selected date
- a re-zoning converts from the **selected date's** offset
- **a selection that stays in winter is unchanged** — the control, where re-resolving and copying agree
- **a zoned source with no selection keeps its own zone** — #809's rule, unaffected
- **a bare offset has no date to depend on**

All 81 existing temporal tests pass.

## TCK

3,763 evaluated → **3,760 pass (99.9%)**, **`wrong result` = 0**, `errored` = 3. Manifest diff: 2 fixed, **0 regressions**.

That zero is H1 gate condition 5's bar exactly: *"zero open P0 wrong-answer bugs"*, for which `CH-TCK wrong_result` is the tracked proxy.