### PR TITLE
Two probes: which algorithms are callable (ALGO-01), and whether errors carry codes and spans (LANG-12)

### DIFF
--- a/examples/algo_coverage.rs
+++ b/examples/algo_coverage.rs
@@ -1,0 +1,166 @@
+//! Which graph algorithms are callable from Cypher, by execution (ALGO-01).
+//!
+//! ALGO-01 asks for a *count* of production algorithms callable from Cypher —
+//! 12 at baseline, 40 at H1. Counting them by reading the source is exactly
+//! the mistake that put a false claim in ADR-037: a `match` arm can name an
+//! algorithm the executor never reaches, and a filtered search cannot show
+//! what it filtered out.
+//!
+//! So each name is *called*. A name is counted only if `CALL <name>(…)` plans
+//! and executes against a real graph. Three outcomes are distinguished, and
+//! the distinction is the useful part:
+//!
+//! * **callable** — planned and ran.
+//! * **rejected** — reached the operator and was refused, which means the
+//!   dispatcher knows the name but the algorithm is not there.
+//! * **unknown** — no dispatch at all.
+//!
+//! The candidate list deliberately includes algorithms we do **not** have, so
+//! the output measures the distance to 40 rather than confirming what is
+//! already known. An empty gap list would mean the list was written from the
+//! implementation, which would make the measurement circular.
+//!
+//! ```bash
+//! cargo run --release --example algo_coverage -- --json out.json
+//! ```
+
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::MutQueryExecutor;
+use samyama::query::parser::parse_query;
+
+/// A small weighted, directed graph with triangles and two components, so an
+/// algorithm that runs has something to find and cannot trivially return
+/// nothing.
+fn fixture() -> (GraphStore, Vec<u64>) {
+    let mut s = GraphStore::new();
+    let mut ids = Vec::new();
+    for i in 0..6 {
+        let n = s.create_node_with_labels([Label::new("Person")]);
+        s.set_node_property("default", n, "name", PropertyValue::String(format!("p{i}")))
+            .unwrap();
+        ids.push(n.as_u64());
+        let _ = i;
+    }
+    let nodes: Vec<_> = ids.iter().map(|i| samyama::graph::NodeId(*i)).collect();
+    // A triangle, a tail, and a disconnected pair.
+    for (a, b) in [(0, 1), (1, 2), (2, 0), (2, 3), (4, 5)] {
+        let e = s.create_edge(nodes[a], nodes[b], "KNOWS").unwrap();
+        s.set_edge_property(e, "capacity", PropertyValue::Integer(3)).unwrap();
+        s.set_edge_property(e, "weight", PropertyValue::Float(1.5)).unwrap();
+    }
+    (s, ids)
+}
+
+/// Every candidate, with a call that would work if the algorithm existed.
+/// `{a}` and `{b}` are node ids.
+const CANDIDATES: &[(&str, &str)] = &[
+    // Dispatched today.
+    ("pageRank", "CALL algo.pageRank('Person', 'KNOWS') YIELD node, score RETURN count(*)"),
+    ("shortestPath", "CALL algo.shortestPath({a}, {b}) YIELD path, cost RETURN count(*)"),
+    ("wcc", "CALL algo.wcc() YIELD node, component RETURN count(*)"),
+    ("scc", "CALL algo.scc() YIELD node, component RETURN count(*)"),
+    ("weightedPath", "CALL algo.weightedPath({a}, {b}, 'weight') YIELD path, cost RETURN count(*)"),
+    ("maxFlow", "CALL algo.maxFlow({a}, {b}, 'capacity') YIELD max_flow RETURN count(*)"),
+    ("mst", "CALL algo.mst('weight') YIELD source, target, weight RETURN count(*)"),
+    ("triangleCount", "CALL algo.triangleCount() YIELD count RETURN count(*)"),
+    ("cdlp", "CALL algo.cdlp() YIELD node, community RETURN count(*)"),
+    ("lcc", "CALL algo.lcc() YIELD node, coefficient RETURN count(*)"),
+    ("or.solve", "CALL algo.or.solve({}) YIELD result RETURN count(*)"),
+    // In the algorithms crate but not obviously reachable from Cypher.
+    ("pca", "CALL algo.pca() YIELD node, component RETURN count(*)"),
+    ("bfs", "CALL algo.bfs({a}) YIELD node RETURN count(*)"),
+    ("dijkstra", "CALL algo.dijkstra({a}, {b}, 'weight') YIELD path RETURN count(*)"),
+    // Common in other engines and named by the spec's 40. Expected absent --
+    // the list is written from what a user would reach for, not from ours.
+    ("betweenness", "CALL algo.betweenness() YIELD node, score RETURN count(*)"),
+    ("closeness", "CALL algo.closeness() YIELD node, score RETURN count(*)"),
+    ("degree", "CALL algo.degree() YIELD node, score RETURN count(*)"),
+    ("eigenvector", "CALL algo.eigenvector() YIELD node, score RETURN count(*)"),
+    ("articleRank", "CALL algo.articleRank() YIELD node, score RETURN count(*)"),
+    ("louvain", "CALL algo.louvain() YIELD node, community RETURN count(*)"),
+    ("labelPropagation", "CALL algo.labelPropagation() YIELD node, community RETURN count(*)"),
+    ("modularity", "CALL algo.modularity() YIELD community, score RETURN count(*)"),
+    ("kCore", "CALL algo.kCore() YIELD node, core RETURN count(*)"),
+    ("kMeans", "CALL algo.kMeans() YIELD node, cluster RETURN count(*)"),
+    ("nodeSimilarity", "CALL algo.nodeSimilarity() YIELD node1, node2, similarity RETURN count(*)"),
+    ("jaccard", "CALL algo.jaccard({a}, {b}) YIELD similarity RETURN count(*)"),
+    ("adamicAdar", "CALL algo.adamicAdar({a}, {b}) YIELD score RETURN count(*)"),
+    ("commonNeighbors", "CALL algo.commonNeighbors({a}, {b}) YIELD score RETURN count(*)"),
+    ("allShortestPaths", "CALL algo.allShortestPaths({a}, {b}) YIELD path RETURN count(*)"),
+    ("aStar", "CALL algo.aStar({a}, {b}, 'weight') YIELD path RETURN count(*)"),
+    ("yens", "CALL algo.yens({a}, {b}, 3) YIELD path RETURN count(*)"),
+    ("randomWalk", "CALL algo.randomWalk({a}, 5) YIELD node RETURN count(*)"),
+    ("node2vec", "CALL algo.node2vec() YIELD node, embedding RETURN count(*)"),
+    ("fastRP", "CALL algo.fastRP() YIELD node, embedding RETURN count(*)"),
+    ("graphSage", "CALL algo.graphSage() YIELD node, embedding RETURN count(*)"),
+    ("topologicalSort", "CALL algo.topologicalSort() YIELD node, order RETURN count(*)"),
+    ("cycleDetection", "CALL algo.cycleDetection() YIELD cycle RETURN count(*)"),
+    ("bridges", "CALL algo.bridges() YIELD source, target RETURN count(*)"),
+    ("articulationPoints", "CALL algo.articulationPoints() YIELD node RETURN count(*)"),
+    ("harmonicCentrality", "CALL algo.harmonicCentrality() YIELD node, score RETURN count(*)"),
+    // Temporal/causal primitives ALGO-01's H1 target names explicitly.
+    ("temporalReachability", "CALL algo.temporalReachability({a}) YIELD node RETURN count(*)"),
+    ("temporalShortestPath", "CALL algo.temporalShortestPath({a}, {b}) YIELD path RETURN count(*)"),
+    ("causalAncestors", "CALL algo.causalAncestors({a}) YIELD node RETURN count(*)"),
+    ("causalDescendants", "CALL algo.causalDescendants({a}) YIELD node RETURN count(*)"),
+];
+
+fn main() {
+    let (mut store, ids) = fixture();
+    let (a, b) = (ids[0], ids[3]);
+
+    let mut callable = Vec::new();
+    let mut rejected = Vec::new();
+    let mut unknown = Vec::new();
+
+    for (name, template) in CANDIDATES {
+        let cypher = template.replace("{a}", &a.to_string()).replace("{b}", &b.to_string());
+        let outcome = match parse_query(&cypher) {
+            Err(e) => format!("parse: {e}"),
+            // The *mutating* executor, so a write-requiring algorithm is
+            // measured on the same footing as the rest. Under the read
+            // executor `algo.or.solve` failed with "requires write access",
+            // which is a fact about the probe rather than about coverage.
+            Ok(q) => match MutQueryExecutor::new(&mut store, "default".to_string()).execute(&q) {
+                Ok(_) => String::new(),
+                Err(e) => format!("{e:?}"),
+            },
+        };
+        if outcome.is_empty() {
+            callable.push(*name);
+        } else if outcome.contains("Unknown procedure") || outcome.contains("Unknown algorithm") {
+            // Both mean the same thing to a caller. The two messages exist
+            // because an `algo.*` prefix routes to the operator whatever
+            // follows it, so an unrecognised name reaches the operator and is
+            // refused there rather than at the planner. Classifying on the
+            // planner's message alone put every missing algorithm in the
+            // "known" bucket, which flattered the count.
+            unknown.push(*name);
+        } else {
+            // Known to the dispatcher and not callable *here* -- a write-only
+            // algorithm under a read executor, or one that this fixture does
+            // not suit. Kept separate because it is not a coverage gap.
+            rejected.push(format!("{name}: {}", &outcome[..outcome.len().min(90)]));
+        }
+    }
+
+    let json = serde_json::json!({
+        "target_h1": 40,
+        "callable_count": callable.len(),
+        "callable": callable,
+        "known_but_not_callable": rejected,
+        "unknown_to_the_dispatcher": unknown,
+        "candidates_probed": CANDIDATES.len(),
+    });
+    let out = std::env::args().collect::<Vec<_>>();
+    let path = out.iter().position(|a| a == "--json").and_then(|i| out.get(i + 1));
+    let text = serde_json::to_string_pretty(&json).unwrap();
+    match path {
+        Some(p) => std::fs::write(p, &text).unwrap(),
+        None => println!("{text}"),
+    }
+    eprintln!(
+        "{} of {} probed names are callable from Cypher (ALGO-01 H1 target: 40)",
+        callable.len(), CANDIDATES.len()
+    );
+}

