### PR TITLE
Export the Louvain partition so it can be checked against its invariant

### DIFF
--- a/examples/algo_parity_export.rs
+++ b/examples/algo_parity_export.rs
@@ -31,6 +31,7 @@ use samyama_graph_algorithms::{
     average_neighbour_degree, degree_assortativity, diameter, eccentricity, radius,
     pathfinding_extra::random_walk,
     articulation_points, bridges, find_cycle, topological_sort, TopoResult,
+    community_detect::louvain,
 };
 
 /// How many shortest paths to enumerate per pair before stopping. The count is
@@ -415,6 +416,14 @@ fn main() {
         // sequence returned really is a cycle.
         let cycle: Option<Vec<NodeId>> = find_cycle(&view);
 
+        // Louvain's partition is not unique -- it is greedy, and NetworkX's own
+        // implementation takes a seed -- so there is nothing to agree with. What
+        // *is* checkable is that the result partitions the nodes and that its
+        // modularity beats the two trivial partitions, which is the whole point
+        // of running it. Exported on the undirected collapse, which is what
+        // modularity is defined on here.
+        let louvain_partition = louvain(&single, 10);
+
         let mut h2 = serde_json::Map::new();
         let mut put = |k: &str, v: serde_json::Value| { h2.insert(k.to_string(), v); };
         put("katz", serde_json::to_value(&katz).unwrap());
@@ -444,6 +453,7 @@ fn main() {
         // *given a seed*, and nothing in this export exercised a seed until
         // this line. It is the clause most likely to rot, because a caller
         // switching to an unseeded RNG breaks nothing that compiles.
+        put("louvain_partition", serde_json::to_value(&louvain_partition).unwrap());
         put("random_walk_seeded",
             serde_json::to_value(random_walk(&view, 0, 32, 0x5A_4D)
                 .to_vec()).unwrap());


### PR DESCRIPTION
Louvain was one of ALGO-02's unchecked algorithms. It is greedy and its partition is not unique — NetworkX's own implementation takes a `seed` — so agreeing with NetworkX would be luck.

It does not follow that nothing can be checked:

- a partition either covers every node exactly once, or it does not;
- its modularity either beats the two trivial partitions, or it does not.

The second is the entire reason to run the algorithm, and it is what makes the check non-vacuous: a result that returns one community per node, or one community for the whole graph, satisfies the first and fails the second.

Same argument as the three greedy results already exported for their invariants, and the same reason it is the stronger check — it says the answer is *right*, not that it matches someone else's arbitrary tie-break.

Exported on the undirected collapse, which is where the engine computes modularity.

The harness half checks it:

```
  ok  undirected-40   louvain_partition  6 communities, modularity 0.4495 > all-apart -0.0287 and all-together 0.0000
  ok  directed-40     louvain_partition  7 communities, modularity 0.4149 > all-apart -0.0281 and all-together 0.0000
  ok  undirected-120  louvain_partition  11 communities, modularity 0.5008 > all-apart -0.0098 and all-together 0.0000
  ok  dag-40          louvain_partition  7 communities, modularity 0.3879 > all-apart -0.0286 and all-together 0.0000
```

and it was checked that it can fail — singletons, all-in-one and a short label vector are each rejected with the reason.

https://claude.ai/code/session_01LfRydo2qAUMYWL44vVfUbV