### PR TITLE
The BI bench reports host calibration, like every other bench

### DIFF
--- a/benches/ldbc_bi_benchmark.rs
+++ b/benches/ldbc_bi_benchmark.rs
@@ -537,6 +537,18 @@ async fn run_benchmark(
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     bench_setup::init();
+    // Opening calibration, before anything else competes for the CPU. Closed
+    // out at the end of the suite so a host that changed speed mid-run says so
+    // rather than being read as a code change (#529).
+    //
+    // Every other bench in this directory did this and the BI bench did not,
+    // so `report_calibration` was compiled and never called from here -- the
+    // compiler said `function is never used` on each build, which is as close
+    // as a warning gets to naming the gap. The effect is that BI is the one
+    // LDBC suite whose numbers cannot be ruled comparable *or* incomparable
+    // against a run from another host, which is the whole point of #529.
+    // The BI adapter reads this line too (CH-BENCH-LDBC `params`).
+    let calibration = bench_setup::report_calibration();
 
     let args: Vec<String> = std::env::args().collect();
 
@@ -686,6 +698,10 @@ async fn main() -> Result<(), Error> {
     // Cache stats
     let stats = client.cache_stats();
     println!("AST cache: {} hits, {} misses", stats.hits(), stats.misses());
+
+    // Before the exit below, so a run that ends in errors still reports
+    // whether the host it ran on held still.
+    bench_setup::report_drift(calibration);
 
     if errors > 0 {
         std::process::exit(1);


### PR DESCRIPTION
`report_calibration` was compiled and never called from `benches/ldbc_bi_benchmark.rs`. Every other bench in the directory calls it; this one did not, and the compiler said `function is never used` on every build — as close as a warning gets to naming the gap.

**The effect:** SNB-BI is the one LDBC suite whose timings cannot be ruled comparable *or* incomparable against a run from another host. That is exactly what #529 exists to prevent, and BI has been quietly outside it. A BI number quoted against one taken elsewhere has had nothing to check.

Opening calibration before anything competes for the CPU, `report_drift` at the end — placed **before** the error exit, so a run that ends in errors still reports whether the host held still.

Verified on SF1:

```
Host calibration: 30 ms for a fixed CPU-bound loop (load 0.55, cpu 1976 MHz mean)
  Compare this before comparing timings: two runs whose calibration differs
  were taken on hosts of different speed, whatever their milliseconds say (#529).
BI-19   Interaction Path        1    2.0ms    2.1ms    2.1ms  OK
Host calibration after the suite: 29 ms (load 0.77, cpu 810 MHz mean) — 0.96x the opening figure
```

The `function is never used` warning for `report_calibration` is gone from the build.

Found while taking the first write-buffer/CSR A/B on the BI workload (samyama-graph-competitor-benchmarks#131) — both arms were the same host back to back, so that comparison stands, but nothing in the logs said so. The harness adapter is updated in a companion change to record the line in the BI-only envelope's `params`, on the same footing as the Interactive path.

https://claude.ai/code/session_01S5sAcU4QgoPoZP3FgR3Nbw