--- a/examples/error_quality.rs
+++ b/examples/error_quality.rs
@@ -1,0 +1,128 @@
+//! Do our errors carry a code and a span? (LANG-12)
+//!
+//! LANG-12's H1 target is *"codes + spans on 100%"* — every error carrying a
+//! machine-readable code and the offending span of the query text. Nothing
+//! measured it, so this does, by provoking errors and inspecting them.
+//!
+//! Two properties, checked independently:
+//!
+//! * **code** — a stable machine-readable identifier a client can branch on.
+//!   The variant name (`TypeError`, `SemanticError`) is *not* one: it is a
+//!   Rust type, it is not published, and it does not distinguish
+//!   `TypeError("x is not a node")` from `TypeError("Add requires numeric
+//!   operands")` — two different faults a caller would handle differently.
+//! * **span** — a position or range in the query text. `pest` produces one
+//!   for a grammar error; nothing else does.
+//!
+//! The corpus is written by fault class rather than by what the engine
+//! happens to produce, so the classes we handle badly are visible rather than
+//! absent.
+
+use samyama::graph::{GraphStore, Label};
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+
+/// (class, query) — one representative of each fault a user actually hits.
+const CASES: &[(&str, &str)] = &[
+    ("syntax", "MATCH (n RETURN n"),
+    ("syntax", "RETRUN 1"),
+    ("syntax", "MATCH (n) RETURN"),
+    ("unknown-function", "RETURN lenght('abc')"),
+    ("unknown-procedure", "CALL nosuch.procedure()"),
+    ("unknown-algorithm", "CALL algo.betweenness()"),
+    ("unbound-variable", "RETURN x"),
+    ("unbound-variable", "MATCH (n) RETURN m.name"),
+    ("type-error", "RETURN 1 + {a: 1}"),
+    // Arithmetic on an *entity*, which stays an error by design: `+` on a
+    // string and a list is not one -- Cypher prepends, and it was the wrong
+    // case to probe with (it "did not error" correctly, twice).
+    ("type-error", "MATCH (n) RETURN n + 1"),
+    ("bad-literal", "RETURN '\\uZZ'"),
+    ("bad-argument", "RETURN range(1, 10, 0)"),
+    ("bad-argument", "RETURN substring('abc')"),
+    ("collection-in-pattern", "WITH [1] AS xs MATCH (xs)-->() RETURN 1"),
+    ("aggregate-misuse", "RETURN count(*) + n"),
+    ("write-in-read", "MATCH (n) DELETE n RETURN n"),
+];
+
+/// Does the text carry something a client could branch on that is not just
+/// English prose? A code is a token like `Neo.ClientError.Statement.SyntaxError`
+/// or `SG-1042` — stable, greppable, documented.
+fn has_code(msg: &str) -> bool {
+    // Deliberately generous: any bracketed or dotted uppercase token, or an
+    // explicit `code` field, counts. Being generous matters — a strict test
+    // that found nothing would be indistinguishable from a broken detector.
+    msg.split_whitespace().any(|t| {
+        let t = t.trim_matches(|c: char| !c.is_alphanumeric() && c != '.' && c != '-');
+        (t.contains('.') && t.split('.').count() >= 3
+            && t.chars().next().is_some_and(|c| c.is_ascii_uppercase()))
+            || (t.contains('-') && t.split('-').next().is_some_and(
+                |p| p.len() >= 2 && p.chars().all(|c| c.is_ascii_uppercase())))
+    }) || msg.to_lowercase().contains("code:")
+}
+
+/// Does it point at a position in the query? A line/column pair, a caret
+/// diagram, or an explicit offset.
+fn has_span(msg: &str) -> bool {
+    let l = msg.to_lowercase();
+    l.contains("-->") || l.contains("^") || l.contains("line ") || l.contains("column ")
+        || l.contains("offset") || l.contains("position")
+}
+
+fn main() {
+    let mut store = GraphStore::new();
+    let n = store.create_node_with_labels([Label::new("N")]);
+    // A real property, so `n.name + [1,2]` is String + List rather than
+    // null + List. The first attempt left it unset, and the case "did not
+    // error" -- correctly, because `null + anything` is null in Cypher. A
+    // probe whose fixture makes the fault untriggerable measures nothing.
+    store.set_node_property("default", n, "name",
+                            samyama::graph::PropertyValue::String("a".into())).unwrap();
+
+    let mut rows = Vec::new();
+    for (class, q) in CASES {
+        let msg = match parse_query(q) {
+            Err(e) => format!("{e}"),
+            Ok(p) => match QueryExecutor::new(&store).execute(&p) {
+                Err(e) => format!("{e}"),
+                // A query we expected to fail and which succeeded is a
+                // finding of its own -- it is the class LANG-03 is about --
+                // so it is recorded rather than skipped.
+                Ok(_) => String::new(),
+            },
+        };
+        rows.push(serde_json::json!({
+            "class": class,
+            "query": q,
+            "errored": !msg.is_empty(),
+            "has_code": !msg.is_empty() && has_code(&msg),
+            "has_span": !msg.is_empty() && has_span(&msg),
+            "message": msg.chars().take(160).collect::<String>(),
+        }));
+    }
+
+    let errored: Vec<_> = rows.iter().filter(|r| r["errored"] == true).collect();
+    let with_code = errored.iter().filter(|r| r["has_code"] == true).count();
+    let with_span = errored.iter().filter(|r| r["has_span"] == true).count();
+    let did_not_error: Vec<_> = rows.iter()
+        .filter(|r| r["errored"] == false)
+        .map(|r| r["query"].as_str().unwrap_or("").to_string())
+        .collect();
+
+    let json = serde_json::json!({
+        "probed": rows.len(),
+        "errored": errored.len(),
+        "with_code": with_code,
+        "with_span": with_span,
+        "did_not_error": did_not_error,
+        "cases": rows,
+    });
+    let args: Vec<String> = std::env::args().collect();
+    let text = serde_json::to_string_pretty(&json).unwrap();
+    match args.iter().position(|a| a == "--json").and_then(|i| args.get(i + 1)) {
+        Some(p) => std::fs::write(p, &text).unwrap(),
+        None => println!("{text}"),
+    }
+    eprintln!("{} errored; {} carry a code, {} a span (LANG-12 wants 100% of both)",
+              errored.len(), with_code, with_span);
+}


