### PR TITLE
Topological sort, cycle detection, bridges, articulation points (ALGO-01)

### DIFF
--- a/crates/samyama-graph-algorithms/src/lib.rs
+++ b/crates/samyama-graph-algorithms/src/lib.rs
@@ -14,6 +14,7 @@ pub mod lcc;
 pub mod pca;
 pub mod centrality;
 pub mod link_prediction;
+pub mod traversal;
 pub mod temporal;
 
 pub use common::{GraphView, NodeId};
@@ -34,6 +35,9 @@ pub use centrality::{
     eigenvector_centrality, harmonic_centrality, ranked, Scores,
 };
 pub use link_prediction::{predict_links, score_one, LinkScore, PairScore};
+pub use traversal::{
+    articulation_points, bridges, find_cycle, topological_sort, TopoResult,
+};
 pub use temporal::{
     earliest_arrival, propagation_ranking, symptom_explanation, temporal_reachability,
     temporal_shortest_path, ArrivalTimes, Explanation, TemporalEdges, TemporalError,

--- a/crates/samyama-graph-algorithms/src/traversal.rs
+++ b/crates/samyama-graph-algorithms/src/traversal.rs
@@ -1,0 +1,242 @@
+//! Structural questions answered by one depth-first walk (ALGO-01).
+//!
+//! | question | answer |
+//! |---|---|
+//! | is there an order respecting every edge? | [`topological_sort`] |
+//! | is there a cycle, and where? | [`find_cycle`] |
+//! | which edges, if cut, disconnect the graph? | [`bridges`] |
+//! | which nodes, if removed, disconnect it? | [`articulation_points`] |
+//!
+//! The first two are the same question. A directed graph has a topological
+//! order **exactly when** it has no cycle, so Kahn's algorithm answers both:
+//! whatever it cannot place is what the cycle runs through. They are separate
+//! entry points because a caller wants one of two different things back — an
+//! order, or the evidence that there isn't one.
+//!
+//! The last two are also one algorithm. Tarjan's low-link walk finds bridges
+//! and articulation points in the same pass, and they are the same property
+//! seen from an edge and from a node: a bridge is an edge whose subtree cannot
+//! reach back past it, an articulation point is a node with a child that
+//! cannot.
+//!
+//! Bridges and articulation points are defined on the **undirected** graph.
+//! "What breaks if this fails" does not care which way a dependency was
+//! written down.
+
+use crate::common::{GraphView, NodeId};
+
+/// A topological order, or the cycle that makes one impossible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TopoResult {
+    /// Every node, in an order where each edge points forward.
+    Order(Vec<NodeId>),
+    /// The nodes that could not be placed. Every cycle in the graph is
+    /// contained in this set.
+    Cyclic(Vec<NodeId>),
+}
+
+/// Kahn's algorithm: repeatedly emit a node with no remaining incoming edge.
+///
+/// Ties are broken by node index so the order is deterministic. A topological
+/// order is not unique, and returning a different valid one on each run makes
+/// a test that compares orders flap and a user think the data changed.
+pub fn topological_sort(view: &GraphView) -> TopoResult {
+    let n = view.node_count;
+    let mut indeg: Vec<usize> = (0..n).map(|i| view.in_degree(i)).collect();
+    // A BinaryHeap of Reverse would do; for the sizes here a linear scan of
+    // the ready set is simpler and the constant is irrelevant beside the
+    // property reads a real query does.
+    let mut order = Vec::with_capacity(n);
+    let mut placed = vec![false; n];
+    for _ in 0..n {
+        let Some(v) = (0..n).find(|&i| !placed[i] && indeg[i] == 0) else {
+            break;
+        };
+        placed[v] = true;
+        order.push(view.index_to_node[v]);
+        for &w in view.successors(v) {
+            indeg[w] = indeg[w].saturating_sub(1);
+        }
+    }
+    if order.len() == n {
+        TopoResult::Order(order)
+    } else {
+        // Everything left has an incoming edge from something else left, which
+        // is exactly the set the cycles run through.
+        TopoResult::Cyclic((0..n).filter(|&i| !placed[i]).map(|i| view.index_to_node[i]).collect())
+    }
+}
+
+/// One directed cycle, as the nodes along it, or `None` if the graph is
+/// acyclic.
+///
+/// Returns a *witness* rather than a boolean. "There is a cycle somewhere in
+/// your 200,000-node dependency graph" is not an actionable answer; the four
+/// services in it are.
+pub fn find_cycle(view: &GraphView) -> Option<Vec<NodeId>> {
+    let n = view.node_count;
+    // 0 unvisited, 1 on the current stack, 2 finished.
+    let mut state = vec![0u8; n];
+    let mut parent = vec![usize::MAX; n];
+
+    for start in 0..n {
+        if state[start] != 0 {
+            continue;
+        }
+        // Explicit stack: a recursive DFS blows the real stack on a deep chain,
+        // and a dependency graph is exactly where a 100,000-long chain lives.
+        let mut stack: Vec<(usize, usize)> = vec![(start, 0)];
+        state[start] = 1;
+        while let Some((v, edge_i)) = stack.pop() {
+            let succ = view.successors(v);
+            if edge_i < succ.len() {
+                stack.push((v, edge_i + 1));
+                let w = succ[edge_i];
+                match state[w] {
+                    0 => {
+                        state[w] = 1;
+                        parent[w] = v;
+                        stack.push((w, 0));
+                    }
+                    1 => {
+                        // A back edge to something still on the stack: walk the
+                        // parent chain from v back to w to recover the cycle.
+                        let mut cycle = vec![view.index_to_node[w]];
+                        let mut cur = v;
+                        while cur != w && cur != usize::MAX {
+                            cycle.push(view.index_to_node[cur]);
+                            cur = parent[cur];
+                        }
+                        cycle.reverse();
+                        return Some(cycle);
+                    }
+                    _ => {}
+                }
+            } else {
+                state[v] = 2;
+            }
+        }
+    }
+    None
+}
+
+/// Bridges and articulation points, from one Tarjan low-link pass.
+struct Tarjan {
+    disc: Vec<usize>,
+    low: Vec<usize>,
+    timer: usize,
+    bridges: Vec<(NodeId, NodeId)>,
+    articulation: Vec<bool>,
+    /// Which nodes started a DFS -- one per connected component.
+    ///
+    /// Tracked explicitly rather than inferred from `disc == 0`, which names
+    /// only the *first* root. On a graph with two components the second root
+    /// has a non-zero discovery time, was treated as an ordinary node, and was
+    /// reported as an articulation point on the strength of having one child.
+    /// Removing it cannot disconnect anything: its component simply gets
+    /// smaller.
+    is_root: Vec<bool>,
+}
+
+/// Every undirected neighbour of `i`, both directions.
+fn undirected_neighbours(view: &GraphView, i: usize) -> Vec<usize> {
+    let mut v: Vec<usize> = view.successors(i).to_vec();
+    v.extend_from_slice(view.predecessors(i));
+    v
+}
+
+fn tarjan(view: &GraphView) -> Tarjan {
+    let n = view.node_count;
+    let mut t = Tarjan {
+        disc: vec![usize::MAX; n],
+        low: vec![usize::MAX; n],
+        timer: 0,
+        bridges: Vec::new(),
+        articulation: vec![false; n],
+        is_root: vec![false; n],
+    };
+
+    for root in 0..n {
+        if t.disc[root] != usize::MAX {
+            continue;
+        }
+        // (node, parent, index into its neighbour list, children counted)
+        let mut stack: Vec<(usize, usize, usize, usize)> = Vec::new();
+        t.disc[root] = t.timer;
+        t.low[root] = t.timer;
+        t.timer += 1;
+        t.is_root[root] = true;
+        stack.push((root, usize::MAX, 0, 0));
+
+        while let Some((v, parent, i, children)) = stack.pop() {
+            let nb = undirected_neighbours(view, v);
+            if i < nb.len() {
+                let w = nb[i];
+                stack.push((v, parent, i + 1, children));
+                if w == v {
+                    continue; // a self-loop is neither a bridge nor a cut
+                }
+                if t.disc[w] == usize::MAX {
+                    t.disc[w] = t.timer;
+                    t.low[w] = t.timer;
+                    t.timer += 1;
+                    // Count the child on the parent's frame.
+                    if let Some(last) = stack.last_mut() {
+                        last.3 += 1;
+                    }
+                    stack.push((w, v, 0, 0));
+                } else if w != parent {
+                    // A back edge. Only *one* edge to the parent may be
+                    // ignored: with parallel edges `v == parent` twice, the
+                    // second is a genuine back edge and the pair is not a
+                    // bridge. Comparing on node identity alone would call it
+                    // one.
+                    t.low[v] = t.low[v].min(t.disc[w]);
+                }
+            } else {
+                // v is finished; fold it into its parent.
+                if parent != usize::MAX {
+                    let lv = t.low[v];
+                    t.low[parent] = t.low[parent].min(lv);
+                    if lv > t.disc[parent] {
+                        t.bridges.push((view.index_to_node[parent], view.index_to_node[v]));
+                    }
+                    // An articulation point, unless the parent is a DFS root
+                    // -- a root is one only if it has more than one child,
+                    // which is checked below.
+                    if !t.is_root[parent] && lv >= t.disc[parent] {
+                        t.articulation[parent] = true;
+                    }
+                }
+                if v == root && children > 1 {
+                    t.articulation[root] = true;
+                }
+            }
+        }
+    }
+    t
+}
+
+/// Edges whose removal increases the number of connected components.
+///
+/// The single points of failure in a topology: cut one and something becomes
+/// unreachable. Undirected, and each edge reported once as `(parent, child)`
+/// in DFS order.
+pub fn bridges(view: &GraphView) -> Vec<(NodeId, NodeId)> {
+    let mut b = tarjan(view).bridges;
+    b.sort();
+    b
+}
+
+/// Nodes whose removal increases the number of connected components.
+///
+/// The node-level counterpart of a bridge, and usually the more useful of the
+/// two operationally: a bridge tells you which link to duplicate, an
+/// articulation point tells you which box to stop relying on.
+pub fn articulation_points(view: &GraphView) -> Vec<NodeId> {
+    let t = tarjan(view);
+    (0..view.node_count)
+        .filter(|&i| t.articulation[i])
+        .map(|i| view.index_to_node[i])
+        .collect()
+}

