### PR TITLE
A per-operator row budget, so an exploding intermediate fails instead of running

### DIFF
--- a/examples/plan_budget_probe.rs
+++ b/examples/plan_budget_probe.rs
@@ -33,24 +33,46 @@ fn explain(engine: &QueryEngine, store: &GraphStore, q: &str) -> String {
     }
 }
 
+/// 400^3 = 64,000,000 intermediate rows, which crosses the shipped default
+/// budget of 50,000,000. Deliberately sized against the *default* and not
+/// against a budget this probe sets for itself: a guard that only works when
+/// the test configures it is not a guard the shipped engine has.
+const NODES: usize = 400;
+
 fn main() {
-    let store = fixture(200);
+    let store = fixture(NODES);
     let engine = QueryEngine::new();
 
-    // A three-way cartesian product: 200^3 = 8,000,000 intermediate rows from
-    // 200 nodes. Nothing in the query says "stop".
+    // A three-way cartesian product: NODES^3 intermediate rows. Nothing in the
+    // query says "stop", so only the engine can.
     let blowup = "MATCH (a:N), (b:N), (c:N) RETURN count(*)";
     let plan = explain(&engine, &store, blowup);
 
-    // Does EXPLAIN say how many rows it expects anywhere in the plan?
-    let exposes_rows = ["rows", "cardinality", "estimated_rows", "est_rows"]
+    // Does EXPLAIN say how many rows it *expects*, per operator?
+    //
+    // Deliberately not a search for "rows": the plan now prints a row-budget
+    // section that contains the word, and matching it would report row
+    // estimates that do not exist -- a probe answering yes about a feature
+    // nobody built. Only phrasings that can mean an estimate count, and the
+    // budget section is cut out before looking.
+    let without_budget = plan
+        .to_lowercase()
+        .split("--- row budget ---")
+        .next()
+        .unwrap_or_default()
+        .to_string();
+    let exposes_rows = ["estimated_rows", "est_rows", "est. rows", "cardinality", "estimated rows"]
         .iter()
-        .any(|k| plan.to_lowercase().contains(k));
+        .any(|k| without_budget.contains(k));
     // Does it expose a budget, a spill, or a re-plan -- the three things
     // PERF-05 names as the response to an exploding intermediate?
     let exposes_budget = ["budget", "spill", "re-plan", "replan"]
         .iter()
         .any(|k| plan.to_lowercase().contains(k));
+    debug_assert!(
+        !exposes_rows || !without_budget.is_empty(),
+        "row estimates must be found outside the budget section or not at all"
+    );
 
     println!("PERF-05 explain_exposes_row_estimates={exposes_rows}");
     println!("PERF-05 explain_exposes_budget_or_spill={exposes_budget}");
@@ -74,8 +96,8 @@ fn main() {
         }
     };
     println!(
-        "PERF-05 unbounded_product_of_{}_nodes: {outcome} in {:?}",
-        200, started.elapsed()
+        "PERF-05 unbounded_product_of_{NODES}_nodes: {outcome} in {:?}",
+        started.elapsed()
     );
     println!("PERF-05 plan_head: {}", plan.chars().take(160).collect::<String>().replace('\n', " | "));
 }

--- a/src/query/error_code.rs
+++ b/src/query/error_code.rs
@@ -78,6 +78,14 @@ pub const PLANNING: &str = "Samyama.ClientError.Statement.PlanningFailed";
 /// that no error is left without a code at all; every site that a caller would
 /// genuinely handle differently should get its own constant above, and the
 /// count of errors still landing here is worth watching.
+/// A query refused because one operator exceeded the per-operator row budget.
+///
+/// A client error rather than a database error: the engine is working, the
+/// query asked for more intermediate rows than the budget allows -- almost
+/// always an unintended cartesian product. Its own code so a caller can
+/// branch on it and retry with a narrower pattern.
+pub const ROW_BUDGET_EXCEEDED: &str = "Samyama.ClientError.Statement.RowBudgetExceeded";
+
 pub const RUNTIME: &str = "Samyama.ClientError.Statement.RuntimeError";
 /// The store or the engine failed. The query is not necessarily wrong.
 pub const GRAPH_ACCESS: &str = "Samyama.DatabaseError.Statement.GraphAccessFailed";

