### PR TITLE
Error codes: 0 to 10 distinct, over 10 fault classes (LANG-12)

### DIFF
--- a/examples/error_quality.rs
+++ b/examples/error_quality.rs
@@ -41,13 +41,42 @@ const CASES: &[(&str, &str)] = &[
     ("bad-argument", "RETURN range(1, 10, 0)"),
     ("bad-argument", "RETURN substring('abc')"),
     ("collection-in-pattern", "WITH [1] AS xs MATCH (xs)-->() RETURN 1"),
-    ("aggregate-misuse", "RETURN count(*) + n"),
+    // `RETURN count(*) + n` was the case here, and it does not test what it
+    // says: it fails because `n` is unbound, which is correct and has nothing
+    // to do with aggregation. It reported an aggregate-misuse code identical
+    // to unbound-variable's -- a collision that looked like a coding gap and
+    // was a corpus bug. Bind the variable so the aggregate is the only fault
+    // left.
+    ("aggregate-misuse", "MATCH (n) WHERE count(*) > 1 RETURN n"),
     ("write-in-read", "MATCH (n) DELETE n RETURN n"),
 ];
 
 /// Does the text carry something a client could branch on that is not just
 /// English prose? A code is a token like `Neo.ClientError.Statement.SyntaxError`
 /// or `SG-1042` — stable, greppable, documented.
+/// The code itself, if there is one, so distinctness can be checked.
+///
+/// Presence is the easy half of LANG-12 and the half that can be satisfied
+/// without helping anyone: give every error the same code and 100% of them
+/// "carry a code". The requirement says a caller can branch on it, and a
+/// constant is not something to branch on -- which is exactly the objection
+/// the scorecard already records against using the Rust variant name.
+///
+/// So the probe reads the code out and reports how many *distinct* ones the
+/// fault classes produce. That number is the one that cannot be gamed by
+/// adding a prefix.
+fn extract_code(msg: &str) -> Option<String> {
+    msg.split_whitespace()
+        .map(|t| t.trim_matches(|c: char| !c.is_alphanumeric() && c != '.' && c != '-'))
+        .find(|t| {
+            (t.contains('.') && t.split('.').count() >= 3
+                && t.chars().next().is_some_and(|c| c.is_ascii_uppercase()))
+                || (t.contains('-') && t.split('-').next().is_some_and(
+                    |p| p.len() >= 2 && p.chars().all(|c| c.is_ascii_uppercase())))
+        })
+        .map(str::to_string)
+}
+
 fn has_code(msg: &str) -> bool {
     // Deliberately generous: any bracketed or dotted uppercase token, or an
     // explicit `code` field, counts. Being generous matters — a strict test
@@ -96,6 +125,7 @@ fn main() {
             "query": q,
             "errored": !msg.is_empty(),
             "has_code": !msg.is_empty() && has_code(&msg),
+            "code": extract_code(&msg),
             "has_span": !msg.is_empty() && has_span(&msg),
             "message": msg.chars().take(160).collect::<String>(),
         }));
@@ -109,11 +139,49 @@ fn main() {
         .map(|r| r["query"].as_str().unwrap_or("").to_string())
         .collect();
 
+    // Distinctness, per fault class. Two probes of the *same* class sharing a
+    // code is right and expected; two different classes sharing one means a
+    // caller cannot tell them apart, which is the whole point of the
+    // requirement.
+    let mut class_codes: std::collections::BTreeMap<String, std::collections::BTreeSet<String>> =
+        std::collections::BTreeMap::new();
+    for r in &errored {
+        if let Some(c) = r["code"].as_str() {
+            class_codes
+                .entry(r["class"].as_str().unwrap_or("?").to_string())
+                .or_default()
+                .insert(c.to_string());
+        }
+    }
+    let distinct_codes: std::collections::BTreeSet<&String> =
+        class_codes.values().flatten().collect();
+    // A class whose code is shared with a different class. Reported by name,
+    // because "3 collisions" tells nobody which two faults look alike.
+    let mut collisions: Vec<String> = Vec::new();
+    for (class, codes) in &class_codes {
+        for code in codes {
+            let others: Vec<&String> = class_codes
+                .iter()
+                .filter(|(o, cs)| *o != class && cs.contains(code))
+                .map(|(o, _)| o)
+                .collect();
+            if !others.is_empty() {
+                collisions.push(format!("{class} shares {code} with {others:?}"));
+            }
+        }
+    }
+    collisions.sort();
+    collisions.dedup();
+
     let json = serde_json::json!({
         "probed": rows.len(),
         "errored": errored.len(),
         "with_code": with_code,
         "with_span": with_span,
+        "fault_classes": class_codes.len(),
+        "distinct_codes": distinct_codes.len(),
+        "code_collisions": collisions,
+        "codes_by_class": class_codes,
         "did_not_error": did_not_error,
         "cases": rows,
     });
@@ -123,6 +191,9 @@ fn main() {
         Some(p) => std::fs::write(p, &text).unwrap(),
         None => println!("{text}"),
     }
-    eprintln!("{} errored; {} carry a code, {} a span (LANG-12 wants 100% of both)",
-              errored.len(), with_code, with_span);
+    eprintln!(
+        "{} errored; {} carry a code, {} a span; {} distinct codes over {} fault classes \
+         (LANG-12 wants 100% of both, and one code per class)",
+        errored.len(), with_code, with_span, distinct_codes.len(), class_codes.len()
+    );
 }

