### PR TITLE
Answer a pinned EXISTS hop by lookup instead of walking a popular neighbour

### DIFF
--- a/examples/bi11_ab.rs
+++ b/examples/bi11_ab.rs
@@ -1,0 +1,83 @@
+//! A/B for the pinned-endpoint lookup in `EXISTS` (#1071 follow-up).
+//!
+//! LDBC BI-11 asks, for every reply-to-post pair, whether the two share a tag:
+//!
+//!   MATCH (reply:Comment)-[:REPLY_OF]->(post:Post)
+//!   WHERE NOT (reply)-[:HAS_TAG]->(:Tag)<-[:HAS_TAG]-(post)
+//!
+//! The inner pattern reaches the anonymous Tag with `post` already bound, so
+//! the closing hop is an existence test between two known nodes. Walking the
+//! Tag to run it costs that tag's whole popularity.
+//!
+//! Both arms run in one process against one loaded graph, so the only
+//! difference between them is the flag. Each arm prints its answer as well as
+//! its time: a faster arm that changed the count is not a faster arm.
+//!
+//!   SAMYAMA_EXISTS_PIN_LOOKUP=0 cargo run --release --example bi11_ab -- --data-dir <dir>
+//!   SAMYAMA_EXISTS_PIN_LOOKUP=1 cargo run --release --example bi11_ab -- --data-dir <dir>
+
+#[path = "../benches/ldbc_bi_common/mod.rs"]
+mod ldbc_bi_common;
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+use std::path::PathBuf;
+
+/// Bounded so both arms terminate: unbounded BI-11 does not finish on the walk,
+/// and "one arm never returned" is a worse measurement than a ratio over a
+/// slice. The bound is on the outer scan only -- the inner anti-join, which is
+/// what changed, runs in full for every row the slice keeps.
+fn bounded(limit: u64) -> String {
+    format!(
+        "MATCH (reply:Comment)-[:REPLY_OF]->(post:Post)
+         WHERE reply.id < {limit}
+           AND NOT (reply)-[:HAS_TAG]->(:Tag)<-[:HAS_TAG]-(post)
+         RETURN count(reply) AS unrelatedReplies"
+    )
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().collect();
+    let data_dir = args
+        .iter()
+        .position(|a| a == "--data-dir")
+        .and_then(|i| args.get(i + 1))
+        .map(PathBuf::from)
+        .expect("--data-dir <path> is required");
+
+    let arm = std::env::var("SAMYAMA_EXISTS_PIN_LOOKUP").unwrap_or_else(|_| "1".into());
+
+    let mut graph = GraphStore::new();
+    eprintln!("loading {} ...", data_dir.display());
+    let t = std::time::Instant::now();
+    ldbc_bi_common::load_dataset(&mut graph, &data_dir)?;
+    eprintln!("loaded in {:.1}s", t.elapsed().as_secs_f64());
+
+    // Quantiles of the actual reply-to-post comment ids at SF1, not round
+    // numbers: LDBC ids run from 557 to 2.199e12, so a plausible-looking
+    // `reply.id < 1_000_000` keeps a handful of rows and measures nothing.
+    // These are the 1st, 5th and 20th percentiles of the 1,011,420 REPLY_OF
+    // edges into Posts, so each arm is doing a known amount of work.
+    for limit in [137_440_184_271u64, 412_317_278_587, 824_634_888_495] {
+        let cypher = bounded(limit);
+        let q = parse_query(&cypher)?;
+        let t = std::time::Instant::now();
+        match QueryExecutor::new(&graph).execute(&q) {
+            Ok(out) => {
+                let v = out
+                    .records
+                    .first()
+                    .and_then(|r| r.get("unrelatedReplies"))
+                    .map(|v| format!("{v:?}"))
+                    .unwrap_or_else(|| "<none>".into());
+                println!(
+                    "@@ pin={arm} reply.id<{limit:<9} {:>9.3}s  unrelatedReplies={v}",
+                    t.elapsed().as_secs_f64()
+                );
+            }
+            Err(e) => println!("@@ pin={arm} reply.id<{limit:<9} failed: {e}"),
+        }
+    }
+    Ok(())
+}

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -2340,6 +2340,46 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         }
     }
 
