### PR TITLE
An auto-embedded vector has to survive a rebuild, and only a property does (#310)

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -879,10 +879,32 @@ impl GraphStore {
 
     /// Start the background indexer loop
     pub async fn start_background_indexer(
+        receiver: tokio::sync::mpsc::UnboundedReceiver<crate::graph::event::IndexEvent>,
+        vector_index: Arc<VectorIndexManager>,
+        property_index: Arc<IndexManager>,
+        tenant_manager: Arc<crate::persistence::TenantManager>,
+    ) {
+        Self::start_background_indexer_with_store(
+            receiver,
+            vector_index,
+            property_index,
+            tenant_manager,
+            None,
+        )
+        .await
+    }
+
+    /// The indexer loop, with a handle back to the store it indexes.
+    ///
+    /// Only auto-embed needs it, and only so the embedding it computes can be written
+    /// onto the node — see [`spawn_auto_embed`]. Passing `None` keeps the old behaviour:
+    /// the vector goes into the in-memory index and nowhere else.
+    pub async fn start_background_indexer_with_store(
         mut receiver: tokio::sync::mpsc::UnboundedReceiver<crate::graph::event::IndexEvent>,
         vector_index: Arc<VectorIndexManager>,
         property_index: Arc<IndexManager>,
         tenant_manager: Arc<crate::persistence::TenantManager>,
+        store: Option<Arc<tokio::sync::RwLock<GraphStore>>>,
     ) {
         use crate::graph::event::IndexEvent::*;
         
@@ -905,57 +927,23 @@ impl GraphStore {
                             property_index.index_insert(label, key, value.clone(), id);
                         }
                         
-                        // Auto-Embed check
+                        // Auto-Embed check (#310)
                         if let PropertyValue::String(text) = value {
                             if let Ok(tenant) = tenant_manager.get_tenant(&tenant_id) {
                                 if let Some(config) = tenant.embed_config {
                                     for label in &labels {
-                                        if let Some(keys) = config.embedding_policies.get(label.as_str()) {
-                                            if keys.contains(key) {
-                                                // Trigger Auto-Embed
-                                                let vector_index_clone = Arc::clone(&vector_index);
-                                                let label_str = label.as_str().to_string();
-                                                // The vector is indexed under the
-                                                // *target* property, not the source text
-                                                // property it was generated from: an index
-                                                // is created on `Person.embedding`, never
-                                                // on `Person.headline`, so indexing under
-                                                // the source key put every vector in an
-                                                // index nobody queried (#310).
-                                                let target_key = config.embedding_property.clone();
-                                                let text_clone = text.clone();
-                                                let config_clone = config.clone();
-
-                                                tokio::spawn(async move {
-                                                    match crate::embed::EmbedPipeline::new(config_clone) {
-                                                        Ok(pipeline) => match pipeline.process_text(&text_clone).await {
-                                                            Ok(chunks) => {
-                                                                for chunk in chunks {
-                                                                    if let Err(e) = vector_index_clone.add_vector(
-                                                                        &label_str,
-                                                                        &target_key,
-                                                                        id,
-                                                                        &chunk.embedding,
-                                                                    ) {
-                                                                        tracing::warn!(
-                                                                            "auto-embed: could not index {}.{} for node {}: {}",
-                                                                            label_str, target_key, id.as_u64(), e
-                                                                        );
-                                                                    }
-                                                                }
-                                                            }
-                                                            Err(e) => tracing::warn!(
-                                                                "auto-embed: embedding failed for {}.{}: {}",
-                                                                label_str, target_key, e
-                                                            ),
-                                                        },
-                                                        Err(e) => tracing::warn!(
-                                                            "auto-embed: pipeline unavailable for {}.{}: {}",
-                                                            label_str, target_key, e
-                                                        ),
-                                                    }
-                                                });
-                                            }
+                                        if config.embedding_policies.get(label.as_str())
+                                            .is_some_and(|keys| keys.contains(key))
+                                        {
+                                            spawn_auto_embed(
+                                                config.clone(),
+                                                label.as_str().to_string(),
+                                                id,
+                                                tenant_id.clone(),
+                                                text.clone(),
+                                                Arc::clone(&vector_index),
+                                                store.clone(),
+                                            );
                                         }
                                     }
                                 }
@@ -1017,48 +1005,23 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
                         }
                     }
                     
-                    // Auto-Embed check
+                    // Auto-Embed check (#310)
                     if let PropertyValue::String(text) = &new_value {
                         if let Ok(tenant) = tenant_manager.get_tenant(&tenant_id) {
                             if let Some(config) = tenant.embed_config {
                                 for label in &labels {
-                                    if let Some(keys) = config.embedding_policies.get(label.as_str()) {
-                                        if keys.contains(&key) {
-                                            let vector_index_clone = Arc::clone(&vector_index);
-                                            let label_str = label.as_str().to_string();
-                                            // Index under the target property, not the
-                                            // source text property -- see NodeCreated.
-                                            let target_key = config.embedding_property.clone();
-                                            let text_clone = text.clone();
-                                            let config_clone = config.clone();
-
-                                            tokio::spawn(async move {
-                                                match crate::embed::EmbedPipeline::new(config_clone) {
-                                                    Ok(pipeline) => match pipeline.process_text(&text_clone).await {
-                                                        Ok(chunks) => {
-                                                            if let Some(first) = chunks.first() {
-                                                                if let Err(e) = vector_index_clone.add_vector(
-                                                                    &label_str, &target_key, id, &first.embedding,
-                                                                ) {
-                                                                    tracing::warn!(
-                                                                        "auto-embed: could not index {}.{} for node {}: {}",
-                                                                        label_str, target_key, id.as_u64(), e
-                                                                    );
-                                                                }
-                                                            }
-                                                        }
-                                                        Err(e) => tracing::warn!(
-                                                            "auto-embed: embedding failed for {}.{}: {}",
-                                                            label_str, target_key, e
-                                                        ),
-                                                    },
-                                                    Err(e) => tracing::warn!(
-                                                        "auto-embed: pipeline unavailable for {}.{}: {}",
-                                                        label_str, target_key, e
-                                                    ),
-                                                }
-                                            });
-                                        }
+                                    if config.embedding_policies.get(label.as_str())
+                                        .is_some_and(|keys| keys.contains(&key))
+                                    {
+                                        spawn_auto_embed(
+                                            config.clone(),
+                                            label.as_str().to_string(),
+                                            id,
+                                            tenant_id.clone(),
+                                            text.clone(),
+                                            Arc::clone(&vector_index),
+                                            store.clone(),
+                                        );
                                     }
                                 }
                             }
@@ -1100,47 +1063,22 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
                         }
                         property_index.index_insert(&label, &key, value.clone(), id);
                         
-                        // Auto-Embed check
+                        // Auto-Embed check (#310)
                         if let PropertyValue::String(text) = &value {
                             if let Ok(tenant) = tenant_manager.get_tenant(&tenant_id) {
                                 if let Some(config) = tenant.embed_config {
-                                    if let Some(keys) = config.embedding_policies.get(label.as_str()) {
-                                        if keys.contains(&key) {
-                                            let vector_index_clone = Arc::clone(&vector_index);
-                                            let label_str = label.as_str().to_string();
-                                            // Index under the target property, not the
-                                            // source text property -- see NodeCreated.
-                                            let target_key = config.embedding_property.clone();
-                                            let text_clone = text.clone();
-                                            let config_clone = config.clone();
-
-                                            tokio::spawn(async move {
-                                                match crate::embed::EmbedPipeline::new(config_clone) {
-                                                    Ok(pipeline) => match pipeline.process_text(&text_clone).await {
-                                                        Ok(chunks) => {
-                                                            if let Some(first) = chunks.first() {
-                                                                if let Err(e) = vector_index_clone.add_vector(
-                                                                    &label_str, &target_key, id, &first.embedding,
-                                                                ) {
-                                                                    tracing::warn!(
-                                                                        "auto-embed: could not index {}.{} for node {}: {}",
-                                                                        label_str, target_key, id.as_u64(), e
-                                                                    );
-                                                                }
-                                                            }
-                                                        }
-                                                        Err(e) => tracing::warn!(
-                                                            "auto-embed: embedding failed for {}.{}: {}",
-                                                            label_str, target_key, e
-                                                        ),
-                                                    },
-                                                    Err(e) => tracing::warn!(
-                                                        "auto-embed: pipeline unavailable for {}.{}: {}",
-                                                        label_str, target_key, e
-                                                    ),
-                                                }
-                                            });
-                                        }
+                                    if config.embedding_policies.get(label.as_str())
+                                        .is_some_and(|keys| keys.contains(&key))
+                                    {
+                                        spawn_auto_embed(
+                                            config.clone(),
+                                            label.as_str().to_string(),
+                                            id,
+                                            tenant_id.clone(),
+                                            text.clone(),
+                                            Arc::clone(&vector_index),
+                                            store.clone(),
+                                        );
                                     }
                                 }
                             }
@@ -4197,6 +4135,77 @@ impl Default for GraphStore {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// One auto-embed trigger: embed `text`, then make the vector findable *after a rebuild*.
+///
+/// The vector used to go into the in-memory index and nowhere else.
+/// [`GraphStore::rebuild_vector_index`] rebuilds from node properties — and it runs on
+/// snapshot import, on the reindex endpoint, and implicitly on every restart — so every
+/// auto-embedded vector vanished and vector search went back to answering zero rows with
+/// a 200 (#310). Writing the embedding onto the node is what survives that: the
+/// `PropertySet` event it emits indexes the vector through the `to_vector` branch, and
+/// cannot re-trigger auto-embed, which fires only on a `String`.
+///
+/// With no store handle — the embedded and test wirings — it indexes directly, which is
+/// still lost on rebuild but is all that path can reach.
+fn spawn_auto_embed(
+    config: crate::persistence::tenant::AutoEmbedConfig,
+    label: String,
+    id: NodeId,
+    tenant_id: String,
+    text: String,
+    vector_index: Arc<VectorIndexManager>,
+    store: Option<Arc<tokio::sync::RwLock<GraphStore>>>,
+) {
+    // The vector is indexed under the *target* property, not the source text property it
+    // was generated from: an index is created on `Person.embedding`, never on
+    // `Person.headline`, so indexing under the source key put every vector in an index
+    // nobody queried (#310).
+    let target_key = config.embedding_property.clone();
+    tokio::spawn(async move {
+        let pipeline = match crate::embed::EmbedPipeline::new(config) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!("auto-embed: pipeline unavailable for {}.{}: {}", label, target_key, e);
+                return;
+            }
+        };
+        // The first chunk only. Indexing every chunk put several vectors under one node id
+        // in an index keyed by node id, where they could only overwrite each other; the
+        // other two trigger sites already took the first.
+        let embedding = match pipeline.process_text(&text).await {
+            Ok(chunks) => match chunks.into_iter().next() {
+                Some(chunk) => chunk.embedding,
+                None => return,
+            },
+            Err(e) => {
+                tracing::warn!("auto-embed: embedding failed for {}.{}: {}", label, target_key, e);
+                return;
+            }
+        };
+        if let Some(store) = store {
+            let mut guard = store.write().await;
+            match guard.set_node_property(
+                &tenant_id,
+                id,
+                target_key.clone(),
+                PropertyValue::Vector(embedding.clone()),
+            ) {
+                Ok(()) => return,
+                Err(e) => tracing::warn!(
+                    "auto-embed: could not store {}.{} on node {}: {}",
+                    label, target_key, id.as_u64(), e
+                ),
+            }
+        }
+        if let Err(e) = vector_index.add_vector(&label, &target_key, id, &embedding) {
+            tracing::warn!(
+                "auto-embed: could not index {}.{} for node {}: {}",
+                label, target_key, id.as_u64(), e
+            );
+        }
+    });
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -609,7 +609,7 @@ async fn start_server() {
 
     // Start background indexer now that store is wrapped in Arc
     if let Some(ref pm) = persistence {
-        pm.start_indexer(&*store.read().await, rx);
+        pm.start_indexer(Arc::clone(&store), rx);
     }
 
     // Start HTTP server for Visualizer API (port from --http-port, default 8080)

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -111,18 +111,29 @@ impl PersistenceManager {
         Arc::clone(&self.tenants)
     }
 
-    /// Start the background indexer for a store
-    pub fn start_indexer(&self, store: &GraphStore, receiver: tokio::sync::mpsc::UnboundedReceiver<crate::graph::event::IndexEvent>) {
-        let vector_index = Arc::clone(&store.vector_index);
-        let property_index = Arc::clone(&store.property_index);
+    /// Start the background indexer for a store.
+    ///
+    /// Takes the shared handle rather than a borrow so auto-embed can write the
+    /// embedding it computes back onto the node; without that the vector lives only in
+    /// the in-memory index and the next rebuild drops it (#310).
+    pub fn start_indexer(
+        &self,
+        store: Arc<tokio::sync::RwLock<GraphStore>>,
+        receiver: tokio::sync::mpsc::UnboundedReceiver<crate::graph::event::IndexEvent>,
+    ) {
         let tenant_manager = Arc::clone(&self.tenants);
 
         tokio::spawn(async move {
-            GraphStore::start_background_indexer(
+            let (vector_index, property_index) = {
+                let guard = store.read().await;
+                (Arc::clone(&guard.vector_index), Arc::clone(&guard.property_index))
+            };
+            GraphStore::start_background_indexer_with_store(
                 receiver,
                 vector_index,
                 property_index,
                 tenant_manager,
+                Some(store),
             ).await;
         });
     }

--- a/tests/auto_embed_indexing.rs
+++ b/tests/auto_embed_indexing.rs
@@ -127,3 +127,87 @@ async fn a_property_outside_the_policy_is_not_embedded() {
         .expect("search");
     assert!(hits.is_empty(), "only policy properties should be embedded");
 }
+
+/// The vector has to survive a rebuild, and only a stored property does (#310).
+///
+/// `rebuild_vector_index` rebuilds every index from node properties. It runs on snapshot
+/// import, on reindex, and implicitly on every restart. An auto-embedded vector that
+/// lived only in the in-memory index was therefore dropped by all three, and vector
+/// search went back to answering zero rows with a success — the same silence the
+/// wrong-index bug produced, reached from the other side.
+///
+/// Written against the shared-handle wiring the server uses, because that is the only
+/// wiring in which auto-embed can reach the store to write the property at all.
+#[tokio::test]
+async fn an_auto_embedded_vector_survives_a_rebuild() {
+    let tenants = Arc::new(TenantManager::new());
+    tenants
+        .update_embed_config("default", Some(embed_config("headline")))
+        .expect("set embed config");
+
+    let (store, rx) = GraphStore::with_async_indexing();
+    // the store's own index, not a side one: a rebuild only touches the store's.
+    let vector_index = Arc::clone(&store.vector_index);
+    vector_index
+        .create_index("Person", "embedding", MOCK_DIM, DistanceMetric::Cosine)
+        .expect("create index");
+
+    let store = Arc::new(tokio::sync::RwLock::new(store));
+    let (vi, pi, tm, sh) = (
+        Arc::clone(&vector_index),
+        Arc::new(IndexManager::new()),
+        Arc::clone(&tenants),
+        Arc::clone(&store),
+    );
+    tokio::spawn(async move {
+        GraphStore::start_background_indexer_with_store(rx, vi, pi, tm, Some(sh)).await
+    });
+
+    let id = {
+        let mut guard = store.write().await;
+        let id = guard.create_node("Person");
+        guard
+            .set_node_property(
+                "default",
+                id,
+                "headline".to_string(),
+                PropertyValue::String("a graph database engineer".to_string()),
+            )
+            .expect("set property");
+        id
+    };
+
+    // auto-embed runs on a spawned task, and the write-back is a second hop through it
+    tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
+
+    let before = vector_index
+        .search("Person", "embedding", &vec![0.1f32; MOCK_DIM], 5)
+        .expect("search");
+    assert_eq!(before.len(), 1, "the embedding should be indexed to begin with");
+
+    // the property is what a rebuild reads, so it has to be on the node
+    {
+        let guard = store.read().await;
+        let stored = guard
+            .get_node(id)
+            .and_then(|n| n.get_property("embedding").cloned());
+        assert!(
+            stored.is_some_and(|v| v.to_vector().is_some_and(|v| v.len() == MOCK_DIM)),
+            "the embedding should be stored on the node, not only in the index"
+        );
+    }
+
+    {
+        let mut guard = store.write().await;
+        guard.rebuild_vector_index();
+    }
+
+    let after = vector_index
+        .search("Person", "embedding", &vec![0.1f32; MOCK_DIM], 5)
+        .expect("search");
+    assert_eq!(
+        after.len(),
+        1,
+        "a rebuild must not lose an auto-embedded vector — it is the restart path"
+    );
+}


### PR DESCRIPTION
## What was still broken

The wrong-index half of #310 was fixed: auto-embed indexes under the *target* property (`Person.embedding`), not the source text property. The other half was not, and it is the half the reporter opened the issue with:

> `MATCH (p:Person) WHERE p.embedding IS NOT NULL RETURN count(p)` → **0**

Still true on `main`, by construction. The generated vector went into the in-memory `VectorIndexManager` and nowhere else. `GraphStore::rebuild_vector_index` rebuilds every index **from node properties** — inline first, columnar as fallback — so anything that never became a property cannot come back. It runs on:

- snapshot import (`snapshot/mod.rs`),
- the reindex endpoint (`http/handler.rs:803`),
- and implicitly on every restart, because the index is in memory.

So auto-embed worked until the first of those, then vector search silently returned zero rows with a 200. The same silence as the wrong-index bug, reached from the other side.

## The fix

Write the embedding onto the node. The `PropertySet` event that emits indexes the vector through the `to_vector` branch, so the index is still populated, and it cannot re-trigger auto-embed — that fires only on a `String`.

For that the indexer needs a handle to the store it indexes:

- `start_background_indexer_with_store` takes `Option<Arc<RwLock<GraphStore>>>`; the existing `start_background_indexer` delegates with `None`, so the embedded and test wirings behave exactly as before.
- `PersistenceManager::start_indexer` takes the shared handle `main.rs` already holds, instead of a borrow.

## Also folded in

The trigger was copy-pasted three times (NodeCreated, PropertySet, LabelAdded) and had already drifted: NodeCreated indexed **every** chunk under the same node id, in an index keyed by node id, where they could only overwrite each other. The other two took the first. All three now go through one `spawn_auto_embed`, taking the first chunk.

## Evidence

`an_auto_embedded_vector_survives_a_rebuild` asserts three things in order: the vector is findable, the embedding is *on the node*, and it is still findable after `rebuild_vector_index()`.

Checked it can fail — passing `None` for the store handle stops it at the "stored on the node" assertion:

```
test an_auto_embedded_vector_survives_a_rebuild ... FAILED
panicked at tests/auto_embed_indexing.rs:194
```

Release lib suite: **2184 passed, 0 failed**. Mock provider throughout, so no network and no model.

## What this does not do

The write-back takes the store's write lock once per embedded node. On a bulk load with a policy on a hot label that serialises against the loader. It is the right trade against losing every vector, but it is a throughput cost worth measuring before anyone turns auto-embed on for an import.

https://claude.ai/code/session_01LfRydo2qAUMYWL44vVfUbV