### PR TITLE
Three algorithms were not deterministic between processes (re-land)

### DIFF
--- a/crates/samyama-graph-algorithms/src/community_detect.rs
+++ b/crates/samyama-graph-algorithms/src/community_detect.rs
@@ -105,8 +105,16 @@ pub fn modularity(view: &GraphView, communities: &[usize]) -> Option<f64> {
             }
         }
     }
+    // Summed over communities in id order, not `HashMap` order. Rust seeds its
+    // hasher per process, floating-point addition is not associative, and the
+    // 120-node reference graph produced a Q differing in the last bit between
+    // runs. Q is compared against a recorded reference with a 1e-9 tolerance,
+    // so nothing was going to catch this by comparing answers -- only by
+    // running the same input twice and diffing bit for bit.
+    let mut communities: Vec<(usize, f64)> = tot.into_iter().collect();
+    communities.sort_unstable_by_key(|&(c, _)| c);
     let q: f64 = inside / two_m
-        - tot.values().map(|&t| (t / two_m) * (t / two_m)).sum::<f64>();
+        - communities.iter().map(|&(_, t)| (t / two_m) * (t / two_m)).sum::<f64>();
     Some(q)
 }
 

--- a/crates/samyama-graph-algorithms/src/link_prediction.rs
+++ b/crates/samyama-graph-algorithms/src/link_prediction.rs
@@ -78,9 +78,25 @@ fn score_pair(sets: &[HashSet<usize>], u: usize, v: usize, which: LinkScore) -> 
                 a.intersection(b).count() as f64 / union as f64
             }
         }
-        LinkScore::AdamicAdar => a
-            .intersection(b)
-            .map(|&w| {
+        LinkScore::AdamicAdar => {
+            // Summed in **sorted** order, not `HashSet` order.
+            //
+            // Floating-point addition is not associative, and Rust's `HashSet`
+            // seeds its hasher per process, so the same graph in two processes
+            // summed these terms in different orders and produced answers
+            // differing in the last bit. Measured across three runs of the
+            // parity export: 3 of 6,840 pairs on the 120-node graph, worst
+            // 4.4e-16 relative.
+            //
+            // Numerically that is nothing. It is still a determinism bug --
+            // LANG-14 and ALGO-11 ask for *identical* output, and the parity
+            // check's 1e-9 tolerance is exactly wide enough to hide it, so
+            // nothing was ever going to catch this by comparing answers.
+            let mut shared: Vec<usize> = a.intersection(b).copied().collect();
+            shared.sort_unstable();
+            shared
+            .into_iter()
+            .map(|w| {
                 let d = sets[w].len() as f64;
                 // A degree-1 shared neighbour gives ln(1) = 0 and would
                 // divide by zero. NetworkX's convention is to skip it, and
@@ -89,7 +105,8 @@ fn score_pair(sets: &[HashSet<usize>], u: usize, v: usize, which: LinkScore) -> 
                 // graph -- but a self-loop or a stale index could.
                 if d > 1.0 { 1.0 / d.ln() } else { 0.0 }
             })
-            .sum(),
+            .sum()
+        }
     }
 }
 

--- a/crates/samyama-graph-algorithms/src/similarity_extra.rs
+++ b/crates/samyama-graph-algorithms/src/similarity_extra.rs
@@ -133,10 +133,18 @@ pub fn constraint(view: &GraphView, u: usize) -> Option<f64> {
         }
         1.0 / na.len() as f64
     };
+    // Sorted, not `HashSet` order. Floating-point addition is not associative
+    // and Rust seeds its hasher per process, so the same graph gave answers
+    // differing in the last bit between runs -- 6 to 12 of the nodes on these
+    // graphs, worst 2.9e-16 relative. Harmless as a number and still a
+    // determinism bug: LANG-14 and ALGO-11 ask for identical output, and a
+    // parity check with a 1e-9 tolerance is exactly wide enough to hide it.
+    let mut ordered: Vec<usize> = ego.iter().copied().collect();
+    ordered.sort_unstable();
     let mut total = 0.0;
