### PR TITLE
Stop copying a neighbour list to walk it once (#1078)

### DIFF
--- a/examples/bi17_plan.rs
+++ b/examples/bi17_plan.rs
@@ -1,0 +1,64 @@
+//! Print the plan BI-17 gets, so the pushdown question has an answer rather
+//! than an assumption (#1078).
+//!
+//! The row arithmetic in #1078 assumes `a.id < b.id` is applied *after* the
+//! full triangle is built. That is worth ~6x if true and worth nothing if the
+//! planner already applies it at the first expand -- and the last several
+//! things assumed about this query were wrong, so this reads the plan.
+
+#[path = "../benches/ldbc_bi_common/mod.rs"]
+mod ldbc_bi_common;
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+use std::path::PathBuf;
+
+const QUERIES: &[(&str, &str)] = &[
+    (
+        "bi17-triangle",
+        "EXPLAIN MATCH (a:Person)-[:KNOWS]-(b:Person)-[:KNOWS]-(c:Person)-[:KNOWS]-(a)
+         WHERE a.id < b.id AND b.id < c.id
+         RETURN count(a) AS triangles",
+    ),
+    (
+        "two-hop-one-pred",
+        "EXPLAIN MATCH (a:Person)-[:KNOWS]-(b:Person)-[:KNOWS]-(c:Person)
+         WHERE a.id < b.id
+         RETURN count(a) AS n",
+    ),
+    (
+        "one-hop",
+        "EXPLAIN MATCH (a:Person)-[:KNOWS]-(b:Person)
+         WHERE a.id < b.id
+         RETURN count(a) AS n",
+    ),
+];
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().collect();
+    let data_dir = args
+        .iter()
+        .position(|a| a == "--data-dir")
+        .and_then(|i| args.get(i + 1))
+        .map(PathBuf::from)
+        .expect("--data-dir <path> is required");
+
+    let mut graph = GraphStore::new();
+    eprintln!("loading {} ...", data_dir.display());
+    ldbc_bi_common::load_dataset(&mut graph, &data_dir)?;
+    eprintln!("loaded");
+
+    for (name, q) in QUERIES {
+        println!("=== {name} ===");
+        let parsed = parse_query(q)?;
+        let out = QueryExecutor::new(&graph).execute(&parsed)?;
+        for rec in &out.records {
+            for v in rec.values() {
+                println!("{v:?}");
+            }
+        }
+        println!();
+    }
+    Ok(())
+}

