### PR TITLE
shortestPath scanned the whole label to find its target

### DIFF
--- a/examples/shortestpath_plan_probe.rs
+++ b/examples/shortestpath_plan_probe.rs
@@ -1,0 +1,43 @@
+//! Which operators does `shortestPath` between two indexed anchors plan?
+//!
+//! Bidirectional BFS did not move CR-3 at all (541 ms -> 547 ms on SF10), so
+//! the BFS was not the cost. This asks what the plan actually is.
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+fn main() {
+    let mut s = GraphStore::new();
+    let mut ids = Vec::new();
+    for i in 0..40_000i64 {
+        let n = s.create_node_with_labels([Label::new("Account")]);
+        s.set_node_property("default", n, "id", PropertyValue::Integer(i)).unwrap();
+        ids.push(n);
+    }
+    for i in 0..(ids.len() - 1) {
+        let _ = s.create_edge(ids[i], ids[i + 1], "TRANSFER");
+    }
+    let idx = parse_query("CREATE INDEX ON :Account(id)").unwrap();
+    MutQueryExecutor::new(&mut s, "default".to_string()).execute(&idx).unwrap();
+
+    for (label, q) in [
+        ("inline properties (what CR-3 writes)",
+         "MATCH p = shortestPath((a:Account {id: 5})-[:TRANSFER*]-(b:Account {id: 40})) RETURN length(p) AS l"),
+        ("WHERE predicates",
+         "MATCH (a:Account), (b:Account) WHERE a.id = 5 AND b.id = 40 \
+          MATCH p = shortestPath((a)-[:TRANSFER*]-(b)) RETURN length(p) AS l"),
+    ] {
+        let plan = parse_query(&format!("EXPLAIN {q}")).ok()
+            .and_then(|p| QueryExecutor::new(&s).execute(&p).ok())
+            .and_then(|b| b.records.first().and_then(|r| r.get("plan")).map(|v| format!("{v:?}")))
+            .unwrap_or_default();
+        let ops: Vec<&str> = ["IndexScan", "NodeScan", "NodeById", "Filter", "CartesianProduct", "ShortestPath"]
+            .into_iter().filter(|o| plan.contains(o)).collect();
+        let t = std::time::Instant::now();
+        let rows = parse_query(q).ok()
+            .and_then(|p| QueryExecutor::new(&s).execute(&p).ok())
+            .map(|b| b.records.len());
+        println!("{label:38} {:>9?}  rows={rows:?}", t.elapsed());
+        println!("    operators: {ops:?}");
+    }
+}

--- a/examples/shortestpath_target_index_correctness.rs
+++ b/examples/shortestpath_target_index_correctness.rs
@@ -1,0 +1,67 @@
+//! An indexed target scan must return the same rows as the scan it replaced.
+//!
+//! Narrowing a scan is only a win if it narrows to the right set. The cases
+//! that matter are the ones where the index answers *part* of the question:
+//! a second inline property the index does not cover, a label the index is
+//! not on, and a value that is not in the index at all. In each the filter
+//! above must still decide, and the answer must equal the unindexed answer.
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+fn build(indexed: bool) -> GraphStore {
+    let mut s = GraphStore::new();
+    let mut ids = Vec::new();
+    for i in 0..300i64 {
+        let n = s.create_node_with_labels([Label::new("Account")]);
+        s.set_node_property("default", n, "id", PropertyValue::Integer(i)).unwrap();
+        // Two accounts share `id`-adjacent values but differ on `kind`, so a
+        // query naming both properties has a wrong answer available to it.
+        s.set_node_property("default", n, "kind",
+            PropertyValue::String(if i % 2 == 0 { "even" } else { "odd" }.into())).unwrap();
+        ids.push(n);
+    }
+    for i in 0..(ids.len() - 1) {
+        let _ = s.create_edge(ids[i], ids[i + 1], "TRANSFER");
+    }
+    if indexed {
+        let q = parse_query("CREATE INDEX ON :Account(id)").unwrap();
+        MutQueryExecutor::new(&mut s, "default".to_string()).execute(&q).unwrap();
+    }
+    s
+}
+
+fn run(s: &GraphStore, q: &str) -> Option<usize> {
+    let parsed = parse_query(q).ok()?;
+    QueryExecutor::new(s).execute(&parsed).ok().map(|b| b.records.len())
+}
+
+fn main() {
+    let plain = build(false);
+    let indexed = build(true);
+    let cases = [
+        ("single indexed property",
+         "MATCH p = shortestPath((a:Account {id: 3})-[:TRANSFER*]-(b:Account {id: 40})) RETURN length(p) AS l"),
+        ("second property the index does not cover, matching",
+         "MATCH p = shortestPath((a:Account {id: 3})-[:TRANSFER*]-(b:Account {id: 40, kind: \"even\"})) RETURN length(p) AS l"),
+        ("second property the index does not cover, NOT matching",
+         "MATCH p = shortestPath((a:Account {id: 3})-[:TRANSFER*]-(b:Account {id: 40, kind: \"odd\"})) RETURN length(p) AS l"),
+        ("target value absent from the graph",
+         "MATCH p = shortestPath((a:Account {id: 3})-[:TRANSFER*]-(b:Account {id: 9999})) RETURN length(p) AS l"),
+        ("label with no index on it",
+         "MATCH p = shortestPath((a:Account {id: 3})-[:TRANSFER*]-(b:Account {kind: \"odd\"})) RETURN length(p) AS l"),
+        ("directed",
+         "MATCH p = shortestPath((a:Account {id: 3})-[:TRANSFER*]->(b:Account {id: 40})) RETURN length(p) AS l"),
+        ("directed backwards, unreachable",
+         "MATCH p = shortestPath((a:Account {id: 40})-[:TRANSFER*]->(b:Account {id: 3})) RETURN length(p) AS l"),
+    ];
+    let mut bad = 0;
+    for (label, q) in cases {
+        let (u, i) = (run(&plain, q), run(&indexed, q));
+        let ok = u == i;
+        if !ok { bad += 1; }
+        println!("{:<52} unindexed={:?} indexed={:?}  {}", label, u, i, if ok { "ok" } else { "MISMATCH" });
+    }
+    assert_eq!(bad, 0, "{bad} cases where the index changed the answer");
+    println!("\nOK: the indexed target scan returns what the unindexed scan returned");
+}

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -3580,10 +3580,29 @@ impl QueryPlanner {
                             op,
                             val,
                         )),
