### PR TITLE
TypeAdjacency neighbour lists are sorted, which is now a promise

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -460,6 +460,23 @@ pub struct TypeAdjacency {
 
 impl TypeAdjacency {
     /// This node's neighbours of the indexed type, or empty.
+    ///
+    /// **Sorted by `(target, edge)`, ascending**, and both build paths sort.
+    /// That is a promise, not an accident of the walk: it makes a neighbour
+    /// list binary-searchable and two lists intersectable by sorted merge,
+    /// which is what a cyclic pattern's closing hop wants (#1082). The
+    /// measured ceiling for that is 170x on LDBC BI-17 (#1086), against which
+    /// one sort per type at build time does not register.
+    ///
+    /// Sorting *here* rather than through `compact_adjacency` is the point:
+    /// the frozen CSR sorts the whole store for every type and costs 7% across
+    /// the BI suite (competitor-benchmarks#131), while this sorts one type's
+    /// lists, in a structure that is already rebuilt from scratch whenever its
+    /// source changes.
+    ///
+    /// The contents still match the walk exactly -- `tests/type_adjacency.rs`
+    /// compares them as sets, and asserts the order separately, so neither
+    /// property can quietly stand in for the other.
     #[inline]
     pub fn neighbors(&self, node: NodeId) -> &[(NodeId, EdgeId)] {
         match self.index.get(&node) {
@@ -2830,6 +2847,16 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             }
             let len = entries.len() - start;
             if len > 0 {
+                // Sorted per node, by target and then edge id. See the
+                // `TypeAdjacency` doc comment: the order is now part of what
+                // this structure promises, because an intersection needs it.
+                //
+                // By `(target, edge)` rather than by target alone, so parallel
+                // edges between the same pair come out in a fixed order
+                // instead of whichever the walk happened to produce. A
+                // structure that is sorted except where it ties is one whose
+                // ties are a source of run-to-run difference nobody looks at.
+                entries[start..].sort_unstable_by_key(|&(t, e)| (t.as_u64(), e.as_u64()));
                 index.insert(node, (start as u32, len as u32));
             }
             if entries.len() > Self::TYPE_ADJ_MAX_ENTRIES {
@@ -2896,7 +2923,10 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
                 rows.push((tgt, src, eid));
             }
         }
-        rows.sort_unstable_by_key(|(owner, _, _)| owner.as_u64());
+        // By owner **and then target and edge**, so each owner's block comes
+        // out sorted rather than merely contiguous. Grouping alone was enough
+        // while `neighbors` promised nothing about order; it no longer is.
+        rows.sort_unstable_by_key(|&(owner, t, e)| (owner.as_u64(), t.as_u64(), e.as_u64()));
 
         let mut index: HashMap<NodeId, (u32, u32)> = HashMap::new();
         let mut entries: Vec<(NodeId, EdgeId)> = Vec::with_capacity(rows.len());

--- a/tests/type_adjacency.rs
+++ b/tests/type_adjacency.rs
@@ -302,6 +302,66 @@ fn an_edge_added_between_queries_is_visible() {
     assert_ne!(before, after, "a new edge must be visible through the index");
 }
 
+/// The order is now a promise, and both build paths must keep it.
+///
+/// `neighbors` returned whatever the walk produced. An intersection over two
+/// neighbour lists needs them sorted (#1082, measured ceiling 170x on BI-17 in
+/// #1086), and "sorted by construction" is a claim this repo has been wrong
+/// about before -- a list that happens to come out ascending on the fixture in
+/// front of you is not a sorted list. So: assert it, on a graph whose insertion
+/// order is deliberately not ascending.
+#[test]
+fn every_neighbour_list_is_sorted_by_target_then_edge() {
+    let (store, people) = mixed();
+    let mut checked = 0usize;
+    let mut nontrivial = 0usize;
+    for &type_name in &["LIKES", "WORKS_AT", "STUDIES_AT"] {
+        let Some(t) = store.edge_type_id(&EdgeType::new(type_name)) else { continue };
+        for outgoing in [true, false] {
+            let Some(idx) = store.type_adjacency(t, outgoing) else { continue };
+            for &n in &people {
+                let list = idx.neighbors(n);
+                let keys: Vec<(u64, u64)> =
+                    list.iter().map(|&(t, e)| (t.as_u64(), e.as_u64())).collect();
+                let mut sorted = keys.clone();
+                sorted.sort_unstable();
+                assert_eq!(keys, sorted,
+                    "{type_name} outgoing={outgoing} node {n:?} is not sorted: {keys:?}");
+                checked += 1;
+                if keys.len() > 1 {
+                    nontrivial += 1;
+                }
+            }
+        }
+    }
+    // A list of length 0 or 1 is sorted for free, so the assertion above would
+    // pass on a store where nothing has two neighbours. This is the half that
+    // makes the check able to fail.
+    assert!(checked > 0, "no type index was built, so nothing was checked");
+    assert!(nontrivial > 20,
+        "only {nontrivial} lists had more than one entry — the sort assertion is nearly vacuous");
+}
+
+/// Sorting must not change *what* the index holds.
+///
+/// The set comparison and the order assertion are separate on purpose: an
+/// index that dropped half its entries would still be sorted, and one that
+/// kept them all in the walk's order would still match the walk as a set.
+/// Neither property can stand in for the other.
+#[test]
+fn sorting_did_not_change_the_contents() {
+    let (store, people) = mixed();
+    for &type_name in &["LIKES", "WORKS_AT", "STUDIES_AT"] {
+        let Some(t) = store.edge_type_id(&EdgeType::new(type_name)) else { continue };
+        for outgoing in [true, false] {
+            for &n in &people {
+                assert_eq!(indexed(&store, n, t, outgoing), walked(&store, n, t, outgoing),
+                    "{type_name} outgoing={outgoing} node {n:?}");
+            }
+        }
+    }
+}
+
 fn _unused(store: &mut GraphStore) {
     let q = parse_query("RETURN 1").unwrap();
     let _ = MutQueryExecutor::new(store, "default".to_string()).execute(&q);


### PR DESCRIPTION
Prerequisite for #1082. `TypeAdjacency::neighbors` returned whatever the walk produced. An intersection over two neighbour lists needs them sorted, and the ceiling for that idea measured **170×** on BI-17 (#1086) — 6.590 s to 0.039 s, both arms agreeing on 387,573 triangles.

### Sorted here, not through `compact_adjacency`

That is the point. The frozen CSR sorts the whole store for every type, costs **7% across the BI suite**, and buys BI-17 **nothing at all** (1.00×, samyama-graph-competitor-benchmarks#131). This sorts *one type's* lists, in a structure that is already rebuilt from scratch whenever its source changes, and taxes nothing that does not use that type.

By `(target, edge)` rather than by target alone, so parallel edges between the same pair come out in a fixed order instead of whichever the walk happened to produce. A structure that is sorted except where it ties has ties that are a source of run-to-run difference nobody looks at.

Both build paths sort — the walk-based one per node after filling its block, and the edge-type-index one by extending its grouping key, which grouped owners without ordering within an owner.

### Two tests, deliberately separate

- **`every_neighbour_list_is_sorted_by_target_then_edge`** asserts the order, and refuses to pass on a fixture where nothing has two neighbours: a list of length 0 or 1 is sorted for free, so it counts non-trivial lists and requires more than 20. **Verified to fail** — removing either sort turns it red while the contents test stays green.
- **`sorting_did_not_change_the_contents`** compares index against walk as sets.

An index that dropped half its entries would still be sorted, and one left in the walk's order would still match the walk as a set. Neither property can stand in for the other, which is why they are not one test.

`tests/type_adjacency.rs`: 11 passed.

### Behaviour note

The type index is built lazily after `TYPE_INDEX_AFTER_ROWS` (512) rows, so only queries above that threshold see the new order, and Cypher promises no row order without `ORDER BY`. Result *sets* are unchanged — that is what the contents test asserts.

https://claude.ai/code/session_01S5sAcU4QgoPoZP3FgR3Nbw