### PR TITLE
Arrow and Parquet export for query results (#1097)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -45,6 +47,12 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -133,6 +141,179 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "arrow"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a3ec4fe573f9d1f59d99c085197ef669b00b088ba1d7bb75224732d9357a74"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dcf19f07792d8c7f91086c67b574a79301e367029b17fcf63fb854332246a10"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7845c32b41f7053e37a075b3c2f29c6f5ea1b3ca6e5df7a2d325ee6e1b4a63cf"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.15.5",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b5c681a99606f3316f2a99d9c8b6fa3aad0b1d34d8f6d7a1b471893940219d8"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6365f8527d4f87b133eeb862f9b8093c009d41a210b8f101f91aa2392f61daac"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd962fc3bf7f60705b25bcaa8eb3318b2545aa1d528656525ebdd6a17a6cd6fb"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3527365b24372f9c948f16e53738eb098720eea2093ae73c7af04ac5e30a39b"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79af2db0e62a508d34ddf4f76bfd6109b6ecc845257c9cba6f939653668f89ac"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-row"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da30e9d10e9c52f09ea0cf15086d6d785c11ae8dcc3ea5f16d402221b6ac7735"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b0f9c0c3582dd55db0f136d3b44bfa0189df07adcf7dc7f2f2e74db0f52eb8"
+
+[[package]]
+name = "arrow-select"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92fc337f01635218493c23da81a364daf38c694b05fc20569c3193c11c561984"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num",
+]
+
+[[package]]
+name = "arrow-string"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d596a9fc25dae556672d5069b090331aca8acb93cae426d8b7dcdf1c558fa0ce"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +331,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -273,24 +463,6 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.9.4",
- "cexpr",
- "clang-sys",
- "itertools",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.106",
 ]