--- a/src/query/executor/budget.rs
+++ b/src/query/executor/budget.rs
@@ -1,0 +1,304 @@
+//! A per-operator row budget, so an exploding intermediate fails instead of
+//! running (`PERF-05`).
+//!
+//! # What this answers
+//!
+//! Nothing bounded intermediate cardinality. A three-way cartesian product
+//! over 200 nodes materialized eight million rows and finished, and the same
+//! query over 2,000 nodes materializes eight *billion* -- it does not fail,
+//! it just does not come back, and the operator responsible is invisible
+//! while it happens. `examples/plan_budget_probe.rs` measured that; this is
+//! the response to it.
+//!
+//! # How it works
+//!
+//! The same shape as `PROFILE` (see `profile.rs`): the plan is a Volcano tree
+//! of `Box<dyn PhysicalOperator>`, and every node is wrapped in a
+//! [`BudgetedOperator`] that counts the rows it hands upward and refuses once
+//! it passes the budget. Wrapping rather than editing each operator is what
+//! makes this tractable -- there are dozens of operators and they construct in
+//! many places, and a rule enforced in one wrapper cannot be forgotten by the
+//! next operator someone adds.
+//!
+//! # Choices worth stating
+//!
+//! * **The error names the operator and the budget.** "Query failed" would
+//!   send someone hunting through a plan; "CartesianProduct produced more than
+//!   50,000,000 rows" is a place to look and a number to change. A budget that
+//!   refuses anonymously is barely better than a hang.
+//! * **A refusal is a client error, not a crash.** It carries its own code so
+//!   a caller can branch on it, rather than joining the 144 sites behind the
+//!   generic runtime code that `LANG-12` exists to break up.
+//! * **The default is generous on purpose.** The point is to stop explosions,
+//!   not to second-guess large-but-real queries. `SNB-Interactive` at SF10
+//!   does not approach 50M rows through any single operator; a cartesian
+//!   blowup passes it in the first second. Set `SAMYAMA_ROW_BUDGET=0` to
+//!   disable, or any other value to change it.
+//! * **It counts rows produced, not rows retained.** An operator that streams
+//!   a billion rows through without holding them is still doing a billion
+//!   rows of work, and that is the thing worth refusing.
+//! * **Only amplifying operators are budgeted**, via
+//!   `PhysicalOperator::amplifies_rows`. This is the load-bearing decision. A
+//!   blanket per-operator budget refuses `MATCH (n) RETURN count(n)` on a
+//!   187M-node graph -- one we publish ourselves -- because the scan produces
+//!   187M rows. But a scan is bounded by the data; it is large, not
+//!   exploding. What turns a large graph into an impossible one is an
+//!   operator whose output is the product of its inputs, and today that is
+//!   `CartesianProduct`. The default is `false` so a new operator is never
+//!   silently enrolled: a missed explosion leaves today's behaviour, while a
+//!   false refusal breaks a query that works.
+//!
+//! # What it does not catch, stated rather than discovered
+//!
+//! The count resets with the operator, so a budgeted operator driven by a
+//! nested loop starts again on each `reset()`. A cartesian product re-executed
+//! a million times can therefore do a million budgets' worth of work without
+//! ever crossing one. Cartesian products sit near the top of the plans this
+//! guards against, so it holds in practice -- but it is a per-pass bound, not
+//! a per-query one, and reading it as the latter would be wrong.
+
+use crate::graph::GraphStore;
+use crate::query::error_code;
+use crate::query::executor::operator::{
+    OperatorBox, OperatorDescription, PhysicalOperator,
+};
+use crate::query::executor::{ExecutionError, ExecutionResult, Record, RecordBatch};
+
+/// Rows a single operator may produce before the query is refused.
+///
+/// Chosen to sit far above any legitimate operator in the benchmark suites and
+/// far below what an unbounded cartesian product reaches in its first moments.
+pub const DEFAULT_ROW_BUDGET: u64 = 50_000_000;
+
+/// The budget in force, from `SAMYAMA_ROW_BUDGET` if set.
+///
+/// `0` disables enforcement. An unparseable value falls back to the default
+/// rather than to unlimited: a typo in an environment variable must not
+/// silently turn a guard off, which is the failure mode where the guard is
+/// discovered to have been absent only after the incident.
+pub fn configured_budget() -> u64 {
+    match std::env::var("SAMYAMA_ROW_BUDGET") {
+        Ok(v) => v.trim().parse::<u64>().unwrap_or(DEFAULT_ROW_BUDGET),
+        Err(_) => DEFAULT_ROW_BUDGET,
+    }
+}
+
+/// Wraps one operator and refuses once it has produced more than `budget`.
+struct BudgetedOperator {
+    inner: OperatorBox,
+    /// The operator's name, captured before wrapping so the message names the
+    /// plan the planner produced rather than "BudgetedOperator".
+    name: String,
+    produced: u64,
+    budget: u64,
+}
+
+impl BudgetedOperator {
+    fn charge(&mut self, rows: usize) -> ExecutionResult<()> {
+        self.produced += rows as u64;
+        if self.produced > self.budget {
+            return Err(ExecutionError::Coded {
+                code: error_code::ROW_BUDGET_EXCEEDED,
+                message: format!(
+                    "operator {} produced more than {} rows (the per-operator row \
+                     budget) and the query was refused rather than run to \
+                     completion. This is usually an unintended cartesian product \
+                     -- check for a MATCH with no relationship joining its \
+                     patterns. Raise or disable the budget with SAMYAMA_ROW_BUDGET \
+                     (0 disables it).",
+                    self.name, self.budget
+                ),
+            });
+        }
+        Ok(())
+    }
+}
+
+impl PhysicalOperator for BudgetedOperator {
+    fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        let out = self.inner.next(store)?;
+        self.charge(usize::from(out.is_some()))?;
+        Ok(out)
+    }
+
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        let out = self.inner.next_mut(store, tenant_id)?;
+        self.charge(usize::from(out.is_some()))?;
+        Ok(out)
+    }
+
+    fn next_batch(&mut self, store: &GraphStore, batch_size: usize) -> ExecutionResult<Option<RecordBatch>> {
+        let out = self.inner.next_batch(store, batch_size)?;
+        self.charge(out.as_ref().map_or(0, |b| b.records.len()))?;
+        Ok(out)
+    }
+
+    fn next_batch_mut(
+        &mut self,
+        store: &mut GraphStore,
+        tenant_id: &str,
+        batch_size: usize,
+    ) -> ExecutionResult<Option<RecordBatch>> {
+        let out = self.inner.next_batch_mut(store, tenant_id, batch_size)?;
+        self.charge(out.as_ref().map_or(0, |b| b.records.len()))?;
+        Ok(out)
+    }
+
+    // Everything else forwards, for the reason `ProfiledOperator` gives: an
+    // operator that overrides `next_batch` must keep using its own override,
+    // and `try_push_limit` must still reach the scan underneath or enforcing a
+    // budget would change the plan it is enforcing on.
+    fn try_push_limit(&mut self, n: usize) -> bool {
+        self.inner.try_push_limit(n)
+    }
+
+    fn reset(&mut self) {
+        self.produced = 0;
+        self.inner.reset()
+    }
+
+    fn is_mutating(&self) -> bool {
+        self.inner.is_mutating()
+    }
+
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        self.inner.children_mut()
+    }
+
+    /// Forwarded, like `describe`. `enforce` runs once per plan today, so
+    /// nothing re-walks a wrapped tree -- but a wrapper that answered `false`
+    /// here would quietly make a second pass skip the very operator the first
+    /// pass wrapped, and that is a bug best not left available.
+    fn amplifies_rows(&self) -> bool {
+        self.inner.amplifies_rows()
+    }
+
+    fn describe(&self) -> OperatorDescription {
+        self.inner.describe()
+    }
+}
+
+/// A stand-in used only while a slot is being swapped. Never executed.
+struct Vacated;
+
+impl PhysicalOperator for Vacated {
+    fn next(&mut self, _store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        Ok(None)
+    }
+    fn reset(&mut self) {}
+}
+
+fn wrap(slot: &mut OperatorBox, budget: u64) {
+    // Name taken before wrapping, so the refusal names the planner's operator.
+    let name = slot.describe().name;
+    let amplifies = slot.amplifies_rows();
+    for child in slot.children_mut() {
+        wrap(child, budget);
+    }
+    // Only amplifying operators are budgeted. A scan of a 187M-node graph
+    // produces 187M rows and is reading the data it was asked for; refusing it
+    // would break `MATCH (n) RETURN count(n)` on graphs we publish. Wrapping
+    // everything also put a virtual call on every operator of every query,
+    // which is the cost `PROFILE` is opt-in to avoid.
+    if amplifies {
+        let inner = std::mem::replace(slot, Box::new(Vacated));
+        *slot = Box::new(BudgetedOperator { inner, name, produced: 0, budget });
+    }
+}
+
+/// Wrap every node of `root` so each refuses past `budget` rows.
+///
+/// A budget of `0` is a no-op and leaves the tree untouched, so a disabled
+/// budget costs nothing at all -- not a branch, not a counter.
+pub fn enforce(root: &mut OperatorBox, budget: u64) {
+    if budget == 0 {
+        return;
+    }
+    wrap(root, budget);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::{Label, PropertyValue};
+    use crate::query::QueryEngine;
+
+    fn store(n: usize) -> GraphStore {
+        let mut s = GraphStore::new();
+        for i in 0..n {
+            let node = s.create_node_with_labels([Label::new("N")]);
+            s.set_node_property("default", node, "i", PropertyValue::Integer(i as i64)).unwrap();
+        }
+        s
+    }
+
+    /// The budget refuses a blowup, and says which operator and what limit.
+    #[test]
+    fn an_exploding_operator_is_refused_by_name() {
+        let s = store(120);
+        let engine = QueryEngine::new().with_row_budget(10_000);
+        let err = engine
+            .execute("MATCH (a:N), (b:N), (c:N) RETURN count(*)", &s)
+            .expect_err("1,728,000 rows must not pass a 10,000 row budget");
+        let msg = err.to_string();
+        assert!(msg.contains(error_code::ROW_BUDGET_EXCEEDED), "{msg}");
+        assert!(msg.contains("10000"), "the message must name the budget: {msg}");
+        assert!(
+            msg.contains("CartesianProduct"),
+            "the message must name the operator, not just fail: {msg}"
+        );
+    }
+
+    /// The converse, and the one that matters: a budget that refuses
+    /// everything would pass the test above while making the engine useless.
+    #[test]
+    fn a_query_inside_the_budget_is_untouched() {
+        let s = store(120);
+        let engine = QueryEngine::new().with_row_budget(10_000);
+        let batch = engine
+            .execute("MATCH (a:N) RETURN count(*)", &s)
+            .expect("120 rows are well inside a 10,000 row budget");
+        assert_eq!(batch.records.len(), 1);
+    }
+
+    /// The case the `amplifies_rows` distinction exists for, and the one a
+    /// blanket per-operator budget got wrong: a plain scan producing far more
+    /// rows than the budget must run. `MATCH (n) RETURN count(n)` over a
+    /// 187M-node graph is a query we publish results for; refusing it as an
+    /// "explosion" would be a false refusal against our own data.
+    #[test]
+    fn a_large_scan_is_not_an_explosion_and_is_not_refused() {
+        let s = store(500);
+        let engine = QueryEngine::new().with_row_budget(100);
+        let batch = engine
+            .execute("MATCH (n:N) RETURN n", &s)
+            .expect("a 500-row scan under a 100-row budget must still run: a scan \
+                     is bounded by the data, not amplifying");
+        assert_eq!(batch.records.len(), 500);
+    }
+
+    /// Disabling it must actually disable it, or `SAMYAMA_ROW_BUDGET=0` is a
+    /// lie people will discover in an incident.
+    #[test]
+    fn a_zero_budget_enforces_nothing() {
+        let s = store(60);
+        let engine = QueryEngine::new().with_row_budget(0);
+        engine
+            .execute("MATCH (a:N), (b:N), (c:N) RETURN count(*)", &s)
+            .expect("a zero budget must not refuse anything");
+    }
+
+    /// A bad environment value must not silently disable the guard.
+    #[test]
+    fn an_unparseable_budget_falls_back_to_the_default_not_to_unlimited() {
+        // Scoped: the variable is process-wide and other tests read it.
+        let prev = std::env::var("SAMYAMA_ROW_BUDGET").ok();
+        std::env::set_var("SAMYAMA_ROW_BUDGET", "banana");
+        let got = configured_budget();
+        match prev {
+            Some(v) => std::env::set_var("SAMYAMA_ROW_BUDGET", v),
+            None => std::env::remove_var("SAMYAMA_ROW_BUDGET"),
+        }
+        assert_eq!(got, DEFAULT_ROW_BUDGET);
+    }
+}

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -86,6 +86,7 @@ pub mod logical_optimizer;
 pub mod logical_plan;
 pub mod temporal;
 pub mod operator;
