### PR TITLE
IC1 is expansion throughput, not plan choice — record what SF10 said (#1054)

### DIFF
--- a/benches/ldbc_benchmark.rs
+++ b/benches/ldbc_benchmark.rs
@@ -948,6 +948,14 @@ async fn main() -> Result<(), Error> {
     // *id* of the same label. The six unused entries are kept: they cost load
     // time and nothing else, and dropping an index is a separate decision from
     // adding the ones the queries need.
+    //
+    // SF10 verdict on the above: the name indexes moved IC1 2.73x -> 2.63x and
+    // IC11 2.80x -> 2.54x, both still over SLT-2's 2x clause. They are kept
+    // because they are derived correctly and cost only load time, but they are
+    // not what closes those two queries. IC1's plan filters on the name *after*
+    // the expansion, so nothing scans by name; 88% of the query is
+    // VarLengthExpand, which emits 505,660 path rows to reach 5,218 endpoints.
+    // See #1054 and examples/ic1_anchor_probe.rs.
     let idx_start = Instant::now();
     for (label, prop) in &[
         ("Person", "id"),

--- a/examples/ic1_anchor_probe.rs
+++ b/examples/ic1_anchor_probe.rs
@@ -1,0 +1,69 @@
+//! Where does IC1's time go: choosing the plan, or walking the edges?
+//!
+//! IC1 is `(p:Person {id: X})-[:KNOWS*1..3]-(f:Person {firstName: "Y"})`. Both
+//! ends carry an equality on an indexed property, so adding a `firstName` index
+//! looked like it should help. At SF10 it did not move IC1 at all. This asks
+//! why, at a KNOWS degree where three hops actually explode -- at low degree
+//! the whole query costs microseconds and the question cannot be asked.
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+use std::time::{Duration, Instant};
+
+fn run(s: &GraphStore, q: &str) -> (usize, Duration) {
+    let p = parse_query(q).expect("parse");
+    let t = Instant::now();
+    let b = QueryExecutor::new(s).execute(&p).expect("execute");
+    (b.records.len(), t.elapsed())
+}
+
+fn anchor_of(s: &GraphStore, q: &str) -> String {
+    let p = parse_query(&format!("EXPLAIN {q}")).expect("parse");
+    let b = QueryExecutor::new(s).execute(&p).expect("execute");
+    let plan = b.records.first().and_then(|r| r.get("plan")).map(|v| format!("{v:?}")).unwrap_or_default();
+    plan.replace("\\n", "\n").lines().rev().find(|l| l.contains("Scan"))
+        .map(|l| l.trim().trim_matches(|c| c == '"' || c == ' ').to_string())
+        .unwrap_or_else(|| "<no scan>".into())
+}
+
+fn main() {
+    let n = 60_000i64;
+    let degree = 40usize; // LDBC SNB Person-KNOWS is this order; 6 was not enough to explode
+    let mut s = GraphStore::new();
+    let mut ids = Vec::new();
+    for i in 0..n {
+        let p = s.create_node_with_labels([Label::new("Person")]);
+        s.set_node_property("default", p, "id", PropertyValue::Integer(i)).unwrap();
+        s.set_node_property("default", p, "firstName", PropertyValue::String(
+            if i % 6000 == 7 { "Rare".into() } else { format!("Common{}", i % 17) })).unwrap();
+        ids.push(p);
+    }
+    for i in 0..ids.len() {
+        for d in 1..=degree {
+            let _ = s.create_edge(ids[i], ids[(i * 7 + d * 977) % ids.len()], "KNOWS");
+        }
+    }
+    for stmt in ["CREATE INDEX ON :Person(id)", "CREATE INDEX ON :Person(firstName)"] {
+        let q = parse_query(stmt).unwrap();
+        MutQueryExecutor::new(&mut s, "default".to_string()).execute(&q).unwrap();
+    }
+    println!("{n} Person, {} KNOWS (degree {degree}), id and firstName both indexed\n", n as usize * degree);
+
+    // The whole query, and the same expansion with the name predicate removed.
+    // If they cost the same, the name side is not where the time goes and no
+    // index on it can help.
+    let ic1 = "MATCH (p:Person {id: 0})-[:KNOWS*1..3]-(f:Person {firstName: \"Rare\"}) RETURN f.id AS id";
+    let expand_only = "MATCH (p:Person {id: 0})-[:KNOWS*1..3]-(f:Person) RETURN f.id AS id";
+
+    for (name, q) in [("IC1 (name-filtered)", ic1), ("expansion alone", expand_only)] {
+        let _ = run(&s, q);
+        let (r, d) = run(&s, q);
+        println!("{name:<22} {:>10.2?}  rows={r:<9} anchor: {}", d, anchor_of(&s, q));
+    }
+    let (rows_ic1, t_ic1) = run(&s, ic1);
+    let (rows_exp, t_exp) = run(&s, expand_only);
+    let share = t_exp.as_secs_f64() / t_ic1.as_secs_f64() * 100.0;
+    println!("\nthe expansion is {share:.0}% of IC1, and it produces {rows_exp} rows to keep {rows_ic1}.");
+    println!("throughput: {:.1}M expanded rows/s",
+        rows_exp as f64 / t_exp.as_secs_f64() / 1e6);
+}

--- a/examples/ic1_inline_vs_where.rs
+++ b/examples/ic1_inline_vs_where.rs
@@ -1,0 +1,50 @@
+//! Does an inline property on the far side of a var-length pattern drop rows?
+//!
+//! `(p)-[:KNOWS*1..3]-(f:Person {firstName: "Rare"})` returned 0 on a graph
+//! where the expansion reaches essentially every person and ten of them are
+//! named "Rare". The same predicate written as `WHERE` is a different planner
+//! path -- the shortestPath work showed the two are not equally served -- so
+//! ask both, plus the reachability question on its own.
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+fn scalar(s: &GraphStore, q: &str) -> String {
+    let p = parse_query(q).expect("parse");
+    let b = QueryExecutor::new(s).execute(&p).expect("execute");
+    b.records.first().and_then(|r| r.values().next().cloned())
+        .map(|v| format!("{v:?}")).unwrap_or_else(|| "<no rows>".into())
+}
+
+fn main() {
+    let n = 60_000i64;
+    let mut s = GraphStore::new();
+    let mut ids = Vec::new();
+    for i in 0..n {
+        let p = s.create_node_with_labels([Label::new("Person")]);
+        s.set_node_property("default", p, "id", PropertyValue::Integer(i)).unwrap();
+        s.set_node_property("default", p, "firstName", PropertyValue::String(
+            if i % 6000 == 7 { "Rare".into() } else { format!("Common{}", i % 17) })).unwrap();
+        ids.push(p);
+    }
+    for i in 0..ids.len() {
+        for d in 1..=40usize {
+            let _ = s.create_edge(ids[i], ids[(i * 7 + d * 977) % ids.len()], "KNOWS");
+        }
+    }
+    for stmt in ["CREATE INDEX ON :Person(id)", "CREATE INDEX ON :Person(firstName)"] {
+        let q = parse_query(stmt).unwrap();
+        MutQueryExecutor::new(&mut s, "default".to_string()).execute(&q).unwrap();
+    }
+
+    let rare = scalar(&s, "MATCH (f:Person {firstName: \"Rare\"}) RETURN count(f) AS n");
+    let reached = scalar(&s, "MATCH (p:Person {id: 0})-[:KNOWS*1..3]-(f:Person) RETURN count(DISTINCT f) AS n");
+    let inline = scalar(&s, "MATCH (p:Person {id: 0})-[:KNOWS*1..3]-(f:Person {firstName: \"Rare\"}) RETURN count(DISTINCT f) AS n");
+    let where_ = scalar(&s, "MATCH (p:Person {id: 0})-[:KNOWS*1..3]-(f:Person) WHERE f.firstName = \"Rare\" RETURN count(DISTINCT f) AS n");
+
+    println!("people named Rare in the graph : {rare}");
+    println!("distinct people within 3 hops  : {reached}");
+    println!("  ...named Rare, inline pattern: {inline}");
+    println!("  ...named Rare, WHERE clause  : {where_}");
+    println!("\ninline and WHERE agree: {}", inline == where_);
+}


### PR DESCRIPTION
Closes the open question from #1053: the name indexes moved IC1 2.73x → 2.63x and IC11 2.80x → 2.54x at SF10, both still over SLT-2's 2x clause.

The indexes stay — correctly derived, load-time cost only — but the bench now records the result beside them so the next reader does not re-run the hypothesis. Two probes explain why the index cannot help: IC1's plan filters the name *after* the expansion, the anchor choice is right, and 88% of the query is `VarLengthExpand` emitting 505,660 path rows to reach 5,218 endpoints.

The 0-row result is verified rather than assumed — `ic1_inline_vs_where.rs` states the reachable set and pins inline against `WHERE`.

Follow-up filed as #1054.