### PR TITLE
The probe was asserting the absence of something we now ship

### DIFF
--- a/examples/error_quality.rs
+++ b/examples/error_quality.rs
@@ -29,7 +29,12 @@ const CASES: &[(&str, &str)] = &[
     ("syntax", "MATCH (n) RETURN"),
     ("unknown-function", "RETURN lenght('abc')"),
     ("unknown-procedure", "CALL nosuch.procedure()"),
-    ("unknown-algorithm", "CALL algo.betweenness()"),
+    // `algo.betweenness` was the case here and it stopped erroring: betweenness
+    // centrality was implemented for ALGO-01, so the probe was asserting the
+    // absence of something we now ship. A corpus written against today's gaps
+    // decays into a corpus asserting yesterday's -- and this one reported it
+    // honestly, as a probe that did not error, rather than quietly passing.
+    ("unknown-algorithm", "CALL algo.noSuchAlgorithmExists()"),
     ("unbound-variable", "RETURN x"),
     ("unbound-variable", "MATCH (n) RETURN m.name"),
     ("type-error", "RETURN 1 + {a: 1}"),


### PR DESCRIPTION
`CALL algo.betweenness()` was the unknown-algorithm case. Betweenness centrality was implemented for ALGO-01 this week, so the probe stopped seeing an error and reported `probes_that_did_not_error: 1`.

Which is the right outcome, and worth noting: **a corpus written against today's gaps decays into one asserting yesterday's**, and the usual way that shows up is silence — the case stops testing anything and nothing says so. This probe is built to record a case that failed to provoke its fault, because a query expected to fail and succeeding is a finding rather than a skip.

Replaced with a name nothing will implement. **16 of 16 errors raise; 11 distinct codes across 11 fault classes; no collisions.**

Harness side reports the distinctness number: samyama-graph-competitor-benchmarks#63.

3,786 tests pass, 0 fail.

https://claude.ai/code/session_01YMFy59PQM3rQ71fc35Kr8v