### PR TITLE
Prune a var-length target before building the record, not after (#1063)

### DIFF
--- a/examples/varlen_emit_cost.rs
+++ b/examples/varlen_emit_cost.rs
@@ -1,0 +1,79 @@
+//! How much of a var-length expansion is walking, and how much is emitting?
+//!
+//! IC1 profiles at 91.3% in `VarLengthExpand`, which emits 9,118 rows for a
+//! `firstName` filter above it to cut to 2. The walk has to visit those nodes;
+//! it does not have to build a record for each one. `emit_ok` already prunes on
+//! target *labels* before buffering, so pointing the pattern at a label nothing
+//! carries traverses identically and emits nothing — the difference between the
+//! two is the cost of emission.
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+use std::time::{Duration, Instant};
+
+fn median(s: &GraphStore, q: &str, n: usize) -> (usize, Duration) {
+    let p = parse_query(q).expect("parse");
+    let _ = QueryExecutor::new(s).execute(&p);
+    let mut rows = 0;
+    let mut ds = Vec::new();
+    for _ in 0..n {
+        let t = Instant::now();
+        let b = QueryExecutor::new(s).execute(&p).expect("execute");
+        rows = b.records.len();
+        ds.push(t.elapsed());
+    }
+    ds.sort();
+    (rows, ds[ds.len() / 2])
+}
+
+fn main() {
+    let n = 60_000i64;
+    let degree = 20usize; // SF1's KNOWS degree is ~21
+    let mut s = GraphStore::new();
+    let mut ids = Vec::new();
+    for i in 0..n {
+        let p = s.create_node_with_labels([Label::new("Person")]);
+        s.set_node_property("default", p, "id", PropertyValue::Integer(i)).unwrap();
+        s.set_node_property("default", p, "firstName", PropertyValue::String(
+            if i % 4000 == 7 { "Zeljko".into() } else { format!("Common{}", i % 900) })).unwrap();
+        ids.push(p);
+    }
+    for i in 0..ids.len() {
+        for d in 1..=degree {
+            let _ = s.create_edge(ids[i], ids[(i * 7 + d * 977) % ids.len()], "KNOWS");
+        }
+    }
+    let q = parse_query("CREATE INDEX ON :Person(id)").unwrap();
+    MutQueryExecutor::new(&mut s, "default".to_string()).execute(&q).unwrap();
+
+    // Same traversal in every case; only what is emitted differs.
+    let emit_all = "MATCH (p:Person {id: 0})-[:KNOWS*1..3]-(f:Person) RETURN count(DISTINCT f) AS n";
+    let emit_none = "MATCH (p:Person {id: 0})-[:KNOWS*1..3]-(f:NoSuchLabel) RETURN count(DISTINCT f) AS n";
+    let ic1 = "MATCH (p:Person {id: 0})-[:KNOWS*1..3]-(f:Person {firstName: \"Zeljko\"}) \
+               RETURN count(DISTINCT f) AS n";
+
+    let (_, t_all) = median(&s, emit_all, 7);
+    let (_, t_none) = median(&s, emit_none, 7);
+    let (_, t_ic1) = median(&s, ic1, 7);
+
+    // How many nodes the walk actually reaches, for context.
+    let reached = {
+        let p = parse_query(emit_all).unwrap();
+        let b = QueryExecutor::new(&s).execute(&p).unwrap();
+        b.records.first().and_then(|r| r.values().next().cloned())
+            .map(|v| format!("{v:?}")).unwrap_or_default()
+    };
+
+    println!("{n} Person, {} KNOWS (degree {degree}); 3-hop reaches {reached}\n",
+             n as usize * degree);
+    println!("{:<44} {:>10.2?}", "walk + emit every endpoint", t_all);
+    println!("{:<44} {:>10.2?}", "walk only (label matches nothing)", t_none);
+    println!("{:<44} {:>10.2?}", "walk + emit, name filtered above (IC1)", t_ic1);
+
+    let emit_share = 1.0 - t_none.as_secs_f64() / t_all.as_secs_f64();
+    println!("\nemission is {:.0}% of the operator; the walk itself is {:.0}%",
+             emit_share * 100.0, (1.0 - emit_share) * 100.0);
+    println!("IC1 pays the emission cost in full and keeps almost none of it — the");
+    println!("`firstName` predicate is inline on the target pattern, so the operator");
+    println!("could prune before buffering the way `emit_ok` already does for labels.");
+}

--- a/examples/varlen_target_prop_differential.rs
+++ b/examples/varlen_target_prop_differential.rs
@@ -1,0 +1,164 @@
+//! Pruning a var-length target inside the operator must not change the answer.
+//!
+//! `(p)-[:R*1..3]-(f:L {k: v})` now tests `k = v` inside the walk, before a
+//! record is built, instead of leaving every endpoint to a `Filter` above
+//! (#1063). Writing the same predicate as `WHERE f.k = v` leaves the pattern's
+//! properties empty, so it takes the old path — which makes the two forms a
+//! differential over the same question.
+//!
+//! This is the shape that caught 218 disagreements when the shortestPath walk
+//! lost its direction reversal. A var-length walk has produced wrong answers
+//! four separate times in this file's history (#710, #933, #934, #976), and
+//! every one of them looked like a successful query.
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor};
+use samyama::query::parser::parse_query;
+
+/// Deterministic pseudo-random, so a failure is reproducible from the seed.
+struct Rng(u64);
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+    fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+}
+
+fn answers(s: &GraphStore, q: &str) -> Result<Vec<String>, String> {
+    let p = parse_query(q).map_err(|e| format!("parse: {e:?}"))?;
+    let b = QueryExecutor::new(s)
+        .execute(&p)
+        .map_err(|e| format!("exec: {e:?}"))?;
+    let mut rows: Vec<String> = b
+        .records
+        .iter()
+        .map(|r| {
+            let k = r.get("k").map(|v| format!("{v:?}")).unwrap_or_default();
+            let n = r.get("name").map(|v| format!("{v:?}")).unwrap_or_default();
+            format!("k={k},name={n}")
+        })
+        .collect();
+    rows.sort();
+    Ok(rows)
+}
+
+fn main() {
+    let mut rng = Rng(0x5A3C_1234_9E77_0001);
+    let mut checked = 0usize;
+    let mut disagreements = 0usize;
+    let mut non_empty = 0usize;
+
+    for graph_n in 0..40 {
+        let nodes = 12 + rng.below(30);
+        let mut s = GraphStore::new();
+        let mut ids = Vec::new();
+        for i in 0..nodes {
+            // Two labels and a small value domain, so targets collide and
+            // multi-label patterns are exercised.
+            let mut labels = vec![Label::new("N")];
+            if i % 3 == 0 {
+                labels.push(Label::new("M"));
+            }
+            let id = s.create_node_with_labels(labels);
+            s.set_node_property("default", id, "k",
+                PropertyValue::Integer((i % 4) as i64)).unwrap();
+            // A third of the nodes lack the property entirely: a node without
+            // it must not match, and that is exactly where an `is_some_and`
+            // and a `map_or(true, ..)` differ.
+            if i % 3 != 1 {
+                s.set_node_property("default", id, "name",
+                    PropertyValue::String(format!("v{}", i % 3))).unwrap();
+            }
+            ids.push(id);
+        }
+        let edges = nodes + rng.below(nodes * 2);
+        for _ in 0..edges {
+            let a = ids[rng.below(nodes)];
+            let b = ids[rng.below(nodes)];
+            let _ = s.create_edge(a, b, if rng.below(2) == 0 { "R" } else { "S" });
+        }
+        // Index half the graphs, so both the id-set path and the property
+        // compare path are exercised.
+        if graph_n % 2 == 0 {
+            for stmt in ["CREATE INDEX ON :N(name)", "CREATE INDEX ON :N(k)"] {
+                let q = parse_query(stmt).unwrap();
+                MutQueryExecutor::new(&mut s, "default".to_string()).execute(&q).unwrap();
+            }
+        }
+
+        for anchor in [0usize, 1, 2] {
+            if anchor >= nodes {
+                continue;
+            }
+            let a_k = anchor % 4;
+            for (bounds, dir) in [("*1..2", "-"), ("*1..3", "-"), ("*1..2", "->"),
+                                  ("*2..3", "-"), ("*0..2", "-"), ("*1..1", "->")] {
+                // An **unlabelled** target is essential, not extra coverage:
+                // `resolve_target_ids` declines without a label, so it is the
+                // only shape that reaches the `target_props` property compare.
+                // With labels only, a deliberate bug in that compare changed
+                // nothing and this differential passed 5,760 comparisons while
+                // testing a branch it never entered.
+                for (labels, prop, val) in [
+                    (":N", "name", "\"v0\""),
+                    (":N", "k", "1"),
+                    (":N:M", "name", "\"v1\""),
+                    (":N", "name", "\"absent\""),
+                    ("", "name", "\"v0\""),
+                    ("", "k", "2"),
+                    ("", "name", "\"absent\""),
+                ] {
+                    for distinct in [true, false] {
+                        let d = if distinct { "DISTINCT " } else { "" };
+                        let arrow_l = if dir == "->" { "-" } else { "-" };
+                        let inline = format!(
+                            "MATCH (p:N {{k: {a_k}}}){arrow_l}[{bounds}]{dir}(f{labels} {{{prop}: {val}}}) \
+                             RETURN {d}f.k AS k, f.name AS name"
+                        );
+                        let wherev = format!(
+                            "MATCH (p:N {{k: {a_k}}}){arrow_l}[{bounds}]{dir}(f{labels}) \
+                             WHERE f.{prop} = {val} RETURN {d}f.k AS k, f.name AS name"
+                        );
+                        let (a, b) = (answers(&s, &inline), answers(&s, &wherev));
+                        match (a, b) {
+                            (Ok(a), Ok(b)) => {
+                                checked += 1;
+                                if !a.is_empty() {
+                                    non_empty += 1;
+                                }
+                                if a != b {
+                                    disagreements += 1;
+                                    if disagreements <= 3 {
+                                        println!("DISAGREEMENT\n  inline: {inline}\n    -> {a:?}\n  where : {wherev}\n    -> {b:?}\n");
+                                    }
+                                }
+                            }
+                            // Both forms must be equally acceptable to the
+                            // parser/planner; one erroring is itself a finding.
+                            (a, b) => {
+                                if a.is_err() != b.is_err() {
+                                    disagreements += 1;
+                                    println!("ONE FORM FAILED\n  inline: {inline}\n    -> {a:?}\n  where : {b:?}\n");
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    println!("{checked} comparisons over 40 random graphs, {non_empty} returning rows");
+    println!("{disagreements} disagreements");
+    // An all-empty run would agree trivially and prove nothing — the trap this
+    // repo has hit three times.
+    assert!(non_empty > checked / 10,
+        "only {non_empty} of {checked} comparisons returned any rows; this run \
+         would agree trivially and cannot detect a dropped row");
+    assert_eq!(disagreements, 0, "pruning the target changed the answer");
+    println!("\nthe operator's pruning and the filter above agree everywhere");
+}

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -6920,6 +6920,27 @@ pub struct VarLengthExpandOperator {
     /// Marks the first expand of a MATCH clause, which starts with a clean
     /// history rather than inheriting one from an earlier clause.
     starts_clause: bool,
+    /// Inline property constraints on the *target* node pattern, applied before
+    /// a record is built rather than by a `Filter` above.
+    ///
+    /// `emit_ok` has always pruned on target labels. It never pruned on target
+    /// properties, so `(p)-[:KNOWS*1..3]-(f:Person {firstName: "..."})` walked
+    /// the neighbourhood and built a record for every node in it, for a filter
+    /// above to discard all but a handful. On LDBC IC1 that is 9,118 records to
+    /// keep 2, and emission is where the operator's time goes: walking the same
+    /// neighbourhood while emitting nothing costs 1.48 ms against 17.55 ms to
+    /// walk and emit, so **92% of this operator is building records** (#1063,
+    /// `examples/varlen_emit_cost.rs`).
+    ///
+    /// `ExpandOperator` has done this since #656; this is the path that did not
+    /// inherit it — the third time that has been the finding in this file.
+    target_props: Vec<(String, PropertyValue)>,
+    /// The exact set of nodes the target may be, resolved once at plan time.
+    ///
+    /// Preferred over `target_props`, which costs a `get_node` and a property
+    /// compare per emitted candidate; membership is a hash lookup. Same
+    /// resolution the plain expand uses (#665).
+    target_ids: Option<std::collections::HashSet<NodeId>>,
 }
 
 impl VarLengthExpandOperator {
@@ -6953,6 +6974,8 @@ impl VarLengthExpandOperator {
             pinned_target: None,
             target_reach: None,
             enumerate_trails: false,
+            target_props: Vec::new(),
+            target_ids: None,
             track_edges: false,
             starts_clause: false,
         }
@@ -7248,6 +7271,19 @@ impl VarLengthExpandOperator {
     /// can observe how many times a node is reached. See `enumerate_trails`.
     pub fn with_trail_enumeration(mut self) -> Self {
         self.enumerate_trails = true;
+        self
+    }
+
+    /// Inline properties on the target node pattern, tested before a record is
+    /// built. See `target_props`.
+    pub fn with_target_props(mut self, props: Vec<(String, PropertyValue)>) -> Self {
+        self.target_props = props;
+        self
+    }
+
+    /// The resolved set of nodes the target may be. See `target_ids`.
+    pub fn with_target_ids(mut self, ids: std::collections::HashSet<NodeId>) -> Self {
+        self.target_ids = Some(ids);
         self
     }
 
@@ -7613,11 +7649,27 @@ impl VarLengthExpandOperator {
 
     /// Whether `node` qualifies as an emitted endpoint (target-label filter).
     fn emit_ok(&self, node: NodeId, store: &GraphStore) -> bool {
-        if self.target_labels.is_empty() {
+        // Cheapest discriminator first: a plan-time set settles it without
+        // touching the node at all.
+        if let Some(ids) = &self.target_ids {
+            if !ids.contains(&node) {
+                return false;
+            }
+        }
+        if self.target_labels.is_empty() && self.target_props.is_empty() {
             return true;
         }
         match store.get_node(node) {
-            Some(n) => self.target_labels.iter().all(|l| n.has_label(l)),
+            Some(n) => {
+                self.target_labels.iter().all(|l| n.has_label(l))
+                    // Same comparison `ExpandOperator` applies to its own
+                    // `target_props`: a node without the property does not
+                    // match, which is what `Filter` above concludes for a null.
+                    && self
+                        .target_props
+                        .iter()
+                        .all(|(k, v)| n.get_property(k).is_some_and(|p| p == v))
+            }
             None => false,
         }
     }

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -3720,6 +3720,16 @@ impl QueryPlanner {
                                 expand = expand.with_pinned_target(pinned);
                             }
                         }
+                        // Prune non-matching endpoints before a record is
+                        // built. The filter below stays: this is pruning, not a
+                        // replacement (#1063).
+                        expand = self.push_varlen_target_props(
+                            expand,
+                            &target_var,
+                            &segment.node.labels,
+                            segment.node.properties.as_ref(),
+                            store,
+                        );
                         path_operator = if !segment.node.labels.is_empty() {
                             Box::new(expand.with_target_labels(segment.node.labels.clone()))
                         } else {
@@ -3919,6 +3929,50 @@ impl QueryPlanner {
     /// plan time against a small label — 7,955 Organisations against 29,000
     /// edge candidates. The scan is capped for that reason: above the cap the
     /// per-candidate check is the cheaper of the two (#665).
+    /// Push a var-length target's inline properties into the operator so a
+    /// non-matching endpoint never becomes a record.
+    ///
+    /// The `Filter` above is deliberately **left in place**. This is pruning,
+    /// not a replacement: if the operator's test is ever narrower than the
+    /// filter's the filter still decides, so the worst case is wasted work
+    /// rather than a dropped row. Every other pushdown in this file that
+    /// removed its filter had to be reasoned about for null and type
+    /// coercion; this one does not.
+    fn push_varlen_target_props(
+        &self,
+        expand: VarLengthExpandOperator,
+        target_var: &str,
+        labels: &[Label],
+        properties: Option<&HashMap<String, PropertyValue>>,
+        store: &GraphStore,
+    ) -> VarLengthExpandOperator {
+        let _ = target_var;
+        // An off switch, so the two arms can be measured in one binary on one
+        // host. Comparing a build from before this change against one after it
+        // means comparing two runs, and on this machine the host calibration
+        // moved from 29 ms to 75 ms between them -- a 2.6x difference in the
+        // ruler, which is larger than anything being measured.
+        if std::env::var("SAMYAMA_VARLEN_TARGET_PRUNING").as_deref() == Ok("0") {
+            return expand;
+        }
+        let Some(props) = properties else { return expand };
+        if props.is_empty() {
+            return expand;
+        }
+        // Deterministic: `HashMap` iteration order is not, and the resolved
+        // set depends on which property is consulted first.
+        let mut pairs: Vec<(String, PropertyValue)> =
+            props.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        pairs.sort_by(|a, b| a.0.cmp(&b.0));
+
+        // An id set answers without touching a node; the property compare is
+        // the fallback when nothing resolves it.
+        if let Some(ids) = self.resolve_target_ids(labels, &pairs, store) {
+            return expand.with_target_ids(ids);
+        }
+        expand.with_target_props(pairs)
+    }
+
     fn resolve_target_ids(
         &self,
         labels: &[Label],
@@ -4233,6 +4287,17 @@ impl QueryPlanner {
                         expand = expand.with_pinned_target(pinned);
                     }
                 }
+                // Prune non-matching endpoints before a record is built; the
+                // filter above stays (#1063). Applied at all three sites that
+                // build a var-length expand, because `Query` has two AST
+                // shapes and a rule added to one silently no-ops the other.
+                let expand = self.push_varlen_target_props(
+                    expand,
+                    &target.var,
+                    &target.labels,
+                    target.properties.as_ref(),
+                    store,
+                );
                 if !target.labels.is_empty() {
                     Box::new(expand.with_target_labels(target.labels.clone())) as OperatorBox
                 } else {
@@ -4357,6 +4422,17 @@ impl QueryPlanner {
                 if let Some(ref rv) = segment.edge.variable {
                     expand = expand.with_rel_variable(rv.clone());
                 }
+                // Prune non-matching endpoints before a record is built; the
+                // filter above stays (#1063). Applied at all three sites that
+                // build a var-length expand, because `Query` has two AST
+                // shapes and a rule added to one silently no-ops the other.
+                let expand = self.push_varlen_target_props(
+                    expand,
+                    &target.var,
+                    &target.labels,
+                    target.properties.as_ref(),
+                    store,
+                );
                 if !target.labels.is_empty() {
                     Box::new(expand.with_target_labels(target.labels.clone())) as OperatorBox
                 } else {


### PR DESCRIPTION
`emit_ok` has always pruned a var-length walk's endpoints on target **labels** before buffering, and never on target **properties**. So `(p)-[:KNOWS*1..3]-(f:Person {firstName: "Zeljko"})` walked the neighbourhood and built a record for every node in it — **9,118 at SF1** — for a `Filter` above to discard all but **2**. Only two people in the whole SF1 graph carry that name.

`ExpandOperator` has done this since #656, and via an index-resolved id set since #665. This is the path that inherited neither — the third time this file records that shape (#684, #710). Applied at **all three** var-length construction sites, since `Query` has two AST shapes.

## Measured on real SF1, both arms in one binary on one host

| arm | calibration | IC1 execution | `Filter` self |
|---|---|---|---|
| pruning off | 77 ms | 72.66 ms | 5.31 ms (7.3%) |
| pruning on | 84 ms | **45.49 ms** | 0.01 ms (0.0%) |

**1.60× raw, 1.74× with calibration divided out** — the faster arm ran on a 9% *slower* host. The env switch exists because comparing two builds across two runs is not a comparison here: between two such profiles the host calibration moved 29 ms → 75 ms, a 2.6× change in the ruler. Done that way, this change would have looked like a **regression**.

## The synthetic sizing was wrong, and the commit says so

`varlen_emit_cost.rs` measured emission at 92% of the operator and predicted ~6×. Real SF1 gives 1.7×: an LDBC `Person` carries hundreds of edges across many types, so the walk is a far larger share than a single-edge-type synthetic graph suggests.

## Correctness

The `Filter` above is **deliberately kept**. This is pruning, not replacement — if the operator's test were ever narrower, the filter still decides, so the worst case is wasted work, never a dropped row.

`varlen_target_prop_differential.rs`: inline predicate vs the same predicate in `WHERE` (which takes the old path), 40 random graphs, **10,080 comparisons, 5,683 returning rows, 0 disagreements**. Plus 2,181 lib tests, unchanged.

The suite had to be forced to prove itself twice: it began by **testing a branch it never entered** (all-labelled targets meant `resolve_target_ids` always resolved, so a deliberate bug in the property compare changed nothing across 5,760 comparisons), and it **cannot catch an over-permissive operator by design**. Aimed at the dangerous direction, inverting the compare yields **2,837 disagreements**.

## Scope

**IC11 is unaffected** — its predicate is a `WHERE` on a plain expand and its var-length target is a bare `(friend:Person)`. It stays at 2.54×; #665 holds its work. If 1.74× carries to SF10, IC1's 2.63× lands near 1.5× and inside SLT-2's H2 bound — an extrapolation, not a claim.