+pub mod budget;
 pub mod profile;
 pub mod physical_planner;
 pub mod plan_enumerator;
@@ -223,6 +224,7 @@ pub struct QueryExecutor<'a> {
     planner: QueryPlanner,
     params: HashMap<String, crate::graph::PropertyValue>,
     deadline: Option<std::time::Instant>,
+    row_budget: u64,
 }
 
 impl<'a> QueryExecutor<'a> {
@@ -233,6 +235,7 @@ impl<'a> QueryExecutor<'a> {
             planner: QueryPlanner::new(),
             params: HashMap::new(),
             deadline: None,
+            row_budget: 0,
         }
     }
 
@@ -243,12 +246,25 @@ impl<'a> QueryExecutor<'a> {
             planner,
             params: HashMap::new(),
             deadline: None,
+            row_budget: 0,
         }
     }
 
     /// Set a query execution deadline
     pub fn with_deadline(mut self, deadline: std::time::Instant) -> Self {
         self.deadline = deadline.into();
+        self
+    }
+
+    /// Refuse the query if any single operator produces more than `rows`.
+    ///
+    /// Defaults to `0` (off) on a directly-constructed executor rather than to
+    /// the configured budget: the many tests and callers that build an
+    /// executor by hand should get exactly the engine they asked for, and the
+    /// policy decision belongs to `QueryEngine`, which is the surface a real
+    /// caller goes through.
+    pub fn with_row_budget(mut self, rows: u64) -> Self {
+        self.row_budget = rows;
         self
     }
 
