### PR TITLE
The FinBench bench never built indexes, so every anchor was a full scan

### DIFF
--- a/benches/finbench_benchmark.rs
+++ b/benches/finbench_benchmark.rs
@@ -588,6 +588,27 @@ async fn main() -> Result<(), Error> {
         format_num(load_result.total_nodes),
         format_num(load_result.total_edges),
         format_duration(load_time));
+    // Build property indexes on `id` for the labels the queries anchor on.
+    //
+    // Without these every `MATCH (a:Account {id: ...})` is a full label scan.
+    // On SF10 that is the difference between a seek and a walk over millions
+    // of accounts, and it is what `SR-1 Account by ID` -- one row, one
+    // predicate -- was actually measuring at 753 ms.
+    //
+    // `ldbc_benchmark.rs` has done this since it was written; this bench never
+    // did. Both competitor runners create exactly these indexes before timing
+    // (`CREATE INDEX FOR (n:L) ON (n.id)` over Account, Person, Company, Loan,
+    // Medium), so the published FinBench comparison had us scanning while they
+    // seeked. That is our harness understating our engine, not the engine.
+    let idx_start = Instant::now();
+    for label in ["Account", "Person", "Company", "Loan", "Medium"] {
+        let stmt = format!("CREATE INDEX ON :{label}(id)");
+        if let Err(e) = client.query("default", &stmt).await {
+            eprintln!("  WARN: index {label}(id) failed: {e}");
+        }
+    }
+    eprintln!("Indexes built in {} (Account/Person/Company/Loan/Medium on id)",
+        format_duration(idx_start.elapsed()));
     eprintln!("Runs per query: {}", runs);
     eprintln!();
 

--- a/examples/finbench_index_probe.rs
+++ b/examples/finbench_index_probe.rs
@@ -1,0 +1,47 @@
+//! Does `MATCH (a:Account {id: N})` use an index once one exists?
+//!
+//! The FinBench bench never created indexes, so every anchor was a label scan
+//! over millions of accounts. Adding the `CREATE INDEX` is only half the fix:
+//! the planner has to lower the inline-property MATCH to an IndexScan, and a
+//! benchmark cannot tell you whether it did -- it only tells you the query got
+//! faster, which a warm cache also does.
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+fn main() {
+    let mut s = GraphStore::new();
+    for i in 0..50_000i64 {
+        let n = s.create_node_with_labels([Label::new("Account")]);
+        s.set_node_property("default", n, "id", PropertyValue::Integer(i)).unwrap();
+    }
+
+    let q = "MATCH (a:Account {id: 49999}) RETURN a.id";
+    let explain = |s: &GraphStore| -> String {
+        let parsed = parse_query(&format!("EXPLAIN {q}")).unwrap();
+        QueryExecutor::new(s).execute(&parsed).ok()
+            .and_then(|b| b.records.first().and_then(|r| r.get("plan")).map(|v| format!("{v:?}")))
+            .unwrap_or_default()
+    };
+    let time = |s: &GraphStore| {
+        let parsed = parse_query(q).unwrap();
+        let t = std::time::Instant::now();
+        let n = QueryExecutor::new(s).execute(&parsed).map(|b| b.records.len());
+        (t.elapsed(), n)
+    };
+
+    let before_plan = explain(&s);
+    let (before, _) = time(&s);
+    println!("without an index: {before:?}");
+    println!("  plan: {}", before_plan.lines().next().unwrap_or("").chars().take(90).collect::<String>());
+
+    let stmt = parse_query("CREATE INDEX ON :Account(id)").unwrap();
+    MutQueryExecutor::new(&mut s, "default".to_string()).execute(&stmt).expect("index created");
+
+    let after_plan = explain(&s);
+    let (after, rows) = time(&s);
+    println!("with an index   : {after:?}  rows={rows:?}");
+    println!("  plan: {}", after_plan.lines().next().unwrap_or("").chars().take(90).collect::<String>());
+    println!("\nplan mentions IndexScan: {}", after_plan.contains("IndexScan"));
+    println!("speedup: {:.1}x", before.as_secs_f64() / after.as_secs_f64().max(1e-9));
+}


### PR DESCRIPTION
Measuring FinBench SF10 across three engines yesterday put us at a geometric mean of **246x** the best competitor, with `SR-1 Account by ID` — one row, one predicate — taking **753 ms** against FalkorDB's 0.10 ms. A point lookup taking three quarters of a second is not a slow engine, it is a missing index.

`benches/finbench_benchmark.rs` creates none. `benches/ldbc_benchmark.rs` has built them since it was written, and its comment says exactly why:

> Without these, `MATCH (m:Post {id: ...})` triggers a full label scan

And **both competitor runners create precisely these indexes before timing**:

```bash
for L in Account Person Company Loan Medium; do
  CREATE INDEX FOR (n:$L) ON (n.id)
```

So the published FinBench comparison had them seeking and us scanning. **That is our harness understating our engine, not the engine losing.**

### Verifying the half a benchmark cannot

`examples/finbench_index_probe.rs` checks that the planner actually *lowers* the inline-property MATCH to an IndexScan — a query getting faster is also what a warm cache looks like, so it reads the plan, then the clock. On 50,000 accounts:

```
without an index: 8.33ms    plan: Filter -> NodeScan
with an index   : 10.9us    plan: IndexScan
speedup: 761.8x
```

SF10 has far more than 50,000 accounts, so the effect should be larger there. **Whether it reaches PERF-03's H1 bar of 10x is a question for the SF10 re-run, not for this commit** — CR-8 and CR-10 are already within 2.1x and 1.6x and are not anchor-bound, so index lowering will not move them.

21/21 FinBench queries still pass at synthetic scale; indexes build in 2 ms with no warnings.