@@ -503,15 +675,16 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -655,6 +828,26 @@ dependencies = [
  "crossterm",
  "unicode-segmentation",
  "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -954,6 +1147,16 @@ name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+
+[[package]]
+name = "flatbuffers"
+version = "24.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
+dependencies = [
+ "bitflags 1.3.2",
+ "rustc_version",
+]
 
 [[package]]
 name = "flate2"
@@ -1267,6 +1470,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -1608,6 +1812,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,6 +1943,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,7 +2027,7 @@ version = "0.16.0+8.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "bzip2-sys",
  "cc",
  "glob",
@@ -2070,6 +2337,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,6 +2375,27 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2178,6 +2490,15 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
@@ -2233,6 +2554,36 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "parquet"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f8cf58b29782a7add991f655ff42929e31a7859f5319e53db9e39a714cb113c"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "bytes",
+ "chrono",
+ "half",
+ "hashbrown 0.15.5",
+ "num",
+ "num-bigint",
+ "paste",
+ "seq-macro",
+ "snap",
+ "thrift",
+ "twox-hash",
+ "zstd",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -2915,6 +3266,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3041,6 +3401,7 @@ name = "samyama"
 version = "1.7.1"
 dependencies = [
  "anyhow",
+ "arrow",
  "async-trait",
  "axum",
  "bincode",
@@ -3059,6 +3420,7 @@ dependencies = [
  "openraft",
  "oxiri",
  "oxrdf",
+ "parquet",
  "percent-encoding",
  "pest",
  "pest_derive",
@@ -3208,6 +3570,12 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -3370,6 +3738,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snap"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
 
 [[package]]
 name = "socket2"
@@ -3621,6 +3995,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float 2.10.1",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -3894,6 +4288,16 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
 
 [[package]]
 name = "typenum"
@@ -4239,7 +4643,7 @@ dependencies = [
  "ndk-sys",
  "objc",
  "once_cell",
- "ordered-float",
+ "ordered-float 4.6.0",
  "parking_lot",
  "profiling",
  "range-alloc",
@@ -4899,12 +5303,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
+name = "zstd"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
- "bindgen 0.72.1",
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
  "cc",
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,17 @@ chrono = "0.4"
 chrono-tz = "0.10"
 sha2 = "0.10"
 
+# Arrow + Parquet export (INT-05 / ML-01, #1097). Version 53 matches what
+# samyama-graph-enterprise already vets and ships, so this adds no new licence
+# surface -- both are Apache-2.0.
+#
+# `arrow` is taken with default features off and only the two enabled that the
+# export needs: `ipc` for the streaming format the HTTP endpoint writes, and
+# `prettyprint` left off deliberately (it pulls comfy-table for a debug
+# rendering nothing here uses).
+arrow = { version = "53", default-features = false, features = ["ipc"] }
+parquet = { version = "53", default-features = false, features = ["arrow", "snap", "zstd"] }
+
 # High Availability (Phase 4)
 openraft = { version = "0.9", features = ["serde"] }
 async-trait = "0.1"

--- a/README.md
+++ b/README.md
@@ -393,6 +393,26 @@ pip install samyama[mcp]
 samyama-mcp-serve --demo cricket    # Instant AI agent tools for any graph
 ```
 
+**Out to pandas** — Any read query as Arrow or Parquet, straight into a
+dataframe, with no intermediate file.
+
+```bash
+curl -X POST http://localhost:8080/api/query/export \
+  -H 'content-type: application/json' \
+  -d '{"query":"MATCH (d:Doc) RETURN d.id, d.title, d.embedding","format":"parquet"}' \
+  -o result.parquet
+```
+
+```python
+import pandas as pd
+pd.read_parquet("result.parquet")
+```
+
+`"format":"arrow"` streams the Arrow IPC format instead. Column types come from
+the values in the result — integers stay `Int64`, a vector arrives as
+`List<Float64>` — and temporal values leave as ISO-8601 text, because Arrow
+carries one time zone per column while Cypher carries one per value.
+
 ---
 
 ## Benchmarks

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -1,0 +1,477 @@
+//! Arrow and Parquet export for query results (INT-05, ML-01 — #1097).
+//!
+//! A Cypher result is a list of records; Arrow is columnar and needs one type
+//! per column. The whole of this module is that reconciliation, and the
+//! interesting part is what it refuses to guess.
+//!
+//! **A column's type is inferred from the values actually in it**, in one pass,
+//! by unifying a per-value kind:
+//!
+//! | values in the column | Arrow type |
+//! |---|---|
+//! | booleans (and nulls) | `Boolean` |
+//! | integers | `Int64` |
+//! | integers and floats | `Float64` |
+//! | strings | `Utf8` |
+//! | lists of integers | `List<Int64>` |
+//! | vectors, or lists with any fractional number | `List<Float64>` |
+//! | lists of strings | `List<Utf8>` |
+//! | anything else, or a mix of the above | `Utf8` holding JSON |
+//!
+//! Null is absorbed by every kind and every column is nullable, so a column
+//! that is entirely null comes out as `Null`-typed rather than being guessed
+//! at.
+//!
+//! **Temporal values are exported as ISO-8601 text, not as Arrow timestamps**,
+//! and that is a decision rather than a shortcut. Arrow carries one time zone
+//! per *column*; Cypher carries a zone per *value*, and a `ZonedDateTime` may
+//! carry a named IANA zone that an offset cannot reconstruct across a DST
+//! boundary. Mapping the five temporal types onto `Timestamp` would silently
+//! drop that for exactly the values where it matters, and a lossy export is
+//! worse than a text one — the text round-trips, and `pandas.to_datetime`
+//! reads it.
+//!
+//! Nodes, relationships, paths and maps become JSON text for the same reason:
+//! Arrow has no type for them, and inventing a flattening here would produce a
+//! column whose meaning depends on which query wrote it.
+
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, BooleanBuilder, Float64Builder, Int64Builder, ListBuilder, NullArray, StringBuilder,
+};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch as ArrowBatch;
+
+use crate::graph::PropertyValue;
+use crate::query::executor::record::{RecordBatch, Value};
+
+/// Why an export could not be produced.
+#[derive(Debug, thiserror::Error)]
+pub enum ExportError {
+    /// Arrow itself refused the batch — a schema/array length mismatch, and a
+    /// bug here rather than in the caller's query.
+    #[error("arrow: {0}")]
+    Arrow(String),
+    /// Parquet writing failed.
+    #[error("parquet: {0}")]
+    Parquet(String),
+}
+
+/// The Arrow type a single value would need, before unification.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Kind {
+    /// Absorbed by everything: a null fits in any column.
+    Null,
+    Bool,
+    Int,
+    Float,
+    Str,
+    ListInt,
+    ListFloat,
+    ListStr,
+    /// A list with no elements, which cannot say what it is a list of. It
+    /// takes the column's word for it, rather than forcing the column to JSON
+    /// because one row happened to be `[]`.
+    ListEmpty,
+    /// JSON text — either a value Arrow has no type for, or a column whose
+    /// values disagree.
+    Json,
+}
+
+impl Kind {
+    /// The narrowest kind that can hold both.
+    fn unify(self, other: Kind) -> Kind {
+        use Kind::*;
+        match (self, other) {
+            (Null, k) | (k, Null) => k,
+            (a, b) if a == b => a,
+            // The one widening worth having: a column of counts that happens to
+            // contain an average is a Float64 column, not a JSON one.
+            (Int, Float) | (Float, Int) => Float,
+            // `[]` next to `["a"]` is a column of string lists with an empty
+            // one in it, not a type conflict.
+            (ListEmpty, ListInt) | (ListInt, ListEmpty) => ListInt,
+            (ListEmpty, ListFloat) | (ListFloat, ListEmpty) => ListFloat,
+            (ListEmpty, ListStr) | (ListStr, ListEmpty) => ListStr,
+            // A list of ids stays a list of ids unless something in the column
+            // is fractional. `[1, 2, 3]` arriving as `[1.0, 2.0, 3.0]` is a
+            // small wrongness that a downstream join on those ids would feel.
+            (ListInt, ListFloat) | (ListFloat, ListInt) => ListFloat,
+            _ => Json,
+        }
+    }
+}
+
+fn kind_of_property(p: &PropertyValue) -> Kind {
+    match p {
+        PropertyValue::Null => Kind::Null,
+        PropertyValue::Boolean(_) => Kind::Bool,
+        PropertyValue::Integer(_) => Kind::Int,
+        PropertyValue::Float(_) => Kind::Float,
+        PropertyValue::String(_) => Kind::Str,
+        // See the module docs: text, deliberately.
+        PropertyValue::Date(_)
+        | PropertyValue::LocalTime(_)
+        | PropertyValue::Time { .. }
+        | PropertyValue::LocalDateTime { .. }
+        | PropertyValue::ZonedDateTime { .. }
+        | PropertyValue::DateTime(_)
+        | PropertyValue::Duration { .. } => Kind::Str,
+        PropertyValue::Vector(_) => Kind::ListFloat,
+        PropertyValue::Array(items) if items.is_empty() => Kind::ListEmpty,
+        PropertyValue::Array(items) => {
+            let mut k = Kind::Null;
+            for it in items {
+                k = k.unify(kind_of_property(it));
+            }
+            match k {
+                // All-null elements have no type either; float is as good a
+                // carrier as any and keeps the column a list.
+                Kind::Null | Kind::Float => Kind::ListFloat,
+                Kind::Int => Kind::ListInt,
+                Kind::Str => Kind::ListStr,
+                _ => Kind::Json,
+            }
+        }
+        PropertyValue::Map(_) => Kind::Json,
+    }
+}
+
+fn kind_of(v: &Value) -> Kind {
+    match v {
+        Value::Null => Kind::Null,
+        Value::Property(p) => kind_of_property(p),
+        Value::List(items) if items.is_empty() => Kind::ListEmpty,
+        Value::List(items) => {
+            let mut k = Kind::Null;
+            for it in items {
+                k = k.unify(kind_of(it));
+            }
+            match k {
+                Kind::Null | Kind::Float => Kind::ListFloat,
+                Kind::Int => Kind::ListInt,
+                Kind::Str => Kind::ListStr,
+                _ => Kind::Json,
+            }
+        }
+        _ => Kind::Json,
+    }
+}
+
+fn as_f64(v: &Value) -> Option<f64> {
+    match v {
+        Value::Property(PropertyValue::Integer(i)) => Some(*i as f64),
+        Value::Property(PropertyValue::Float(f)) => Some(*f),
+        _ => None,
+    }
+}
+
+fn prop_as_f64(p: &PropertyValue) -> Option<f64> {
+    match p {
+        PropertyValue::Integer(i) => Some(*i as f64),
+        PropertyValue::Float(f) => Some(*f),
+        _ => None,
+    }
+}
+
+/// The float sequence behind a value that a `List<Float64>` column holds, or
+/// `None` for a null.
+fn float_list(v: &Value) -> Option<Vec<Option<f64>>> {
+    match v {
+        Value::Null | Value::Property(PropertyValue::Null) => None,
+        Value::Property(PropertyValue::Vector(xs)) => {
+            Some(xs.iter().map(|x| Some(*x as f64)).collect())
+        }
+        Value::Property(PropertyValue::Array(items)) => {
+            Some(items.iter().map(prop_as_f64).collect())
+        }
+        Value::List(items) => Some(items.iter().map(as_f64).collect()),
+        _ => None,
+    }
+}
+
+fn int_list(v: &Value) -> Option<Vec<Option<i64>>> {
+    let one = |p: &PropertyValue| match p {
+        PropertyValue::Integer(i) => Some(*i),
+        _ => None,
+    };
+    match v {
+        Value::Null | Value::Property(PropertyValue::Null) => None,
+        Value::Property(PropertyValue::Array(items)) => Some(items.iter().map(one).collect()),
+        Value::List(items) => Some(
+            items
+                .iter()
+                .map(|it| match it {
+                    Value::Property(p) => one(p),
+                    _ => None,
+                })
+                .collect(),
+        ),
+        _ => None,
+    }
+}
+
+fn string_list(v: &Value) -> Option<Vec<Option<String>>> {
+    let one = |p: &PropertyValue| match p {
+        PropertyValue::String(s) => Some(s.clone()),
+        PropertyValue::Null => None,
+        other => Some(other.to_cypher_string()),
+    };
+    match v {
+        Value::Null | Value::Property(PropertyValue::Null) => None,
+        Value::Property(PropertyValue::Array(items)) => Some(items.iter().map(one).collect()),
+        Value::List(items) => Some(
+            items
+                .iter()
+                .map(|it| match it {
+                    Value::Property(p) => one(p),
+                    Value::Null => None,
+                    other => Some(json_of(other).to_string()),
+                })
+                .collect(),
+        ),
+        _ => None,
+    }
+}
+
+/// The text an `Utf8` column holds for a value whose kind is `Str`.
+fn as_text(v: &Value) -> Option<String> {
+    match v {
+        Value::Null | Value::Property(PropertyValue::Null) => None,
+        Value::Property(PropertyValue::String(s)) => Some(s.clone()),
+        Value::Property(p) => Some(p.to_cypher_string()),
+        _ => None,
+    }
+}
+
+/// JSON for the fallback column, and for entities inside a list.
+fn json_of(v: &Value) -> serde_json::Value {
+    use serde_json::json;
+    match v {
+        Value::Null => serde_json::Value::Null,
+        Value::Property(p) => p.to_json(),
+        Value::List(items) => serde_json::Value::Array(items.iter().map(json_of).collect()),
+        Value::Map(entries) => serde_json::Value::Object(
+            entries.iter().map(|(k, v)| (k.clone(), json_of(v))).collect(),
+        ),
+        Value::Node(id, node) => json!({
+            "id": id.as_u64(),
+            "labels": node.labels.iter().map(|l| l.as_str().to_string()).collect::<Vec<_>>(),
+            "properties": node.properties.iter()
+                .map(|(k, v)| (k.clone(), v.to_json()))
+                .collect::<serde_json::Map<_, _>>(),
+        }),
+        Value::NodeRef(id) => json!({ "id": id.as_u64() }),
+        Value::Edge(id, edge) => json!({
+            "id": id.as_u64(),
+            "type": edge.edge_type.as_str(),
+            "source": edge.source.as_u64(),
+            "target": edge.target.as_u64(),
+        }),
+        Value::EdgeRef(id, src, tgt, ty) => json!({
+            "id": id.as_u64(), "type": ty.as_str(),
+            "source": src.as_u64(), "target": tgt.as_u64(),
+        }),
+        Value::Path { nodes, edges } => json!({
+            "nodes": nodes.iter().map(|n| n.as_u64()).collect::<Vec<_>>(),
+            "edges": edges.iter().map(|e| e.as_u64()).collect::<Vec<_>>(),
+        }),
+    }
+}
+
+fn build_column(kind: Kind, values: &[Option<&Value>]) -> (DataType, ArrayRef) {
+    match kind {
+        Kind::Null => (
+            DataType::Null,
+            Arc::new(NullArray::new(values.len())) as ArrayRef,
+        ),
+        Kind::Bool => {
+            let mut b = BooleanBuilder::with_capacity(values.len());
+            for v in values {
+                match v {
+                    Some(Value::Property(PropertyValue::Boolean(x))) => b.append_value(*x),
+                    _ => b.append_null(),
+                }
+            }
+            (DataType::Boolean, Arc::new(b.finish()) as ArrayRef)
+        }
+        Kind::Int => {
+            let mut b = Int64Builder::with_capacity(values.len());
+            for v in values {
+                match v {
+                    Some(Value::Property(PropertyValue::Integer(x))) => b.append_value(*x),
+                    _ => b.append_null(),
+                }
+            }
+            (DataType::Int64, Arc::new(b.finish()) as ArrayRef)
+        }
+        Kind::Float => {
+            let mut b = Float64Builder::with_capacity(values.len());
+            for v in values {
+                match v.and_then(|v| as_f64(v)) {
+                    Some(x) => b.append_value(x),
+                    None => b.append_null(),
+                }
+            }
+            (DataType::Float64, Arc::new(b.finish()) as ArrayRef)
+        }
+        Kind::Str => {
+            let mut b = StringBuilder::new();
+            for v in values {
+                match v.and_then(as_text) {
+                    Some(s) => b.append_value(s),
+                    None => b.append_null(),
+                }
+            }
+            (DataType::Utf8, Arc::new(b.finish()) as ArrayRef)
+        }
+        // A column whose lists are all empty has no element type to read off the
+        // data; `Float64` carries it, and every list in it is empty anyway.
+        Kind::ListFloat | Kind::ListEmpty => {
+            let mut b = ListBuilder::new(Float64Builder::new());
+            for v in values {
+                match v.and_then(float_list) {
+                    Some(items) => {
+                        for x in items {
+                            match x {
+                                Some(x) => b.values().append_value(x),
+                                None => b.values().append_null(),
+                            }
+                        }
+                        b.append(true);
+                    }
+                    None => b.append(false),
+                }
+            }
+            let arr = b.finish();
+            let dt = arrow::array::Array::data_type(&arr).clone();
+            (dt, Arc::new(arr) as ArrayRef)
+        }
+        Kind::ListInt => {
+            let mut b = ListBuilder::new(Int64Builder::new());
+            for v in values {
+                match v.and_then(int_list) {
+                    Some(items) => {
+                        for x in items {
+                            match x {
+                                Some(x) => b.values().append_value(x),
+                                None => b.values().append_null(),
+                            }
+                        }
+                        b.append(true);
+                    }
+                    None => b.append(false),
+                }
+            }
+            let arr = b.finish();
+            let dt = arrow::array::Array::data_type(&arr).clone();
+            (dt, Arc::new(arr) as ArrayRef)
+        }
+        Kind::ListStr => {
+            let mut b = ListBuilder::new(StringBuilder::new());
+            for v in values {
+                match v.and_then(string_list) {
+                    Some(items) => {
+                        for s in items {
+                            match s {
+                                Some(s) => b.values().append_value(s),
+                                None => b.values().append_null(),
+                            }
+                        }
+                        b.append(true);
+                    }
+                    None => b.append(false),
+                }
+            }
+            let arr = b.finish();
+            let dt = arrow::array::Array::data_type(&arr).clone();
+            (dt, Arc::new(arr) as ArrayRef)
+        }
+        Kind::Json => {
+            let mut b = StringBuilder::new();
+            for v in values {
+                match v {
+                    None | Some(Value::Null) | Some(Value::Property(PropertyValue::Null)) => {
+                        b.append_null()
+                    }
+                    Some(v) => b.append_value(json_of(v).to_string()),
+                }
+            }
+            (DataType::Utf8, Arc::new(b.finish()) as ArrayRef)
+        }
+    }
+}
+
+/// A query result as an Arrow record batch.
+///
+/// Column order is the result's own; a column the records never bound is all
+/// null, which is what a projection of a missing property means in Cypher.
+pub fn to_arrow(batch: &RecordBatch) -> Result<ArrowBatch, ExportError> {
+    let mut fields = Vec::with_capacity(batch.columns.len());
+    let mut arrays: Vec<ArrayRef> = Vec::with_capacity(batch.columns.len());
+
+    for name in &batch.columns {
+        let values: Vec<Option<&Value>> =
+            batch.records.iter().map(|r| r.get(name)).collect();
+        let kind = values
+            .iter()
+            .map(|v| v.map(kind_of).unwrap_or(Kind::Null))
+            .fold(Kind::Null, Kind::unify);
+        let (dt, arr) = build_column(kind, &values);
+        // Every column is nullable: a Cypher projection can always be null,
+        // and a non-nullable Arrow column that later meets one is a panic
+        // rather than a null.
+        fields.push(Field::new(name, dt, true));
+        arrays.push(arr);
+    }
+
+    let schema = Arc::new(Schema::new(fields));
+    // A result with columns but no rows is a real answer and must survive as an
+    // empty batch with the schema intact, which `try_new` alone cannot express.
+    if batch.records.is_empty() {
+        return Ok(ArrowBatch::new_empty(schema));
+    }
+    ArrowBatch::try_new(schema, arrays).map_err(|e| ExportError::Arrow(e.to_string()))
+}
+
+/// The Arrow IPC *stream* format — what a client reads incrementally.
+pub fn to_ipc(batch: &RecordBatch) -> Result<Vec<u8>, ExportError> {
+    let arrow_batch = to_arrow(batch)?;
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut writer = arrow::ipc::writer::StreamWriter::try_new(&mut buf, &arrow_batch.schema())
+            .map_err(|e| ExportError::Arrow(e.to_string()))?;
+        writer
+            .write(&arrow_batch)
+            .map_err(|e| ExportError::Arrow(e.to_string()))?;
+        writer
+            .finish()
+            .map_err(|e| ExportError::Arrow(e.to_string()))?;
+    }
+    Ok(buf)
+}
+
+/// The same batch as a Parquet file, Snappy-compressed.
+pub fn to_parquet(batch: &RecordBatch) -> Result<Vec<u8>, ExportError> {
+    use parquet::arrow::ArrowWriter;
+    use parquet::basic::Compression;
+    use parquet::file::properties::WriterProperties;
+
+    let arrow_batch = to_arrow(batch)?;
+    let props = WriterProperties::builder()
+        .set_compression(Compression::SNAPPY)
+        .build();
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut writer = ArrowWriter::try_new(&mut buf, arrow_batch.schema(), Some(props))
+            .map_err(|e| ExportError::Parquet(e.to_string()))?;
+        writer
+            .write(&arrow_batch)
+            .map_err(|e| ExportError::Parquet(e.to_string()))?;
+        writer
+            .close()
+            .map_err(|e| ExportError::Parquet(e.to_string()))?;
+    }
+    Ok(buf)
+}

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -24,6 +24,114 @@ fn default_graph() -> String {
     "default".to_string()
 }
 
+/// Request for exporting a query result as Arrow or Parquet (#1097).
+#[derive(Deserialize)]
+pub struct ExportRequest {
+    pub query: String,
+    #[serde(default = "default_graph")]
+    pub graph: String,
+    /// `arrow` (IPC stream) or `parquet`. Defaults to `arrow`, which is the
+    /// one that needs no intermediate file at either end.
+    #[serde(default = "default_export_format")]
+    pub format: String,
+}
+
+fn default_export_format() -> String {
+    "arrow".to_string()
+}
+
+/// `POST /api/query/export` — a read query's result as Arrow IPC or Parquet.
+///
+/// Read-only on purpose. A write whose result is streamed to a column store is
+/// a shape nobody asked for and one where a partially consumed stream leaves
+/// the caller unable to say whether the write happened; `/api/query` remains
+/// the way to write.
+///
+/// The column types are inferred from the values in the result — see
+/// [`crate::export`] for the table and for why temporal values leave as
+/// ISO-8601 text rather than as Arrow timestamps.
+pub async fn export_handler(
+    State(state): State<AppState>,
+    Json(payload): Json<ExportRequest>,
+) -> impl IntoResponse {
+    if payload.graph != default_graph() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": format!(
+                    "This build serves a single graph ('{}'); the requested graph '{}' does \
+                     not exist and the argument cannot be honoured.",
+                    default_graph(), payload.graph
+                ),
+            })),
+        )
+            .into_response();
+    }
+
+    let format = payload.format.to_lowercase();
+    if format != "arrow" && format != "parquet" {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": format!("unknown format '{}'; use 'arrow' or 'parquet'", payload.format),
+            })),
+        )
+            .into_response();
+    }
+
+    let batch = {
+        let store_guard = state.store.read().await;
+        state.engine.execute(&payload.query, &*store_guard)
+    };
+    let batch = match batch {
+        Ok(b) => b,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response()
+        }
+    };
+
+    let (bytes, content_type, filename) = if format == "parquet" {
+        match crate::export::to_parquet(&batch) {
+            Ok(b) => (b, "application/vnd.apache.parquet", "result.parquet"),
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": e.to_string() })),
+                )
+                    .into_response()
+            }
+        }
+    } else {
+        match crate::export::to_ipc(&batch) {
+            Ok(b) => (b, "application/vnd.apache.arrow.stream", "result.arrows"),
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": e.to_string() })),
+                )
+                    .into_response()
+            }
+        }
+    };
+
+    (
+        StatusCode::OK,
+        [
+            (axum::http::header::CONTENT_TYPE, content_type.to_string()),
+            (
+                axum::http::header::CONTENT_DISPOSITION,
+                format!("attachment; filename=\"{filename}\""),
+            ),
+        ],
+        bytes,
+    )
+        .into_response()
+}
+
 /// Response containing both graph data and raw tabular data
 #[derive(Serialize)]
 pub struct QueryResponse {

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -16,7 +16,7 @@ use tokio::sync::RwLock;
 use tower_http::cors::CorsLayer;
 use tracing::info;
 use super::handler::{
-    query_handler, status_handler, schema_handler, sample_handler,
+    query_handler, export_handler, status_handler, schema_handler, sample_handler,
     import_csv_handler, import_json_handler,
     export_snapshot_handler, restore_snapshot_handler,
     set_enrich_policy_handler, enrich_handler, verify_handler,
@@ -167,6 +167,7 @@ impl HttpServer {
         let main_router = Router::new()
             .route("/", get(static_handler))
             .route("/api/query", post(query_handler))
+            .route("/api/query/export", post(export_handler))
             .route("/api/enrich/policy", post(set_enrich_policy_handler))
             .route("/api/enrich", post(enrich_handler))
             .route("/api/verify", post(verify_handler))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@ pub mod index;
 pub mod sharding;
 pub mod http;
 pub mod embed;
+pub mod export;
 pub mod nlq;
 pub mod agent;
 pub mod snapshot;

--- a/tests/arrow_parquet_export.rs
+++ b/tests/arrow_parquet_export.rs
@@ -1,0 +1,256 @@
+//! A query result survives the trip out through Arrow and Parquet (#1097).
+//!
+//! Spec 09 sets the bar for this one: the round-trip has to cover **nulls,
+//! unicode, floats, nested lists and vectors** — the types that break
+//! exporters — and not merely ints and strings, which any exporter gets right.
+//!
+//! Both directions are read back with the Arrow and Parquet readers rather than
+//! inspected as bytes: a writer that produces a file nothing can open is the
+//! failure this is for, and a byte-length assertion cannot see it.
+
+use arrow::array::{Array, AsArray, BooleanArray, Float64Array, Int64Array, StringArray};
+use arrow::datatypes::{DataType, Float64Type, Int64Type};
+use samyama::export::{to_arrow, to_ipc, to_parquet};
+use samyama::graph::{GraphStore, PropertyValue};
+use samyama::query::executor::{MutQueryExecutor, QueryExecutor, RecordBatch};
+use samyama::query::parser::parse_query;
+
+fn run(store: &mut GraphStore, cypher: &str) {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    MutQueryExecutor::new(store, "default".to_string())
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"));
+}
+
+fn query(store: &GraphStore, cypher: &str) -> RecordBatch {
+    let q = parse_query(cypher).unwrap_or_else(|e| panic!("`{cypher}` should parse: {e}"));
+    QueryExecutor::new(store)
+        .execute(&q)
+        .unwrap_or_else(|e| panic!("`{cypher}` should run: {e}"))
+}
+
+/// Three rows, and every awkward type in one place.
+///
+/// The middle row omits `score`, `tags` and `embedding` entirely, which is how
+/// a null reaches a column in Cypher — there is no stored null.
+fn fixture() -> GraphStore {
+    let mut store = GraphStore::new();
+    run(
+        &mut store,
+        r#"CREATE (:Doc {ord: 1, title: "café — naïve 日本語 🌏", score: 1.5,
+                         live: true, tags: ["a", "b"], counts: [1, 2, 3]})"#,
+    );
+    run(&mut store, r#"CREATE (:Doc {ord: 2, title: "plain", live: false})"#);
+    run(
+        &mut store,
+        r#"CREATE (:Doc {ord: 3, title: "", score: -0.25,
+                         live: true, tags: [], counts: [7]})"#,
+    );
+    // A vector is set through the API: a list literal stays a list in Cypher.
+    //
+    // Selected by `ord`, not by position in a label scan. The scan's order is
+    // not defined, so "skip the second one" would have skipped whichever node
+    // the scan happened to yield second and moved the null to a different row
+    // between runs.
+    let targets: Vec<_> = store
+        .get_nodes_by_label(&samyama::graph::types::Label::new("Doc"))
+        .iter()
+        .filter(|n| {
+            !matches!(n.get_property("ord"), Some(PropertyValue::Integer(2)))
+        })
+        .map(|n| n.id)
+        .collect();
+    assert_eq!(targets.len(), 2, "two of the three rows get an embedding");
+    for id in targets {
+        store
+            .set_node_property(
+                "default",
+                id,
+                "embedding".to_string(),
+                PropertyValue::Vector(vec![0.5, -1.5, 2.0]),
+            )
+            .expect("set embedding");
+    }
+    store
+}
+
+const Q: &str = "MATCH (d:Doc) RETURN d.ord AS ord, d.title AS title, d.score AS score, \
+                 d.live AS live, d.tags AS tags, d.counts AS counts, \
+                 d.embedding AS embedding ORDER BY ord";
+
+#[test]
+fn every_column_gets_the_type_its_values_need() {
+    let store = fixture();
+    let batch = to_arrow(&query(&store, Q)).expect("export");
+
+    assert_eq!(batch.num_rows(), 3);
+    let f = |name: &str| batch.schema().field_with_name(name).unwrap().data_type().clone();
+
+    assert_eq!(f("ord"), DataType::Int64, "whole numbers stay integers");
+    assert_eq!(f("title"), DataType::Utf8);
+    // 1.5 and -0.25 with a null between them: still a float column.
+    assert_eq!(f("score"), DataType::Float64);
+    assert_eq!(f("live"), DataType::Boolean);
+    assert!(matches!(f("tags"), DataType::List(_)), "a list of strings is a list");
+    match f("counts") {
+        DataType::List(field) => assert_eq!(
+            field.data_type(),
+            &DataType::Int64,
+            "a list of whole numbers stays a list of integers — an id list turning \
+             into floats is a small wrongness a downstream join would feel"
+        ),
+        other => panic!("counts should be a list, got {other:?}"),
+    }
+    assert!(matches!(f("embedding"), DataType::List(_)), "a vector is a list of floats");
+
+    // Every column is nullable, because a Cypher projection always can be.
+    for field in batch.schema().fields() {
+        assert!(field.is_nullable(), "{} should be nullable", field.name());
+    }
+}
+
+#[test]
+fn the_values_survive_including_the_awkward_ones() {
+    let store = fixture();
+    let batch = to_arrow(&query(&store, Q)).expect("export");
+
+    let ord = batch.column_by_name("ord").unwrap()
+        .as_any().downcast_ref::<Int64Array>().unwrap();
+    assert_eq!(ord.values(), &[1, 2, 3]);
+
+    let title = batch.column_by_name("title").unwrap()
+        .as_any().downcast_ref::<StringArray>().unwrap();
+    assert_eq!(title.value(0), "café — naïve 日本語 🌏", "unicode survives byte-for-byte");
+    assert_eq!(title.value(2), "", "an empty string is not a null");
+    assert!(!title.is_null(2));
+
+    let score = batch.column_by_name("score").unwrap()
+        .as_any().downcast_ref::<Float64Array>().unwrap();
+    assert_eq!(score.value(0), 1.5);
+    assert!(score.is_null(1), "the row that never set `score` is null, not 0.0");
+    assert_eq!(score.value(2), -0.25);
+
+    let live = batch.column_by_name("live").unwrap()
+        .as_any().downcast_ref::<BooleanArray>().unwrap();
+    assert!(live.value(0) && !live.value(1) && live.value(2));
+
+    let counts = batch.column_by_name("counts").unwrap().as_list::<i32>();
+    assert!(counts.is_null(1), "an absent list is null, not an empty list");
+    let first: Vec<i64> = counts.value(0).as_primitive::<Int64Type>().values().to_vec();
+    assert_eq!(first, vec![1, 2, 3], "a list of integers stays integers");
+
+    let tags = batch.column_by_name("tags").unwrap().as_list::<i32>();
+    assert_eq!(tags.value(0).len(), 2);
+    assert_eq!(
+        tags.value(2).len(),
+        0,
+        "an empty list is an empty list, distinct from the null on row 2"
+    );
+    assert!(!tags.is_null(2));
+
+    let emb = batch.column_by_name("embedding").unwrap().as_list::<i32>();
+    let v: Vec<f64> = emb.value(0).as_primitive::<Float64Type>().values().to_vec();
+    assert_eq!(v, vec![0.5, -1.5, 2.0], "a vector keeps its values and its order");
+    assert!(emb.is_null(1));
+}
+
+#[test]
+fn parquet_reads_back_as_what_was_written() {
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+    let store = fixture();
+    let source = query(&store, Q);
+    let written = to_arrow(&source).expect("arrow");
+    let bytes = to_parquet(&source).expect("parquet");
+
+    let reader = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(bytes))
+        .expect("the file opens")
+        .build()
+        .expect("reader");
+    let back: Vec<_> = reader.map(|b| b.expect("batch")).collect();
+    assert_eq!(back.len(), 1, "one batch for three rows");
+    let back = &back[0];
+
+    assert_eq!(back.num_rows(), written.num_rows());
+    assert_eq!(back.schema().fields().len(), written.schema().fields().len());
+    let back_schema = back.schema();
+    for field in written.schema().fields() {
+        let there = back_schema
+            .field_with_name(field.name())
+            .expect("column survives");
+        assert_eq!(there.data_type(), field.data_type(), "{} type", field.name());
+    }
+    let title = back.column_by_name("title").unwrap()
+        .as_any().downcast_ref::<StringArray>().unwrap();
+    assert_eq!(title.value(0), "café — naïve 日本語 🌏");
+    let score = back.column_by_name("score").unwrap()
+        .as_any().downcast_ref::<Float64Array>().unwrap();
+    assert!(score.is_null(1));
+}
+
+#[test]
+fn the_arrow_stream_reads_back_as_what_was_written() {
+    let store = fixture();
+    let source = query(&store, Q);
+    let bytes = to_ipc(&source).expect("ipc");
+
+    let reader = arrow::ipc::reader::StreamReader::try_new(std::io::Cursor::new(bytes), None)
+        .expect("the stream opens");
+    let back: Vec<_> = reader.map(|b| b.expect("batch")).collect();
+    assert_eq!(back.len(), 1);
+    let back = &back[0];
+    assert_eq!(back.num_rows(), 3);
+
+    let emb = back.column_by_name("embedding").unwrap().as_list::<i32>();
+    let v: Vec<f64> = emb.value(0).as_primitive::<Float64Type>().values().to_vec();
+    assert_eq!(v, vec![0.5, -1.5, 2.0]);
+}
+
+#[test]
+fn a_mixed_column_falls_back_to_json_rather_than_guessing() {
+    let mut store = GraphStore::new();
+    run(&mut store, r#"CREATE (:M {ord: 1, v: 7})"#);
+    run(&mut store, r#"CREATE (:M {ord: 2, v: "seven"})"#);
+    let batch = to_arrow(&query(
+        &store,
+        "MATCH (m:M) RETURN m.ord AS ord, m.v AS v ORDER BY ord",
+    ))
+    .expect("export");
+
+    assert_eq!(
+        batch.schema().field_with_name("v").unwrap().data_type(),
+        &DataType::Utf8,
+        "an integer and a string in one column cannot be Int64 or Utf8-as-text"
+    );
+    let v = batch.column_by_name("v").unwrap()
+        .as_any().downcast_ref::<StringArray>().unwrap();
+    assert_eq!(v.value(0), "7", "JSON, so the integer is not quoted");
+    assert_eq!(v.value(1), "\"seven\"", "and the string is");
+}
+
+#[test]
+fn an_entity_column_becomes_json_and_says_what_it_is() {
+    let mut store = GraphStore::new();
+    run(&mut store, r#"CREATE (:P {name: "Ada"})"#);
+    let batch = to_arrow(&query(&store, "MATCH (p:P) RETURN p")).expect("export");
+
+    let col = batch.column_by_name("p").unwrap()
+        .as_any().downcast_ref::<StringArray>().unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(col.value(0)).expect("valid JSON");
+    assert_eq!(parsed["labels"][0], "P");
+    assert_eq!(parsed["properties"]["name"], "Ada");
+}
+
+#[test]
+fn an_empty_result_keeps_its_schema() {
+    let store = fixture();
+    let batch = to_arrow(&query(&store, "MATCH (d:Doc) WHERE d.ord > 99 RETURN d.ord AS ord"))
+        .expect("export");
+    assert_eq!(batch.num_rows(), 0);
+    assert_eq!(batch.schema().fields().len(), 1, "no rows is not no columns");
+    // And it still writes: a reader that gets zero bytes cannot tell an empty
+    // answer from a failed one.
+    assert!(!to_parquet(&query(&store, "MATCH (d:Doc) WHERE d.ord > 99 RETURN d.ord AS ord"))
+        .expect("parquet")
+        .is_empty());
+}

--- a/tests/integration/test_arrow_export.py
+++ b/tests/integration/test_arrow_export.py
@@ -1,0 +1,100 @@
+"""The Parquet and Arrow export, read in pandas, against the same query's JSON.
+
+The Rust suite (`tests/arrow_parquet_export.rs`) checks the writer with Arrow's
+own readers. This checks the half that one cannot: that **pandas** opens what we
+write and gets the same values back. Spec 09 asks for exactly that — "read in
+pandas/polars, compare against the direct query result" — and a round-trip that
+only Arrow can read would satisfy the letter of it and none of the point.
+
+Needs a running server and `pip install pandas pyarrow`:
+
+    cargo run --release -- --ephemeral --http-port 8080 &
+    python3 tests/integration/test_arrow_export.py
+
+Set `SAMYAMA_HTTP` to point at another host. Exits non-zero on any mismatch.
+"""
+import io, json, os, sys, urllib.request, uuid
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+BASE = os.environ.get("SAMYAMA_HTTP", "http://localhost:8080")
+# A label of its own per run, so the fixture is three rows whether or not the
+# server has been used before. Re-running against a live graph should not make
+# the answer depend on how many times this has been run.
+LABEL = "ArrowExportProbe" + uuid.uuid4().hex[:8]
+Q = (f"MATCH (d:{LABEL}) RETURN d.ord AS ord, d.title AS title, d.score AS score, "
+     "d.live AS live, d.tags AS tags, d.counts AS counts ORDER BY ord")
+
+
+def post(path, body, raw=False):
+    req = urllib.request.Request(
+        BASE + path, data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req) as r:
+        return r.read() if raw else json.loads(r.read())
+
+
+for c in [
+    f'CREATE (:{LABEL} {{ord: 1, title: "café — naïve 日本語 🌏", score: 1.5, live: true, '
+    'tags: ["a", "b"], counts: [1, 2, 3]})',
+    f'CREATE (:{LABEL} {{ord: 2, title: "plain", live: false}})',
+    f'CREATE (:{LABEL} {{ord: 3, title: "", score: -0.25, live: true, tags: [], '
+    'counts: [7]})',
+]:
+    post("/api/query", {"graph": "default", "query": c})
+
+js = post("/api/query", {"graph": "default", "query": Q})
+cols = js["columns"]
+rows = js["records"]
+
+pqt = pq.read_table(pa.BufferReader(
+    post("/api/query/export", {"graph": "default", "query": Q, "format": "parquet"}, raw=True)))
+ipc = pa.ipc.open_stream(io.BytesIO(
+    post("/api/query/export", {"graph": "default", "query": Q, "format": "arrow"}, raw=True))
+).read_all()
+
+df = pqt.to_pandas()
+print("pandas dtypes:")
+print(df.dtypes.to_string())
+print()
+print(df.to_string())
+print()
+
+fail = []
+if list(pqt.column_names) != cols:
+    fail.append(f"columns {pqt.column_names} != {cols}")
+if pqt.num_rows != 3:
+    fail.append(f"{pqt.num_rows} rows, expected the 3 this run created")
+if pqt.num_rows != len(rows):
+    fail.append(f"{pqt.num_rows} parquet rows != {len(rows)} json rows")
+if not pqt.equals(ipc):
+    fail.append("the parquet and arrow-stream tables differ")
+
+def norm(v):
+    if v is None or (isinstance(v, float) and v != v):
+        return None
+    if hasattr(v, "tolist"):
+        v = v.tolist()
+    if isinstance(v, list):
+        return [norm(x) for x in v]
+    if isinstance(v, float) and v.is_integer():
+        return v
+    return v
+
+for i, row in enumerate(rows):
+    for j, col in enumerate(cols):
+        want, got = norm(row[j]), norm(df.iloc[i][col])
+        # JSON has no int/float distinction to preserve; compare numerically.
+        if isinstance(want, (int, float)) and isinstance(got, (int, float)):
+            same = float(want) == float(got)
+        else:
+            same = want == got
+        if not same:
+            fail.append(f"row {i} col {col}: json {want!r} != parquet {got!r}")
+
+print("FAIL:" if fail else "PASS — parquet and arrow match the JSON result on every cell")
+for f in fail:
+    print(" ", f)
+sys.exit(1 if fail else 0)


### PR DESCRIPTION
Closes the export half of #1097. INT-05 and ML-01 both read "partial" on the strength of a read-only Parquet example in the enterprise repo; there was **no Arrow or Parquet dependency in samyama-graph at all**.

## The endpoint

```bash
curl -X POST http://localhost:8080/api/query/export \
  -H 'content-type: application/json' \
  -d '{"query":"MATCH (d:Doc) RETURN d.id, d.title, d.embedding","format":"parquet"}' \
  -o result.parquet
```

`format` is `arrow` (IPC stream, the default) or `parquet`. **Read-only on purpose**: a write whose result is streamed to a column store leaves a caller who consumed half the stream unable to say whether the write happened. `/api/query` remains the way to write.

## Column types come from the values

| values in the column | Arrow type |
|---|---|
| booleans | `Boolean` |
| integers | `Int64` |
| integers and floats | `Float64` |
| strings | `Utf8` |
| lists of integers | `List<Int64>` |
| vectors, or lists with any fractional number | `List<Float64>` |
| lists of strings | `List<Utf8>` |
| anything else, or a mix | `Utf8` holding JSON |

Every column is nullable, because a Cypher projection always can be.

## Two decisions worth stating rather than discovering

**Temporal values leave as ISO-8601 text, not as Arrow timestamps.** Arrow carries one time zone per *column*; Cypher carries one per *value*, and a `ZonedDateTime` may hold a named IANA zone that an offset cannot reconstruct across a DST boundary. Mapping the five temporal types onto `Timestamp` would drop that silently for exactly the values where it matters. Text round-trips, and `pandas.to_datetime` reads it.

**An empty list does not force a column to JSON.** `[]` beside `["a"]` is a string-list column with an empty list in it — a first pass got this wrong and turned the whole column into JSON. And a list of whole numbers stays `List<Int64>`: an id list arriving as `[1.0, 2.0]` is a small wrongness a downstream join would feel.

Nodes, relationships, paths and maps become JSON text. Arrow has no type for them, and a flattening invented here would mean something different for every query that wrote one.

## Tested in both directions

`tests/arrow_parquet_export.rs` — 7 tests, checking the writer with Arrow's and Parquet's **own readers** rather than by inspecting bytes, because a file nothing can open is the failure this is for. Covers spec 09's stated bar (nulls, unicode, floats, nested lists, vectors) plus an empty result keeping its schema, a mixed column falling back to JSON, and an entity column parsing as JSON.

`tests/integration/test_arrow_export.py` — the half those cannot check: that **pandas** opens what we write and agrees with the JSON API, cell by cell.

```
pandas 3.0.5 / pyarrow 25.0.1

   ord               title  score   live    tags     counts
0    1  café — naïve 日本語 🌏   1.50   True  [a, b]  [1, 2, 3]
1    2               plain    NaN  False    None       None
2    3                      -0.25   True      []        [7]

PASS — parquet and arrow match the JSON result on every cell
```

Note row 1: the property was never set, and it is `NaN`/`None`, not `0.0`/`[]`. Row 2's `tags` is an empty list and stays distinguishable from the null above it.

Release lib suite **2184 passed, 0 failed**; `cargo check --workspace --tests` clean.

## Still open on #1097

The Python SDK helper that hands back a `pyarrow.Table` without going through HTTP. The SDK is a PyO3 extension, so that is a C-data-interface change and a wheel rebuild rather than a few lines here.

`arrow`/`parquet` are pinned at **53**, the version samyama-graph-enterprise already vets and ships, so this adds no new licence surface — both Apache-2.0. Default features are off; only `ipc`, `arrow`, `snap` and `zstd` are enabled.

https://claude.ai/code/session_01LfRydo2qAUMYWL44vVfUbV