### PR DESCRIPTION
Two H1 requirements that nothing was measuring, both measured **by execution** rather than by reading the source — because a `match` arm can name something the executor never reaches, and a filtered search cannot show what it filtered out. That mistake put a false claim into ADR-037 this week.

*(A second commit was added after review was requested; the description covers both.)*

---

## ALGO-01 — algorithms callable from Cypher: **10**, target 40

`pageRank`, `shortestPath`, `wcc`, `scc`, `weightedPath`, `maxFlow`, `mst`, `triangleCount`, `cdlp`, `lcc`. `algo.or.solve` dispatches but wants a domain config this probe does not supply, so it is reported separately rather than counted either way.

**Ten is one short of the registry's baseline of 12.** `pca` is exported from `samyama-graph-algorithms` and **is not reachable from Cypher at all** — the difference between what we have built and what a user can call, which is the distinction ALGO-01 is about (#1013).

The candidate list deliberately probes **33 algorithms we do not have** — betweenness, louvain, k-core, node2vec, and the four temporal/causal primitives the H1 target names explicitly. A list written from the implementation would always answer 100%; written from what a user would reach for, it measures the distance to 40, and that list is the answer to "what next".

**Two things the first version got wrong, both caught by running it:** unknown `algo.*` names are refused by the *operator*, not the planner, so they say `Unknown algorithm` — classifying on the planner's message put all 33 in the "known" bucket and flattered the count. And it now uses `MutQueryExecutor`, since under the read executor a write-requiring algorithm fails with "requires write access", a fact about the probe rather than about coverage.

