### PR TITLE
Parquet import back into nodes, so INT-05's round-trip is real (#1098)

### DIFF
--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -475,3 +475,137 @@ pub fn to_parquet(batch: &RecordBatch) -> Result<Vec<u8>, ExportError> {
     }
     Ok(buf)
 }
+
+/// Reading Parquet back in.
+///
+/// Deliberately the node direction only. Edges need identity resolution — a
+/// `source` column names *something*, and which property it names is a decision
+/// the file cannot make — and guessing it here would produce an importer whose
+/// meaning depends on which exporter wrote the file. `LOAD PARQUET` (#1098) is
+/// where that belongs, with the mapping written in the query.
+pub mod import {
+    use std::collections::HashMap;
+
+    use arrow::array::{Array, AsArray};
+    use arrow::datatypes::{DataType, Float64Type, Int64Type};
+
+    use crate::graph::{GraphStore, PropertyValue};
+
+    use super::ExportError;
+
+    /// What an import did, for the caller to check against what it sent.
+    #[derive(Debug, Default, serde::Serialize)]
+    pub struct ImportStats {
+        pub nodes_created: usize,
+        pub columns: Vec<String>,
+        /// Columns whose Arrow type has no `PropertyValue` and were skipped.
+        /// Named rather than dropped: a column that silently does not arrive is
+        /// the failure an importer is least able to notice.
+        pub skipped_columns: Vec<String>,
+    }
+
+    fn cell(col: &dyn Array, row: usize) -> Option<PropertyValue> {
+        if col.is_null(row) {
+            return None;
+        }
+        Some(match col.data_type() {
+            DataType::Boolean => PropertyValue::Boolean(col.as_boolean().value(row)),
+            DataType::Int64 => PropertyValue::Integer(col.as_primitive::<Int64Type>().value(row)),
+            DataType::Float64 => PropertyValue::Float(col.as_primitive::<Float64Type>().value(row)),
+            DataType::Utf8 => PropertyValue::String(col.as_string::<i32>().value(row).to_string()),
+            DataType::LargeUtf8 => {
+                PropertyValue::String(col.as_string::<i64>().value(row).to_string())
+            }
+            DataType::List(field) => {
+                let items = col.as_list::<i32>().value(row);
+                match field.data_type() {
+                    DataType::Int64 => PropertyValue::Array(
+                        items
+                            .as_primitive::<Int64Type>()
+                            .iter()
+                            .map(|v| v.map_or(PropertyValue::Null, PropertyValue::Integer))
+                            .collect(),
+                    ),
+                    DataType::Float64 => PropertyValue::Array(
+                        items
+                            .as_primitive::<Float64Type>()
+                            .iter()
+                            .map(|v| v.map_or(PropertyValue::Null, PropertyValue::Float))
+                            .collect(),
+                    ),
+                    DataType::Utf8 => PropertyValue::Array(
+                        items
+                            .as_string::<i32>()
+                            .iter()
+                            .map(|v| {
+                                v.map_or(PropertyValue::Null, |s| {
+                                    PropertyValue::String(s.to_string())
+                                })
+                            })
+                            .collect(),
+                    ),
+                    _ => return None,
+                }
+            }
+            _ => return None,
+        })
+    }
+
+    /// Create one node per row, with the file's columns as its properties.
+    ///
+    /// A null cell sets no property at all, which is what a null means in
+    /// Cypher — there is no stored null — and is what makes the round-trip with
+    /// [`super::to_parquet`] exact rather than approximate.
+    pub fn parquet_to_nodes(
+        store: &mut GraphStore,
+        tenant: &str,
+        label: &str,
+        bytes: Vec<u8>,
+    ) -> Result<ImportStats, ExportError> {
+        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+        let reader = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(bytes))
+            .map_err(|e| ExportError::Parquet(e.to_string()))?
+            .build()
+            .map_err(|e| ExportError::Parquet(e.to_string()))?;
+
+        let mut stats = ImportStats::default();
+        let mut skipped: HashMap<String, ()> = HashMap::new();
+
+        for batch in reader {
+            let batch = batch.map_err(|e| ExportError::Parquet(e.to_string()))?;
+            if stats.columns.is_empty() {
+                stats.columns = batch
+                    .schema()
+                    .fields()
+                    .iter()
+                    .map(|f| f.name().clone())
+                    .collect();
+            }
+            for row in 0..batch.num_rows() {
+                let id = store.create_node(label);
+                for (i, field) in batch.schema().fields().iter().enumerate() {
+                    let col = batch.column(i);
+                    match cell(col.as_ref(), row) {
+                        Some(v) => {
+                            store
+                                .set_node_property(tenant, id, field.name().clone(), v)
+                                .map_err(|e| ExportError::Parquet(e.to_string()))?;
+                        }
+                        None if col.is_null(row) => {}
+                        None => {
+                            skipped.insert(field.name().clone(), ());
+                        }
+                    }
+                }
+                stats.nodes_created += 1;
+            }
+        }
+        stats.skipped_columns = {
+            let mut v: Vec<String> = skipped.into_keys().collect();
+            v.sort();
+            v
+        };
+        Ok(stats)
+    }
+}

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -132,6 +132,90 @@ pub async fn export_handler(
         .into_response()
 }
 