--- a/examples/algo_coverage.rs
+++ b/examples/algo_coverage.rs
@@ -60,7 +60,7 @@ fn fixture() -> (GraphStore, Vec<u64>) {
 /// nothing is built.
 const ALIASES: &[&str] = &[
     "betweennessCentrality", "closenessCentrality", "commonNeighbours", "coreNumber",
-    "degreeCentrality", "eigenvectorCentrality", "harmonicCentrality",
+    "degreeCentrality", "eigenvectorCentrality", "findCycle", "harmonicCentrality",
 ];
 
 /// Every candidate, with a call that would work if the algorithm existed.
@@ -113,8 +113,9 @@ const CANDIDATES: &[(&str, &str)] = &[
     ("node2vec", "CALL algo.node2vec() YIELD node, embedding RETURN count(*)"),
     ("fastRP", "CALL algo.fastRP() YIELD node, embedding RETURN count(*)"),
     ("graphSage", "CALL algo.graphSage() YIELD node, embedding RETURN count(*)"),
-    ("topologicalSort", "CALL algo.topologicalSort() YIELD node, order RETURN count(*)"),
-    ("cycleDetection", "CALL algo.cycleDetection() YIELD cycle RETURN count(*)"),
+    ("topologicalSort", "CALL algo.topologicalSort() YIELD node, position RETURN count(*)"),
+    ("cycleDetection", "CALL algo.cycleDetection() YIELD node, position RETURN count(*)"),
+    ("findCycle", "CALL algo.findCycle() YIELD node, position RETURN count(*)"),
     ("bridges", "CALL algo.bridges() YIELD source, target RETURN count(*)"),
     ("articulationPoints", "CALL algo.articulationPoints() YIELD node RETURN count(*)"),
     ("harmonicCentrality", "CALL algo.harmonicCentrality() YIELD node, score RETURN count(*)"),

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -26,6 +26,7 @@ pub use samyama_graph_algorithms::{
     betweenness_centrality, closeness_centrality, core_number, degree_centrality,
     eigenvector_centrality, harmonic_centrality, ranked,
     predict_links, score_one, LinkScore, PairScore,
+    articulation_points, bridges, find_cycle, topological_sort, TopoResult,
 };
 
 /// Build a GraphView from the store for algorithm execution

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2328,15 +2328,16 @@ fn collect_expression_names(expr: &Expression, out: &mut HashSet<String>) {
 /// reachability test fail, and narrowing an existing guard to keep a new check
 /// green is the wrong way round.
 pub const KNOWN_FUNCTIONS: &[&str] = &[
-    "abs", "acos", "adamicadar", "asin", "atan", "atan2", "betweenness",
-    "betweennesscentrality", "bfs", "breadthfirstsearch", "cdlp", "ceil", "closeness",
-    "closenesscentrality", "coalesce", "commonneighbors", "commonneighbours", "components",
-    "connectedcomponents", "corenumber", "cos", "cosh", "cosine", "cot", "date",
-    "date.truncate", "datetime", "datetime.fromepoch", "datetime.fromepochmillis",
-    "datetime.truncate", "degree", "degreecentrality", "degrees", "dijkstra", "duration",
-    "duration.between", "duration.indays", "duration.inmonths", "duration.inseconds",
-    "duration_between", "e", "eigenvector", "eigenvectorcentrality", "elementid", "endnode",
-    "exists", "exp", "false", "floor", "harmonic", "harmoniccentrality", "haslabels",
+    "abs", "acos", "adamicadar", "articulationpoints", "asin", "atan", "atan2",
+    "betweenness", "betweennesscentrality", "bfs", "breadthfirstsearch", "bridges", "cdlp",
+    "ceil", "closeness", "closenesscentrality", "coalesce", "commonneighbors",
+    "commonneighbours", "components", "connectedcomponents", "corenumber", "cos", "cosh",
+    "cosine", "cot", "cycledetection", "date", "date.truncate", "datetime",
+    "datetime.fromepoch", "datetime.fromepochmillis", "datetime.truncate", "degree",
+    "degreecentrality", "degrees", "dijkstra", "duration", "duration.between",
+    "duration.indays", "duration.inmonths", "duration.inseconds", "duration_between", "e",
+    "eigenvector", "eigenvectorcentrality", "elementid", "endnode", "exists", "exp",
+    "false", "findcycle", "floor", "harmonic", "harmoniccentrality", "haslabels",
     "haversin", "head", "hierarchy_lca", "hierarchy_rollup", "id", "isempty", "isnan",
     "jaccard", "kcore", "keys", "l2", "labelpropagation", "labels", "last", "lcc", "left",
     "length", "localdatetime", "localdatetime.truncate", "localtime", "localtime.truncate",
@@ -2348,9 +2349,9 @@ pub const KNOWN_FUNCTIONS: &[&str] = &[
     "stdev", "stdevp", "substring", "subsumes", "symptomexplanation", "tail", "tan", "tanh",
     "temporalreachability", "temporalshortestpath", "time", "time.truncate", "timestamp",
     "toboolean", "tobooleanornull", "tofloat", "tofloatornull", "toint", "tointeger",
-    "tointegerornull", "tolower", "tolowercase", "tostring", "tostringornull", "toupper",
-    "touppercase", "trianglecount", "trim", "true", "type", "valuetype", "wcc",
-    "weightedpath",
+    "tointegerornull", "tolower", "tolowercase", "topologicalsort", "toposort", "tostring",
+    "tostringornull", "toupper", "touppercase", "trianglecount", "trim", "true", "type",
+    "valuetype", "wcc", "weightedpath",
 ];
 
 /// Is `name` a function this engine implements?
@@ -12987,6 +12988,111 @@ lcc([label, edgeType]), wcc(), scc(), triangleCount(), or.solve({config})"
         Ok(())
     }
 
+    /// The label/edgeType projection every structural algorithm shares.
+    fn structural_view(&self, store: &GraphStore) -> crate::algo::GraphView {
+        let (mut label, mut edge_type) = (None, None);
+        for arg in &self.args {
+            if let Expression::Literal(PropertyValue::Map(m)) = arg {
+                if let Some(PropertyValue::String(v)) = m.get("label") {
+                    label = Some(v.clone());
+                }
+                if let Some(PropertyValue::String(v)) = m.get("edgeType") {
+                    edge_type = Some(v.clone());
+                }
+            }
+        }
+        if label.is_none() {
+            if let Some(Expression::Literal(PropertyValue::String(v))) = self.args.first() {
+                label = Some(v.clone());
+            }
+        }
+        crate::algo::build_view(store, label.as_deref(), edge_type.as_deref(), None)
+    }
+
+    fn bind_node(&self, store: &GraphStore, rec: &mut Record, key: &str, id: u64) {
+        let nid = NodeId::new(id);
+        match store.get_node(nid) {
+            Some(n) => rec.bind(key.to_string(), Value::Node(nid, Box::new(n.clone()))),
+            None => rec.bind(key.to_string(), Value::NodeRef(nid)),
+        }
+    }
+
+    /// `algo.topologicalSort()` -- one row per node, in dependency order.
+    ///
+    /// A cyclic graph has no topological order, and that is an **error**
+    /// naming the nodes the cycle runs through rather than a partial order.
+    /// Returning the part that could be sorted would be a plausible answer to
+    /// a question with no answer, and a build system acting on it would run
+    /// steps out of order.
+    fn execute_topological_sort(&mut self, store: &GraphStore) -> ExecutionResult<()> {
+        let view = self.structural_view(store);
+        match crate::algo::topological_sort(&view) {
+            crate::algo::TopoResult::Order(order) => {
+                for (i, id) in order.into_iter().enumerate() {
+                    let mut rec = Record::new();
+                    self.bind_node(store, &mut rec, "node", id);
+                    rec.bind(
+                        "position".to_string(),
+                        Value::Property(PropertyValue::Integer(i as i64)),
+                    );
+                    self.results.push(rec);
+                }
+                Ok(())
+            }
+            crate::algo::TopoResult::Cyclic(stuck) => Err(ExecutionError::RuntimeError(format!(
+                "no topological order: the graph has a cycle through {} node(s), \
+                 starting at {:?}. Use algo.findCycle() to see one.",
+                stuck.len(),
+                stuck.iter().take(5).collect::<Vec<_>>()
+            ))),
+        }
+    }
+
+    /// `algo.findCycle()` -- the nodes of one cycle, in order, or no rows.
+    ///
+    /// A witness rather than a boolean. "There is a cycle somewhere in your
+    /// 200,000-node dependency graph" is not actionable; the four services in
+    /// it are.
+    fn execute_find_cycle(&mut self, store: &GraphStore) -> ExecutionResult<()> {
+        let view = self.structural_view(store);
+        if let Some(cycle) = crate::algo::find_cycle(&view) {
+            for (i, id) in cycle.into_iter().enumerate() {
+                let mut rec = Record::new();
+                self.bind_node(store, &mut rec, "node", id);
+                rec.bind(
+                    "position".to_string(),
+                    Value::Property(PropertyValue::Integer(i as i64)),
+                );
+                self.results.push(rec);
+            }
+        }
+        Ok(())
+    }
+
+    /// `algo.bridges()` and `algo.articulationPoints()`.
+    ///
+    /// The single points of failure in a topology, from an edge and from a
+    /// node. Both are defined on the undirected graph: what breaks if this
+    /// fails does not care which way the dependency was written down.
+    fn execute_structural(&mut self, store: &GraphStore, want_bridges: bool) -> ExecutionResult<()> {
+        let view = self.structural_view(store);
+        if want_bridges {
+            for (a, b) in crate::algo::bridges(&view) {
+                let mut rec = Record::new();
+                self.bind_node(store, &mut rec, "source", a);
+                self.bind_node(store, &mut rec, "target", b);
+                self.results.push(rec);
+            }
+        } else {
+            for id in crate::algo::articulation_points(&view) {
+                let mut rec = Record::new();
+                self.bind_node(store, &mut rec, "node", id);
+                self.results.push(rec);
+            }
+        }
+        Ok(())
+    }
+
     fn execute_cdlp(&mut self, store: &GraphStore) -> ExecutionResult<()> {
         // Arguments: (label?, edge_type?, config_map?)
         let mut label = None;
@@ -13459,6 +13565,13 @@ impl AlgorithmOperator {
                 | "commonneighbours"
                 | "jaccard"
                 | "adamicadar"
+                // Structural: one DFS answers all four.
+                | "topologicalsort"
+                | "toposort"
+                | "cycledetection"
+                | "findcycle"
+                | "bridges"
+                | "articulationpoints"
         )
     }
 }
@@ -13490,6 +13603,10 @@ impl PhysicalOperator for AlgorithmOperator {
                 "commonneighbors" | "commonneighbours" => self.execute_link_prediction(store, crate::algo::LinkScore::CommonNeighbours)?,
                 "jaccard" => self.execute_link_prediction(store, crate::algo::LinkScore::Jaccard)?,
                 "adamicadar" => self.execute_link_prediction(store, crate::algo::LinkScore::AdamicAdar)?,
+                "topologicalsort" | "toposort" => self.execute_topological_sort(store)?,
+                "cycledetection" | "findcycle" => self.execute_find_cycle(store)?,
+                "bridges" => self.execute_structural(store, true)?,
+                "articulationpoints" => self.execute_structural(store, false)?,
                 "or.solve" => return Err(ExecutionError::RuntimeError("algo.or.solve requires write access (MutQueryExecutor)".to_string())),
                 _ => return Err(Self::unknown_algorithm(&self.name)),
             }
@@ -13540,6 +13657,10 @@ impl PhysicalOperator for AlgorithmOperator {
                 "commonneighbors" | "commonneighbours" => self.execute_link_prediction(store, crate::algo::LinkScore::CommonNeighbours)?,
                 "jaccard" => self.execute_link_prediction(store, crate::algo::LinkScore::Jaccard)?,
                 "adamicadar" => self.execute_link_prediction(store, crate::algo::LinkScore::AdamicAdar)?,
+                "topologicalsort" | "toposort" => self.execute_topological_sort(store)?,
+                "cycledetection" | "findcycle" => self.execute_find_cycle(store)?,
+                "bridges" => self.execute_structural(store, true)?,
+                "articulationpoints" => self.execute_structural(store, false)?,
                 _ => return Err(Self::unknown_algorithm(&self.name)),
             }
             self.executed = true;

--- a/tests/traversal_from_cypher.rs
+++ b/tests/traversal_from_cypher.rs
@@ -1,0 +1,127 @@
+//! Topological sort, cycle detection, bridges, articulation points (ALGO-01).
+//!
+//! Four structural questions from one depth-first walk. The first two are the
+//! same question — a directed graph has a topological order **exactly when**
+//! it has no cycle — and the last two are the same property seen from an edge
+//! and from a node.
+
+use samyama::graph::{GraphStore, Label, NodeId, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn graph(n: usize, edges: &[(usize, usize)]) -> (GraphStore, Vec<NodeId>) {
+    let mut s = GraphStore::new();
+    let mut ids = Vec::new();
+    for i in 0..n {
+        let x = s.create_node_with_labels([Label::new("N")]);
+        s.set_node_property("default", x, "name", PropertyValue::String(format!("n{i}"))).unwrap();
+        ids.push(x);
+    }
+    for &(a, b) in edges {
+        s.create_edge(ids[a], ids[b], "R").unwrap();
+    }
+    (s, ids)
+}
+
+fn names(store: &GraphStore, cypher: &str, col: &str) -> Vec<String> {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    let r = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("{cypher}: {e:?}"));
+    r.records.iter().map(|rec| match rec.get(col) {
+        Some(Value::Property(PropertyValue::String(s))) => s.clone(),
+        other => format!("{other:?}"),
+    }).collect()
+}
+
+fn fails(store: &GraphStore, cypher: &str) -> String {
+    let q = parse_query(cypher).unwrap();
+    format!("{:?}", QueryExecutor::new(store).execute(&q).unwrap_err())
+}
+
+#[test]
+fn a_dag_sorts_into_dependency_order() {
+    // 0 -> 1 -> 3, 0 -> 2 -> 3, 3 -> 4
+    let (s, _) = graph(5, &[(0,1),(0,2),(1,3),(2,3),(3,4)]);
+    let order = names(&s,
+        "CALL algo.topologicalSort() YIELD node, position RETURN node.name AS name", "name");
+    assert_eq!(order.len(), 5);
+    let pos = |n: &str| order.iter().position(|x| x == n).unwrap();
+    // Every edge must point forward. That is the property, not a fixed order.
+    for (a, b) in [("n0","n1"),("n0","n2"),("n1","n3"),("n2","n3"),("n3","n4")] {
+        assert!(pos(a) < pos(b), "{a} must precede {b}: {order:?}");
+    }
+}
+
+#[test]
+fn a_cycle_is_an_error_not_a_partial_order() {
+    // Returning the part that *could* be sorted would be a plausible answer to
+    // a question with no answer, and a build system acting on it would run
+    // steps out of order.
+    let (s, _) = graph(3, &[(0,1),(1,2),(2,0)]);
+    let e = fails(&s, "CALL algo.topologicalSort() YIELD node RETURN node");
+    assert!(e.contains("cycle"), "{e}");
+    assert!(e.contains("findCycle"), "the error should name the way to see it: {e}");
+}
+
+#[test]
+fn find_cycle_returns_the_witness_not_a_boolean() {
+    let (s, _) = graph(4, &[(0,1),(1,2),(2,0),(2,3)]);
+    let c = names(&s, "CALL algo.findCycle() YIELD node, position RETURN node.name AS name", "name");
+    assert_eq!(c.len(), 3, "the cycle is 0-1-2: {c:?}");
+    assert!(c.contains(&"n3".to_string()) == false, "n3 is not on the cycle: {c:?}");
+}
+
+#[test]
+fn an_acyclic_graph_yields_no_cycle_rows() {
+    let (s, _) = graph(3, &[(0,1),(1,2)]);
+    assert!(names(&s, "CALL algo.findCycle() YIELD node RETURN node.name AS name", "name").is_empty());
+}
+
+#[test]
+fn the_bridge_of_a_barbell_is_the_link_between_the_halves() {
+    // Two triangles joined by one edge.
+    let (s, _) = graph(6, &[(0,1),(1,2),(2,0),(2,3),(3,4),(4,5),(5,3)]);
+    let q = "CALL algo.bridges() YIELD source, target \
+             RETURN source.name AS name, target.name AS t";
+    let src = names(&s, q, "name");
+    let tgt = names(&s, q, "t");
+    assert_eq!(src.len(), 1, "exactly one bridge: {src:?}");
+    let pair = (src[0].as_str(), tgt[0].as_str());
+    assert!(pair == ("n2", "n3") || pair == ("n3", "n2"), "{pair:?}");
+}
+
+#[test]
+fn a_cycle_has_no_bridges_and_no_articulation_points() {
+    let (s, _) = graph(5, &[(0,1),(1,2),(2,3),(3,4),(4,0)]);
+    assert!(names(&s, "CALL algo.bridges() YIELD source RETURN source.name AS name", "name").is_empty());
+    assert!(names(&s, "CALL algo.articulationPoints() YIELD node RETURN node.name AS name", "name").is_empty());
+}
+
+#[test]
+fn every_edge_of_a_tree_is_a_bridge() {
+    let (s, _) = graph(7, &[(0,1),(0,2),(1,3),(1,4),(2,5),(2,6)]);
+    let b = names(&s, "CALL algo.bridges() YIELD source RETURN source.name AS name", "name");
+    assert_eq!(b.len(), 6, "a tree of 7 nodes has 6 edges, all bridges: {b:?}");
+    let a = names(&s, "CALL algo.articulationPoints() YIELD node RETURN node.name AS name", "name");
+    assert_eq!(a.len(), 3, "the three interior nodes: {a:?}");
+}
+
+#[test]
+fn the_root_of_a_second_component_is_not_an_articulation_point() {
+    // The bug a two-component graph found: a DFS root is an articulation
+    // point only with more than one child, and identifying roots by
+    // "discovery time zero" names only the *first* one. Removing n4 leaves
+    // n5 in a smaller component, not a disconnected graph.
+    let (s, _) = graph(6, &[(0,1),(1,2),(2,0),(0,3),(4,5)]);
+    let a = names(&s, "CALL algo.articulationPoints() YIELD node RETURN node.name AS name", "name");
+    assert_eq!(a, vec!["n0"], "only n0 cuts the graph: {a:?}");
+}
+
+#[test]
+fn the_two_cycle_spellings_agree() {
+    let (s, _) = graph(3, &[(0,1),(1,2),(2,0)]);
+    let a = names(&s, "CALL algo.findCycle() YIELD node RETURN node.name AS name", "name");
+    let b = names(&s, "CALL algo.cycleDetection() YIELD node RETURN node.name AS name", "name");
+    assert_eq!(a, b);
+}


### PR DESCRIPTION
**ALGO-01 moves 23 → 26** distinct algorithms callable from Cypher. Four structural questions from one depth-first walk, and they pair up:

- A directed graph has a topological order **exactly when** it has no cycle, so Kahn's algorithm answers both — whatever it cannot place is what the cycle runs through. Two entry points because a caller wants either the order *or* the evidence there isn't one.
- A **bridge** and an **articulation point** are the same property seen from an edge and from a node, and Tarjan's low-link pass finds both at once.

## Refusing rather than half-answering

A cycle makes `topologicalSort` an **error** naming the stuck nodes, not a partial order. Returning the part that *could* be sorted is a plausible answer to a question with no answer — and a build system acting on it would run steps out of order.

`findCycle` returns the nodes of one cycle rather than a boolean. *"There is a cycle somewhere in your 200,000-node dependency graph"* is not actionable; the four services in it are.

## The bug worth recording

Tarjan marks a DFS root as an articulation point only when it has **more than one child**. I identified roots by `disc == 0` — which names only the **first** one.

On a graph with two components the second root has a non-zero discovery time, was treated as an ordinary node, and was reported as a cut vertex on the strength of having one child. Removing it does not disconnect anything; its component simply gets smaller.

**The three reference graphs could not have caught it.** They are dense and connected — one bridge and one articulation point between all three.

It surfaced on a purpose-built two-component graph, which is why the parity set for this family is **eight hand-built structures** — barbell, path, star, cycle, tree, two-component, DAG, directed cycle — carrying **18 bridges and 11 articulation points** between them, all agreeing with NetworkX.

Verified against **both** sets: the eight structures and the three dense reference graphs.

## Tests

Nine through Cypher, including the two-component case that found the bug, `every_edge_of_a_tree_is_a_bridge`, and a cycle having neither bridges nor articulation points.

TCK unchanged: 3,760 pass, `wrong_result` **0**, zero manifest diff. 59 algorithm-crate tests pass. Six more names in `KNOWN_FUNCTIONS` — the reachability invariant caught them again.