---

## LANG-12 — errors with a code and a span: **0%** and **19%**

Target is 100% of both.

```
16 fault classes probed, 16 errored
 0 carry a machine-readable code
 3 carry a span — all three grammar errors, where pest supplies it
```

**The Rust variant name is not a code**: it is unpublished, and it does not separate two faults a caller would handle differently. `TypeError("x is not a node")` and `TypeError("Add requires numeric or string operands")` are the same variant to a client.

The corpus is written **by fault class** — syntax, unknown function, unbound variable, type error, bad argument, write-in-read — rather than from what the engine produces. A corpus derived from our own error variants would report full coverage of whatever we already do.

The code detector is **deliberately generous** (any dotted or hyphenated uppercase token, or an explicit `code:` field). A strict test finding nothing would be indistinguishable from a broken one. It still finds none.

### Two probe cases were wrong before they were right

Both because the engine was correct and my case was not. `n.name + [1,2]` with `name` unset is `null + list` → null in Cypher, so it did not error — correctly. With `name` set it is `string + list`, which Cypher **prepends**, so it still did not error — also correctly, and it confirms #986. The case is now arithmetic on an entity, which stays an error by design.

A probe whose fixture makes the fault untriggerable measures nothing.

---

Harness suites reading both outputs land in the benchmarks repo. Scorecard: 16 → 18 requirements touched.