+/// Query parameters for `POST /api/import/parquet`.
+#[derive(Deserialize)]
+pub struct ParquetImportParams {
+    /// The label every created node gets. Required: a Parquet file carries a
+    /// schema, not a label, and inventing one from the filename would make the
+    /// import depend on what the file was called.
+    pub label: String,
+    #[serde(default = "default_graph")]
+    pub graph: String,
+}
+
+/// `POST /api/import/parquet?label=Doc` — one node per row, columns as
+/// properties (#1098, the bulk-load half).
+///
+/// The node direction only. Edges need identity resolution — a `source` column
+/// names *something*, and which property it names is a decision the file cannot
+/// make — so guessing it here would produce an importer whose meaning depends
+/// on which exporter wrote the file. That belongs in `LOAD PARQUET`, where the
+/// mapping is written in the query.
+pub async fn import_parquet_handler(
+    State(state): State<AppState>,
+    Query(params): Query<ParquetImportParams>,
+    mut multipart: Multipart,
+) -> impl IntoResponse {
+    if params.graph != default_graph() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": format!(
+                    "This build serves a single graph ('{}'); '{}' does not exist.",
+                    default_graph(), params.graph
+                ),
+            })),
+        )
+            .into_response();
+    }
+    if params.label.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "label must not be empty" })),
+        )
+            .into_response();
+    }
+
+    let mut data: Option<Vec<u8>> = None;
+    while let Ok(Some(field)) = multipart.next_field().await {
+        if field.name().unwrap_or("") == "file" {
+            match field.bytes().await {
+                Ok(b) => data = Some(b.to_vec()),
+                Err(e) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(json!({ "error": format!("could not read the file: {e}") })),
+                    )
+                        .into_response()
+                }
+            }
+        }
+    }
+    let Some(data) = data else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "no `file` field in the multipart request" })),
+        )
+            .into_response();
+    };
+
+    let mut store_guard = state.store.write().await;
+    match crate::export::import::parquet_to_nodes(
+        &mut store_guard,
+        &params.graph,
+        &params.label,
+        data,
+    ) {
+        Ok(stats) => (StatusCode::OK, Json(json!({ "status": "ok", "stats": stats })))
+            .into_response(),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
 /// Response containing both graph data and raw tabular data
 #[derive(Serialize)]
 pub struct QueryResponse {

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -16,7 +16,7 @@ use tokio::sync::RwLock;
 use tower_http::cors::CorsLayer;
 use tracing::info;
 use super::handler::{
-    query_handler, export_handler, status_handler, schema_handler, sample_handler,
+    query_handler, export_handler, import_parquet_handler, status_handler, schema_handler, sample_handler,
     import_csv_handler, import_json_handler,
     export_snapshot_handler, restore_snapshot_handler,
     set_enrich_policy_handler, enrich_handler, verify_handler,
@@ -168,6 +168,7 @@ impl HttpServer {
             .route("/", get(static_handler))
             .route("/api/query", post(query_handler))
             .route("/api/query/export", post(export_handler))
+            .route("/api/import/parquet", post(import_parquet_handler))
             .route("/api/enrich/policy", post(set_enrich_policy_handler))
             .route("/api/enrich", post(enrich_handler))
             .route("/api/verify", post(verify_handler))

--- a/tests/arrow_parquet_export.rs
+++ b/tests/arrow_parquet_export.rs
@@ -254,3 +254,91 @@ fn an_empty_result_keeps_its_schema() {
         .expect("parquet")
         .is_empty());
 }
+
+/// Export and import are the same shape: what goes out comes back (#1098).
+///
+/// This is the claim INT-05 actually makes — *round-trip* tested — and it is the
+/// one an export alone cannot support. Every value is compared through a second
+/// export of the re-imported nodes, so the comparison is between two things the
+/// engine produced from the same data rather than between the engine and a
+/// hand-written expectation that could be wrong in the same direction.
+#[test]
+fn parquet_round_trips_back_into_nodes() {
+    use samyama::export::import::parquet_to_nodes;
+
+    let store = fixture();
+    let out = to_parquet(&query(&store, Q)).expect("export");
+
+    let mut fresh = GraphStore::new();
+    let stats = parquet_to_nodes(&mut fresh, "default", "Round", out.clone()).expect("import");
+    assert_eq!(stats.nodes_created, 3);
+    assert!(
+        stats.skipped_columns.is_empty(),
+        "nothing we wrote should be unreadable on the way back: {:?}",
+        stats.skipped_columns
+    );
+
+    let back = to_arrow(&query(
+        &fresh,
+        "MATCH (r:Round) RETURN r.ord AS ord, r.title AS title, r.score AS score, \
+         r.live AS live, r.tags AS tags, r.counts AS counts, r.embedding AS embedding \
+         ORDER BY ord",
+    ))
+    .expect("re-export");
+    let there = to_arrow(&query(&store, Q)).expect("first export");
+
+    assert_eq!(back.num_rows(), there.num_rows());
+    let back_schema = back.schema();
+    for field in there.schema().fields() {
+        let mirrored = back_schema
+            .field_with_name(field.name())
+            .unwrap_or_else(|_| panic!("{} survives the round trip", field.name()));
+        assert_eq!(
+            mirrored.data_type(),
+            field.data_type(),
+            "{} keeps its type",
+            field.name()
+        );
+        assert_eq!(
+            back.column_by_name(field.name()).unwrap().as_ref(),
+            there.column_by_name(field.name()).unwrap().as_ref(),
+            "{} keeps its values",
+            field.name()
+        );
+    }
+}
+
+/// A null cell sets no property, rather than a property set to null.
+///
+/// Cypher has no stored null, so "the column was null" and "the node has no
+/// such key" have to be the same state on the way back in — otherwise
+/// `keys(n)` and `properties(n)` report a key nobody set.
+#[test]
+fn a_null_cell_creates_no_property() {
+    use samyama::export::import::parquet_to_nodes;
+
+    let store = fixture();
+    let out = to_parquet(&query(&store, Q)).expect("export");
+    let mut fresh = GraphStore::new();
+    parquet_to_nodes(&mut fresh, "default", "Round", out).expect("import");
+
+    let batch = query(
+        &fresh,
+        "MATCH (r:Round) WHERE r.ord = 2 RETURN size(keys(r)) AS n, r.score AS score",
+    );
+    let rec = &batch.records[0];
+    assert!(
+        matches!(
+            rec.get("score"),
+            None | Some(samyama::query::executor::Value::Null)
+                | Some(samyama::query::executor::Value::Property(PropertyValue::Null))
+        ),
+        "the row that never had a score still has none"
+    );
+    match rec.get("n") {
+        Some(samyama::query::executor::Value::Property(PropertyValue::Integer(n))) => {
+            assert_eq!(*n, 3, "ord, title and live — not the three nulls beside them")
+        }
+        other => panic!("expected a count, got {other:?}"),
+    }
+}


### PR DESCRIPTION
The export half (#1101) made INT-05 half true: a file goes out and nothing can read it back in, so "round-trip tested" was still unsupportable. This adds the ingest side for the node case.

`POST /api/import/parquet?label=Doc` creates one node per row with the file's columns as its properties.

**A null cell sets no property**, rather than a property set to null. Cypher has no stored null, so "the column was null" and "the node has no such key" have to be the same state on the way back in — otherwise `keys(n)` reports a key nobody set, and the round-trip stops being one.

**Nodes only, deliberately.** Edges need identity resolution: a `source` column names *something*, and which property it names is a decision the file cannot make. Guessing here would produce an importer whose meaning depends on which exporter wrote the file. That belongs in `LOAD PARQUET`, where the mapping is written in the query — #1098 stays open for it.

**A column whose Arrow type has no `PropertyValue` is named in the response** rather than dropped. A column that silently does not arrive is the failure an importer is least able to notice.

### Testing

`parquet_round_trips_back_into_nodes` re-exports the re-imported nodes and compares that against the first export — column type and values — so both sides are things the engine produced from the same data, rather than a hand-written expectation that could be wrong in the same direction as the code.

I checked the test can fail: perturbing the float reader by 1e-4 fails it on `score keeps its values`. (Reverted; `grep -c 0.0001 src/export/mod.rs` is 0.)

9 tests in `tests/arrow_parquet_export.rs`, all green in release.

### What this does not close

INT-05 stays 🔵, not 🟢 — the round-trip is real for nodes and absent for edges. #1098 (`LOAD PARQUET`) and #1099 (`.sgsnap` v3) are unaffected.

https://claude.ai/code/session_01QoSJsxd4ZBEU21XjaMbsVL