-    for &j in &ego {
+    for &j in &ordered {
         // (p_uj + sum_q p_uq * p_qj)^2, q over u's other neighbours
-        let indirect: f64 = ego.iter().filter(|&&q| q != j && q != u)
+        let indirect: f64 = ordered.iter().filter(|&&q| q != j && q != u)
             .map(|&q| p(u, q) * p(q, j))
             .sum();
         let c = p(u, j) + indirect;

--- a/tests/algorithms_are_bit_identical_across_processes.rs
+++ b/tests/algorithms_are_bit_identical_across_processes.rs
@@ -1,0 +1,76 @@
+//! Every algorithm gives byte-identical output in a *fresh process* (LANG-14,
+//! ALGO-11).
+//!
+//! `algorithm_output_is_deterministic.rs` checks determinism **within** one
+//! process, which is the easy half: a `HashMap` iterates in the same order
+//! twice in a row inside one run. Rust seeds its hasher **per process**, so
+//! the order changes between runs — and floating-point addition is not
+//! associative, so a sum over a `HashSet` gives answers differing in the last
+//! bit from one process to the next.
+//!
+//! Three algorithms were doing exactly that, and nothing was going to catch
+//! it: `adamic_adar`, `constraint` and `modularity` are all compared against a
+//! recorded reference with a **1e-9 tolerance**, which is roughly seven orders
+//! of magnitude wider than a last-bit difference. A check that compares
+//! answers cannot find this. Only running the same input twice and diffing
+//! byte for byte can.
+//!
+//! The differences were ~1e-16 relative and numerically meaningless. LANG-14
+//! asks for *identical* output and ALGO-11 for determinism, and "almost
+//! identical" is a different claim — one that makes a result set undiffable
+//! and a reproduction unverifiable.
+
+use std::process::Command;
+
+/// Run `algo_parity_export`, which exercises every algorithm with a recorded
+/// answer, and return its JSON.
+///
+/// A separate process each time is the entire point of the test; calling the
+/// functions in a loop would re-measure what the in-process test already
+/// covers and would have passed throughout the bug.
+fn export(path: &str) -> String {
+    let out = Command::new(env!("CARGO"))
+        .args(["run", "--release", "--quiet", "--example", "algo_parity_export", "--", path])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("algo_parity_export runs");
+    assert!(
+        out.status.success(),
+        "algo_parity_export failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    std::fs::read_to_string(path).expect("export wrote its JSON")
+}
+
+#[test]
+#[ignore = "spawns cargo twice; run explicitly or in the nightly job"]
+fn two_processes_produce_byte_identical_output() {
+    let dir = std::env::temp_dir();
+    let a = export(dir.join("samyama-det-a.json").to_str().unwrap());
+    let b = export(dir.join("samyama-det-b.json").to_str().unwrap());
+
+    if a != b {
+        // Name the families that differ rather than dumping two megabytes of
+        // JSON. "the output differs" sends someone hunting; "constraint
+        // differs" is a place to look.
+        let va: serde_json::Value = serde_json::from_str(&a).unwrap();
+        let vb: serde_json::Value = serde_json::from_str(&b).unwrap();
+        let mut differing: Vec<String> = Vec::new();
+        for (ga, gb) in va["graphs"].as_array().unwrap().iter()
+            .zip(vb["graphs"].as_array().unwrap())
+        {
+            let name = ga["name"].as_str().unwrap_or("?");
+            for (k, v) in ga["results"].as_object().unwrap() {
+                if gb["results"].get(k) != Some(v) {
+                    differing.push(format!("{name}/{k}"));
+                }
+            }
+        }
+        panic!(
+            "two processes disagree on {} result families: {differing:?}\n\
+             Almost certainly a float sum over HashMap/HashSet iteration order. \
+             Sort before summing.",
+            differing.len()
+        );
+    }
+}


### PR DESCRIPTION
Re-lands the work from #1029, which merged **empty**. My error, and worth recording because the mechanism is not obvious: a background task ran `git checkout main` in this working tree while I was editing, so the commit landed on `main` instead of the branch, and the subsequent push sent a stale branch ref. The PR then had no diff and squashed to nothing. Recovered from the reflog; all four files intact.

---

`adamic_adar`, `constraint` and `modularity` summed floating-point terms in `HashMap`/`HashSet` iteration order. **Rust seeds its hasher per process**, and float addition is not associative, so the same graph gave different answers in two runs:

| | differing |
|---|---|
| `constraint` | 6–12 of 40 nodes |
| `adamic_adar` | 3 of 6,840 pairs |
| `modularity` | Q on the 120-node graph |

Differences ~**1e-16 relative** — numerically nothing. LANG-14 asks for *identical* output and ALGO-11 for determinism, and "almost identical" is a different claim: it makes a result set undiffable and a reproduction unverifiable.

### Nothing was ever going to catch this

All three are compared against a recorded reference with a **1e-9 tolerance** — seven orders of magnitude wider than a last-bit difference — so 62,481 parity checks passed throughout. `algorithm_output_is_deterministic.rs` checks determinism *within* one process, where a `HashMap` iterates the same way twice in a row.

**A check that compares answers cannot find this.** Only running the same input twice in separate processes and diffing byte for byte can. Found by doing exactly that on my own new code, because `constraint` sums over a `HashSet` and I wondered. Two of the three predate today.

### Made catchable, and checked in both directions

`algorithms_are_bit_identical_across_processes.rs` spawns the export twice and diffs, naming the families that differ. With `constraint`'s sort removed it fails:

```
two processes disagree on 3 result families:
["undirected-40/constraint", "directed-40/constraint", "undirected-120/constraint"]
Almost certainly a float sum over HashMap/HashSet iteration order. Sort before summing.
```

Bit-identical across **four** separate processes after the fix.

**3,806 tests pass, 0 fail. 62,481 of 62,481 parity checks agree.**

https://claude.ai/code/session_01YMFy59PQM3rQ71fc35Kr8v