### PR TITLE
shortestPath searches from both ends and meets in the middle

### DIFF
--- a/examples/shortestpath_differential.rs
+++ b/examples/shortestpath_differential.rs
@@ -1,0 +1,91 @@
+//! Bidirectional shortestPath must agree with the one-sided walk on *length*.
+//!
+//! `shortestPath` returns **a** shortest path, so the specific path may
+//! legitimately differ between the two algorithms when several are tied. The
+//! length may not, and neither may reachability: a bidirectional search that
+//! reverses the wrong way finds nothing on directed graphs and everything on
+//! undirected ones, and both failures look like "a different path" until you
+//! check the number.
+//!
+//! `allShortestPaths` still uses the one-sided walk, so it doubles as the
+//! reference: on the same graph and endpoints, `min(len(allShortestPaths))`
+//! must equal `len(shortestPath)`.
+
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+
+/// Deterministic pseudo-random graph; no RNG crate, and the seed is printed
+/// so a failure is reproducible.
+fn graph(seed: u64, n: usize, edges: usize, directed_only: bool) -> GraphStore {
+    let mut s = GraphStore::new();
+    let mut ids = Vec::new();
+    for i in 0..n {
+        let node = s.create_node_with_labels([Label::new("N")]);
+        s.set_node_property("default", node, "id", PropertyValue::Integer(i as i64)).unwrap();
+        ids.push(node);
+    }
+    let mut x = seed | 1;
+    let mut next = || { x ^= x << 13; x ^= x >> 7; x ^= x << 17; x };
+    for _ in 0..edges {
+        let a = (next() as usize) % n;
+        let b = (next() as usize) % n;
+        if a != b {
+            let _ = s.create_edge(ids[a], ids[b], "R");
+            if !directed_only && next() % 2 == 0 {
+                let _ = s.create_edge(ids[b], ids[a], "R");
+            }
+        }
+    }
+    s
+}
+
+fn len_of(store: &GraphStore, cypher: &str) -> Option<i64> {
+    let parsed = parse_query(cypher).ok()?;
+    let batch = QueryExecutor::new(store).execute(&parsed).ok()?;
+    batch.records.iter().filter_map(|r| match r.get("l") {
+        Some(v) => format!("{v:?}").split("Integer(").nth(1)
+            .and_then(|t| t.split(')').next()).and_then(|t| t.parse::<i64>().ok()),
+        None => None,
+    }).min()
+}
+
+fn main() {
+    let mut checked = 0usize;
+    let mut disagreed = Vec::new();
+    let mut reachable = 0usize;
+
+    for seed in 1u64..=40 {
+        for (n, e, directed) in [(60usize, 120usize, true), (60, 90, false), (120, 400, true)] {
+            let s = graph(seed, n, e, directed);
+            for (a, b) in [(0i64, (n - 1) as i64), (1, 7), (3, (n / 2) as i64)] {
+                for arrow in ["-[:R*]->", "-[:R*]-"] {
+                    let one = format!(
+                        "MATCH p = allShortestPaths((x:N {{id: {a}}}){arrow}(y:N {{id: {b}}})) \
+                         RETURN length(p) AS l");
+                    let two = format!(
+                        "MATCH p = shortestPath((x:N {{id: {a}}}){arrow}(y:N {{id: {b}}})) \
+                         RETURN length(p) AS l");
+                    let (r_all, r_one) = (len_of(&s, &one), len_of(&s, &two));
+                    checked += 1;
+                    if r_all.is_some() { reachable += 1; }
+                    if r_all != r_one {
+                        disagreed.push(format!(
+                            "seed={seed} n={n} e={e} directed={directed} {a}->{b} {arrow}: \
+                             allShortestPaths={r_all:?} shortestPath={r_one:?}"));
+                    }
+                }
+            }
+        }
+    }
+
+    println!("cases checked : {checked}");
+    println!("reachable     : {reachable}   (a run where nothing is reachable proves nothing)");
+    println!("disagreements : {}", disagreed.len());
+    for d in disagreed.iter().take(10) {
+        println!("  {d}");
+    }
+    assert!(reachable > checked / 10, "fixture too sparse: only {reachable} reachable pairs");
+    assert!(disagreed.is_empty(), "{} disagreements", disagreed.len());
+    println!("\nOK: bidirectional shortestPath agrees with the one-sided reference on every case");
+}

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -16467,6 +16467,146 @@ impl ShortestPathOperator {
     /// Neighbours come from the allocation-free visitor with the edge type
     /// filtered on its interned id, so an incident edge of the wrong type
     /// costs a comparison rather than an `Edge` clone (#520).
+    /// Neighbours as seen from the *target* end, for the backward half of a
+    /// bidirectional search.
+    ///
+    /// The reversal is the whole correctness of that search. Walking backwards
+    /// from the target of `(a)-[:R*]->(b)` means following edges that point
+    /// *into* the current node, so `Outgoing` and `Incoming` swap. `Both` is
+    /// its own mirror and does not.
+    fn for_each_neighbor_reverse(
+        &self,
+        node: NodeId,
+        type_ids: Option<&[u16]>,
+        store: &GraphStore,
+        mut visit: impl FnMut(NodeId, crate::graph::EdgeId),
+    ) {
+        match self.direction {
+            Direction::Outgoing => store.for_each_incoming_neighbor(node, type_ids, &mut visit),
+            Direction::Incoming => store.for_each_outgoing_neighbor(node, type_ids, &mut visit),
+            Direction::Both => {
+                store.for_each_outgoing_neighbor(node, type_ids, &mut visit);
+                store.for_each_incoming_neighbor(node, type_ids, &mut visit);
+            }
+        }
+    }
+
+    /// Bidirectional BFS for the single-shortest-path case.
+    ///
+    /// A one-sided BFS explores on the order of `b^d` nodes; searching from
+    /// both ends and meeting in the middle explores `2 * b^(d/2)`. On LDBC
+    /// FinBench SF10 -- 6.2M TRANSFER edges, high fan-out --
+    /// `shortestPath((a1)-[:TRANSFER*]-(a2))` took 541 ms one-sided against
+    /// Neo4j's 14 ms, which is that exponent difference and nothing else.
+    ///
+    /// Only for `shortestPath`, not `allShortestPaths`. Enumerating *every*
+    /// shortest path from a two-sided search means stitching two predecessor
+    /// DAGs at every meeting point, and getting that subtly wrong yields
+    /// missing paths rather than slow ones. `all_paths` keeps the one-sided
+    /// walk, which is already correct.
+    ///
+    /// Termination is the part worth reading. It does **not** stop at the
+    /// first meeting: an alternating level-synchronous search can meet on a
+    /// node that is not on any shortest path. It tracks the best total seen
+    /// and keeps expanding while `depth_f + depth_b < best`, which is the
+    /// point past which no shorter path can still exist.
+    fn bfs_shortest_bidirectional(
+        &self,
+        store: &GraphStore,
+        source: NodeId,
+        target: NodeId,
+        type_ids: Option<&[u16]>,
+    ) -> Option<(Vec<NodeId>, Vec<crate::graph::EdgeId>)> {
+        use rustc_hash::FxHashMap;
+
+        let mut dist_f: FxHashMap<NodeId, u32> = FxHashMap::default();
+        let mut dist_b: FxHashMap<NodeId, u32> = FxHashMap::default();
+        // (predecessor, edge that reached this node)
+        let mut pred_f: FxHashMap<NodeId, (NodeId, crate::graph::EdgeId)> = FxHashMap::default();
+        let mut pred_b: FxHashMap<NodeId, (NodeId, crate::graph::EdgeId)> = FxHashMap::default();
+        dist_f.insert(source, 0);
+        dist_b.insert(target, 0);
+
+        let mut frontier_f = vec![source];
+        let mut frontier_b = vec![target];
+        let (mut depth_f, mut depth_b) = (0u32, 0u32);
+        let mut best: Option<(u32, NodeId)> = None;
+
+        while !frontier_f.is_empty() && !frontier_b.is_empty() {
+            if let Some((b, _)) = best {
+                if depth_f + depth_b >= b {
+                    break;
+                }
+            }
+            // Expand the cheaper side, which is what keeps the exponent halved
+            // on graphs whose fan-out differs by direction.
+            let forward = frontier_f.len() <= frontier_b.len();
+            let mut next = Vec::new();
+            if forward {
+                depth_f += 1;
+                for &current in &frontier_f {
+                    self.for_each_neighbor(current, type_ids, store, |nb, eid| {
+                        if !dist_f.contains_key(&nb) {
+                            dist_f.insert(nb, depth_f);
+                            pred_f.insert(nb, (current, eid));
+                            next.push(nb);
+                        }
+                        if let Some(&db) = dist_b.get(&nb) {
+                            let total = depth_f + db;
+                            if best.is_none_or(|(b, _)| total < b) {
+                                best = Some((total, nb));
+                            }
+                        }
+                    });
+                }
+                frontier_f = next;
+            } else {
+                depth_b += 1;
+                for &current in &frontier_b {
+                    self.for_each_neighbor_reverse(current, type_ids, store, |nb, eid| {
+                        if !dist_b.contains_key(&nb) {
+                            dist_b.insert(nb, depth_b);
+                            pred_b.insert(nb, (current, eid));
+                            next.push(nb);
+                        }
+                        if let Some(&df) = dist_f.get(&nb) {
+                            let total = df + depth_b;
+                            if best.is_none_or(|(b, _)| total < b) {
+                                best = Some((total, nb));
+                            }
+                        }
+                    });
+                }
+                frontier_b = next;
+            }
+        }
+
+        let (_, meet) = best?;
+
+        // source -> meet, walking `pred_f` back and reversing.
+        let mut nodes = vec![meet];
+        let mut edges: Vec<crate::graph::EdgeId> = Vec::new();
+        let mut cur = meet;
+        while cur != source {
+            let (parent, eid) = *pred_f.get(&cur)?;
+            nodes.push(parent);
+            edges.push(eid);
+            cur = parent;
+        }
+        nodes.reverse();
+        edges.reverse();
+
+        // meet -> target, walking `pred_b` forward; it already points that way.
+        let mut cur = meet;
+        while cur != target {
+            let (nextn, eid) = *pred_b.get(&cur)?;
+            nodes.push(nextn);
+            edges.push(eid);
+            cur = nextn;
+        }
+        Some((nodes, edges))
+    }
+
     fn bfs_shortest(
         &self,
         store: &GraphStore,
@@ -16476,6 +16616,12 @@ impl ShortestPathOperator {
     ) -> Vec<(Vec<NodeId>, Vec<crate::graph::EdgeId>)> {
         if source == target {
             return vec![(vec![source], vec![])];
+        }
+        if !self.all_paths {
+            return self
+                .bfs_shortest_bidirectional(store, source, target, type_ids)
+                .into_iter()
+                .collect();
         }
 
         // Phase 1: level BFS building the shortest-path DAG.


### PR DESCRIPTION
FinBench SF10, after the index fix (#1049), left **exactly one query** above PERF-03's H1 bar of 10x: **CR-3 at 38.6x** — `shortestPath((a1)-[:TRANSFER*]-(a2))`, 541 ms against Neo4j's 14 ms.

`bfs_shortest` walked outward from the source alone. A one-sided BFS explores on the order of `b^d` nodes; meeting in the middle explores `2 * b^(d/2)`. On 6.2M TRANSFER edges with high fan-out **that exponent is the whole gap** — there is nothing else wrong with the query.

**Scoped to `shortestPath` deliberately.** `allShortestPaths` keeps the one-sided walk: enumerating *every* shortest path from a two-sided search means stitching two predecessor DAGs at every meeting point, and getting that subtly wrong **drops paths** rather than slowing them. A missing path is a wrong answer; a slow path is just slow.

### The two details that are the correctness of it

- **The reversal.** Walking backwards from the target of `(a)-[:R*]->(b)` means following edges pointing *into* the current node, so `Outgoing` and `Incoming` swap; `Both` is its own mirror. Get this wrong and the search finds **nothing** on directed graphs and **everything** on undirected ones.
- **Termination.** It does not stop at first contact — an alternating level-synchronous search can meet on a node that is not on any shortest path. It tracks the best total and expands while `depth_f + depth_b < best`.

### Verified three ways

- `examples/shortestpath_differential.rs` — **720 cases**, directed and undirected random graphs, **623 reachable**, comparing every `shortestPath` length against `allShortestPaths` on the same graph and endpoints. Since `allShortestPaths` still uses the one-sided walk, it is an independent reference rather than a restatement. **0 disagreements.**
- The same test with the reversal **deliberately removed: 218 disagreements.** A differential test that has only ever passed is indistinguishable from one that cannot fail.
- **openCypher TCK unchanged**: 3,760 of 3,763 evaluated (99.92%), 0 wrong results, 3 errored — identical to the run before this change. Plus 7 shortestPath unit tests.

`shortestPath` returns *a* shortest path, so which one comes back may differ where several are tied. The length may not, and that is what the differential test pins.

Whether this clears CR-3's 10x bar is for the SF10 re-run to say.