### PR TITLE
LDBC indexed six properties no query filters on, and missed five that do

### DIFF
--- a/benches/ldbc_benchmark.rs
+++ b/benches/ldbc_benchmark.rs
@@ -930,16 +930,39 @@ async fn main() -> Result<(), Error> {
     // anchor on. Without these, `MATCH (m:Post {id: ...})` triggers a
     // full label scan (1.19M Posts on SF1, ~5–9s per IS4–7). With them
     // the inline-property MATCH lowers to an IndexScan.
+    // Derived from what the 21 queries actually filter on, not from a guess and
+    // not copied from a competitor's script.
+    //
+    // The previous list indexed six properties no query in the corpus anchors
+    // on -- Comment.id, Forum.id, Place.id, Organisation.id, Tag.id,
+    // TagClass.id -- and missed five that queries do:
+    //
+    //   Person.firstName   IC1    was 2.73x the best competitor
+    //   Organisation.name  IC11   was 2.80x
+    //   Tag.name           IC6
+    //   Place.name         IC3
+    //   TagClass.name      IC12
+    //
+    // Both SNB-I queries above SLT-2's "no single query > 2x" clause were in
+    // that missing set, and both anchor on a *name* while we had indexed the
+    // *id* of the same label. The six unused entries are kept: they cost load
+    // time and nothing else, and dropping an index is a separate decision from
+    // adding the ones the queries need.
     let idx_start = Instant::now();
     for (label, prop) in &[
         ("Person", "id"),
+        ("Person", "firstName"),
         ("Post", "id"),
         ("Comment", "id"),
         ("Forum", "id"),
         ("Place", "id"),
+        ("Place", "name"),
         ("Organisation", "id"),
+        ("Organisation", "name"),
         ("Tag", "id"),
+        ("Tag", "name"),
         ("TagClass", "id"),
+        ("TagClass", "name"),
     ] {
         let stmt = format!("CREATE INDEX ON :{}({})", label, prop);
         if let Err(e) = client.query("default", &stmt).await {
@@ -947,7 +970,8 @@ async fn main() -> Result<(), Error> {
         }
     }
     eprintln!(
-        "Indexes built in {} (Person/Post/Comment/Forum/Place/Org/Tag/TagClass on id)",
+        "Indexes built in {} (id for the 8 anchor labels, plus Person.firstName, \
+Place/Organisation/Tag/TagClass .name -- the properties the 21 queries filter on)",
         format_duration(idx_start.elapsed())
     );
 

--- a/examples/ldbc_name_index_probe.rs
+++ b/examples/ldbc_name_index_probe.rs
@@ -1,0 +1,63 @@
+//! Do the LDBC `name`/`firstName` anchors lower to an IndexScan?
+//!
+//! IC1 anchors on `(friend:Person {firstName: "..."})` inline; IC11 and IC3
+//! filter with `WHERE org.name = "..."`. Those are two different planner
+//! paths -- inline properties and deferred predicates -- and the shortestPath
+//! work showed they are not equally well served. Adding an index is only half
+//! a fix; the plan has to change. A query getting faster is also what a warm
+//! cache looks like, so this reads the plan first.
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+fn fixture(indexed: bool) -> GraphStore {
+    let mut s = GraphStore::new();
+    for i in 0..40_000i64 {
+        let p = s.create_node_with_labels([Label::new("Person")]);
+        s.set_node_property("default", p, "id", PropertyValue::Integer(i)).unwrap();
+        s.set_node_property("default", p, "firstName",
+            PropertyValue::String(format!("name{}", i % 500))).unwrap();
+        let o = s.create_node_with_labels([Label::new("Organisation")]);
+        s.set_node_property("default", o, "name",
+            PropertyValue::String(format!("org{}", i % 500))).unwrap();
+    }
+    if indexed {
+        for stmt in ["CREATE INDEX ON :Person(firstName)", "CREATE INDEX ON :Organisation(name)"] {
+            let q = parse_query(stmt).unwrap();
+            MutQueryExecutor::new(&mut s, "default".to_string()).execute(&q).unwrap();
+        }
+    }
+    s
+}
+
+fn probe(label: &str, q: &str) {
+    let (plain, idx) = (fixture(false), fixture(true));
+    let plan = |s: &GraphStore| -> String {
+        parse_query(&format!("EXPLAIN {q}")).ok()
+            .and_then(|p| QueryExecutor::new(s).execute(&p).ok())
+            .and_then(|b| b.records.first().and_then(|r| r.get("plan")).map(|v| format!("{v:?}")))
+            .unwrap_or_default()
+    };
+    let run = |s: &GraphStore| {
+        let p = parse_query(q).unwrap();
+        let t = std::time::Instant::now();
+        let n = QueryExecutor::new(s).execute(&p).map(|b| b.records.len()).unwrap_or(0);
+        (t.elapsed(), n)
+    };
+    let (t0, n0) = run(&plain);
+    let (t1, n1) = run(&idx);
+    let ops = |pl: &str| ["IndexScan", "NodeScan", "Filter"].iter()
+        .filter(|o| pl.contains(*o)).cloned().collect::<Vec<_>>().join("+");
+    println!("{label}");
+    println!("   without index: {t0:>10?}  rows={n0}  [{}]", ops(&plan(&plain)));
+    println!("   with index   : {t1:>10?}  rows={n1}  [{}]", ops(&plan(&idx)));
+    println!("   same answer: {}   speedup: {:.0}x",
+        n0 == n1, t0.as_secs_f64() / t1.as_secs_f64().max(1e-9));
+}
+
+fn main() {
+    probe("IC1 shape — inline (p:Person {firstName: ...})",
+          "MATCH (p:Person {firstName: \"name7\"}) RETURN count(p) AS n");
+    probe("IC11 shape — WHERE org.name = ...",
+          "MATCH (o:Organisation) WHERE o.name = \"org7\" RETURN count(o) AS n");
+}


### PR DESCRIPTION
SLT-2's second clause — *no single query above 2× the best competitor* — was failing on **IC1 (2.73×)** and **IC11 (2.80×)** at SF10. Both anchor on a *name*, and both were scanning:

```
IC1    (friend:Person {firstName: "..."})   inline
IC11   WHERE org.name = "..."               deferred predicate
```

The index list was Person/Post/Comment/Forum/Place/Organisation/Tag/TagClass, **all on `id`**. Reading what the 21 queries actually filter on:

| property | queries | |
|---|---|---|
| `Person.id` | 17 | indexed |
| `Post.id` | 4 | indexed |
| `Person.firstName` | IC1 | **missing** |
| `Organisation.name` | IC11 | **missing** |
| `Tag.name` | IC6 | **missing** |
| `Place.name` | IC3 | **missing** |
| `TagClass.name` | IC12 | **missing** |

So **six of the eight entries are on properties no query anchors on**, and in four cases we indexed the *id* of a label the query anchors on by *name*.

Derived from the queries, **not copied from the competitor's script**. That it converges on Neo4j's list is a cross-check, not the method — their list is derived from the same queries.

The six unused entries are kept: they cost load time and nothing else, and dropping an index is a separate decision from adding the ones queries need.

### Correctness first

`ldbc_name_index_probe.rs` checks the **plan**, not the clock — a query getting faster is also what a warm cache looks like, and the shortestPath work showed inline properties and `WHERE` predicates take different planner paths that are not equally served:

```
IC1 shape  (inline)   NodeScan+Filter -> IndexScan          7x, same rows
IC11 shape (WHERE)    NodeScan+Filter -> IndexScan+Filter   5x, same rows
```

Then the whole suite on real SF1 data, old index set vs new, same parameters and extract: **all 21 queries return the same number of rows.**

IC6 is empty in **both** — the SF1 parameters match no tag co-occurrence. That predates this change, and it is worth stating because an empty result that "passes" is the trap this repo has hit three times today.

### Expectations

SF1 gains are modest (IC6 3.1×, IC13 2.0×, IC11 1.5×, IC1 barely moved) because SF1 holds ~11K persons and name selectivity hardly matters at that size. **Whether this clears the 2× clause is for SF10 to say, not this PR.**