+    /// Every edge from `source` to `target` accepted by `type_ids`, found by
+    /// lookup rather than by walking `source`'s adjacency list.
+    ///
+    /// `type_ids` follows [`GraphStore::for_each_outgoing_neighbor`]: `None`
+    /// is any type and `Some(&[])` is none. `visit` returns `true` to stop.
+    ///
+    /// This exists because an existence test between two *known* nodes should
+    /// not cost the degree of either one. Walking one endpoint and discarding
+    /// every neighbour but the other is how LDBC BI-11's anti-join came to
+    /// cost a Tag's entire popularity: `(reply)-[:HAS_TAG]->(t)<-[:HAS_TAG]-
+    /// (post)` arrives at `t` with `post` already bound, and at SF10 a popular
+    /// tag carries millions of `HAS_TAG` edges, all but one of them discarded.
+    ///
+    /// Each frozen segment is searched on its own and the write buffer is
+    /// scanned -- see `for_each_edge_between` for why neither may be treated
+    /// as one sorted array (#1071).
+    pub fn for_each_edge_between_typed(
+        &self,
+        source: NodeId,
+        target: NodeId,
+        type_ids: Option<&[u16]>,
+        mut visit: impl FnMut(EdgeId) -> bool,
+    ) {
+        let idx = source.as_u64() as usize;
+        for seg in &self.frozen_outgoing.segments {
+            for &(_n, eid) in seg.neighbor_range(idx, target) {
+                if self.edge_type_matches(eid, type_ids) && visit(eid) {
+                    return;
+                }
+            }
+        }
+        if let Some(entries) = self.outgoing.get(idx) {
+            for &(nid, eid) in entries {
+                if nid == target && self.edge_type_matches(eid, type_ids) && visit(eid) {
+                    return;
+                }
+            }
+        }
+    }
+
     /// Visit each incoming neighbour of `node`, without allocating.
     /// See [`GraphStore::for_each_outgoing_neighbor`].
     pub fn for_each_incoming_neighbor(

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -1144,6 +1144,17 @@ fn exists_node_matches(
     true
 }
 
+/// Is the pinned-endpoint lookup in `exists_for_each_neighbor` on?
+///
+/// A kill switch, not a tuning knob. It exists so the change can be measured
+/// against its own absence on one binary and one loaded graph, rather than
+/// against a second build on a second load where the difference could be
+/// anything. `SAMYAMA_EXISTS_PIN_LOOKUP=0` takes the walk.
+fn pinned_lookup_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("SAMYAMA_EXISTS_PIN_LOOKUP").as_deref() != Ok("0"))
+}
+
 /// Visit the neighbours of `node` reachable by an edge matching `edge_pat`.
 ///
 /// This used to build a `Vec<(Edge, NodeId)>`: it fetched **every** edge
@@ -1223,6 +1234,39 @@ fn exists_for_each_neighbor(
             Err(e) => *err = Some(e),
         }
     };
