### PR TITLE
Refresh the README's TCK claim to 99.9%, and say the failures are not wrong answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ into a public-health trifecta.* [Browse the catalogue →](case_studies)
 
 ## The 30-Second Tour
 
-**Cypher queries** — MATCH, CREATE, MERGE, aggregations, path finding, 30+ functions. **99.8% of the openCypher TCK's evaluated scenarios pass** (3,754 of 3,763, at 96.6% coverage of the 3,897-scenario corpus, measured 2026-08-30); on the same corpus and comparator Neo4j 5 scores 79.5%. That is conformance only — not performance or scale — and the competitor figure is a fixed baseline from one run. See [`docs/CYPHER_COMPATIBILITY.md`](docs/CYPHER_COMPATIBILITY.md) for a per-feature matrix verified by an executable probe, and [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) for the full accounting.
+**Cypher queries** — MATCH, CREATE, MERGE, aggregations, path finding, 30+ functions. **99.9% of the openCypher TCK's evaluated scenarios pass** (3,760 of 3,763, at 96.6% coverage of the 3,897-scenario corpus, measured 2026-08-30), and **none of the three remaining failures is a wrong answer** — all three raise; on the same corpus and comparator Neo4j 5 scores 79.5%. That is conformance only — not performance or scale — and the competitor figure is a fixed baseline from one run. See [`docs/CYPHER_COMPATIBILITY.md`](docs/CYPHER_COMPATIBILITY.md) for a per-feature matrix verified by an executable probe, and [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) for the full accounting.
 
 ```cypher
 MATCH (a:Person)-[:KNOWS*1..3]->(b:Person)


### PR DESCRIPTION
3,760 of 3,763 evaluated, measured 2026-08-30 at `9201b4f`. The claim was 99.8% from earlier the same day.

## The added clause is the substantive part

> …and **none of the three remaining failures is a wrong answer** — all three raise.

A conformance percentage does not distinguish *"answered incorrectly"* from *"declined to answer"*, and those are very different things to a caller. It is also the distinction the H1 gate's **condition 5** turns on — which is now **MET at zero**, taking the gate to **6 of 7**.

## Third refresh today, each one forced rather than chosen

`claims.py` treats improving past a published claim as making the published claim wrong, so condition 6 goes red the moment the engine gets better than the README. The README, `harness/claims.json` and the run envelope have to move together.

Benchmarks-repo PR #37 carries the other two and the gate verdict.