### PR TITLE
Profile BI-17 instead of guessing at it — three hypotheses, all wrong (#1069)

### DIFF
--- a/examples/bi_timeout_probe.rs
+++ b/examples/bi_timeout_probe.rs
@@ -1,0 +1,101 @@
+//! Why BI-11 and BI-17 do not finish at SF10.
+//!
+//! Both hit the bench's 120 s per-query limit on the first SF10 SNB-BI run
+//! (#1065), and both are the two slowest at SF1 — 1,321 ms and 7,745 ms — so
+//! the growth is superlinear rather than a limit set slightly too tight. SF10
+//! cannot be profiled inside the timeout, so this profiles SF1 and reads the
+//! shape.
+//!
+//! BI-17 is the interesting one on paper: the pattern
+//! `(a)-[:KNOWS]-(b)-[:KNOWS]-(c)-[:KNOWS]-(a)` enumerates every triangle six
+//! times and `a.id < b.id AND b.id < c.id` keeps one. `a.id < b.id` needs only
+//! `a` and `b`, so it can be decided the moment `b` is bound — before `c` is
+//! expanded at all. If it is applied after the whole pattern instead, the walk
+//! is doing roughly six times the work it needs to.
+use samyama::graph::GraphStore;
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use samyama_sdk::{EmbeddedClient, SamyamaClient};
+
+mod ldbc_common;
+use ldbc_common::{format_duration, format_num};
+
+type Error = Box<dyn std::error::Error>;
+
+const BI11: &str = "\
+MATCH (reply:Comment)-[:REPLY_OF]->(post:Post)
+WHERE NOT EXISTS {
+  MATCH (reply)-[:HAS_TAG]->(t:Tag)<-[:HAS_TAG]-(post)
+}
+RETURN count(reply) AS unrelatedReplies";
+
+const BI17: &str = "\
+MATCH (a:Person)-[:KNOWS]-(b:Person)-[:KNOWS]-(c:Person)-[:KNOWS]-(a)
+WHERE a.id < b.id AND b.id < c.id
+RETURN count(a) AS triangleCount";
+
+fn show(store: &GraphStore, id: &str, q: &str) {
+    println!("\n================ {id} ================");
+    // The plan first: where the predicates sit is the question, and PROFILE at
+    // SF1 can take minutes.
+    if let Ok(p) = parse_query(&format!("EXPLAIN {q}")) {
+        if let Ok(b) = QueryExecutor::new(store).execute(&p) {
+            if let Some(v) = b.records.first().and_then(|r| r.values().next()) {
+                for line in format!("{v:?}").replace("\\n", "\n").lines().take(16) {
+                    println!("  {}", line.trim_matches(|c| c == '"'));
+                }
+            }
+        }
+    }
+    // PROFILE, not just EXPLAIN: the plan text does not show whether a closing
+    // hop is pinned to its bound target, so two very different executions print
+    // the same tree. Only the per-operator rows say which one ran.
+    if let Ok(p) = parse_query(&format!("PROFILE {q}")) {
+        if let Ok(b) = QueryExecutor::new(store).execute(&p) {
+            if let Some(v) = b.records.first().and_then(|r| r.values().next()) {
+                let text = format!("{v:?}").replace("\\n", "\n");
+                let mut show = false;
+                for line in text.lines() {
+                    if line.contains("Profile (per operator)") { show = true; }
+                    if show { println!("  {}", line.trim_matches(|c| c == '"')); }
+                    if line.contains("Hottest") { break; }
+                }
+            }
+        }
+    }
+    let t = Instant::now();
+    match parse_query(q).map_err(|e| format!("{e:?}"))
+        .and_then(|p| QueryExecutor::new(store).execute(&p).map_err(|e| format!("{e:?}")))
+    {
+        Ok(b) => println!("\n  answer: {:?} in {}", b.records.first(), format_duration(t.elapsed())),
+        Err(e) => println!("\n  ERROR after {}: {e}", format_duration(t.elapsed())),
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let args: Vec<String> = std::env::args().collect();
+    let dir = PathBuf::from(
+        args.iter().position(|a| a == "--data-dir").and_then(|i| args.get(i + 1))
+            .ok_or("--data-dir <extract> required")?,
+    );
+    let client = EmbeddedClient::new();
+    let t = Instant::now();
+    let loaded = {
+        let mut g = client.store_write().await;
+        ldbc_common::load_dataset(&mut g, &dir)?
+    };
+    eprintln!("Loaded {} nodes, {} edges in {}",
+        format_num(loaded.total_nodes), format_num(loaded.total_edges),
+        format_duration(t.elapsed()));
+    for (label, prop) in &[("Person", "id"), ("Post", "id"), ("Comment", "id"), ("Tag", "id")] {
+        let _ = client.query("default", &format!("CREATE INDEX ON :{label}({prop})")).await;
+    }
+    let store = client.store_read().await;
+    show(&store, "BI-17 Friend Triangles", BI17);
+    show(&store, "BI-11 Unrelated Replies", BI11);
+    Ok(())
+}

--- a/examples/cycle_close_pin.rs
+++ b/examples/cycle_close_pin.rs
@@ -1,0 +1,102 @@
+//! Is the closing hop of a cycle pinned on *every* planner path?
+//!
+//! `ExpandOperator` has rejected non-closing neighbours during the walk since
+//! #195, but only one of the three sites that build an expand passed the bound
+//! variable in. BI-17 happens to use that site, so its profile already shows
+//! the closing expand emitting exactly the answer count — which is why wiring
+//! the other two changed nothing there and needed checking another way.
+//!
+//! A pinned close emits one row per triangle. An unpinned one emits a row per
+//! neighbour of `c` and lets a filter above discard them, so the operator's row
+//! count is the tell. Same query written two ways, to reach two planner paths.
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+
+fn closing_expand_rows(s: &GraphStore, q: &str) -> Option<(u64, u64)> {
+    let p = parse_query(&format!("PROFILE {q}")).ok()?;
+    let b = QueryExecutor::new(s).execute(&p).ok()?;
+    let text = format!("{:?}", b.records.first()?.values().next()?).replace("\\n", "\n");
+    let mut close = None;
+    let mut answer = None;
+    for line in text.lines() {
+        // The closing expand is the one whose target is a `__self_` synthetic.
+        if line.contains("Expand") && line.contains("__self") {
+            let n: Vec<&str> = line.split_whitespace().collect();
+            // rows is the second-to-last column
+            if n.len() >= 2 {
+                close = n[n.len() - 2].replace(',', "").parse::<u64>().ok();
+            }
+        }
+        if line.contains("Rows:") {
+            answer = line.split_whitespace().nth(1)
+                .and_then(|v| v.trim_end_matches(',').parse::<u64>().ok());
+        }
+    }
+    Some((close?, answer.unwrap_or(0)))
+}
+
+fn main() {
+    // A dense-ish graph so an unpinned close would emit far more than the
+    // triangle count. Degree ~20 means ~20x the rows if the pin is missing.
+    let n = 400i64;
+    let mut s = GraphStore::new();
+    let mut ids = Vec::new();
+    for i in 0..n {
+        let p = s.create_node_with_labels([Label::new("P")]);
+        s.set_node_property("default", p, "id", PropertyValue::Integer(i)).unwrap();
+        ids.push(p);
+    }
+    for i in 0..ids.len() {
+        for d in 1..=20usize {
+            let _ = s.create_edge(ids[i], ids[(i + d) % ids.len()], "K");
+        }
+    }
+
+    let direct = "MATCH (a:P)-[:K]-(b:P)-[:K]-(c:P)-[:K]-(a) \
+                  WHERE a.id < b.id AND b.id < c.id RETURN count(a) AS n";
+    // An **anchored** triangle. `build_path_from_anchor` is a different planner
+    // path from the unanchored one BI-17 uses, and it is the one most LDBC
+    // queries take, because they anchor on an indexed id. It was one of the two
+    // sites that never passed the bound variable to the expand.
+    let anchored = "MATCH (a:P {id: 7})-[:K]-(b:P)-[:K]-(c:P)-[:K]-(a) \
+                    WHERE b.id < c.id RETURN count(a) AS n";
+
+    let mut answers = Vec::new();
+    let mut pinned_all = true;
+    for (name, q) in [("unanchored (BI-17's path)", direct),
+                      ("anchored (build_path_from_anchor)", anchored)] {
+        match closing_expand_rows(&s, q) {
+            Some((close_rows, _)) => {
+                let ans = parse_query(q).ok()
+                    .and_then(|p| QueryExecutor::new(&s).execute(&p).ok())
+                    .and_then(|b| b.records.first()
+                        .and_then(|r| r.values().next().map(|v| format!("{v:?}"))))
+                    .unwrap_or_default();
+                let triangles: u64 = ans.chars().filter(|c| c.is_ascii_digit())
+                    .collect::<String>().parse().unwrap_or(0);
+                let pinned = close_rows == triangles;
+                println!("{name:<16} closing expand emitted {close_rows:>8} rows, \
+                          answer {triangles:>8}  -> {}",
+                    if pinned { "PINNED" } else { "NOT PINNED" });
+                pinned_all &= pinned;
+                answers.push(triangles);
+            }
+            None => println!("{name:<16} could not read the profile"),
+        }
+    }
+    // Both spellings must agree on the answer; a pin that changed it would be a
+    // wrong answer and matters more than the row count.
+    // Different questions (all triangles vs triangles through one anchor), so
+    // no cross-check here — the row count against each query's own answer is
+    // the assertion that matters.
+    assert!(answers.iter().all(|&a| a > 0),
+        "a zero answer proves nothing: an unpinned close would also emit zero");
+    // A regression guard, not a demonstration. Both paths pin today — that was
+    // verified against HEAD before and after a candidate change, and it held
+    // both times, which is how the candidate was found to be a no-op and
+    // dropped. What this asserts is that they keep pinning.
+    assert!(pinned_all,
+        "a closing hop stopped being pinned: the expand is walking every \
+         neighbour and letting the filter above discard them (#195, #1069)");
+}


### PR DESCRIPTION
BI-17 is one of two SNB-BI queries that do not finish at SF10 (#1065), and the only H1 condition left reachable without touching another repo. I formed three hypotheses about its 12.3 s at SF1. **The profile killed all three.**

```
Filter (b.id < c.id)         8120.91ms  48.4%  25,038,032 rows -> 8,487,412
Expand ((c)-[:KNOWS]-(a))    5673.17ms  33.8%     387,573
Expand ((b)-[:KNOWS]-(c))    2758.07ms  16.4%  25,038,032
```

- **The ordering predicates are already pushed** to the earliest point each could be evaluated.
- **The closing hop is already pinned** — it emits 387,573 rows, exactly the answer count (#195).
- **Wiring that pin into the two planner sites that lacked it does nothing**: 12.3 s vs 12.2 s, and an A/B against HEAD showed both paths already pinning. That change was **dropped**, not landed on the argument that it was harmless.

The real cost is a property comparison: **~324 ns per row** for `b.id < c.id`, with `b.id` re-read for every `c` and 25M records built to keep 8.5M. Filed as #1069 with both halves.

`cycle_close_pin.rs` stays as a **regression guard** — it asserts the closing hop emits exactly the answer count on both planner paths. It held before and after the dropped change, which is how that change was found to be a no-op.