-                        None => Box::new(NodeScanOperator::new(
-                            target_var.clone(),
-                            last_segment.node.labels.clone(),
-                        )),
+                        // Then an indexed **inline** property. `#584` taught
+                        // the `WHERE` form to use the index and left this one
+                        // behind, so `shortestPath((a {id: 1})-[*]-(b {id: 2}))`
+                        // -- which is how the pattern is actually written --
+                        // planned `IndexScan(a) x NodeScan(b)`: the source
+                        // seeked and the target scanned the whole label.
+                        //
+                        // On FinBench SF10 that scan was the entire cost of
+                        // CR-3. Making the BFS bidirectional first (#1050)
+                        // moved it 541 ms -> 547 ms, because the search was
+                        // never what the query was spending its time on.
+                        None => match inline_index_scan(
+                            &target_var,
+                            &last_segment.node.labels,
+                            last_segment.node.properties.as_ref(),
+                            store,
+                        ) {
+                            Some(op) => op,
+                            None => Box::new(NodeScanOperator::new(
+                                target_var.clone(),
+                                last_segment.node.labels.clone(),
+                            )),
+                        },
                     },
                 };
                 // Add property filter for target node
@@ -5506,6 +5525,42 @@ fn find_id_predicate(var: &str, preds: &[Expression]) -> Option<(usize, Vec<crat
                 }
             }
             _ => {}
+        }
+    }
+    None
+}
+
+/// An `IndexScan` for an inline property, when one of the node's labels has an
+/// index on it.
+///
+/// The property filter stays above this regardless: an index answers one
+/// equality, and a pattern may carry several inline properties. Narrowing the
+/// scan is the win; the filter still decides correctness.
+fn inline_index_scan(
+    var: &str,
+    labels: &[Label],
+    properties: Option<&HashMap<String, PropertyValue>>,
+    store: &GraphStore,
+) -> Option<OperatorBox> {
+    let props = properties?;
+    if props.is_empty() || labels.is_empty() {
+        return None;
+    }
+    // Deterministic: a pattern with two indexed properties must plan the same
+    // way on every run, and `HashMap` iteration order does not.
+    let mut keys: Vec<&String> = props.keys().collect();
+    keys.sort();
+    for label in labels {
+        for key in &keys {
+            if store.property_index.has_index(label, key) {
+                return Some(Box::new(IndexScanOperator::new(
+                    var.to_string(),
+                    label.clone(),
+                    (*key).clone(),
+                    BinaryOp::Eq,
+                    props[*key].clone(),
+                )) as OperatorBox);
+            }
         }
     }
     None


### PR DESCRIPTION
Bidirectional BFS (#1050) moved FinBench CR-3 from 541 ms to **547 ms**. That is a falsified hypothesis, and reading the plan rather than guessing again found the real cost:

```
MATCH p = shortestPath((a:Account {id: 1})-[:TRANSFER*]-(b:Account {id: 100}))

operators: IndexScan, NodeScan, Filter, CartesianProduct, ShortestPath
                      ^^^^^^^^ the target
```

**The source seeked and the target scanned every `Account` in the graph.** On SF10 that scan *was* the query — which is why making the search cleverer changed nothing.

The planner already handles this for the `WHERE` form: #584 taught it that `WHERE a.id = 1 AND b.id = 2` must not plan as `IndexScan(a) x NodeScan(b)`. Its comment even calls the inline form *"what the inline form already got right"*. **It did not** — `find_index_predicate` reads deferred predicates, and inline properties are not predicates. The form the pattern is actually written in was the one left behind.

`inline_index_scan` gives the target the same treatment. On 40,000 accounts:

```
before  4.415 ms   IndexScan, NodeScan, Filter, CartesianProduct, ShortestPath
after   49.27 us   IndexScan,           Filter, CartesianProduct, ShortestPath
```

### The filter stays above the scan

An index answers one equality and a pattern may carry several inline properties, so narrowing the scan is the win and the **filter still decides correctness**. `shortestpath_target_index_correctness.rs` compares an indexed store against an unindexed one on the cases where an index could plausibly return the wrong set:

| case | unindexed | indexed |
|---|---|---|
| single indexed property | 1 | 1 |
| second property the index does not cover, matching | 1 | 1 |
| second property the index does not cover, **NOT** matching | 0 | 0 |
| target value absent from the graph | 0 | 0 |
| label with no index on it | 150 | 150 |
| directed | 1 | 1 |
| directed backwards, unreachable | 0 | 0 |

Index selection sorts the property keys before choosing, so a pattern with two indexed properties plans the same way every run — `HashMap` order does not.

**openCypher TCK unchanged**: 3,760 of 3,763 (99.92%), 0 wrong results. The 720-case bidirectional differential still reports 0 disagreements.