### PR TITLE
Give both GPU backends the same adjacency: LCC and CDLP disagreed (#1075, #1076)

### DIFF
--- a/crates/samyama-gpu/src/cdlp.rs
+++ b/crates/samyama-gpu/src/cdlp.rs
@@ -32,6 +32,59 @@ pub struct GpuCdlpResult {
     pub iterations: usize,
 }
 
+/// The neighbour **multiset** CDLP counts labels over: every incident edge
+/// contributes, in both directions, with no deduplication.
+///
+/// The multiset is the whole algorithm. Label propagation gives a node the most
+/// frequent label among its neighbours, so how many times a neighbour is
+/// counted decides which label wins. The CPU implementation counts each
+/// successor and each predecessor separately:
+///
+/// ```ignore
+/// for &neighbor in view.successors(idx)   { *counts.entry(labels[neighbor]).or_insert(0) += 1; }
+/// for &neighbor in view.predecessors(idx) { *counts.entry(labels[neighbor]).or_insert(0) += 1; }
+/// ```
+///
+/// so a **reciprocal** neighbour votes twice and parallel edges vote once each.
+/// That is also what the wgpu shader sees, because it is handed the four raw
+/// CSR arrays. The CUDA path used to merge them through a `BTreeSet` first,
+/// which collapsed every one of those repeats into a single vote.
+///
+/// On three nodes with one reciprocal edge -- `0<->2` and `1->0`, labels
+/// starting at node ids -- the two disagree from the first iteration and
+/// converge to different communities:
+///
+/// ```text
+/// CPU + wgpu (multiset)   final labels = [2, 0, 0]
+/// CUDA       (deduped)    final labels = [1, 0, 0]
+/// ```
+///
+/// Deliberately **not** `crate::lcc::undirected_adjacency`, which dedups, drops
+/// self-loops and sorts. LCC's kernel binary-searches a neighbour *set*;
+/// CDLP's kernel counts over a range and needs the multiset. Two different
+/// questions -- unifying them would break one.
+pub(crate) fn incident_multiset(
+    node_count: usize,
+    out_offsets: &[usize],
+    out_targets: &[usize],
+    in_offsets: &[usize],
+    in_sources: &[usize],
+) -> (Vec<u32>, Vec<u32>) {
+    let mut offsets: Vec<u32> = Vec::with_capacity(node_count + 1);
+    let mut targets: Vec<u32> = Vec::new();
+    offsets.push(0);
+    for i in 0..node_count {
+        for idx in out_offsets[i]..out_offsets[i + 1] {
+            targets.push(out_targets[idx] as u32);
+        }
+        for idx in in_offsets[i]..in_offsets[i + 1] {
+            targets.push(in_sources[idx] as u32);
+        }
+        offsets.push(targets.len() as u32);
+    }
+    (offsets, targets)
+}
+
 /// Run CDLP on the GPU using raw CSR data
 ///
 /// `initial_labels` should contain the actual vertex IDs (as u32) for each
@@ -56,23 +109,9 @@ pub fn gpu_cdlp(
     // Try CUDA first
     #[cfg(feature = "cuda")]
     if let Some(cuda_ctx) = crate::runtime::GpuRuntime::get().and_then(|rt| rt.cuda()) {
-        // Build merged adjacency for CUDA
-        let mut merged_offsets: Vec<u32> = Vec::with_capacity(node_count + 1);
-        let mut merged_targets: Vec<u32> = Vec::new();
-        merged_offsets.push(0);
-        for i in 0..node_count {
-            let mut neighbors = std::collections::BTreeSet::new();
-            for idx in out_offsets[i]..out_offsets[i + 1] {
-                neighbors.insert(out_targets[idx] as u32);
-            }
-            for idx in in_offsets[i]..in_offsets[i + 1] {
-                neighbors.insert(in_sources[idx] as u32);
-            }
-            for n in &neighbors {
-                merged_targets.push(*n);
-            }
-            merged_offsets.push(merged_targets.len() as u32);
-        }
+        let (merged_offsets, merged_targets) = incident_multiset(
+            node_count, out_offsets, out_targets, in_offsets, in_sources,
+        );
         match crate::cuda::cdlp::cuda_cdlp(
             cuda_ctx,
             &merged_offsets,
@@ -225,4 +264,74 @@ pub fn gpu_cdlp(
     let labels = download_u32(ctx, final_buf, node_count)?;
 
     Ok(GpuCdlpResult { labels, iterations })
+}
+
+#[cfg(test)]
+mod multiset_tests {
+    use super::incident_multiset;
+
+    fn csr(rows: &[&[usize]]) -> (Vec<usize>, Vec<usize>) {
+        let mut offsets = vec![0usize];
+        let mut flat = Vec::new();
+        for r in rows {
+            flat.extend_from_slice(r);
+            offsets.push(flat.len());
+        }
+        (offsets, flat)
+    }
+
+    fn votes(offsets: &[u32], targets: &[u32], node: usize) -> Vec<u32> {
+        let mut v = targets[offsets[node] as usize..offsets[node + 1] as usize].to_vec();
+        v.sort_unstable();
+        v
+    }
+
+    /// A reciprocal neighbour votes twice. The CUDA path used to merge through
+    /// a `BTreeSet`, which gave it one vote and changed which label won -- see
+    /// `incident_multiset` for the three-node graph where CPU/wgpu converge to
+    /// `[2, 0, 0]` and the deduped version to `[1, 0, 0]`.
+    #[test]
+    fn a_reciprocal_neighbour_votes_twice() {
+        // 0 -> 2, 2 -> 0 (reciprocal), 1 -> 0
+        let (out_offsets, out_targets) = csr(&[&[2], &[0], &[0]]);
+        let (in_offsets, in_sources) = csr(&[&[1, 2], &[], &[0]]);
+
+        let (offsets, targets) =
+            incident_multiset(3, &out_offsets, &out_targets, &in_offsets, &in_sources);
+
+        assert_eq!(
+            votes(&offsets, &targets, 0),
+            vec![1, 2, 2],
+            "node 2 is both a successor and a predecessor of node 0, so it votes twice"
+        );
+    }
+
+    /// Parallel edges vote once each, for the same reason.
+    #[test]
+    fn parallel_edges_each_get_a_vote() {
+        // Two distinct 0 -> 1 edges.
+        let (out_offsets, out_targets) = csr(&[&[1, 1], &[]]);
+        let (in_offsets, in_sources) = csr(&[&[], &[0, 0]]);
+
+        let (offsets, targets) =
+            incident_multiset(2, &out_offsets, &out_targets, &in_offsets, &in_sources);
+
+        assert_eq!(votes(&offsets, &targets, 0), vec![1, 1]);
+        assert_eq!(votes(&offsets, &targets, 1), vec![0, 0]);
+    }
+
+    /// Every incident edge is represented exactly once per direction, so the
+    /// flat length is the total degree and the offsets stay monotonic.
+    #[test]
+    fn total_length_is_the_sum_of_both_degrees() {
+        let (out_offsets, out_targets) = csr(&[&[1, 2], &[2], &[]]);
+        let (in_offsets, in_sources) = csr(&[&[], &[0], &[0, 1]]);
+
+        let (offsets, targets) =
+            incident_multiset(3, &out_offsets, &out_targets, &in_offsets, &in_sources);
+
+        assert_eq!(targets.len(), out_targets.len() + in_sources.len());
+        assert!(offsets.windows(2).all(|w| w[0] <= w[1]));
+        assert_eq!(*offsets.last().unwrap() as usize, targets.len());
+    }
 }

--- a/crates/samyama-gpu/src/lcc.rs
+++ b/crates/samyama-gpu/src/lcc.rs
@@ -33,6 +33,54 @@ pub struct GpuLccResult {
     pub average: f64,
 }
 
+/// The undirected neighbour list each LCC backend binary-searches, as sorted,
+/// deduplicated CSR.
+///
+/// This is one function rather than one per backend because the two used to be
+/// two, and they disagreed. The wgpu path dropped self-loops with
+/// `if out_targets[idx] != i`; the CUDA path collected the same edges into a
+/// `BTreeSet` without that guard, so a node carrying a self-loop counted itself
+/// as its own neighbour. That inflates the node's degree, and the denominator
+/// is `d(d-1)` or `d(d-1)/2`, so the coefficient came out **different on the
+/// two backends for the same graph** -- with the CPU implementation, which
+/// excludes self-loops (`if s != idx`), agreeing with wgpu and not with CUDA.
+///
+/// A self-loop is not a neighbour: LCC asks what fraction of the possible edges
+/// *among a node's neighbours* exist, and an edge from a node to itself is
+/// neither a neighbour nor a candidate triangle side. Two of the three
+/// implementations already said so.
+///
+/// Neither backend can drift from the other again while they share this.
+pub(crate) fn undirected_adjacency(
+    node_count: usize,
+    out_offsets: &[usize],
+    out_targets: &[usize],
+    in_offsets: &[usize],
+    in_sources: &[usize],
+) -> (Vec<u32>, Vec<u32>) {
+    let mut offsets: Vec<u32> = Vec::with_capacity(node_count + 1);
+    let mut targets: Vec<u32> = Vec::new();
+    offsets.push(0);
+    for i in 0..node_count {
+        let mut neighbors: Vec<u32> = Vec::new();
+        for idx in out_offsets[i]..out_offsets[i + 1] {
+            if out_targets[idx] != i {
+                neighbors.push(out_targets[idx] as u32);
+            }
+        }
+        for idx in in_offsets[i]..in_offsets[i + 1] {
+            if in_sources[idx] != i {
+                neighbors.push(in_sources[idx] as u32);
+            }
+        }
+        neighbors.sort_unstable();
+        neighbors.dedup();
+        targets.extend_from_slice(&neighbors);
+        offsets.push(targets.len() as u32);
+    }
+    (offsets, targets)
+}
+
 /// Compute LCC on the GPU using raw CSR data
 ///
 /// When `directed` is false, builds undirected sorted adjacency internally
@@ -58,23 +106,9 @@ pub fn gpu_lcc(
     // Try CUDA first
     #[cfg(feature = "cuda")]
     if let Some(cuda_ctx) = crate::runtime::GpuRuntime::get().and_then(|rt| rt.cuda()) {
-        // Build merged sorted adjacency for CUDA
-        let mut merged_offsets: Vec<u32> = Vec::with_capacity(node_count + 1);
-        let mut merged_targets: Vec<u32> = Vec::new();
-        merged_offsets.push(0);
-        for i in 0..node_count {
-            let mut neighbors = std::collections::BTreeSet::new();
-            for idx in out_offsets[i]..out_offsets[i + 1] {
-                neighbors.insert(out_targets[idx] as u32);
-            }
-            for idx in in_offsets[i]..in_offsets[i + 1] {
-                neighbors.insert(in_sources[idx] as u32);
-            }
-            for n in &neighbors {
-                merged_targets.push(*n);
-            }
-            merged_offsets.push(merged_targets.len() as u32);
-        }
+        let (merged_offsets, merged_targets) = undirected_adjacency(
+            node_count, out_offsets, out_targets, in_offsets, in_sources,
+        );
         match crate::cuda::lcc::cuda_lcc(
             cuda_ctx,
             &merged_offsets,
@@ -116,32 +150,10 @@ pub fn gpu_lcc(
         });
     }
 
-    // Build undirected sorted adjacency (used for neighbor enumeration in both modes)
-    let mut sorted_offsets: Vec<u32> = Vec::with_capacity(node_count + 1);
-    let mut sorted_targets: Vec<u32> = Vec::new();
-
-    sorted_offsets.push(0);
-    for i in 0..node_count {
-        let mut neighbors: Vec<u32> = Vec::new();
-        let out_start = out_offsets[i];
-        let out_end = out_offsets[i + 1];
-        for idx in out_start..out_end {
-            if out_targets[idx] != i {
-                neighbors.push(out_targets[idx] as u32);
-            }
-        }
-        let in_start = in_offsets[i];
-        let in_end = in_offsets[i + 1];
-        for idx in in_start..in_end {
-            if in_sources[idx] != i {
-                neighbors.push(in_sources[idx] as u32);
-            }
-        }
-        neighbors.sort();
-        neighbors.dedup();
-        sorted_targets.extend(&neighbors);
-        sorted_offsets.push(sorted_targets.len() as u32);
-    }
+    // The same adjacency the CUDA path above builds, from the same function.
+    let (sorted_offsets, mut sorted_targets) = undirected_adjacency(
+        node_count, out_offsets, out_targets, in_offsets, in_sources,
+    );
 
     // Check max degree — O(d²) shader loop times out on high-degree nodes
     let max_degree = sorted_offsets
@@ -282,4 +294,101 @@ pub fn gpu_lcc(
         coefficients,
         average,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::undirected_adjacency;
+
+    /// Rows of a tiny CSR, as (offsets, flat targets).
+    fn csr(rows: &[&[usize]]) -> (Vec<usize>, Vec<usize>) {
+        let mut offsets = vec![0usize];
+        let mut flat = Vec::new();
+        for r in rows {
+            flat.extend_from_slice(r);
+            offsets.push(flat.len());
+        }
+        (offsets, flat)
+    }
+
+    fn neighbours_of(offsets: &[u32], targets: &[u32], node: usize) -> Vec<u32> {
+        targets[offsets[node] as usize..offsets[node + 1] as usize].to_vec()
+    }
+
+    /// A self-loop is not a neighbour. On the fixture below the two old
+    /// constructions gave node 0 different neighbourhoods, and so different
+    /// denominators for `d(d-1)/2`:
+    ///
+    /// ```text
+    /// node   CUDA (old)   wgpu/CPU    denominator
+    ///    0    [0, 1, 2]     [1, 2]       3 vs 1     <-- differ
+    ///    1       [0, 2]     [0, 2]       1 vs 1
+    ///    2       [0, 1]     [0, 1]       1 vs 1
+    /// ```
+    ///
+    /// A self-loop is not a neighbour. The CUDA path used to include one,
+    /// because it built its own adjacency with a `BTreeSet` and no guard, while
+    /// wgpu and the CPU implementation both excluded it -- so the same graph
+    /// got two different coefficients depending on which backend ran. The
+    /// degree feeds the `d(d-1)` denominator, so counting the node itself does
+    /// not merely add a neighbour, it changes every coefficient it touches.
+    #[test]
+    fn self_loops_are_not_neighbours() {
+        // 0 -> 0 (self), 0 -> 1, 0 -> 2, 1 -> 2
+        let (out_offsets, out_targets) = csr(&[&[0, 1, 2], &[2], &[]]);
+        let (in_offsets, in_sources) = csr(&[&[0], &[0], &[0, 1]]);
+
+        let (offsets, targets) =
+            undirected_adjacency(3, &out_offsets, &out_targets, &in_offsets, &in_sources);
+
+        assert_eq!(
+            neighbours_of(&offsets, &targets, 0),
+            vec![1, 2],
+            "node 0 carries a self-loop and must not be its own neighbour"
+        );
+        assert_eq!(neighbours_of(&offsets, &targets, 1), vec![0, 2]);
+        assert_eq!(neighbours_of(&offsets, &targets, 2), vec![0, 1]);
+    }
+
+    /// The kernels binary-search these slices, so sortedness is a contract and
+    /// not a convenience -- see the `#1071` family of bugs, where a binary
+    /// search over an array nobody had sorted reported present data as absent.
+    #[test]
+    fn adjacency_is_sorted_and_deduplicated() {
+        // Node 0 reaches 3 twice (parallel edges) and its neighbours arrive
+        // out of order, both from the outgoing side and the incoming side.
+        let (out_offsets, out_targets) = csr(&[&[3, 1, 3], &[0], &[], &[0]]);
+        let (in_offsets, in_sources) = csr(&[&[1, 3], &[0], &[], &[0, 0]]);
+
+        let (offsets, targets) =
+            undirected_adjacency(4, &out_offsets, &out_targets, &in_offsets, &in_sources);
+
+        let n0 = neighbours_of(&offsets, &targets, 0);
+        assert_eq!(n0, vec![1, 3], "sorted, and a parallel edge is one neighbour");
+        // Sortedness is per node: the ranges are laid out in node order, so a
+        // check across the whole flat array would be asserting the wrong thing.
+        for node in 0..4 {
+            let ns = neighbours_of(&offsets, &targets, node);
+            assert!(
+                ns.windows(2).all(|w| w[0] < w[1]),
+                "node {node} adjacency {ns:?} is not strictly ascending"
+            );
+        }
+    }
+
+    /// An isolated node contributes an empty range, and the offsets stay
+    /// monotonic so a range read of any node is well formed.
+    #[test]
+    fn isolated_nodes_keep_offsets_monotonic() {
+        let (out_offsets, out_targets) = csr(&[&[2], &[], &[]]);
+        let (in_offsets, in_sources) = csr(&[&[], &[], &[0]]);
+
+        let (offsets, targets) =
+            undirected_adjacency(3, &out_offsets, &out_targets, &in_offsets, &in_sources);
+
+        assert_eq!(offsets.len(), 4);
+        assert!(offsets.windows(2).all(|w| w[0] <= w[1]));
+        assert!(neighbours_of(&offsets, &targets, 1).is_empty());
+        assert_eq!(*offsets.last().unwrap() as usize, targets.len());
+    }
 }


### PR DESCRIPTION

`gpu_lcc` and `gpu_cdlp` each have a CUDA path and a wgpu path, and each built
its input adjacency separately. In both functions the two constructions were
not equivalent, so the same graph got different answers depending on which
device happened to be present. In both cases the CPU implementation agrees with
wgpu, and CUDA is the outlier.

**LCC (#1075) — a self-loop counted as a neighbour.** wgpu dropped self-loops
with `if out_targets[idx] != i`; the CUDA path collected the same edges into a
`BTreeSet` without that guard. The degree feeds the `d(d-1)/2` denominator, so
a phantom self-neighbour does not merely add an entry, it rescales the
coefficient. Replaying both constructions on `0->0, 0->1, 0->2, 1->2`:

    node   CUDA (old)   wgpu/CPU    denominator d(d-1)/2
       0    [0, 1, 2]     [1, 2]       3 vs 1     <-- differ
       1       [0, 2]     [0, 2]       1 vs 1

One self-loop is enough for a threefold error on that node, carried into the
graph-wide average. `samyama-graph-algorithms` excludes self-loops explicitly
(`if s != idx`), so two of three implementations already agreed.

**CDLP (#1076) — the multiset was deduplicated, and the multiset is the
algorithm.** wgpu binds the four raw CSR arrays to the shader and sees every
incident edge in both directions; CUDA merged them through a `BTreeSet` first.
Label propagation takes the most *frequent* neighbouring label, so collapsing a
reciprocal neighbour's two votes into one changes which label wins. The CPU
implementation counts successors and predecessors separately, so again CPU and
wgpu agree. Three nodes suffice -- `0<->2`, `1->0`, labels starting at node ids,
both sides tie-breaking to the smallest label:

    CPU + wgpu (multiset)   final labels = [2, 0, 0]
    CUDA       (deduped)    final labels = [1, 0, 0]

They diverge in the first iteration. Reciprocal edges are the common case on
real graphs, not a corner. The CDLP kernel counts over its range with an O(d²)
double loop and never binary-searches, so the sorted deduplicated form it was
handed bought nothing and cost correctness.

**The two builders are deliberately not one.** `undirected_adjacency` dedups,
drops self-loops and sorts, because LCC's kernel binary-searches a neighbour
*set*. `incident_multiset` does none of those, because CDLP's kernel counts a
multiset. They look alike and are different questions -- unifying them would
break one, and each says so where it is defined.

**On the evidence.** The divergences are replays of the two constructions, not
failing tests against the old code: the buggy branches sit behind
`#[cfg(feature = "cuda")]` and a live CUDA device, so no test on a machine
without one could ever enter them -- which is most of why they survived.
`CH-ALGO-PARITY` compares GPU against CPU, but on fixtures with no self-loops
and no reciprocal edges, so the three implementations were never asked a
question they answer differently. The fix removes the asymmetry rather than
testing around it: both bugs now live in pure functions covered by six tests
that need no GPU at all.

Checked with `cargo check -p samyama-gpu --features cuda`, since the edited
blocks are ones the default build never compiles.

2,184 lib tests and 18 samyama-gpu tests pass.

https://claude.ai/code/https://claude.ai/code/session_01DepCjPd61knSHZky98qXdu

Fixes #1075. Fixes #1076.