--- a/src/query/error_code.rs
+++ b/src/query/error_code.rs
@@ -1,0 +1,96 @@
+//! Stable, machine-readable error codes (LANG-12).
+//!
+//! LANG-12 asks that every error carry "a code, the offending span, and a
+//! suggested repair". Before this, none did. The scorecard's own note said why
+//! the Rust variant name would not do:
+//!
+//! > it is unpublished, and it does not separate two faults a caller would
+//! > handle differently — `TypeError("x is not a node")` and
+//! > `TypeError("Add requires numeric operands")` are the same variant.
+//!
+//! That objection is the design constraint. A code is only worth anything if a
+//! client can **branch** on it, so two faults that call for different handling
+//! must not share one. Giving every error a single prefix would satisfy a
+//! "carries a code" check and help nobody, which is why
+//! `examples/error_quality.rs` now counts *distinct* codes per fault class
+//! rather than presence alone.
+//!
+//! # Shape
+//!
+//! `Samyama.<Category>.<Subsystem>.<Fault>`, four dotted segments, following
+//! the convention Neo4j established (`Neo.ClientError.Statement.SyntaxError`).
+//! Matching the shape is deliberate: the people integrating against this
+//! already have code that parses that form, and inventing a different one buys
+//! nothing.
+//!
+//! `Category` is who is at fault and therefore who can act:
+//!
+//!   * `ClientError` — the query is wrong. Fix the query.
+//!   * `DatabaseError` — the engine or the store failed. Fixing the query will
+//!     not help.
+//!
+//! # Stability
+//!
+//! These strings are API. Renaming one breaks every caller branching on it, so
+//! a code is added rather than changed, and a retired one is left documented
+//! rather than reused for something else.
+
+/// The query did not parse.
+pub const SYNTAX: &str = "Samyama.ClientError.Statement.SyntaxError";
+/// It parsed and does not mean anything — a variable nothing defines, a
+/// clause in an order the language does not allow.
+pub const SEMANTIC: &str = "Samyama.ClientError.Statement.SemanticError";
+/// Valid Cypher this engine does not implement yet. Distinct from `SEMANTIC`
+/// because the query may be correct and the answer is "not here, not yet".
+pub const UNSUPPORTED: &str = "Samyama.ClientError.Statement.NotSupported";
+/// A function name that does not exist.
+pub const UNKNOWN_FUNCTION: &str = "Samyama.ClientError.Statement.UnknownFunction";
+/// A `CALL` to a procedure that does not exist.
+pub const UNKNOWN_PROCEDURE: &str = "Samyama.ClientError.Procedure.NotFound";
+/// A `CALL algo.*` naming an algorithm that does not exist. Separate from
+/// `UNKNOWN_PROCEDURE` because the `algo.` namespace routes to one operator,
+/// so the caller's recovery differs: the procedure surface is fine and the
+/// algorithm is not there.
+pub const UNKNOWN_ALGORITHM: &str = "Samyama.ClientError.Procedure.UnknownAlgorithm";
+/// A known function or procedure called with arguments it cannot accept — a
+/// zero step, a missing required parameter, a value out of range.
+pub const BAD_ARGUMENT: &str = "Samyama.ClientError.Statement.ArgumentError";
+/// An operation on operands of the wrong type.
+pub const TYPE_MISMATCH: &str = "Samyama.ClientError.Statement.TypeError";
+/// A variable that nothing in scope binds.
+pub const VARIABLE_NOT_BOUND: &str = "Samyama.ClientError.Statement.VariableNotBound";
+/// A read of something this query already deleted. Its own code because the
+/// caller can retry a stale read and cannot retry a type error.
+pub const ENTITY_DELETED: &str = "Samyama.ClientError.Statement.EntityDeleted";
+/// An aggregate used where the language does not allow one.
+pub const AGGREGATE_MISUSE: &str = "Samyama.ClientError.Statement.AggregationError";
+/// A write attempted through a read-only path.
+pub const WRITE_IN_READ: &str = "Samyama.ClientError.Statement.WriteInReadTransaction";
+/// A write refused because it would break an invariant the graph guarantees.
+pub const CONSTRAINT: &str = "Samyama.ClientError.Schema.ConstraintValidationFailed";
+/// The planner could not produce a plan.
+pub const PLANNING: &str = "Samyama.ClientError.Statement.PlanningFailed";
+/// A runtime fault not yet classified any more finely than this.
+///
+/// **This one is a placeholder and is meant to shrink.** `RuntimeError` is a
+/// catch-all with 144 construction sites, and a single code across all of them
+/// reproduces exactly the problem this module exists to fix. It is here so
+/// that no error is left without a code at all; every site that a caller would
+/// genuinely handle differently should get its own constant above, and the
+/// count of errors still landing here is worth watching.
+pub const RUNTIME: &str = "Samyama.ClientError.Statement.RuntimeError";
+/// The store or the engine failed. The query is not necessarily wrong.
+pub const GRAPH_ACCESS: &str = "Samyama.DatabaseError.Statement.GraphAccessFailed";
+/// A literal the grammar accepted and cannot mean anything -- a `\\u` escape
+/// that is not four hex digits, an integer outside the range of the type.
+/// Separate from `SYNTAX` because the query's *shape* is fine.
+pub const INVALID_LITERAL: &str = "Samyama.ClientError.Statement.InvalidLiteral";
+/// A variable used where the pattern needs a node or a relationship, and it is
+/// bound to something else -- a list, a path, a scalar.
+pub const VARIABLE_KIND: &str = "Samyama.ClientError.Statement.VariableTypeError";
+/// Two clauses that cannot both be in the same query, or a projection that
+/// does not line up -- UNION column mismatch, a duplicate output column.
+pub const CLAUSE_CONFLICT: &str = "Samyama.ClientError.Statement.ClauseConflict";
+/// A CREATE or MERGE pattern the language does not permit -- an untyped
+/// relationship, an undirected one, a variable-length one.
+pub const INVALID_WRITE_PATTERN: &str = "Samyama.ClientError.Statement.InvalidWritePattern";

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -106,23 +106,23 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum ExecutionError {
     /// Graph store error
-    #[error("Graph error: {0}")]
+    #[error("[{}] Graph error: {0}", crate::query::error_code::GRAPH_ACCESS)]
     GraphError(String),
 
     /// Planning error
-    #[error("Planning error: {0}")]
+    #[error("[{}] Planning error: {0}", crate::query::error_code::PLANNING)]
     PlanningError(String),
 
     /// Runtime error
-    #[error("Runtime error: {0}")]
+    #[error("[{}] Runtime error: {0}", crate::query::error_code::RUNTIME)]
     RuntimeError(String),
 
     /// Type error
-    #[error("Type error: {0}")]
+    #[error("[{}] Type error: {0}", crate::query::error_code::TYPE_MISMATCH)]
     TypeError(String),
 
     /// Variable not found
-    #[error("Variable not found: {0}")]
+    #[error("[{}] Variable not found: {0}", crate::query::error_code::VARIABLE_NOT_BOUND)]
     VariableNotFound(String),
 
     /// Variable not found, with the variables that *are* in scope.
@@ -131,7 +131,7 @@ pub enum ExecutionError {
     /// site that raises it has a record in hand, and a message that says
     /// "in scope: " with an empty list is worse than one that does not claim
     /// to know.
-    #[error("Variable not found: {name} (in scope: {in_scope})")]
+    #[error("[{}] Variable not found: {name} (in scope: {in_scope})", crate::query::error_code::VARIABLE_NOT_BOUND)]
     VariableNotFoundInScope { name: String, in_scope: String },
 
     /// A read of an entity that is no longer in the graph.
@@ -140,8 +140,19 @@ pub enum ExecutionError {
     /// and a null cannot: an unset property and a deleted node both answered
     /// `null`, so a query that read a node it had already deleted looked
     /// exactly like a query reading a property nobody set.
-    #[error("{0} was deleted in this query and cannot be read")]
+    #[error("[{}] {0} was deleted in this query and cannot be read", crate::query::error_code::ENTITY_DELETED)]
     EntityNotFound(String),
+
+    /// A runtime fault that carries its own code.
+    ///
+    /// `RuntimeError` is a catch-all with 144 construction sites, and one code
+    /// across all of them would reproduce the exact problem LANG-12 names: a
+    /// code a caller cannot branch on. This variant exists so a site that
+    /// *does* represent a distinct fault -- an unknown function, a bad
+    /// argument, a write attempted through a read path -- can say so without
+    /// every one of the 144 needing its own variant.
+    #[error("[{code}] {message}")]
+    Coded { code: &'static str, message: String },
 
     /// A write refused because it would break an invariant the graph
     /// guarantees, as distinct from one that is merely wrong.
@@ -149,8 +160,59 @@ pub enum ExecutionError {
     /// Its own variant because the caller's response differs: a `TypeError` is
     /// a bug in the query, while this is the engine declining to do something
     /// destructive the query did not say it wanted (#946).
-    #[error("Constraint verification failed: {0}")]
+    #[error("[{}] Constraint verification failed: {0}", crate::query::error_code::CONSTRAINT)]
     ConstraintVerificationFailed(String),
+}
+
+impl ExecutionError {
+    /// The stable code a client can branch on.
+    ///
+    /// Published as part of the API surface, so it is derived here once rather
+    /// than parsed back out of the message by anyone who needs it.
+    pub fn code(&self) -> &'static str {
+        use crate::query::error_code as c;
+        match self {
+            Self::GraphError(_) => c::GRAPH_ACCESS,
+            Self::PlanningError(_) => c::PLANNING,
+            Self::RuntimeError(_) => c::RUNTIME,
+            Self::TypeError(_) => c::TYPE_MISMATCH,
+            Self::VariableNotFound(_) | Self::VariableNotFoundInScope { .. } => {
+                c::VARIABLE_NOT_BOUND
+            }
+            Self::EntityNotFound(_) => c::ENTITY_DELETED,
+            Self::ConstraintVerificationFailed(_) => c::CONSTRAINT,
+            Self::Coded { code, .. } => code,
+        }
+    }
+
+    /// A fault with a code finer than the variant it would otherwise use.
+    pub fn coded(code: &'static str, message: impl Into<String>) -> Self {
+        Self::Coded { code, message: message.into() }
+    }
+
+    pub fn unknown_function(message: impl Into<String>) -> Self {
+        Self::coded(crate::query::error_code::UNKNOWN_FUNCTION, message)
+    }
+
+    pub fn unknown_procedure(message: impl Into<String>) -> Self {
+        Self::coded(crate::query::error_code::UNKNOWN_PROCEDURE, message)
+    }
+
+    pub fn unknown_algorithm(message: impl Into<String>) -> Self {
+        Self::coded(crate::query::error_code::UNKNOWN_ALGORITHM, message)
+    }
+
+    pub fn bad_argument(message: impl Into<String>) -> Self {
+        Self::coded(crate::query::error_code::BAD_ARGUMENT, message)
+    }
+
+    pub fn aggregate_misuse(message: impl Into<String>) -> Self {
+        Self::coded(crate::query::error_code::AGGREGATE_MISUSE, message)
+    }
+
+    pub fn write_in_read(message: impl Into<String>) -> Self {
+        Self::coded(crate::query::error_code::WRITE_IN_READ, message)
+    }
 }
 
 pub type ExecutionResult<T> = Result<T, ExecutionError>;
@@ -378,7 +440,7 @@ impl<'a> QueryExecutor<'a> {
 
         // Check if this is a write query - if so, error out
         if plan.is_write {
-            return Err(ExecutionError::RuntimeError(
+            return Err(ExecutionError::write_in_read(
                 "Cannot execute write query with read-only executor. Use MutQueryExecutor instead.".to_string()
             ));
         }

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -2458,12 +2458,12 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
             let store = store.ok_or_else(|| ExecutionError::RuntimeError(
                 "subsumes() requires graph context".to_string()))?;
             if args.len() < 2 {
-                return Err(ExecutionError::RuntimeError(
+                return Err(ExecutionError::bad_argument(
                     "subsumes(child, ancestor[, index]) takes 2 or 3 arguments".to_string()));
             }
-            let x = value_node_id(&args[0]).ok_or_else(|| ExecutionError::RuntimeError(
+            let x = value_node_id(&args[0]).ok_or_else(|| ExecutionError::bad_argument(
                 "subsumes(): first argument must be a node".to_string()))?;
-            let y = value_node_id(&args[1]).ok_or_else(|| ExecutionError::RuntimeError(
+            let y = value_node_id(&args[1]).ok_or_else(|| ExecutionError::bad_argument(
                 "subsumes(): second argument must be a node".to_string()))?;
             let entry = match args.get(2) {
                 Some(v) => {
@@ -2496,10 +2496,10 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
             let store = store.ok_or_else(|| ExecutionError::RuntimeError(
                 "hierarchy_rollup() requires graph context".to_string()))?;
             if args.len() < 2 {
-                return Err(ExecutionError::RuntimeError(
+                return Err(ExecutionError::bad_argument(
                     "hierarchy_rollup(root, op[, index]) takes 2 or 3 arguments".to_string()));
             }
-            let root = value_node_id(&args[0]).ok_or_else(|| ExecutionError::RuntimeError(
+            let root = value_node_id(&args[0]).ok_or_else(|| ExecutionError::bad_argument(
                 "hierarchy_rollup(): first argument must be a node".to_string()))?;
             let op_name = extract_string(&args[1])?;
             let op = crate::index::hierarchy::RollupOp::parse(&op_name).ok_or_else(|| {
@@ -2538,12 +2538,12 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
             let store = store.ok_or_else(|| ExecutionError::RuntimeError(
                 "hierarchy_lca() requires graph context".to_string()))?;
             if args.len() < 2 {
-                return Err(ExecutionError::RuntimeError(
+                return Err(ExecutionError::bad_argument(
                     "hierarchy_lca(a, b[, index]) takes 2 or 3 arguments".to_string()));
             }
-            let a = value_node_id(&args[0]).ok_or_else(|| ExecutionError::RuntimeError(
+            let a = value_node_id(&args[0]).ok_or_else(|| ExecutionError::bad_argument(
                 "hierarchy_lca(): first argument must be a node".to_string()))?;
-            let b = value_node_id(&args[1]).ok_or_else(|| ExecutionError::RuntimeError(
+            let b = value_node_id(&args[1]).ok_or_else(|| ExecutionError::bad_argument(
                 "hierarchy_lca(): second argument must be a node".to_string()))?;
             let entry = match args.get(2) {
                 Some(v) => {
@@ -2625,7 +2625,7 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
             Ok(Value::Property(PropertyValue::String(s.replace(&from, &to))))
         }
         "substring" => {
-            if args.len() < 2 { return Err(ExecutionError::RuntimeError("substring() requires at least 2 arguments".to_string())); }
+            if args.len() < 2 { return Err(ExecutionError::bad_argument("substring() requires at least 2 arguments".to_string())); }
             let s = extract_string(&args[0])?;
             let start = extract_int(&args[1])? as usize;
             let chars: Vec<char> = s.chars().collect();
@@ -3083,11 +3083,11 @@ pub fn eval_function(name: &str, args: &[Value], store: Option<&GraphStore>) -> 
         }
         // range() — generate integer list
         "range" => {
-            if args.len() < 2 { return Err(ExecutionError::RuntimeError("range() requires at least 2 arguments".to_string())); }
+            if args.len() < 2 { return Err(ExecutionError::bad_argument("range() requires at least 2 arguments".to_string())); }
             let start = extract_int(&args[0])?;
             let end = extract_int(&args[1])?;
             let step = if args.len() >= 3 { extract_int(&args[2])? } else { 1 };
-            if step == 0 { return Err(ExecutionError::RuntimeError("range() step cannot be 0".to_string())); }
+            if step == 0 { return Err(ExecutionError::bad_argument("range() step cannot be 0".to_string())); }
             let mut result = Vec::new();
             let mut i = start;
             if step > 0 {
@@ -12513,7 +12513,7 @@ lcc([label, edgeType]), wcc(), scc(), triangleCount(), or.solve({config})"
             "connectedcomponents" | "components" => " -- use algo.wcc or algo.scc",
             _ => "",
         };
-        ExecutionError::RuntimeError(format!(
+        ExecutionError::unknown_algorithm(format!(
             "Unknown algorithm: {name}{hint}. Available: {}",
             Self::available()
         ))
@@ -12835,7 +12835,7 @@ lcc([label, edgeType]), wcc(), scc(), triangleCount(), or.solve({config})"
         let list = match self.args.first() {
             Some(Expression::Literal(PropertyValue::Array(a))) => a.clone(),
             _ => {
-                return Err(ExecutionError::RuntimeError(format!(
+                return Err(ExecutionError::bad_argument(format!(
                     "{}() requires a list of [nodeId, seenAt] pairs as its first argument",
                     self.name
                 )))
@@ -13299,7 +13299,7 @@ lcc([label, edgeType]), wcc(), scc(), triangleCount(), or.solve({config})"
         let list = match self.args.first() {
             Some(Expression::Literal(PropertyValue::Array(a))) => a.clone(),
             _ => {
-                return Err(ExecutionError::RuntimeError(format!(
+                return Err(ExecutionError::bad_argument(format!(
                     "{}() requires a list of [nodeId, community] pairs. To score \
                      Louvain's own partition, use algo.louvain(), which returns it.",
                     self.name
@@ -13376,7 +13376,7 @@ lcc([label, edgeType]), wcc(), scc(), triangleCount(), or.solve({config})"
             _ => None,
         }).collect();
         if ids.len() < 2 {
-            return Err(ExecutionError::RuntimeError(format!(
+            return Err(ExecutionError::bad_argument(format!(
                 "{}() requires a source and a target node id", self.name)));
         }
         let idx = |raw: u64| -> ExecutionResult<usize> {
@@ -13447,7 +13447,7 @@ lcc([label, edgeType]), wcc(), scc(), triangleCount(), or.solve({config})"
         let view = self.structural_view(store);
         let src = match self.args.first() {
             Some(Expression::Literal(PropertyValue::Integer(n))) => *n as u64,
-            _ => return Err(ExecutionError::RuntimeError(format!(
+            _ => return Err(ExecutionError::bad_argument(format!(
                 "{}() requires a source node id", self.name))),
         };
         let s = view.node_to_index.get(&src).copied().ok_or_else(|| {
@@ -13629,7 +13629,7 @@ lcc([label, edgeType]), wcc(), scc(), triangleCount(), or.solve({config})"
     }
     fn execute_or_solve(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<()> {
         if self.args.is_empty() {
-             return Err(ExecutionError::RuntimeError("algo.or.solve requires a config map".to_string()));
+             return Err(ExecutionError::bad_argument("algo.or.solve requires a config map".to_string()));
         }
 
         let config_map = match &self.args[0] {

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -3256,7 +3256,11 @@ impl QueryPlanner {
                 call_clause.arguments.clone(),
             )))
         } else {
-            Err(ExecutionError::PlanningError(format!("Unknown procedure: {}", call_clause.procedure_name)))
+            // Its own code: the procedure surface is fine and this name is not
+            // on it, which is a different recovery from "the planner could not
+            // build a plan".
+            Err(ExecutionError::unknown_procedure(format!(
+                "Unknown procedure: {}", call_clause.procedure_name)))
         }
     }
 

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -70,6 +70,7 @@
 //! graph.
 
 pub mod ast;
+pub mod error_code;
 pub mod parser;
 pub mod star;
 pub mod validate;

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -108,16 +108,53 @@ static PRATT_PARSER: LazyLock<PrattParser<Rule>> = LazyLock::new(|| {
 #[derive(Error, Debug)]
 pub enum ParseError {
     /// Pest parsing error
-    #[error("Parse error: {0}")]
+    #[error("[{}] Parse error: {0}", crate::query::error_code::SYNTAX)]
     PestError(#[from] pest::error::Error<Rule>),
 
     /// Semantic error
-    #[error("Semantic error: {0}")]
+    #[error("[{}] Semantic error: {0}", crate::query::error_code::SEMANTIC)]
     SemanticError(String),
 
     /// Unsupported feature
-    #[error("Unsupported feature: {0}")]
+    /// A rejection that carries its own code.
+    ///
+    /// `SemanticError` is where every validation failure landed, so a caller
+    /// saw one string for unknown-function, unbound-variable, a malformed
+    /// literal and an aggregate in the wrong place alike. This lets a site
+    /// that knows which fault it found say so.
+    #[error("[{code}] {message}")]
+    Coded { code: &'static str, message: String },
+
+    #[error("[{}] Unsupported feature: {0}", crate::query::error_code::UNSUPPORTED)]
     UnsupportedFeature(String),
+}
+
+impl ParseError {
+    /// Did the grammar recognise this query and something later refuse it?
+    ///
+    /// The distinction the parser's fallback turns on: a *grammar* failure
+    /// means the general rule could not read the clause order at all, and its
+    /// message points at a token; anything else means the shape was understood
+    /// and a specific obstacle was found, which is the more useful thing to
+    /// report.
+    ///
+    /// A predicate rather than a match on one variant, because the set of
+    /// "not a grammar failure" variants grows -- it just did -- and every
+    /// place that matched the old single variant would have to be found again.
+    pub fn is_semantic(&self) -> bool {
+        !matches!(self, ParseError::PestError(_))
+    }
+
+    /// The stable code a client can branch on (LANG-12).
+    pub fn code(&self) -> &'static str {
+        use crate::query::error_code as c;
+        match self {
+            ParseError::PestError(_) => c::SYNTAX,
+            ParseError::SemanticError(_) => c::SEMANTIC,
+            ParseError::UnsupportedFeature(_) => c::UNSUPPORTED,
+            ParseError::Coded { code, .. } => code,
+        }
+    }
 }
 
 pub type ParseResult<T> = Result<T, ParseError>;
@@ -247,7 +284,7 @@ fn parse_clause_pipeline(input: &str) -> ParseResult<Query> {
     }
     crate::query::star::expand_stars(&mut query);
     crate::query::validate::validate(&query)
-        .map_err(|e| ParseError::SemanticError(e.to_string()))?;
+        .map_err(|e| ParseError::Coded { code: e.code(), message: e.to_string() })?;
     Ok(query)
 }
 
@@ -276,11 +313,17 @@ fn parse_integer_literal(text: &str) -> ParseResult<i64> {
     // i64::MAX -- can be represented before the sign is applied. Without this,
     // `-9223372036854775808` has no valid intermediate form.
     let magnitude = i128::from_str_radix(digits, radix).map_err(|_| {
-        ParseError::SemanticError(format!("integer literal out of range: `{text}`"))
+        ParseError::Coded {
+            code: crate::query::error_code::INVALID_LITERAL,
+            message: format!("integer literal out of range: `{text}`"),
+        }
     })?;
     let value = if negative { -magnitude } else { magnitude };
     i64::try_from(value).map_err(|_| {
-        ParseError::SemanticError(format!("integer literal out of range: `{text}`"))
+        ParseError::Coded {
+            code: crate::query::error_code::INVALID_LITERAL,
+            message: format!("integer literal out of range: `{text}`"),
+        }
     })
 }
 
@@ -361,7 +404,19 @@ pub fn parse_query(input: &str) -> ParseResult<Query> {
             // clause order and then refused to lower one of the clauses. That
             // names the actual obstacle, so it wins; a plain parse failure
             // does not, and the original error is kept instead.
-            Err(e @ ParseError::SemanticError(_)) => return Err(e),
+            //
+            // Asked as a question rather than matched against one variant.
+            // This arm was `Err(e @ ParseError::SemanticError(_))`, and giving
+            // validation failures their own codes moved them to `Coded` -- so
+            // they stopped matching, fell through to the arm below, and the
+            // caller got the raw grammar error again. `WITH [1] AS xs MATCH
+            // (xs)-->()` went from "`xs` is bound to a collection and cannot
+            // be used as a node" back to "expected where_clause at 1:16".
+            //
+            // Nothing failed. The query still errored, the message was still a
+            // real message, and only a probe comparing error *classes* noticed
+            // that it had become the wrong one.
+            Err(e) if e.is_semantic() => return Err(e),
             Err(_) => return Err(original.into()),
         },
     };
@@ -419,7 +474,7 @@ pub fn parse_query(input: &str) -> ParseResult<Query> {
     // failure because that is what they are to a caller: the query was never
     // well-formed, and running it would answer a question nobody asked.
     crate::query::validate::validate(&query)
-        .map_err(|e| ParseError::SemanticError(e.to_string()))?;
+        .map_err(|e| ParseError::Coded { code: e.code(), message: e.to_string() })?;
 
     Ok(query)
 }
@@ -891,9 +946,12 @@ fn unescape_string_literal(literal: &str) -> ParseResult<String> {
                 match decoded {
                     Some(c) => out.push(c),
                     None => {
-                        return Err(ParseError::SemanticError(format!(
-                            "InvalidUnicodeLiteral: `\\u{hex}` is not four hex digits"
-                        )))
+                        return Err(ParseError::Coded {
+                            code: crate::query::error_code::INVALID_LITERAL,
+                            message: format!(
+                                "InvalidUnicodeLiteral: `\\u{hex}` is not four hex digits"
+                            ),
+                        })
                     }
                 }
             }

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -90,6 +90,61 @@ pub enum ValidationError {
     InvalidAggregation,
 }
 
+impl ValidationError {
+    /// The stable code for this rejection (LANG-12).
+    ///
+    /// Every validation failure used to reach the caller as
+    /// `ParseError::SemanticError`, so unknown-function, unbound-variable,
+    /// a malformed literal, a list used as a node and an aggregate in the
+    /// wrong place all arrived under one string. A caller could not tell them
+    /// apart, which is the objection LANG-12 exists to answer.
+    ///
+    /// Grouped by what the caller would *do*, not by which check fired: an
+    /// untyped CREATE relationship and an undirected one are both "fix the
+    /// write pattern", while a list used as a node and a property read on a
+    /// path are both "that variable is not the kind you think".
+    pub fn code(&self) -> &'static str {
+        use crate::query::error_code as c;
+        match self {
+            Self::UnboundVariable { .. } => c::VARIABLE_NOT_BOUND,
+            Self::UnboundPatternVariable { .. } => c::VARIABLE_NOT_BOUND,
+            Self::OrderByUndefinedVariable { .. } => c::VARIABLE_NOT_BOUND,
+            Self::NoVariablesInScope { .. } => c::VARIABLE_NOT_BOUND,
+            Self::VariableTypeConflict { .. } => c::VARIABLE_KIND,
+            Self::VariableKindConflict { .. } => c::VARIABLE_KIND,
+            Self::PropertyAccessOnNonMap { .. } => c::VARIABLE_KIND,
+            Self::SizeOfNonCollection { .. } => c::VARIABLE_KIND,
+            Self::PropertyOnPath { .. } => c::VARIABLE_KIND,
+            Self::InvalidDeleteTarget { .. } => c::VARIABLE_KIND,
+            Self::FunctionArgumentKind { .. } => c::BAD_ARGUMENT,
+            Self::NonBooleanOperand { .. } => c::TYPE_MISMATCH,
+            Self::UnknownFunction { .. } => c::UNKNOWN_FUNCTION,
+            Self::AggregateNotAllowed { .. } => c::AGGREGATE_MISUSE,
+            Self::InvalidAggregation { .. } => c::AGGREGATE_MISUSE,
+            Self::AmbiguousAggregationExpression { .. } => c::AGGREGATE_MISUSE,
+            Self::AmbiguousGroupingExpression { .. } => c::AGGREGATE_MISUSE,
+            Self::DuplicateColumn { .. } => c::CLAUSE_CONFLICT,
+            Self::UnionColumnMismatch { .. } => c::CLAUSE_CONFLICT,
+            Self::MixedUnionAndUnionAll { .. } => c::CLAUSE_CONFLICT,
+            Self::UnaliasedWithItem { .. } => c::CLAUSE_CONFLICT,
+            Self::PatternInProjection { .. } => c::CLAUSE_CONFLICT,
+            Self::PatternInSetValue { .. } => c::CLAUSE_CONFLICT,
+            Self::InvalidPredicatePattern { .. } => c::CLAUSE_CONFLICT,
+            Self::RelationshipUniquenessViolation { .. } => c::CLAUSE_CONFLICT,
+            Self::CreateOnBoundVariable { .. } => c::INVALID_WRITE_PATTERN,
+            Self::CreateRelationshipWithoutType { .. } => c::INVALID_WRITE_PATTERN,
+            Self::CreateUndirectedRelationship { .. } => c::INVALID_WRITE_PATTERN,
+            Self::CreateVariableLengthRelationship { .. } => c::INVALID_WRITE_PATTERN,
+            Self::CreateOnBoundRelationship { .. } => c::INVALID_WRITE_PATTERN,
+            Self::MergeRelationshipWithoutType { .. } => c::INVALID_WRITE_PATTERN,
+            Self::MergeVariableLengthRelationship { .. } => c::INVALID_WRITE_PATTERN,
+            Self::MergeOnBoundVariable { .. } => c::INVALID_WRITE_PATTERN,
+            Self::MergeRelationshipWithNullProperty { .. } => c::INVALID_WRITE_PATTERN,
+            Self::MergeNullProperty { .. } => c::INVALID_WRITE_PATTERN,
+        }
+    }
+}
+
 impl std::fmt::Display for ValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
LANG-12 asks every error to carry a code. None did. The scorecard's note said why a variant name would not do: it *"does not separate two faults a caller would handle differently"*.

That is easy to satisfy in appearance — one prefix on every error and 100% "carry a code". **So the probe was changed first.** `error_quality.rs` now extracts the code and counts **distinct codes per fault class**, naming collisions. That number cannot be moved by adding a prefix, and it went **0 → 5 → 8 → 9 → 10**, catching every shortcut on the way.

Codes are `Samyama.<Category>.<Subsystem>.<Fault>` — Neo4j's shape, because integrators already parse it. `ClientError` means fix the query; `DatabaseError` means fixing the query will not help.

The work is classification, not the wrapper: `RuntimeError` has 144 sites and `SemanticError` was where all 35 validation failures landed. `ValidationError::code()` groups by **what the caller would do**, and the finer runtime faults get constructors. `RUNTIME` stays as a placeholder that says in its own doc comment that it is meant to shrink.

### It broke something, and only the class comparison caught it

The parser keeps a semantic error over a grammar error via `Err(e @ ParseError::SemanticError(_))`. Moving validation failures to a coded variant took them out of that arm — so `WITH [1] AS xs MATCH (xs)-->()` went from *"`xs` is bound to a collection and cannot be used as a node"* back to *"expected where_clause at 1:16"*.

Nothing failed. The query still errored, with a real message, and **3,786 tests still passed**. It is now `e.is_semantic()` — a question, not a match on one variant, because that set just grew and will again.

The last collision was my own corpus: `RETURN count(*) + n` filed under aggregate-misuse fails because `n` is unbound. Replaced.

**15 of 15 carry a code; 10 distinct over 10 classes; no collisions.** Spans remain 3 of 15 — only pest errors carry them, and that half of LANG-12 is untouched and still open.

https://claude.ai/code/session_01YMFy59PQM3rQ71fc35Kr8v