### PR TITLE
CLI: `doctor` and `completions`, and `--format json` now means every command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,6 +585,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3089,10 +3098,13 @@ name = "samyama-cli"
 version = "1.7.1"
 dependencies = [
  "clap",
+ "clap_complete",
  "comfy-table",
  "samyama-sdk",
+ "serde",
  "serde_json",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,6 +14,10 @@ path = "src/main.rs"
 [dependencies]
 samyama-sdk = { path = "../crates/samyama-sdk", version = "1.7.1" }
 clap = { version = "4", features = ["derive"] }
+# `completions` (API-14 asks for shell completion) and `doctor` (DX-09).
+clap_complete = "4"
+serde = { version = "1", features = ["derive"] }
+url = "2"
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"
 comfy-table = ">=7, <7.2"

--- a/cli/src/doctor.rs
+++ b/cli/src/doctor.rs
@@ -1,0 +1,282 @@
+//! `samyama-cli doctor` — DX-09.
+//!
+//! Checks the things that actually go wrong before a first query: no server on
+//! the URL, a server on a different version to the client, no memory headroom,
+//! a data directory nobody can write to.
+//!
+//! Two rules shape this module.
+//!
+//! **A check that cannot fail is not a check.** Every check returns a real
+//! observation or `Skipped` with the reason it could not be made. Nothing
+//! defaults to `Pass`, because a doctor that reports a clean bill of health on
+//! a machine it could not inspect is worse than no doctor.
+//!
+//! **`Skipped` is not `Pass`.** The exit code is non-zero only for `Fail`, so a
+//! check that could not run does not fail the command -- but it is printed as
+//! skipped and carried into the JSON, so it can never be mistaken for a
+//! successful check by anything reading the output.
+
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Verdict {
+    Pass,
+    Warn,
+    Fail,
+    Skipped,
+}
+
+impl fmt::Display for Verdict {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Verdict::Pass => "ok",
+            Verdict::Warn => "warn",
+            Verdict::Fail => "FAIL",
+            Verdict::Skipped => "skip",
+        })
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Check {
+    pub name: &'static str,
+    pub verdict: Verdict,
+    /// What was observed. Never a restatement of the verdict: a reader who
+    /// disagrees with the judgement needs the number it was made from.
+    pub detail: String,
+}
+
+impl Check {
+    fn new(name: &'static str, verdict: Verdict, detail: impl Into<String>) -> Self {
+        Check { name, verdict, detail: detail.into() }
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct Report {
+    pub checks: Vec<Check>,
+    pub failed: usize,
+    pub warned: usize,
+    pub skipped: usize,
+}
+
+impl Report {
+    fn new(checks: Vec<Check>) -> Self {
+        let failed = checks.iter().filter(|c| c.verdict == Verdict::Fail).count();
+        let warned = checks.iter().filter(|c| c.verdict == Verdict::Warn).count();
+        let skipped = checks.iter().filter(|c| c.verdict == Verdict::Skipped).count();
+        Report { checks, failed, warned, skipped }
+    }
+
+    /// Non-zero exactly when a check failed. A warning is information, and a
+    /// skipped check is an absence of information; neither is a failure, and
+    /// treating them as one would make `doctor` useless in a script.
+    pub fn exit_code(&self) -> i32 {
+        i32::from(self.failed > 0)
+    }
+}
+
+/// Total and available memory in MiB, from `/proc/meminfo`.
+fn meminfo() -> Option<(u64, u64)> {
+    let text = std::fs::read_to_string("/proc/meminfo").ok()?;
+    let field = |k: &str| -> Option<u64> {
+        text.lines()
+            .find(|l| l.starts_with(k))?
+            .split_whitespace()
+            .nth(1)?
+            .parse::<u64>()
+            .ok()
+            .map(|kb| kb / 1024)
+    };
+    Some((field("MemTotal:")?, field("MemAvailable:")?))
+}
+
+fn check_url(url: &str) -> Check {
+    match url::Url::parse(url) {
+        Ok(u) if u.scheme() == "http" || u.scheme() == "https" => Check::new(
+            "server url",
+            Verdict::Pass,
+            format!("{url} (host {}, port {})",
+                u.host_str().unwrap_or("?"),
+                u.port_or_known_default().map(|p| p.to_string()).unwrap_or_else(|| "?".into())),
+        ),
+        Ok(u) => Check::new("server url", Verdict::Fail,
+            format!("{url} has scheme '{}'; expected http or https", u.scheme())),
+        Err(e) => Check::new("server url", Verdict::Fail, format!("{url} is not a URL: {e}")),
+    }
+}
+
+fn check_memory() -> Check {
+    match meminfo() {
+        // The engine is in-memory, so headroom is the thing that decides
+        // whether a load succeeds. 1 GiB is a floor for anything non-trivial,
+        // not a recommendation.
+        Some((total, avail)) if avail < 1024 => Check::new(
+            "memory", Verdict::Warn,
+            format!("{avail} MiB available of {total} MiB; under 1 GiB free"),
+        ),
+        Some((total, avail)) => Check::new(
+            "memory", Verdict::Pass, format!("{avail} MiB available of {total} MiB"),
+        ),
+        None => Check::new("memory", Verdict::Skipped, "no /proc/meminfo on this platform"),
+    }
+}
+
+fn check_data_dir(dir: &std::path::Path) -> Check {
+    if !dir.exists() {
+        // Not existing is fine -- the server creates it. Whether it *could* be
+        // created is the question, so test the parent.
+        let parent = dir.parent().unwrap_or(std::path::Path::new("."));
+        return match std::fs::metadata(parent) {
+            Ok(m) if m.permissions().readonly() => Check::new(
+                "data directory", Verdict::Fail,
+                format!("{} does not exist and its parent {} is read-only",
+                        dir.display(), parent.display()),
+            ),
+            Ok(_) => Check::new("data directory", Verdict::Pass,
+                format!("{} does not exist yet; parent {} is writable",
+                        dir.display(), parent.display())),
+            Err(e) => Check::new("data directory", Verdict::Skipped,
+                format!("cannot stat parent {}: {e}", parent.display())),
+        };
+    }
+    // `PermissionsExt::readonly` reports the owner bit, which is not the same
+    // question as "can this process write here". Answer it by writing.
+    let probe = dir.join(".samyama-doctor-write-probe");
+    match std::fs::write(&probe, b"") {
+        Ok(()) => {
+            let _ = std::fs::remove_file(&probe);
+            Check::new("data directory", Verdict::Pass,
+                format!("{} exists and is writable", dir.display()))
+        }
+        Err(e) => Check::new("data directory", Verdict::Fail,
+            format!("{} exists but is not writable: {e}", dir.display())),
+    }
+}
+
+/// Everything that can be decided without talking to a server.
+pub fn local_checks(url: &str, data_dir: &std::path::Path) -> Vec<Check> {
+    vec![
+        Check::new("client version", Verdict::Pass, env!("CARGO_PKG_VERSION")),
+        check_url(url),
+        check_memory(),
+        check_data_dir(data_dir),
+    ]
+}
+
+/// The server half. `status` is the version string the server reported, or the
+/// error that came back instead.
+pub fn server_checks(status: Result<String, String>, client_version: &str) -> Vec<Check> {
+    match status {
+        Err(e) => vec![
+            Check::new("server reachable", Verdict::Fail, e),
+            Check::new("version match", Verdict::Skipped,
+                "no server answered, so its version is unknown"),
+        ],
+        Ok(server_version) => {
+            let reachable = Check::new("server reachable", Verdict::Pass,
+                format!("answered, version {server_version}"));
+            // A mismatched patch level is ordinary; a mismatched major or minor
+            // is the cause of "that query works on my machine".
+            fn same(v: &str) -> Vec<&str> { v.split('.').take(2).collect() }
+            let m = if same(&server_version) == same(client_version) {
+                Check::new("version match", Verdict::Pass,
+                    format!("client {client_version}, server {server_version}"))
+            } else {
+                Check::new("version match", Verdict::Warn,
+                    format!("client {client_version} and server {server_version} differ before \
+                             the patch level; behaviour may not match the client's docs"))
+            };
+            vec![reachable, m]
+        }
+    }
+}
+
+pub fn report(checks: Vec<Check>) -> Report {
+    Report::new(checks)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_failing_check_sets_a_non_zero_exit_code() {
+        let r = report(vec![Check::new("x", Verdict::Fail, "broken")]);
+        assert_eq!(r.exit_code(), 1);
+        assert_eq!(r.failed, 1);
+    }
+
+    #[test]
+    fn warnings_and_skips_do_not_fail_the_command() {
+        // The distinction the whole module turns on: `doctor` must stay usable
+        // in a script on a machine where something merely could not be checked.
+        let r = report(vec![
+            Check::new("a", Verdict::Warn, "low"),
+            Check::new("b", Verdict::Skipped, "no /proc"),
+            Check::new("c", Verdict::Pass, "fine"),
+        ]);
+        assert_eq!(r.exit_code(), 0);
+        assert_eq!((r.failed, r.warned, r.skipped), (0, 1, 1));
+    }
+
+    #[test]
+    fn an_unreachable_server_fails_and_leaves_the_version_unknown() {
+        let cs = server_checks(Err("connection refused".into()), "1.7.1");
+        assert_eq!(cs[0].verdict, Verdict::Fail);
+        // Not Fail: we did not observe a mismatch, we observed nothing.
+        assert_eq!(cs[1].verdict, Verdict::Skipped);
+        assert_eq!(report(cs).exit_code(), 1);
+    }
+
+    #[test]
+    fn a_patch_level_difference_is_not_a_warning() {
+        let cs = server_checks(Ok("1.7.9".into()), "1.7.1");
+        assert_eq!(cs[1].verdict, Verdict::Pass);
+    }
+
+    #[test]
+    fn a_minor_version_difference_warns_but_does_not_fail() {
+        let cs = server_checks(Ok("1.8.0".into()), "1.7.1");
+        assert_eq!(cs[1].verdict, Verdict::Warn);
+        assert_eq!(report(cs).exit_code(), 0);
+    }
+
+    #[test]
+    fn a_bad_url_is_a_failure_and_a_good_one_is_not() {
+        // Both directions: a checker stuck on Fail would pass the first alone.
+        assert_eq!(check_url("http://localhost:8080").verdict, Verdict::Pass);
+        assert_eq!(check_url("localhost:8080").verdict, Verdict::Fail);
+        assert_eq!(check_url("ftp://localhost").verdict, Verdict::Fail);
+    }
+
+    #[test]
+    fn an_unwritable_data_directory_is_a_failure() {
+        let dir = std::env::temp_dir().join("samyama-doctor-test-ro");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        assert_eq!(check_data_dir(&dir).verdict, Verdict::Pass);
+
+        let mut p = std::fs::metadata(&dir).unwrap().permissions();
+        p.set_readonly(true);
+        std::fs::set_permissions(&dir, p).unwrap();
+        // Running as root defeats the permission bit entirely, in which case
+        // the write probe legitimately succeeds and there is nothing to assert.
+        let is_root = std::fs::write(dir.join(".root-probe"), b"").is_ok();
+        if !is_root {
+            assert_eq!(check_data_dir(&dir).verdict, Verdict::Fail);
+        }
+        let mut p = std::fs::metadata(&dir).unwrap().permissions();
+        p.set_readonly(false);
+        let _ = std::fs::set_permissions(&dir, p);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn local_checks_never_return_an_empty_report() {
+        let cs = local_checks("http://localhost:8080", std::path::Path::new("."));
+        assert!(cs.len() >= 4, "a doctor that checks nothing reports a clean bill of health");
+        assert!(cs.iter().all(|c| !c.detail.is_empty()), "every check must show what it saw");
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,9 +2,12 @@
 //!
 //! Uses the samyama-sdk RemoteClient to connect to a running server.
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::Shell;
 use comfy_table::{Table, ContentArrangement};
 use samyama_sdk::{RemoteClient, SamyamaClient};
+
+mod doctor;
 
 #[derive(Parser)]
 #[command(name = "samyama", version, about = "Samyama Graph Database CLI")]
@@ -53,6 +56,20 @@ enum Commands {
         #[arg(long, default_value = "default")]
         graph: String,
     },
+    /// Check environment, server, memory and permissions (DX-09)
+    Doctor {
+        /// Data directory to test for writability
+        #[arg(long, default_value = "./samyama_data", env = "SAMYAMA_DATA")]
+        data_dir: std::path::PathBuf,
+    },
+    /// Print a shell completion script to stdout
+    ///
+    /// Install with e.g. `samyama-cli completions bash > \
+    /// /etc/bash_completion.d/samyama-cli`.
+    Completions {
+        /// Shell to generate for
+        shell: Shell,
+    },
 }
 
 #[tokio::main]
@@ -65,12 +82,42 @@ async fn main() {
             run_query(&client, &graph, &cypher, readonly, &cli.format).await
         }
         Commands::Status => run_status(&client, &cli.format).await,
-        Commands::Ping => run_ping(&client).await,
+        Commands::Ping => run_ping(&client, &cli.format).await,
         Commands::Shell { graph } => run_shell(&client, &graph, &cli.format).await,
+        Commands::Doctor { data_dir } => {
+            // `doctor` reports its findings and exits on its own code: an
+            // unreachable server is a finding, not a CLI error, and routing it
+            // through the error path below would print it twice and lose the
+            // checks that did run.
+            let code = run_doctor(&client, &cli.url, &data_dir, &cli.format).await;
+            std::process::exit(code);
+        }
+        Commands::Completions { shell } => {
+            let mut cmd = Cli::command();
+            // `CARGO_BIN_NAME`, not `cmd.get_name()`. The clap command is named
+            // "samyama" while the installed binary is `samyama-cli`, so
+            // generating for the command name emits `complete ... samyama` --
+            // a completion script that binds to a name the user does not type
+            // and therefore never fires. It looks shipped and does nothing,
+            // which is worse than not shipping it.
+            let name = option_env!("CARGO_BIN_NAME").unwrap_or("samyama-cli");
+            clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
+            Ok(())
+        }
     };
 
     if let Err(e) = result {
-        eprintln!("Error: {}", e);
+        // API-14 asks for `--json` output *everywhere*. An error printed as
+        // prose while the caller asked for JSON is the case that breaks a
+        // script, because the failure is exactly when it is parsing output.
+        match cli.format {
+            OutputFormat::Json => {
+                let body = serde_json::json!({"error": e.to_string()});
+                eprintln!("{}", serde_json::to_string_pretty(&body)
+                    .unwrap_or_else(|_| format!("{{\"error\": \"{e}\"}}")));
+            }
+            _ => eprintln!("Error: {}", e),
+        }
         std::process::exit(1);
     }
 }
@@ -145,9 +192,19 @@ async fn run_status(
     Ok(())
 }
 
-async fn run_ping(client: &RemoteClient) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_ping(
+    client: &RemoteClient,
+    format: &OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
     let result = client.ping().await?;
-    println!("{}", result);
+    // `ping` used to print its reply as bare text whatever `--format` said,
+    // so `--format json` produced output no JSON parser could read. It was the
+    // only subcommand that ignored the flag.
+    match format {
+        OutputFormat::Json => println!("{}",
+            serde_json::to_string_pretty(&serde_json::json!({"ping": result}))?),
+        _ => println!("{}", result),
+    }
     Ok(())
 }
 
@@ -190,7 +247,7 @@ async fn run_shell(
                 }
             }
             ":ping" => {
-                if let Err(e) = run_ping(client).await {
+                if let Err(e) = run_ping(client, format).await {
                     eprintln!("Error: {}", e);
                 }
             }
@@ -243,6 +300,89 @@ fn format_csv_value(v: &serde_json::Value) -> String {
         _ => {
             let json = serde_json::to_string(v).unwrap_or_default();
             format!("\"{}\"", json.replace('"', "\"\""))
+        }
+    }
+}
+
+/// Run the doctor checks and print them. Returns the process exit code.
+async fn run_doctor(
+    client: &RemoteClient,
+    url: &str,
+    data_dir: &std::path::Path,
+    format: &OutputFormat,
+) -> i32 {
+    let mut checks = doctor::local_checks(url, data_dir);
+    // The server's own version, or the error that came back instead. Both are
+    // findings; neither aborts the local checks, which is the point of running
+    // `doctor` when the server is the thing that is broken.
+    let status = client
+        .status()
+        .await
+        .map(|s| s.version)
+        .map_err(|e| e.to_string());
+    checks.extend(doctor::server_checks(status, env!("CARGO_PKG_VERSION")));
+
+    let report = doctor::report(checks);
+    match format {
+        OutputFormat::Json => {
+            match serde_json::to_string_pretty(&report) {
+                Ok(j) => println!("{j}"),
+                Err(e) => {
+                    eprintln!("{{\"error\": \"could not serialise report: {e}\"}}");
+                    return 1;
+                }
+            }
+        }
+        _ => {
+            for c in &report.checks {
+                println!("  {:<7} {:<18} {}", c.verdict.to_string(), c.name, c.detail);
+            }
+            println!(
+                "\n{} check(s): {} failed, {} warned, {} skipped",
+                report.checks.len(), report.failed, report.warned, report.skipped
+            );
+        }
+    }
+    report.exit_code()
+}
+
+#[cfg(test)]
+mod cli_tests {
+    use super::*;
+
+    #[test]
+    fn the_argument_parser_is_internally_consistent() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn completions_bind_to_the_installed_binary_name() {
+        // The clap command is named "samyama" while the binary is
+        // `samyama-cli`. Generating for the command name produced
+        // `complete ... samyama`, which binds to a name nobody types: the
+        // script installs, reports success, and never fires. Assert on the
+        // name the shell will actually match against.
+        let bin = option_env!("CARGO_BIN_NAME").unwrap_or("samyama-cli");
+        for shell in [Shell::Bash, Shell::Zsh, Shell::Fish] {
+            let mut out = Vec::new();
+            clap_complete::generate(shell, &mut Cli::command(), bin, &mut out);
+            let script = String::from_utf8(out).expect("completion script is not UTF-8");
+            assert!(!script.is_empty(), "{shell} produced an empty script");
+            assert!(script.contains(bin), "{shell} script never mentions `{bin}`");
+        }
+    }
+
+    #[test]
+    fn every_subcommand_is_reachable_by_name() {
+        // A subcommand that exists in the enum but is not registered would be
+        // invisible; `doctor` and `completions` are the new ones and the two
+        // this test was written for.
+        let names: Vec<String> = Cli::command()
+            .get_subcommands()
+            .map(|c| c.get_name().to_string())
+            .collect();
+        for want in ["query", "status", "ping", "shell", "doctor", "completions"] {
+            assert!(names.iter().any(|n| n == want), "missing subcommand `{want}` in {names:?}");
         }
     }
 }


### PR DESCRIPTION
Instrumenting the CLI for the conformance harness showed that of DX-09 and API-14's H1 clauses — JSON output everywhere, exit codes, completion, and a `doctor` — **exit codes were the only one we had**.

- **`samyama-cli doctor`** (DX-09): client version, server URL, memory headroom, data-directory writability, server reachability, version match. Local checks run first and always, so a broken server still yields a report — which is when you run it.
- **`samyama-cli completions <shell>`**: bash, zsh, fish, powershell, elvish.
- **`--format json`** is now honoured by `ping` (the one subcommand that ignored it) and by **errors**, which printed prose on stderr at exactly the moment a script is parsing output.

Two things worth a second look:

**The completion script bound to a command nobody types.** The clap command is named `samyama` but the binary is `samyama-cli`, so `cmd.get_name()` emitted `complete -F _samyama ... samyama` — installs cleanly, reports success, never fires. Generated from `CARGO_BIN_NAME`, with a test asserting the script mentions the name the shell actually matches.

**`Skipped` is not `Pass`.** Nothing in `doctor` defaults to `Pass`; a check either observes something or says why it could not. Exit is non-zero only for `Fail`, so a warning or an uninspectable machine does not break a script.

11 tests, pinned in both directions (a bad URL fails *and* a good one passes; a minor mismatch warns *and* a patch mismatch does not).

Does **not** close API-14: the REPL still has no history or completion — it uses `read_line` — and that needs a line-editor dependency worth changing on its own.