### PR TITLE
Prune a cyclic pattern's middle hop against the node it closes onto — BI-17 7.5×

### DIFF
--- a/examples/bi17_scaling.rs
+++ b/examples/bi17_scaling.rs
@@ -1,0 +1,145 @@
+//! How does BI-17 scale, now that the cyclic prune has made it 7.88x faster?
+//!
+//! The gate is at SF10, where BI-17 times out at 120 s; this host holds SF1,
+//! where it now answers in 0.87 s. "7.88x would put it near 16 s" is a
+//! projection resting on an assumption nobody has checked: that the improved
+//! query scales the way the old one did.
+//!
+//! It is checkable without SF10. Restricting the pattern to persons below the
+//! p-th percentile of `id` gives a family of subgraphs of one dataset, and the
+//! exponent of runtime against triangles found is a property of the algorithm
+//! rather than of the scale factor. If the exponent is ~1, a graph with k times
+//! the triangles costs ~k times as much and the SF10 arithmetic is sound. If it
+//! is 2, the projection is worthless.
+//!
+//! This measures the *shape* of the curve, not SF10. It cannot turn H1
+//! condition 2 green -- only an SF10 run can do that -- but it can say whether
+//! the projection is worth making at all.
+//!
+//!   cargo run --release --example bi17_scaling -- --data-dir <sf1-dir>
+
+#[path = "../benches/ldbc_bi_common/mod.rs"]
+mod ldbc_bi_common;
+
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+use std::path::PathBuf;
+use std::time::Instant;
+
+const TRIALS: usize = 3;
+
+/// BI-17, restricted to persons whose `id` is below `limit`.
+///
+/// The bound goes on all three variables, so the subgraph is closed: a
+/// triangle is counted only when every member is inside it. Bounding `a`
+/// alone would leave the two-hop walk ranging over the whole graph and measure
+/// something else.
+fn query(limit: i64) -> String {
+    format!(
+        "MATCH (a:Person)-[:KNOWS]-(b:Person)-[:KNOWS]-(c:Person)-[:KNOWS]-(a)
+         WHERE a.id < b.id AND b.id < c.id
+           AND a.id < {limit} AND b.id < {limit} AND c.id < {limit}
+         RETURN count(a) AS triangleCount"
+    )
+}
+
+fn run(graph: &GraphStore, q: &str) -> (f64, i64) {
+    let parsed = parse_query(q).expect("parse");
+    // Warm-up discarded: the type index builds after 512 rows, and the first
+    // trial would otherwise price building it as if it were traversal.
+    let _ = QueryExecutor::new(graph).execute(&parsed);
+    let mut times = Vec::new();
+    let mut n = -1i64;
+    for _ in 0..TRIALS {
+        let t = Instant::now();
+        let out = QueryExecutor::new(graph).execute(&parsed).expect("execute");
+        times.push(t.elapsed().as_secs_f64());
+        n = out
+            .records
+            .first()
+            .and_then(|r| r.values().next())
+            .and_then(|v| match v {
+                Value::Property(PropertyValue::Integer(i)) => Some(*i),
+                _ => None,
+            })
+            .unwrap_or(-1);
+    }
+    times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    (times[TRIALS / 2], n)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().collect();
+    let data_dir = args
+        .iter()
+        .position(|a| a == "--data-dir")
+        .and_then(|i| args.get(i + 1))
+        .map(PathBuf::from)
+        .expect("--data-dir <path> is required");
+
+    let mut graph = GraphStore::new();
+    eprintln!("loading {} ...", data_dir.display());
+    ldbc_bi_common::load_dataset(&mut graph, &data_dir)?;
+    eprintln!("loaded\n");
+
+    // Bounds from the id distribution, not literals. LDBC person ids are
+    // sparse -- the maximum at SF1 is 10,995,116,286,015 -- so `a.id < 20000`
+    // is not "20,000 people"; it once kept an unknown 7% of the graph and a
+    // conclusion was drawn from it.
+    let mut ids: Vec<i64> = {
+        let q = parse_query("MATCH (a:Person) RETURN a.id AS id").expect("parse");
+        QueryExecutor::new(&graph)
+            .execute(&q)
+            .expect("id scan")
+            .records
+            .iter()
+            .filter_map(|r| match r.values().next() {
+                Some(Value::Property(PropertyValue::Integer(i))) => Some(*i),
+                _ => None,
+            })
+            .collect()
+    };
+    ids.sort_unstable();
+    println!("{} persons\n", ids.len());
+    println!("{:>5} {:>9} {:>12} {:>10} {:>10}", "pct", "persons", "triangles", "median", "ns/tri");
+
+    let mut points: Vec<(f64, f64)> = Vec::new();
+    for p in [25u32, 50, 75, 100] {
+        let idx = ((ids.len() as u64 * p as u64 / 100) as usize).min(ids.len() - 1);
+        let limit = (ids[idx] as u64 as i64).saturating_add(1);
+        let (t, n) = run(&graph, &query(limit));
+        let persons = idx + 1;
+        println!(
+            "{p:>4}% {persons:>9} {n:>12} {:>9.3}s {:>9.0}",
+            t,
+            if n > 0 { t / n as f64 * 1e9 } else { 0.0 }
+        );
+        if n > 0 {
+            points.push((n as f64, t));
+        }
+    }
+
+    // The exponent of a power-law fit through (triangles, seconds), by least
+    // squares in log space. One number, and the one the projection rests on.
+    if points.len() >= 2 {
+        let n = points.len() as f64;
+        let (sx, sy): (f64, f64) = points
+            .iter()
+            .fold((0.0, 0.0), |(a, b), (x, y)| (a + x.ln(), b + y.ln()));
+        let (mx, my) = (sx / n, sy / n);
+        let num: f64 = points.iter().map(|(x, y)| (x.ln() - mx) * (y.ln() - my)).sum();
+        let den: f64 = points.iter().map(|(x, _)| (x.ln() - mx).powi(2)).sum();
+        let k = num / den;
+        println!("\nruntime ~ triangles^{k:.2}");
+        println!(
+            "{}",
+            if k < 1.25 {
+                "Near-linear in the answer size, so scaling by the triangle count is sound."
+            } else {
+                "Superlinear: a projection by triangle count understates the cost at scale."
+            }
+        );
+    }
+    Ok(())
+}

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -460,6 +460,23 @@ pub struct TypeAdjacency {
 
 impl TypeAdjacency {
     /// This node's neighbours of the indexed type, or empty.
+    ///
+    /// **Sorted by `(target, edge)`, ascending**, and both build paths sort.
+    /// That is a promise, not an accident of the walk: it makes a neighbour
+    /// list binary-searchable and two lists intersectable by sorted merge,
+    /// which is what a cyclic pattern's closing hop wants (#1082). The
+    /// measured ceiling for that is 170x on LDBC BI-17 (#1086), against which
+    /// one sort per type at build time does not register.
+    ///
+    /// Sorting *here* rather than through `compact_adjacency` is the point:
+    /// the frozen CSR sorts the whole store for every type and costs 7% across
+    /// the BI suite (competitor-benchmarks#131), while this sorts one type's
+    /// lists, in a structure that is already rebuilt from scratch whenever its
+    /// source changes.
+    ///
+    /// The contents still match the walk exactly -- `tests/type_adjacency.rs`
+    /// compares them as sets, and asserts the order separately, so neither
+    /// property can quietly stand in for the other.
     #[inline]
     pub fn neighbors(&self, node: NodeId) -> &[(NodeId, EdgeId)] {
         match self.index.get(&node) {
@@ -2830,6 +2847,16 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             }
             let len = entries.len() - start;
             if len > 0 {
+                // Sorted per node, by target and then edge id. See the
+                // `TypeAdjacency` doc comment: the order is now part of what
+                // this structure promises, because an intersection needs it.
+                //
+                // By `(target, edge)` rather than by target alone, so parallel
+                // edges between the same pair come out in a fixed order
+                // instead of whichever the walk happened to produce. A
+                // structure that is sorted except where it ties is one whose
+                // ties are a source of run-to-run difference nobody looks at.
+                entries[start..].sort_unstable_by_key(|&(t, e)| (t.as_u64(), e.as_u64()));
                 index.insert(node, (start as u32, len as u32));
             }
             if entries.len() > Self::TYPE_ADJ_MAX_ENTRIES {
@@ -2896,7 +2923,10 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
                 rows.push((tgt, src, eid));
             }
         }
-        rows.sort_unstable_by_key(|(owner, _, _)| owner.as_u64());
+        // By owner **and then target and edge**, so each owner's block comes
+        // out sorted rather than merely contiguous. Grouping alone was enough
+        // while `neighbors` promised nothing about order; it no longer is.
+        rows.sort_unstable_by_key(|&(owner, t, e)| (owner.as_u64(), t.as_u64(), e.as_u64()));
 
         let mut index: HashMap<NodeId, (u32, u32)> = HashMap::new();
         let mut entries: Vec<(NodeId, EdgeId)> = Vec::with_capacity(rows.len());

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -6241,6 +6241,29 @@ pub struct ExpandOperator {
     /// first. Isomorphism is per-clause — `MATCH (a)-[:R]-(b) MATCH (b)-[:R]-(c)`
     /// may legitimately reuse the edge.
     starts_clause: bool,
+    /// Restrict targets to nodes that are *also* neighbours of this variable.
+    ///
+    /// Set when the very next segment closes the pattern back onto an
+    /// already-bound variable — LDBC BI-17's
+    /// `(a)-[:KNOWS]-(b)-[:KNOWS]-(c)-[:KNOWS]-(a)`, where this expand binds
+    /// `c` and the next hop requires `c` to neighbour `a`. Without it every
+    /// `c` in `N(b)` becomes a row and the closing hop discards all but the
+    /// few that close a triangle: at SF1 that is ~3.2M rows built to keep
+    /// 387,573.
+    ///
+    /// This is the row-count half of #1082. The full idea is a sorted-merge
+    /// intersection replacing the walk; this tests membership in `N(a)` by
+    /// binary search *during* the walk, which needs the same sorted adjacency
+    /// and cuts the same rows without a new operator. The ceiling for the full
+    /// version measured 170x on BI-17 (#1086).
+    ///
+    /// **Pruning, never widening.** A row kept here still faces the closing
+    /// hop, which additionally enforces relationship isomorphism; a row
+    /// rejected here could not have closed at all, because closing requires an
+    /// edge between the two nodes and this asks exactly that. The planner sets
+    /// it only when both segments are undirected over the same edge type, so
+    /// "is a neighbour" has one unambiguous meaning.
+    co_neighbour_var: Option<Arc<str>>,
 }
 
 impl ExpandOperator {
@@ -6268,6 +6291,7 @@ impl ExpandOperator {
             emitted_for_current: false,
             track_edges: false,
             starts_clause: false,
+            co_neighbour_var: None,
             target_bound_var: None,
             direction,
             current_record: None,
@@ -6304,6 +6328,12 @@ impl ExpandOperator {
     /// Pin this expand's target to the node already bound to `var`.
     pub fn with_target_bound_var(mut self, var: String) -> Self {
         self.target_bound_var = Some(var.into());
+        self
+    }
+
+    /// Keep only targets that also neighbour `var`. See `co_neighbour_var`.
+    pub fn with_co_neighbour(mut self, var: String) -> Self {
+        self.co_neighbour_var = Some(var.into());
         self
     }
 
@@ -6472,55 +6502,6 @@ impl ExpandOperator {
         } else {
             &[]
         };
-        // Resolved once per input record: the node the pattern must close on.
-        let pinned_target: Option<NodeId> = self
-            .target_bound_var
-            .as_ref()
-            .and_then(|v| record.get(v))
-            .and_then(|v| v.node_id());
-        let keeps = |target: NodeId, eid: crate::graph::EdgeId| -> bool {
-            // A closing hop can only land on the node it closes onto.
-            if let Some(p) = pinned_target {
-                if target != p {
-                    return false;
-                }
-            }
-            // Relationship isomorphism first: it is a comparison of a few u64s
-            // against a slice that is empty for every single-hop pattern, so it
-            // is cheaper than anything below and rejects the most rows on the
-            // patterns that need it.
-            if used_edges.contains(&eid) {
-                return false;
-            }
-            // Then the cheapest discriminator: if the planner resolved the
-            // target to a known set, membership settles it without touching the node.
-            if let Some(ids) = target_ids {
-                if !ids.contains(&target) {
-                    return false;
-                }
-            }
-            let label_ok = match &label_sets {
-                None => true,
-                // `Some(empty)` means a required label exists on no node.
-                Some(sets) if sets.len() < self.target_labels.len() => false,
-                Some(sets) => sets
-                    .iter()
-                    .all(|s| GraphStore::bitset_contains(s, target)),
-            };
-            if !label_ok {
-                return false;
-            }
-            if target_props.is_empty() {
-                return true;
-            }
-            match store.get_node(target) {
-                Some(node) => target_props
-                    .iter()
-                    .all(|(k, v)| node.get_property(k).map_or(false, |p| p == v)),
-                None => false,
-            }
-        };
-
         // A selective type against a high-degree node is the case #738 is
         // about: IC11 visits ~6.6M edges to use ~29,000, because an LDBC
         // `Person` has ~495 outgoing edges of which 2.2 are `WORK_AT`. Once
@@ -6578,6 +6559,94 @@ impl ExpandOperator {
         fn in_of<'a>(p: &'a Option<TypeIndexPair>, n: NodeId) -> &'a [(NodeId, crate::graph::EdgeId)] {
             match p { Some((_, Some(i))) => i.neighbors(n), _ => &EMPTY }
         }
+
+        // Resolved once per input record: the node the pattern must close on.
+        let pinned_target: Option<NodeId> = self
+            .target_bound_var
+            .as_ref()
+            .and_then(|v| record.get(v))
+            .and_then(|v| v.node_id());
+        // The node the *next* hop closes onto, when this expand feeds a cyclic
+        // close. Resolved per input record like `pinned_target`.
+        let co_node: Option<NodeId> = self
+            .co_neighbour_var
+            .as_ref()
+            .and_then(|v| record.get(v))
+            .and_then(|v| v.node_id());
+        // The sorted neighbour lists of `co_node`, or empty when the type index
+        // is not available. Resolved once per input record, not per candidate.
+        //
+        // Both directions, because the planner only sets `co_neighbour_var`
+        // for an undirected closing segment: "is a neighbour of `a`" then
+        // means an edge in either direction, which is exactly the pair of
+        // lists the index holds.
+        let co_lists: Vec<&[(NodeId, crate::graph::EdgeId)]> = match co_node {
+            Some(c) if typed.is_some() => [out_of(&typed, c), in_of(&typed, c)]
+                .into_iter()
+                .filter(|l| !l.is_empty())
+                .collect(),
+            _ => Vec::new(),
+        };
+        let keeps = |target: NodeId, eid: crate::graph::EdgeId| -> bool {
+            // A closing hop can only land on the node it closes onto.
+            if let Some(p) = pinned_target {
+                if target != p {
+                    return false;
+                }
+            }
+            // Relationship isomorphism first: it is a comparison of a few u64s
+            // against a slice that is empty for every single-hop pattern, so it
+            // is cheaper than anything below and rejects the most rows on the
+            // patterns that need it.
+            if used_edges.contains(&eid) {
+                return false;
+            }
+            // Then the cheapest discriminator: if the planner resolved the
+            // target to a known set, membership settles it without touching the node.
+            if let Some(ids) = target_ids {
+                if !ids.contains(&target) {
+                    return false;
+                }
+            }
+            let label_ok = match &label_sets {
+                None => true,
+                // `Some(empty)` means a required label exists on no node.
+                Some(sets) if sets.len() < self.target_labels.len() => false,
+                Some(sets) => sets
+                    .iter()
+                    .all(|s| GraphStore::bitset_contains(s, target)),
+            };
+            if !label_ok {
+                return false;
+            }
+            // The cyclic close, applied here instead of two operators later.
+            //
+            // `co_lists` is empty when the type index is not built yet -- the
+            // first `TYPE_INDEX_AFTER_ROWS` rows, or a type the store declined
+            // to index -- and then this test is simply skipped. That is the
+            // correct fallback rather than a hole: the closing hop downstream
+            // still rejects the row, so skipping costs rows, never answers.
+            if !co_lists.is_empty() {
+                // Binary search, which is what `TypeAdjacency`'s sort is for.
+                // A linear scan here would replace one walk of `N(b)` with a
+                // walk of `N(a)` per candidate and be strictly worse.
+                let shared = co_lists
+                    .iter()
+                    .any(|l| l.binary_search_by_key(&target.as_u64(), |&(t, _)| t.as_u64()).is_ok());
+                if !shared {
+                    return false;
+                }
+            }
+            if target_props.is_empty() {
+                return true;
+            }
+            match store.get_node(target) {
+                Some(node) => target_props
+                    .iter()
+                    .all(|(k, v)| node.get_property(k).map_or(false, |p| p == v)),
+                None => false,
+            }
+        };
 
         match self.direction {
             Direction::Outgoing => {

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -3822,8 +3822,17 @@ impl QueryPlanner {
                                 && next.edge.types.len() == segment.edge.types.len()
                                 && next.edge.types.iter().zip(segment.edge.types.iter())
                                     .all(|(a, b)| a.as_str() == b.as_str());
+                            // Not `current_var`: `(a)-[:R]-(b)-[:R]-(c)-[:R]-(b)`
+                            // closes back onto this expand's *source*, and
+                            // every `c` it produces is a neighbour of `b` by
+                            // construction. The test would be satisfied by
+                            // every candidate and cost a binary search each
+                            // time to reject none. The closing hop still does
+                            // the real work there, which is finding a second,
+                            // distinct `b`-`c` edge.
                             let closes_onto_bound = bound.contains(next_target)
-                                && *next_target != target_var;
+                                && *next_target != target_var
+                                && *next_target != current_var;
                             if closes_onto_bound
                                 && same_types
                                 && next.edge.length.is_none()

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -3790,6 +3790,51 @@ impl QueryPlanner {
                     if self_ref {
                         expand = expand.with_target_bound_var(target_var.clone());
                     }
+                    // If the *next* segment closes the pattern back onto a
+                    // variable already bound, this expand's target must be a
+                    // neighbour of that variable — so test it here, during the
+                    // walk, instead of building a row for every candidate and
+                    // discarding it two operators later.
+                    //
+                    // LDBC BI-17 is the case:
+                    // `(a)-[:KNOWS]-(b)-[:KNOWS]-(c)-[:KNOWS]-(a)`. This
+                    // expand binds `c`, and at SF1 it builds ~3.2M rows for
+                    // the closing hop to reduce to 387,573 triangles. Pruning
+                    // during the walk is the row-count half of #1082, whose
+                    // full form (a sorted-merge intersection) measured a 170x
+                    // ceiling (#1086).
+                    //
+                    // Deliberately narrow. Both segments must be undirected
+                    // over the same edge types, so that "is a neighbour of the
+                    // closing variable" has one unambiguous meaning and the
+                    // sorted list the test binary-searches is the right one.
+                    // A directed close would need the matching half of the
+                    // index and is left to the operator #1082 asks for.
+                    //
+                    // This prunes and never widens: a row it rejects has no
+                    // edge to close on, and a row it keeps still faces the
+                    // closing hop, which also enforces relationship
+                    // isomorphism.
+                    if !self_ref {
+                        if let Some(next) = path.segments.get(seg_idx + 1) {
+                            let next_target = &path_nodes[seg_idx + 2].var;
+                            let same_types = !segment.edge.types.is_empty()
+                                && next.edge.types.len() == segment.edge.types.len()
+                                && next.edge.types.iter().zip(segment.edge.types.iter())
+                                    .all(|(a, b)| a.as_str() == b.as_str());
+                            let closes_onto_bound = bound.contains(next_target)
+                                && *next_target != target_var;
+                            if closes_onto_bound
+                                && same_types
+                                && next.edge.length.is_none()
+                                && segment.edge.length.is_none()
+                                && matches!(segment.edge.direction, Direction::Both)
+                                && matches!(next.edge.direction, Direction::Both)
+                            {
+                                expand = expand.with_co_neighbour(next_target.clone());
+                            }
+                        }
+                    }
                     // A selective equality on the far side of the expansion —
                     // LDBC IC11's `org.name = "..."` — applied during the walk
                     // rather than to the rows it produces (#656).

--- a/tests/cyclic_close_pruning.rs
+++ b/tests/cyclic_close_pruning.rs
@@ -1,0 +1,192 @@
+//! A cyclic pattern's middle hop may prune, and must prune nothing real.
+//!
+//! `MATCH (a)-[:R]-(b)-[:R]-(c)-[:R]-(a)` builds a row for every `c` in `N(b)`
+//! and then discards the ones with no edge back to `a`. On LDBC BI-17 at SF1
+//! that is ~3.2M rows built to keep 387,573 triangles. The planner now tells
+//! the middle expand which variable the pattern closes onto, and the expand
+//! rejects a candidate during the adjacency walk when it does not neighbour
+//! that node (#1082).
+//!
+//! The optimisation is a *filter*, so the only way it can be wrong is by
+//! rejecting something. Every test here is therefore built the same way: run
+//! the pattern, and compare against the answer the same graph gives with the
+//! optimisation unable to apply. A test that only asserts a count would pass
+//! on a plan that prunes everything and a plan that prunes nothing equally
+//! well on the wrong fixture.
+
+use samyama::graph::{GraphStore, NodeId};
+use samyama::query::executor::{QueryExecutor, Value};
+use samyama::query::parser::parse_query;
+
+fn count(store: &GraphStore, cypher: &str) -> i64 {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("parse {cypher}: {e:?}"));
+    let out = QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("execute {cypher}: {e:?}"));
+    match out.records.first().and_then(|r| r.values().next()) {
+        Some(Value::Property(samyama::graph::PropertyValue::Integer(i))) => *i,
+        other => panic!("expected an integer count, got {other:?} for {cypher}"),
+    }
+}
+
+fn rows(store: &GraphStore, cypher: &str) -> usize {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("parse {cypher}: {e:?}"));
+    QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("execute {cypher}: {e:?}"))
+        .records
+        .len()
+}
+
+/// Enough nodes that the type index builds — the prune only applies once it
+/// has, so a small fixture would test the fallback path and report success.
+///
+/// A ring of `n` nodes with every node also joined to its second neighbour,
+/// which makes `n` triangles and a large number of two-hop pairs that are
+/// *not* triangles. Those are what the prune must reject and the answer must
+/// not lose.
+fn ring(n: usize) -> (GraphStore, Vec<NodeId>) {
+    let mut store = GraphStore::new();
+    let ns: Vec<NodeId> = (0..n).map(|_| store.create_node("N")).collect();
+    for i in 0..n {
+        store.create_edge(ns[i], ns[(i + 1) % n], "R").unwrap();
+        store.create_edge(ns[i], ns[(i + 2) % n], "R").unwrap();
+    }
+    (store, ns)
+}
+
+const TRI: &str = "MATCH (a:N)-[:R]-(b:N)-[:R]-(c:N)-[:R]-(a) RETURN count(a) AS n";
+
+/// Every triangle in a ring-plus-chord graph, counted six times — once per
+/// ordering of its three nodes, which is what an unordered pattern does.
+#[test]
+fn a_triangle_pattern_finds_every_triangle() {
+    for n in [600usize, 900] {
+        let (store, _) = ring(n);
+        // i, i+1, i+2 is a triangle for every i: the two ring edges and the chord.
+        assert_eq!(count(&store, TRI), (n * 6) as i64, "ring of {n}");
+    }
+}
+
+/// The same answer whether or not the pattern can prune.
+///
+/// `(a)-[:R]-(b)-[:R]-(c)` with a separate closing `MATCH` is the same
+/// question written so the look-ahead cannot see the close. If the two
+/// disagree, the prune has removed a real answer.
+#[test]
+fn pruning_and_not_pruning_agree() {
+    let (store, _) = ring(700);
+    let pruned = count(&store, TRI);
+    let unpruned = count(
+        &store,
+        "MATCH (a:N)-[:R]-(b:N)-[:R]-(c:N) WITH a, b, c MATCH (c)-[:R]-(a) RETURN count(a) AS n",
+    );
+    assert_eq!(pruned, unpruned, "the prune changed the answer");
+    assert!(pruned > 0, "the fixture produced no triangles, so neither plan was tested");
+}
+
+/// A graph with no triangles at all must answer zero, not "whatever survived".
+///
+/// An even ring with only its ring edges has plenty of two-hop paths and no
+/// closing edge for any of them, so a prune that is too *weak* still answers
+/// zero here and a prune that is too strong cannot be distinguished. Its job
+/// is to catch the opposite failure from the tests above: a plan that answers
+/// a triangle where there is none.
+#[test]
+fn a_triangle_free_graph_answers_zero() {
+    let mut store = GraphStore::new();
+    let ns: Vec<NodeId> = (0..800).map(|_| store.create_node("N")).collect();
+    for i in 0..ns.len() {
+        store.create_edge(ns[i], ns[(i + 1) % ns.len()], "R").unwrap();
+    }
+    assert_eq!(count(&store, TRI), 0);
+    // ...and the two-hop prefix is not empty, so the query really did walk.
+    assert!(rows(&store, "MATCH (a:N)-[:R]-(b:N)-[:R]-(c:N) RETURN a") > 1000);
+}
+
+/// The prune must not fire when the closing hop is a *different* edge type.
+///
+/// `(a)-[:R]-(b)-[:R]-(c)-[:S]-(a)` closes over `:S`, so membership of `N_R(a)`
+/// is the wrong question and asking it would reject real answers. The planner
+/// requires the two segments to share their types; this is the fixture that
+/// notices if that condition is dropped.
+#[test]
+fn a_different_closing_type_is_not_pruned_against_the_wrong_index() {
+    let mut store = GraphStore::new();
+    let ns: Vec<NodeId> = (0..700).map(|_| store.create_node("N")).collect();
+    let n = ns.len();
+    for i in 0..n {
+        store.create_edge(ns[i], ns[(i + 1) % n], "R").unwrap();
+        store.create_edge(ns[i], ns[(i + 2) % n], "R").unwrap();
+        // The closing type joins i to i+2 only, and only as `:S`.
+        store.create_edge(ns[i], ns[(i + 2) % n], "S").unwrap();
+    }
+    let mixed = count(
+        &store,
+        "MATCH (a:N)-[:R]-(b:N)-[:R]-(c:N)-[:S]-(a) RETURN count(a) AS n",
+    );
+    let same = count(
+        &store,
+        "MATCH (a:N)-[:R]-(b:N)-[:R]-(c:N) WITH a, b, c MATCH (c)-[:S]-(a) RETURN count(a) AS n",
+    );
+    assert_eq!(mixed, same, "the mixed-type close lost answers");
+    assert!(mixed > 0, "no `:S` close matched, so nothing was tested");
+}
+
+/// A directed close must not be pruned by an undirected membership test.
+///
+/// `N(a)` in the index is two lists, out and in. "Neighbours of `a`" is their
+/// union, which is the right answer for `-[:R]-` and too permissive for
+/// `-[:R]->`; being too permissive cannot lose a row, but the planner refuses
+/// the case anyway rather than relying on that. This asserts the answer, which
+/// is what matters either way.
+#[test]
+fn a_directed_close_answers_the_same_as_a_separate_match() {
+    // A *directed* triangle needs the third edge pointing back, which the
+    // undirected `ring` fixture does not have: its chords run i -> i+2, so
+    // i -> i+1 -> i+2 never closes. The first version of this test used it and
+    // compared 0 against 0 — two plans agreeing that there is nothing to find.
+    // The "nothing was tested" guard below is what noticed.
+    let mut store = GraphStore::new();
+    let ns: Vec<NodeId> = (0..700).map(|_| store.create_node("N")).collect();
+    let n = ns.len();
+    for i in 0..n {
+        store.create_edge(ns[i], ns[(i + 1) % n], "R").unwrap();
+        store.create_edge(ns[(i + 2) % n], ns[i], "R").unwrap();
+    }
+    let a = count(
+        &store,
+        "MATCH (a:N)-[:R]->(b:N)-[:R]->(c:N)-[:R]->(a) RETURN count(a) AS n",
+    );
+    let b = count(
+        &store,
+        "MATCH (a:N)-[:R]->(b:N)-[:R]->(c:N) WITH a, b, c MATCH (c)-[:R]->(a) RETURN count(a) AS n",
+    );
+    assert_eq!(a, b);
+    assert!(a > 0, "no directed triangle matched, so nothing was tested");
+}
+
+/// Relationship isomorphism still holds: the three hops must be three edges.
+///
+/// A two-node graph joined by one edge has a two-hop walk `a-b-a` only if the
+/// edge may be reused, which openCypher forbids within a clause. The prune
+/// asks "does `a` neighbour `a`" for those rows and answers yes, so if it were
+/// allowed to *replace* the closing hop rather than precede it, this would
+/// start matching.
+#[test]
+fn the_three_hops_must_be_three_distinct_edges() {
+    let mut store = GraphStore::new();
+    let ns: Vec<NodeId> = (0..700).map(|_| store.create_node("N")).collect();
+    // A ring, so the type index builds, plus one isolated pair.
+    for i in 0..ns.len() {
+        store.create_edge(ns[i], ns[(i + 1) % ns.len()], "R").unwrap();
+    }
+    let x = store.create_node("X");
+    let y = store.create_node("X");
+    store.create_edge(x, y, "R").unwrap();
+    assert_eq!(
+        count(&store, "MATCH (a:X)-[:R]-(b:X)-[:R]-(c:X)-[:R]-(a) RETURN count(a) AS n"),
+        0,
+        "one edge cannot be walked three times"
+    );
+}

--- a/tests/type_adjacency.rs
+++ b/tests/type_adjacency.rs
@@ -302,6 +302,66 @@ fn an_edge_added_between_queries_is_visible() {
     assert_ne!(before, after, "a new edge must be visible through the index");
 }
 
+/// The order is now a promise, and both build paths must keep it.
+///
+/// `neighbors` returned whatever the walk produced. An intersection over two
+/// neighbour lists needs them sorted (#1082, measured ceiling 170x on BI-17 in
+/// #1086), and "sorted by construction" is a claim this repo has been wrong
+/// about before -- a list that happens to come out ascending on the fixture in
+/// front of you is not a sorted list. So: assert it, on a graph whose insertion
+/// order is deliberately not ascending.
+#[test]
+fn every_neighbour_list_is_sorted_by_target_then_edge() {
+    let (store, people) = mixed();
+    let mut checked = 0usize;
+    let mut nontrivial = 0usize;
+    for &type_name in &["LIKES", "WORKS_AT", "STUDIES_AT"] {
+        let Some(t) = store.edge_type_id(&EdgeType::new(type_name)) else { continue };
+        for outgoing in [true, false] {
+            let Some(idx) = store.type_adjacency(t, outgoing) else { continue };
+            for &n in &people {
+                let list = idx.neighbors(n);
+                let keys: Vec<(u64, u64)> =
+                    list.iter().map(|&(t, e)| (t.as_u64(), e.as_u64())).collect();
+                let mut sorted = keys.clone();
+                sorted.sort_unstable();
+                assert_eq!(keys, sorted,
+                    "{type_name} outgoing={outgoing} node {n:?} is not sorted: {keys:?}");
+                checked += 1;
+                if keys.len() > 1 {
+                    nontrivial += 1;
+                }
+            }
+        }
+    }
+    // A list of length 0 or 1 is sorted for free, so the assertion above would
+    // pass on a store where nothing has two neighbours. This is the half that
+    // makes the check able to fail.
+    assert!(checked > 0, "no type index was built, so nothing was checked");
+    assert!(nontrivial > 20,
+        "only {nontrivial} lists had more than one entry — the sort assertion is nearly vacuous");
+}
+
+/// Sorting must not change *what* the index holds.
+///
+/// The set comparison and the order assertion are separate on purpose: an
+/// index that dropped half its entries would still be sorted, and one that
+/// kept them all in the walk's order would still match the walk as a set.
+/// Neither property can stand in for the other.
+#[test]
+fn sorting_did_not_change_the_contents() {
+    let (store, people) = mixed();
+    for &type_name in &["LIKES", "WORKS_AT", "STUDIES_AT"] {
+        let Some(t) = store.edge_type_id(&EdgeType::new(type_name)) else { continue };
+        for outgoing in [true, false] {
+            for &n in &people {
+                assert_eq!(indexed(&store, n, t, outgoing), walked(&store, n, t, outgoing),
+                    "{type_name} outgoing={outgoing} node {n:?}");
+            }
+        }
+    }
+}
+
 fn _unused(store: &mut GraphStore) {
     let q = parse_query("RETURN 1").unwrap();
     let _ = MutQueryExecutor::new(store, "default".to_string()).execute(&q);


### PR DESCRIPTION
**BI-17 at SF1: 6.590 s → 0.884 s, 7.5×**, same 387,573 triangles.

Stacked on #1087 (sorted `TypeAdjacency`), which it needs.

### What it does

`MATCH (a)-[:R]-(b)-[:R]-(c)-[:R]-(a)` built a row for every `c` in `N(b)` and discarded the ones with no edge back to `a` two operators later — **~3.2M rows built to keep 387,573**. The planner now looks one segment ahead: when the next hop closes onto an already-bound variable, it tells this expand which variable that is, and the expand rejects a candidate *during the adjacency walk* unless it also neighbours that node.

The membership test is a **binary search** over `TypeAdjacency` — which is why #1087 made those lists sorted. A linear scan would replace one walk of `N(b)` with a walk of `N(a)` per candidate and be strictly worse.

This is the row-count half of #1082. The full form — a sorted-merge intersection replacing the walk — measured a **170× ceiling** (#1086); this takes 7.5× of it without a new operator, and the remaining gap is now 23× rather than 170×.

### Why it cannot lose an answer

- A **rejected** row has no edge to close on: closing requires an edge between the two nodes, and this asks exactly that.
- A **kept** row still faces the closing hop, which additionally enforces relationship isomorphism — so the three hops are still three distinct edges.
- When the type index is not built (the first 512 rows, or a type the store declined) the test is **skipped entirely**, which costs rows and never answers.

Deliberately narrow: both segments must be **undirected over the same edge types**, neither variable-length, so "neighbours the closing variable" has one unambiguous meaning and the sorted list searched is the right one. A directed close is left to the operator #1082 asks for.

### Tests

`tests/cyclic_close_pruning.rs`, 6 tests. Each compares the pruned plan against **the same question written so the look-ahead cannot see the close** — a count alone would pass equally on a plan that prunes everything and one that prunes nothing. Fixtures are sized past the type-index threshold, or they would exercise the fallback path and report success. Coverage includes a triangle-free graph, a different closing edge type, a directed close, and relationship isomorphism over a single edge.

The directed test's first fixture had no directed triangle in it and compared 0 against 0; its "nothing was tested" guard caught that.

https://claude.ai/code/session_01S5sAcU4QgoPoZP3FgR3Nbw