--- a/examples/bi17_width.rs
+++ b/examples/bi17_width.rs
@@ -1,0 +1,162 @@
+//! Does a wider record make an expand's rows more expensive? (#1078)
+//!
+//! Stage isolation (#1081) put the second expand at ~2.5x the per-row cost of
+//! the first, on the same edge type over the same store. The one hypothesis
+//! that survived was record **width**: `Record::clone_with_capacity` copies
+//! every accumulated binding plus `used_edges` for each emitted row, so a
+//! deeper pattern pays for its own history on every row it produces.
+//!
+//! That is testable without touching the traversal. A `WITH` that carries
+//! extra scalar columns widens the record and changes nothing else -- same
+//! scan, same expands, same row count. If width is the cost, the wide arm is
+//! slower per row by a margin that grows with the number of carried columns.
+//! If the arms tie, width is not the answer and the 2.5x is still unexplained.
+//!
+//!   cargo run --release --example bi17_width -- --data-dir <sf1-dir>
+
+#[path = "../benches/ldbc_bi_common/mod.rs"]
+mod ldbc_bi_common;
+
+use samyama::graph::GraphStore;
+use samyama::query::executor::QueryExecutor;
+use samyama::query::parser::parse_query;
+use std::path::PathBuf;
+use std::time::Instant;
+
+/// Median of an odd number of trials, after a warm-up.
+///
+/// A single trial published a closing-hop cost of -257 ns once (#1078); the
+/// median of seven is what made three successive runs of that measurement
+/// agree. Same discipline here.
+const TRIALS: usize = 5;
+
+fn carried(n: usize) -> String {
+    // `a.id` n times over, so every extra column is the same width and the
+    // same read -- the arms differ in how many bindings the record holds and
+    // in nothing else.
+    (0..n)
+        .map(|i| format!(", a.id AS x{i}"))
+        .collect::<String>()
+}
+
+/// Two hops, with `n` extra columns carried through both of them.
+fn two_hop(n: usize, limit: u64) -> String {
+    format!(
+        "MATCH (a:Person) WHERE a.id < {limit}
+         WITH a{}
+         MATCH (a)-[:KNOWS]-(b:Person)-[:KNOWS]-(c:Person)
+         RETURN count(c) AS n",
+        carried(n)
+    )
+}
+
+/// One hop, same carrying. The first expand is the control: if width costs
+/// something it should cost it here too, in proportion to the rows emitted.
+fn one_hop(n: usize, limit: u64) -> String {
+    format!(
+        "MATCH (a:Person) WHERE a.id < {limit}
+         WITH a{}
+         MATCH (a)-[:KNOWS]-(b:Person)
+         RETURN count(b) AS n",
+        carried(n)
+    )
+}
+
+fn run(graph: &GraphStore, q: &str) -> (f64, i64) {
+    let parsed = parse_query(q).expect("parse");
+    // Warm-up, discarded: the type index builds after 512 rows and the first
+    // trial would otherwise price building it as if it were traversal.
+    let _ = QueryExecutor::new(graph).execute(&parsed);
+
+    let mut times = Vec::new();
+    let mut rows = 0i64;
+    for _ in 0..TRIALS {
+        let t = Instant::now();
+        let out = QueryExecutor::new(graph).execute(&parsed).expect("execute");
+        times.push(t.elapsed().as_secs_f64());
+        rows = out
+            .records
+            .first()
+            .and_then(|r| r.values().next())
+            .and_then(|v| match v {
+                samyama::query::executor::Value::Property(
+                    samyama::graph::PropertyValue::Integer(i),
+                ) => Some(*i),
+                _ => None,
+            })
+            .unwrap_or(-1);
+    }
+    times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    (times[TRIALS / 2], rows)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().collect();
+    let data_dir = args
+        .iter()
+        .position(|a| a == "--data-dir")
+        .and_then(|i| args.get(i + 1))
+        .map(PathBuf::from)
+        .expect("--data-dir <path> is required");
+    let pct: Vec<u32> = args
+        .iter()
+        .position(|a| a == "--percentiles")
+        .and_then(|i| args.get(i + 1))
+        .map(|s| s.split(',').filter_map(|p| p.parse().ok()).collect())
+        .unwrap_or_else(|| vec![25, 50, 100]);
+
+    let mut graph = GraphStore::new();
+    eprintln!("loading {} ...", data_dir.display());
+    ldbc_bi_common::load_dataset(&mut graph, &data_dir)?;
+    eprintln!("loaded\n");
+
+    // Bounds taken from the id distribution rather than written as literals.
+    // LDBC person ids are sparse, so `a.id < 20000` is not "20,000 people" --
+    // it kept 25,176 of 361,246 one-hop rows, an unknown 7% of the graph. A
+    // percentile is the same fraction on any scale factor.
+    let mut ids: Vec<i64> = {
+        let q = parse_query("MATCH (a:Person) RETURN a.id AS id").expect("parse id scan");
+        QueryExecutor::new(&graph)
+            .execute(&q)
+            .expect("id scan")
+            .records
+            .iter()
+            .filter_map(|r| match r.values().next() {
+                Some(samyama::query::executor::Value::Property(
+                    samyama::graph::PropertyValue::Integer(i),
+                )) => Some(*i),
+                _ => None,
+            })
+            .collect()
+    };
+    ids.sort_unstable();
+    println!("{} persons, id range {}..={}\n", ids.len(), ids[0], ids[ids.len() - 1]);
+
+    for p in &pct {
+        let idx = ((ids.len() as u64 * *p as u64 / 100) as usize).min(ids.len() - 1);
+        let limit = (ids[idx] as u64).saturating_add(1);
+        for (label, build) in [
+            ("one hop ", one_hop as fn(usize, u64) -> String),
+            ("two hops", two_hop as fn(usize, u64) -> String),
+        ] {
+            println!("--- {label}  p{p} of persons (a.id < {limit}) ---");
+            println!("{:>8}  {:>12}  {:>10}  {:>12}", "carried", "rows", "median s", "ns/row");
+            let mut baseline: Option<f64> = None;
+            for n in [0usize, 4, 8] {
+                let (secs, rows) = run(&graph, &build(n, limit));
+                let per_row = if rows > 0 { secs * 1e9 / rows as f64 } else { f64::NAN };
+                let delta = match baseline {
+                    None => {
+                        baseline = Some(per_row);
+                        String::new()
+                    }
+                    Some(b) => format!("   {:+.1} ns/row vs 0 carried  ({:+.1}/column)",
+                                       per_row - b, (per_row - b) / n as f64),
+                };
+                println!("{n:>8}  {rows:>12}  {secs:>10.3}  {per_row:>12.1}{delta}");
+            }
+            println!();
+        }
+    }
+    Ok(())
+}

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -6557,18 +6557,32 @@ impl ExpandOperator {
             (Some(Some(pair)), Some(_)) => Some(pair.clone()),
             _ => None,
         };