@@ -435,7 +451,7 @@ impl<'a> QueryExecutor<'a> {
 
         // Handle EXPLAIN - return plan description instead of executing
         if query.explain {
-            return Ok(Self::explain_plan_with_stats(&plan, Some(self.store)));
+            return Ok(Self::explain_plan_with_stats(&plan, Some(self.store), self.row_budget));
         }
 
         // Check if this is a write query - if so, error out
@@ -495,11 +511,16 @@ impl<'a> QueryExecutor<'a> {
     }
 
     /// Generate EXPLAIN output from an execution plan, optionally with graph statistics
+    #[cfg(test)]
     fn explain_plan(plan: &ExecutionPlan) -> RecordBatch {
-        Self::explain_plan_with_stats(plan, None)
+        Self::explain_plan_with_stats(plan, None, 0)
     }
 
-    fn explain_plan_with_stats(plan: &ExecutionPlan, store: Option<&GraphStore>) -> RecordBatch {
+    fn explain_plan_with_stats(
+        plan: &ExecutionPlan,
+        store: Option<&GraphStore>,
+        row_budget: u64,
+    ) -> RecordBatch {
         use crate::graph::PropertyValue;
         use crate::query::executor::planner::PLAN_DIAGNOSTICS;
 
@@ -532,6 +553,24 @@ impl<'a> QueryExecutor<'a> {
             }
         }
 
+        // The bound in force, named in the plan. PERF-05 asks for "budget +
+        // EXPLAIN exposure" and the second half is not decoration: a query
+        // refused for exceeding a limit the plan never mentioned looks like a
+        // bug in the engine rather than a limit the caller can raise.
+        plan_text.push_str("\n--- Row budget ---\n");
+        if row_budget == 0 {
+            plan_text.push_str(
+                "per-operator row budget: disabled (SAMYAMA_ROW_BUDGET=0); an \
+                 exploding intermediate will run rather than be refused\n",
+            );
+        } else {
+            plan_text.push_str(&format!(
+                "per-operator row budget: {row_budget} rows; an operator producing \
+                 more is refused with {}\n",
+                crate::query::error_code::ROW_BUDGET_EXCEEDED
+            ));
+        }
+
         // Append statistics summary if store is available
         if let Some(store) = store {
             let stats = store.statistics();
@@ -551,6 +590,9 @@ impl<'a> QueryExecutor<'a> {
     fn execute_plan(&self, mut plan: ExecutionPlan) -> ExecutionResult<RecordBatch> {
         // Set thread-local deadline so operators can check it during materialization
         operator::set_query_deadline(self.deadline);
+
+        // A no-op at budget 0, so the ordinary path allocates nothing.
+        budget::enforce(&mut plan.root, self.row_budget);
 
         let mut records = Vec::new();
         let batch_size = 1024;
@@ -589,6 +631,7 @@ pub struct MutQueryExecutor<'a> {
     planner: QueryPlanner,
     tenant_id: String,
     params: HashMap<String, crate::graph::PropertyValue>,
+    row_budget: u64,
 }
 
 impl<'a> MutQueryExecutor<'a> {
@@ -599,7 +642,15 @@ impl<'a> MutQueryExecutor<'a> {
             planner: QueryPlanner::new(),
             tenant_id,
             params: HashMap::new(),
+            row_budget: 0,
         }
+    }
+
+    /// Refuse the query if any single operator produces more than `rows`.
+    /// `0` is off. See `QueryExecutor::with_row_budget`.
+    pub fn with_row_budget(mut self, rows: u64) -> Self {
+        self.row_budget = rows;
+        self
     }
 
     /// Set query parameters
@@ -642,7 +693,7 @@ impl<'a> MutQueryExecutor<'a> {
         // Handle EXPLAIN - return plan description instead of executing
         if query.explain {
             let store_ref: &GraphStore = self.store;
-            return Ok(QueryExecutor::explain_plan_with_stats(&plan, Some(store_ref)));
+            return Ok(QueryExecutor::explain_plan_with_stats(&plan, Some(store_ref), self.row_budget));
         }
 
         // Execute the plan with mutable access.
@@ -679,6 +730,9 @@ impl<'a> MutQueryExecutor<'a> {
     }
 
     fn execute_plan_mut(&mut self, mut plan: ExecutionPlan) -> ExecutionResult<RecordBatch> {
+        // A no-op at budget 0, so the ordinary path allocates nothing.
+        budget::enforce(&mut plan.root, self.row_budget);
+
         let mut records = Vec::new();
         let batch_size = 1024;
 

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -5107,6 +5107,25 @@ pub trait PhysicalOperator: Send {
         false
     }
 
+    /// Can this operator produce substantially more rows than it consumes?
+    ///
+    /// Only these are subject to the per-operator row budget
+    /// (`executor::budget`), and the distinction is the whole design. A scan
+    /// of a 187M-node graph produces 187M rows and is not exploding -- it is
+    /// reading the data it was asked for, and refusing it would break
+    /// `MATCH (n) RETURN count(n)` on graphs we ship ourselves. Amplification
+    /// is the thing worth bounding: an operator whose output is the *product*
+    /// of its inputs turns a large graph into an impossible one.
+    ///
+    /// Defaults to `false`, so an operator added later is not silently
+    /// enrolled into a guard nobody considered for it. That trades a missed
+    /// explosion for never inventing a false refusal, which is the right way
+    /// round: a false refusal breaks a working query, while a missed one
+    /// leaves today's behaviour.
+    fn amplifies_rows(&self) -> bool {
+        false
+    }
+
     /// Describe this operator for EXPLAIN output
     /// Returns (operator_name, details, children)
     fn describe(&self) -> OperatorDescription {
@@ -10456,6 +10475,13 @@ impl PhysicalOperator for CartesianProductOperator {
         self.left_index = 0;
         self.current_right = None;
         self.left_materialized = false;
+    }
+
+    /// The one operator whose output is the *product* of its inputs, and the
+    /// source of every unbounded intermediate this guard exists for. Two
+    /// scans of 2,000 nodes is four million rows; three is eight billion.
+    fn amplifies_rows(&self) -> bool {
+        true
     }
 
     fn describe(&self) -> OperatorDescription {

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -138,6 +138,9 @@ pub struct QueryEngine {
     stats: CacheStats,
     /// Per-query timeout in seconds (0 = no timeout)
     query_timeout_secs: u64,
+    /// Rows a single operator may produce before the query is refused
+    /// (0 = unlimited). See `executor::budget`.
+    row_budget: u64,
 }
 
 impl QueryEngine {
@@ -154,7 +157,23 @@ impl QueryEngine {
             stats: CacheStats::new(),
             query_timeout_secs: std::env::var("SAMYAMA_QUERY_TIMEOUT")
                 .ok().and_then(|s| s.parse().ok()).unwrap_or(120),
+            row_budget: executor::budget::configured_budget(),
         }
+    }
+
+    /// Set the per-operator row budget; `0` disables enforcement entirely.
+    ///
+    /// Present so a caller that knows its query is legitimately enormous can
+    /// raise the bound for that engine, rather than having to unset a
+    /// process-wide environment variable and lose the guard everywhere.
+    pub fn with_row_budget(mut self, rows: u64) -> Self {
+        self.row_budget = rows;
+        self
+    }
+
+    /// The per-operator row budget in force.
+    pub fn row_budget(&self) -> u64 {
+        self.row_budget
     }
 
     /// Return a reference to the cache statistics (hits/misses).
@@ -211,7 +230,7 @@ impl QueryEngine {
                 std::time::Instant::now() + std::time::Duration::from_secs(self.query_timeout_secs)
             );
         }
-        let result = executor.execute(&query)?;
+        let result = executor.with_row_budget(self.row_budget).execute(&query)?;
 
         Ok(result)
     }
@@ -227,7 +246,7 @@ impl QueryEngine {
         let query = self.cached_parse(query_str)?;
 
         let mut executor = MutQueryExecutor::new(store, tenant_id.to_string());
-        let result = executor.execute(&query)?;
+        let result = executor.with_row_budget(self.row_budget).execute(&query)?;
 
         Ok(result)
     }


### PR DESCRIPTION
`plan_budget_probe` (#1036) measured PERF-05 and the answer was unambiguous: a three-way cartesian product over 200 nodes materialised **eight million** intermediate rows and finished, and `EXPLAIN` never mentioned a bound. The same query over 2,000 nodes is eight *billion* — it doesn't fail, it just never comes back, and the operator responsible is invisible while it happens.

Now:

```
operator CartesianProduct produced more than 50000000 rows (the per-operator row
budget) and the query was refused rather than run to completion. This is usually
an unintended cartesian product -- check for a MATCH with no relationship joining
its patterns. Raise or disable the budget with SAMYAMA_ROW_BUDGET (0 disables it).
```

### The decision worth reviewing: which operators are budgeted

A blanket per-operator budget is wrong, **and I wrote it that way first.** It refuses `MATCH (n) RETURN count(n)` on a 187M-node graph — one we publish hero results for — because the scan produces 187M rows. But a scan is bounded by the data: it is *large*, not *exploding*. What turns a large graph into an impossible one is an operator whose output is the **product** of its inputs.

So `PhysicalOperator::amplifies_rows()` gates enrolment, defaults to `false`, and `CartesianProduct` is the one operator returning `true`. A new operator is never silently enrolled: a missed explosion leaves today's behaviour, a false refusal breaks a working query, and those are not symmetric.

That also disposes of the cost objection — `PROFILE` is opt-in because wrapping every node costs a virtual call per row; wrapping only cartesian products puts the wrapper on approximately no hot path.

Mechanically it is `profile.rs`'s shape (wrap the tree, forward everything else), because an operator overriding `next_batch` must keep using its own override and `try_push_limit` must still reach the scan underneath — or enforcing a budget would change the plan it enforces on.

`EXPLAIN` now prints the budget in force: the second half of PERF-05's H1 target, and not decoration. A query refused for exceeding a limit the plan never mentioned looks like an engine bug rather than a limit you can raise.

### Verified, both directions and both settings

- **5 unit tests**, including the two converses — a 500-row scan under a 100-row budget must still run, and `SAMYAMA_ROW_BUDGET=0` must enforce nothing
- a **typo'd** budget falls back to the default, never to unlimited: a guard must not be switchable off by a misspelling
- `cargo build --release --tests --examples` → **exit 0**
- **openCypher TCK, budget on vs off → identical**: 3,760 of 3,763 evaluated, 99.92%, **0 wrong results**, 3 errored, both ways

### What it does not do

The count resets with the operator, so this is a **per-pass** bound, not per-query: a budgeted operator driven by a nested loop starts again on each `reset()`. Stated in the module docs rather than left to be discovered.

H2 asks for adaptive re-plan or spill. Refusing is neither, and the harness records PERF-05's H2 as `fail` rather than deriving it from this — a budget is not a planner.