+
+    // A pinned far end makes this hop an existence test between two nodes that
+    // are both already known, and such a test should not cost the degree of
+    // either one. The walk below reads every neighbour of `node` and discards
+    // all but `target`, which for BI-11 means reading a Tag's entire
+    // popularity -- millions of HAS_TAG edges at SF10 -- to answer whether one
+    // specific Post is among them. Looking the edge up instead makes the
+    // answer independent of how popular either endpoint is (#1071).
+    //
+    // Direction is written relative to `node`, so an outgoing hop is looked up
+    // from `node` and an incoming one from `target`.
+    if let Some(target) = pinned_target.filter(|_| pinned_lookup_enabled()) {
+        let mut probe = |from: NodeId, to: NodeId, stop: &mut bool, err: &mut Option<ExecutionError>| {
+            store.for_each_edge_between_typed(from, to, type_filter, |eid| {
+                keep(eid, target, stop, err);
+                *stop || err.is_some()
+            });
+        };
+        if matches!(edge_pat.direction, Direction::Outgoing | Direction::Both) {
+            probe(node, target, &mut stop, &mut err);
+        }
+        // A self-relationship is incident to its node twice; under `Both` the
+        // outgoing probe has already taken it, exactly as in the walk below.
+        if matches!(edge_pat.direction, Direction::Incoming | Direction::Both)
+            && !(matches!(edge_pat.direction, Direction::Both) && target == node)
+        {
+            probe(target, node, &mut stop, &mut err);
+        }
+        return match err {
+            Some(e) => Err(e),
+            None => Ok(stop),
+        };
+    }
 
     if matches!(edge_pat.direction, Direction::Outgoing | Direction::Both) {
         store.for_each_outgoing_neighbor(node, type_filter, |target, eid| {


### PR DESCRIPTION

When an `EXISTS` hop's far end is already bound, the hop is an existence test
between two nodes that are both known. `exists_for_each_neighbor` answered it by
walking every neighbour of one endpoint and discarding all but the other. For
LDBC BI-11 that endpoint is a Tag:

    MATCH (reply:Comment)-[:REPLY_OF]->(post:Post)
    WHERE NOT (reply)-[:HAS_TAG]->(:Tag)<-[:HAS_TAG]-(post)

The inner pattern arrives at the Tag with `post` already bound, so the closing
hop reads the tag's whole popularity to find one specific Post. This uses
`for_each_edge_between_typed` instead, which searches each frozen segment and
scans the write buffer, so the cost no longer depends on either endpoint's
degree.

`pinned_target` is already restricted to single-hop segments and is already the
far end, so the two directions map straight onto lookups rooted at whichever
endpoint the edge leaves. `Direction::Both` keeps the walk's self-relationship
rule: the outgoing probe takes a self-loop and the incoming one is skipped.

All six `ExistsSubquery` arms in the executor delegate to the one
`eval_exists_subquery`, and a bare pattern predicate desugars to the same node
with `bare_pattern: true`, so both `NOT EXISTS { ... }` and the portable
`NOT (pattern)` the benchmark uses take this path.

## Measured

`examples/bi11_ab.rs` runs both arms in one process against one loaded graph,
flag-flipped, so the only difference between them is the change.
`SAMYAMA_EXISTS_PIN_LOOKUP=0` takes the walk. Three trials per arm, SF1,
medians:

    slice      walk    lookup   ratio    answer
    1st pct   1.418s   0.957s   1.48x      7177
    5th pct   1.099s   0.667s   1.65x     36251
    20th pct  1.108s   0.804s   1.38x    145183

Every arm returns the same count, which is the point of printing it: a faster
arm that changed the answer is not a faster arm.

**No trend in the ratio across slice sizes.** The first trial showed one --
1.46x, 1.77x, 1.87x -- and it did not survive two more; the 20th-percentile
lookup arm ranges 0.562s to 0.894s across trials, which is most of the apparent
trend. The honest summary is a consistent ~1.4-1.7x, not a widening gap.

**This is SF1, which is not where the claim lives.** The mechanism predicts a
difference that grows with the shared neighbour's degree, and SF1 tags are not
popular enough to show the asymptotic case -- BI-11 at SF1 does not even take a
second here, while at SF10 it times out. So this lands as a measured SF1
improvement on BI-11's shape, not as evidence that BI-11 is fixed at SF10. That
needs an SF10 run, and H1 condition 2 should not be re-read until one exists.

The bound in the A/B is on the outer scan only, and its limits are real
percentiles of the 1,011,420 REPLY_OF edges into Posts rather than round
numbers: LDBC comment ids run from 557 to 2.199e12, so a plausible-looking
`reply.id < 1_000_000` keeps a handful of rows and measures nothing.

2,184 lib tests pass, 921 of them under `query::executor`.

https://claude.ai/code/https://claude.ai/code/session_01DepCjPd61knSHZky98qXdu