-        let empty: [(NodeId, crate::graph::EdgeId); 0] = [];
-        let out_of = |p: &Option<TypeIndexPair>, n: NodeId| -> Vec<(NodeId, crate::graph::EdgeId)> {
-            match p { Some((Some(i), _)) => i.neighbors(n).to_vec(), _ => empty.to_vec() }
-        };
-        let in_of = |p: &Option<TypeIndexPair>, n: NodeId| -> Vec<(NodeId, crate::graph::EdgeId)> {
-            match p { Some((_, Some(i))) => i.neighbors(n).to_vec(), _ => empty.to_vec() }
-        };
+        // Borrowed, not copied. These returned `Vec` and reached it with
+        // `.to_vec()`, so taking the type-index fast path allocated and
+        // memcpy'd the node's entire neighbour list once per input record --
+        // twice for `Direction::Both`, which calls both. The list is then read
+        // once, in order, and dropped.
+        //
+        // The copy bought nothing: `neighbors` already returns a slice, and the
+        // only reason for an owned value was that the `_` arm had nothing of
+        // the right lifetime to return. A `static` empty slice does, so both
+        // arms can borrow -- the fallback array was a local.
+        //
+        // This is also the walk a pinned closing hop uses (#195), where every
+        // input record pays for a copy of a neighbour list it visits once and
+        // keeps at most one entry from.
+        static EMPTY: [(NodeId, crate::graph::EdgeId); 0] = [];
+        fn out_of<'a>(p: &'a Option<TypeIndexPair>, n: NodeId) -> &'a [(NodeId, crate::graph::EdgeId)] {
+            match p { Some((Some(i), _)) => i.neighbors(n), _ => &EMPTY }
+        }
+        fn in_of<'a>(p: &'a Option<TypeIndexPair>, n: NodeId) -> &'a [(NodeId, crate::graph::EdgeId)] {
+            match p { Some((_, Some(i))) => i.neighbors(n), _ => &EMPTY }
+        }
 
         match self.direction {
             Direction::Outgoing => {
                 if typed.is_some() {
-                    for (target, eid) in out_of(&typed, node_id) {
+                    for &(target, eid) in out_of(&typed, node_id) {
                         if keeps(target, eid) {
                             collected.push((eid, node_id, target));
                         }
@@ -6583,7 +6597,7 @@ impl ExpandOperator {
             }
             Direction::Incoming => {
                 if typed.is_some() {
-                    for (source, eid) in in_of(&typed, node_id) {
+                    for &(source, eid) in in_of(&typed, node_id) {
                         if keeps(source, eid) {
                             collected.push((eid, source, node_id));
                         }
@@ -6597,12 +6611,12 @@ impl ExpandOperator {
                 }
             }
             Direction::Both if typed.is_some() => {
-                for (target, eid) in out_of(&typed, node_id) {
+                for &(target, eid) in out_of(&typed, node_id) {
                     if keeps(target, eid) {
                         collected.push((eid, node_id, target));
                     }
                 }
-                for (source, eid) in in_of(&typed, node_id) {
+                for &(source, eid) in in_of(&typed, node_id) {
                     // Same self-loop rule as the walk below: an edge incident
                     // to its own node appears in both indexes and must be
                     // taken once (#640).


### PR DESCRIPTION
`ExpandOperator`'s type-index fast path returned owned `Vec`s from `out_of` and
`in_of` and reached them with `.to_vec()`, so taking that path allocated and
memcpy'd the node's **entire neighbour list once per input record** — twice for
`Direction::Both`, which calls both. The list is then read once, in order, and
dropped.

The copy bought nothing. `neighbors` already returns a slice; the only reason
for an owned value was that the `_` arm had no value of the right lifetime to
return, because the fallback empty array was a local. A `static` empty slice
fixes that and both arms can borrow. Closures cannot express this — a closure's
return lifetime is elided to a fresh one unrelated to its argument's — so these
are `fn` items now.

### What this is, and what it is not

It is a free correctness-neutral removal of an allocation on a hot path. It is
**not** a fix for BI-17, and the diagnostics in this PR are what establish that.

Measured on SF1 at the largest bound (median of 7 after a warm-up, quiet host),
BI-17 divides as 63% building two-hop rows, 22% the two `id` comparisons, 14%
the closing hop. The neighbour-list copy is a small part of the first of those.
I am not quoting a speedup for it because I could not measure one above the
run-to-run band on this query; the reason to land it is the allocation it
removes, which is unambiguous from the code.

### Diagnostics added

**`examples/bi17_plan.rs`** — prints the plan rather than assuming its shape.
This is what killed both levers #1078 proposed: `a.id < b.id` is already applied
directly above the expand that binds `b` (`apply_ready_predicates`, #328), and
the closing hop is already pinned (`with_target_bound_var`, #195). #1078's
headline — "worth ~6x ... that alone would bring SF10 under the limit" — is
wrong, and the correction is posted there.

**`examples/bi17_width.rs`** — carries N extra scalar columns through an
otherwise identical traversal, so record width is the only variable and row
counts are identical across arms:

| carried columns | ns/row (two hops) |
|---:|---:|
| 0 | 106.3 |
| 4 | 169.3 (+15.8/column) |
| 8 | 242.6 (+17.1/column) |

**~16.7 ns per carried binding per emitted row**, linear, reproduced at two
bounds. That prices dead-binding elimination for any query carrying columns
through a deep pattern. It does not explain BI-17 — one binding per hop is ~17
ns of a ~290 ns row.

The bounds in that example are taken from the id distribution, not written as
literals: LDBC person ids are sparse, and my first version's `a.id < 20000` kept
25,176 of 361,246 one-hop rows — an unknown 7% of the graph that I initially
mistook for a per-row cost lower than #1081's. It is not; it is a smaller
measurement. Percentiles are the same fraction at any scale factor.

`cargo test --release` green.

https://claude.ai/code/session_014AiW2oMUJivGp1eY6iTaLh
