### PR TITLE
The note saying three of these fail outlived the failures (#710)

### DIFF
--- a/tests/var_length_path_enumeration.rs
+++ b/tests/var_length_path_enumeration.rs
@@ -10,11 +10,14 @@
 //! The scope is the same one #684 established for fixed-length patterns:
 //! relationships may not repeat within a clause, nodes may.
 //!
-//! Expectations below are openCypher's, matching Neo4j 5 on the same graphs,
-//! and three of the four fail today. They are `#[ignore]`d against #710 rather
-//! than deleted or weakened: the expected values are the specification's, and a
-//! test that asserts the current behaviour would have to be rewritten by
-//! whoever fixes it, which is the opposite of useful.
+//! Expectations below are openCypher's, matching Neo4j 5 on the same graphs.
+//! Three of the original four failed when this file was written and were
+//! `#[ignore]`d against #710 rather than weakened to match the engine. #710 is
+//! fixed and none of them are ignored now — the file grew to twelve as the fix
+//! landed — but the note claiming three still fail outlived the failures by
+//! several months, and a triage sweep read it as evidence the bug was open. A
+//! comment that describes a run nobody has repeated is the same hazard as a
+//! verdict that outlives its measurement: the suite is the statement, so run it.
 
 use samyama::graph::{GraphStore, PropertyValue};
 use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};


### PR DESCRIPTION
Triage finding from samyama-graph-competitor-benchmarks#133, which is sweeping the tracker for the P0 class (an engine answer that is silently wrong through an interface reporting success).

`tests/var_length_path_enumeration.rs` opens with:

> Expectations below are openCypher's, matching Neo4j 5 on the same graphs, and three of the four fail today. They are `#[ignore]`d against #710 …

None of that is true any more. The file has **no** `#[ignore]` outside that sentence, and it is twelve tests, not four:

```
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

(release). So #710 is fixed and can be closed — but the note was the strongest evidence the sweep found that it was still open, and it read as evidence. A comment describing a run nobody has repeated is the same hazard as a verdict that outlives its measurement; the replacement says so, and says the suite is the statement.

No behaviour change — comment only.

https://claude.ai/code/session_01LfRydo2qAUMYWL44vVfUbV