### PR TITLE
Persist what a write changed, not what it returned (#1094)

### DIFF
--- a/examples/import_invariants.rs
+++ b/examples/import_invariants.rs
@@ -29,6 +29,7 @@ use samyama::graph::{GraphStore, PropertyValue};
 use samyama::query::executor::{MutQueryExecutor, QueryExecutor, Value};
 use samyama::query::parser::parse_query;
 use samyama::snapshot::{export_tenant, import_tenant};
+use samyama::persistence::PersistenceManager;
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
 
@@ -172,10 +173,48 @@ fn main() {
         let _ = s.create_edge(a, b, "KNOWS").unwrap();
     }
 
+    // ---- Path 4: written by Cypher with persistence on, then recovered the way
+    // a restart recovers -- `PersistenceManager::recover` into a fresh store.
+    //
+    // The three paths above all live in one process, so between them they could
+    // not see a write that reaches memory and never reaches disk. That is the
+    // half of REL-06 the requirement actually names ("visible before restart is
+    // visible after"), and it is where #1094 was: writes over HTTP returned 200
+    // and were gone on the next start.
+    let restart_dir = tempfile::tempdir().expect("tempdir");
+    let mut restart_store = GraphStore::new();
+    {
+        let pm = PersistenceManager::new(restart_dir.path()).expect("persistence");
+        pm.tenants()
+            .create_tenant("default".to_string(), "default".to_string(), None)
+            .ok();
+
+        let mut live = GraphStore::new();
+        live.enable_write_log();
+        // One statement at a time, as a client issues them: a per-statement
+        // journal that only works when the whole build arrives at once would
+        // pass here and fail for every real caller.
+        for stmt in CYPHER_BUILD.split(';').map(str::trim).filter(|s| !s.is_empty()) {
+            write(&mut live, stmt);
+            let muts = live.take_write_log();
+            pm.apply_mutations("default", &live, &muts).expect("persist");
+        }
+        pm.checkpoint().expect("checkpoint");
+
+        let (nodes, edges) = pm.recover("default").expect("recover");
+        for node in nodes {
+            restart_store.insert_recovered_node(node);
+        }
+        for edge in edges {
+            restart_store.insert_recovered_edge(edge).expect("recovered edge");
+        }
+    }
+
     let built = vec![
         Built { name: "cypher", store: cypher_store },
         Built { name: "snapshot", store: snapshot_store },
         Built { name: "store_api", store: api_store },
+        Built { name: "restart", store: restart_store },
     ];
 
     // The Cypher-built graph is the reference: it is the path a user exercises
@@ -219,7 +258,7 @@ fn main() {
 
     println!("CH-IMPORT — cross-path import invariants");
     println!("{}", "=".repeat(78));
-    println!("paths: cypher (reference), snapshot, store_api");
+    println!("paths: cypher (reference), snapshot, store_api, restart");
     println!("{:<26} {:<12} {}", "probe", "path", "agrees");
     println!("{}", "-".repeat(78));
     for (probe, path, agrees, expected, got) in &results {
@@ -263,7 +302,7 @@ fn main() {
   \"requirement_ids\": [\"LANG-15\", \"REL-06\"],
   \"run_id\": \"import-{commit}\",
   \"engine\": {{\"name\": \"samyama\", \"version\": \"{}\", \"commit\": \"{commit}\"}},
-  \"dataset\": {{\"name\": \"synthetic-fixture\", \"paths\": [\"cypher\", \"snapshot\", \"store_api\"]}},
+  \"dataset\": {{\"name\": \"synthetic-fixture\", \"paths\": [\"cypher\", \"snapshot\", \"store_api\", \"restart\"]}},
   \"measurements\": {{\"agreed\": {agreed}, \"total\": {total}, \"canary_detected\": {canary_detected}, \"cases\": [
       {cases}
   ]}},

--- a/src/graph/event.rs
+++ b/src/graph/event.rs
@@ -34,3 +34,20 @@ pub enum IndexEvent {
         properties: PropertyMap,
     },
 }
+
+/// A change to the graph, recorded so that durability does not depend on what a
+/// query happened to `RETURN` (#1094).
+///
+/// Only the id is carried. The payload is read back from the store when the
+/// mutation is applied, so a node written and then updated twice in one statement
+/// costs three entries and one read of the final state, and no clone of the
+/// properties along the way. An `Upserted` id that no longer exists at apply time
+/// was deleted later in the same statement; the `Deleted` entry that follows it
+/// carries the real outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mutation {
+    NodeUpserted(NodeId),
+    NodeDeleted(NodeId),
+    EdgeUpserted(super::types::EdgeId),
+    EdgeDeleted(super::types::EdgeId),
+}

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -68,5 +68,5 @@ pub use property::{PropertyMap, PropertyValue};
 pub use store::{GraphError, GraphResult, GraphStore, GraphStatistics, PropertyStats, IsolationLevel, TxnId, TxnStatus, Transaction, TypeAdjacency};
 pub use types::{EdgeId, EdgeType, Label, NodeId};
 pub use catalog::GraphCatalog;
-pub use event::IndexEvent;
+pub use event::{IndexEvent, Mutation};
 pub use storage::{Column, ColumnStore};

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -788,6 +788,11 @@ pub struct GraphStore {
     /// Async index event sender
     pub index_sender: Option<UnboundedSender<crate::graph::event::IndexEvent>>,
 
+    /// Journal of graph changes, for callers that must persist them (#1094).
+    /// `None` — the default — records nothing, so an embedded or benchmark store
+    /// pays neither the allocation nor the push.
+    write_log: Option<Vec<crate::graph::event::Mutation>>,
+
     /// Next node ID
     next_node_id: u64,
 
@@ -862,10 +867,44 @@ impl GraphStore {
             node_columns: ColumnStore::new(),
             edge_columns: ColumnStore::new(),
             index_sender: None,
+            write_log: None,
             next_node_id: 1,
             next_edge_id: 1,
             catalog: GraphCatalog::new(),
             statistics_cache: std::sync::RwLock::new(None),
+        }
+    }
+
+    /// Start recording every change to this store, for a caller that has to
+    /// persist them (#1094).
+    ///
+    /// Off by default. Durability used to be read off the *result* of a write
+    /// query -- the persist loop walked the returned bindings -- which made it a
+    /// property of the `RETURN` clause: `CREATE (:Person)` with nothing returned
+    /// reached no storage, and `DELETE` had no row to describe itself with at all.
+    pub fn enable_write_log(&mut self) {
+        if self.write_log.is_none() {
+            self.write_log = Some(Vec::new());
+        }
+    }
+
+    /// Whether this store is recording changes.
+    pub fn write_log_enabled(&self) -> bool {
+        self.write_log.is_some()
+    }
+
+    /// Take the changes recorded since the last take, leaving recording on.
+    pub fn take_write_log(&mut self) -> Vec<crate::graph::event::Mutation> {
+        match &mut self.write_log {
+            Some(log) => std::mem::take(log),
+            None => Vec::new(),
+        }
+    }
+
+    #[inline]
+    fn journal(&mut self, m: crate::graph::event::Mutation) {
+        if let Some(log) = &mut self.write_log {
+            log.push(m);
         }
     }
 
@@ -1173,6 +1212,7 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             }
             versions.push(node);
         }
+        self.journal(crate::graph::event::Mutation::NodeUpserted(node_id));
         node_id
     }
 
@@ -1255,6 +1295,7 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             }
             versions.push(node);
         }
+        self.journal(crate::graph::event::Mutation::NodeUpserted(node_id));
         node_id
     }
 
@@ -1352,6 +1393,7 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             }
             versions.push(node);
         }
+        self.journal(crate::graph::event::Mutation::NodeUpserted(node_id));
         node_id
     }
 
@@ -1525,6 +1567,7 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             }
         }
 
+        self.journal(crate::graph::event::Mutation::NodeUpserted(node_id));
         Ok(())
     }
 
@@ -1585,6 +1628,7 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             }
         }
 
+        self.journal(crate::graph::event::Mutation::EdgeUpserted(edge_id));
         Ok(())
     }
 
@@ -1657,6 +1701,7 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             let _ = self.delete_edge(*edge_id);
         }
 
+        self.journal(crate::graph::event::Mutation::NodeDeleted(id));
         Ok(node)
     }
 
@@ -1704,6 +1749,7 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             }
         }
 
+        self.journal(crate::graph::event::Mutation::NodeUpserted(node_id));
         Ok(true)
     }
 
@@ -1748,6 +1794,7 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             self.handle_index_event(event, None);
         }
 
+        self.journal(crate::graph::event::Mutation::NodeUpserted(node_id));
         Ok(())
     }
 
@@ -1792,6 +1839,7 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         }
         self.edge_endpoints[idx] = (source, target);
 
+        self.journal(crate::graph::event::Mutation::EdgeUpserted(edge_id));
         Ok(edge_id)
     }
 
@@ -1889,6 +1937,7 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         let tgt_labels = label_set(target).unwrap_or(empty);
         self.catalog.on_edge_created(source, src_labels, &edge_type, target, tgt_labels);
 
+        self.journal(crate::graph::event::Mutation::EdgeUpserted(edge_id));
         Ok(edge_id)
     }
 
@@ -1996,6 +2045,7 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         let tgt_labels = label_set(target).unwrap_or(empty);
         self.catalog.on_edge_created(source, src_labels, &edge_type, target, tgt_labels);
 
+        self.journal(crate::graph::event::Mutation::EdgeUpserted(edge_id));
         Ok(edge_id)
     }
 
@@ -2110,6 +2160,7 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             self.remove_edge_property(edge_id, &key);
             return;
         }
+        self.journal(crate::graph::event::Mutation::EdgeUpserted(edge_id));
         let props = self.edge_properties.entry(edge_id).or_insert_with(PropertyMap::new);
         props.insert(key, value);
     }
@@ -2165,6 +2216,7 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         // Update catalog triple stats
         self.catalog.on_edge_deleted(edge.source, &src_labels, &edge.edge_type, edge.target, &tgt_labels);
 
+        self.journal(crate::graph::event::Mutation::EdgeDeleted(id));
         Ok(edge)
     }
 
@@ -2635,6 +2687,7 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         if let Some(node) = self.get_node_mut(node_id) {
             node.remove_property(key);
         }
+        self.journal(crate::graph::event::Mutation::NodeUpserted(node_id));
         self.invalidate_statistics_cache();
     }
 
@@ -2645,6 +2698,7 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
         if let Some(props) = self.get_edge_properties_mut(edge_id) {
             props.remove(key);
         }
+        self.journal(crate::graph::event::Mutation::EdgeUpserted(edge_id));
         self.invalidate_statistics_cache();
     }
 

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -303,7 +303,21 @@ pub async fn query_handler(
     let snapshot_version: u64;
     let (result, full_props) = if is_write {
         let mut store_guard = state.store.write().await;
+        // Record the changes so they can be persisted: a write here used to reach
+        // memory only, and returned 200 all the same (#1094).
+        if state.persistence.is_some() {
+            store_guard.enable_write_log();
+        }
         let result = state.engine.execute_mut(&payload.query, &mut *store_guard, &payload.graph);
+        if let Some(pm) = &state.persistence {
+            let mutations = store_guard.take_write_log();
+            if result.is_ok() {
+                match pm.apply_mutations(&payload.graph, &store_guard, &mutations) {
+                    Ok(n) => tracing::debug!("Persisted {} entities from {} mutations", n, mutations.len()),
+                    Err(e) => tracing::warn!("Failed to persist HTTP write: {}", e),
+                }
+            }
+        }
         snapshot_version = store_guard.current_version;
         let props = result
             .as_ref()
@@ -1218,6 +1232,7 @@ mod tests {
             tenant_manager: None,
             embed_pipeline: None,
             embed_cache: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            persistence: None,
         };
         let app = Router::new()
             .route("/api/query", post(query_handler))
@@ -1276,6 +1291,7 @@ mod tests {
             tenant_manager: None,
             embed_pipeline: None,
             embed_cache: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            persistence: None,
         };
         let app = Router::new()
             .route("/api/schema", get(schema_handler))
@@ -1316,6 +1332,7 @@ mod tests {
             tenant_manager: None,
             embed_pipeline: None,
             embed_cache: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            persistence: None,
         };
         let app = Router::new()
             .route("/api/query", axum::routing::post(query_handler))
@@ -1921,4 +1938,57 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
     }
 
+
+    /// The reproduction from #1094: writes over HTTP returned 200 and reached no
+    /// storage, so a restart with `--data-path` set found an empty graph. Neither
+    /// statement here has a `RETURN` clause, which is the case the older persist
+    /// loop -- it walked the result bindings -- could not see at all.
+    #[tokio::test]
+    async fn http_writes_reach_storage() {
+        let dir = tempfile::tempdir().unwrap();
+        let pm = std::sync::Arc::new(
+            crate::persistence::PersistenceManager::new(dir.path()).unwrap(),
+        );
+        pm.tenants()
+            .create_tenant("default".to_string(), "default".to_string(), None)
+            .ok();
+
+        let state = AppState {
+            store: Arc::new(RwLock::new(GraphStore::new())),
+            engine: Arc::new(QueryEngine::new()),
+            data_path: None,
+            tenant_manager: None,
+            embed_pipeline: None,
+            embed_cache: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            persistence: Some(std::sync::Arc::clone(&pm)),
+        };
+        let app = Router::new()
+            .route("/api/query", post(query_handler))
+            .with_state(state.clone());
+
+        for name in ["ada", "grace"] {
+            let (status, _) = post_query(
+                app.clone(),
+                &format!(r#"{{"query": "CREATE (p:Person {{name: \"{name}\"}})", "graph": "default"}}"#),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+        }
+
+        // What a restart would load.
+        pm.checkpoint().unwrap();
+        let (nodes, _edges) = pm.recover("default").unwrap();
+        let mut names: Vec<String> = nodes
+            .iter()
+            .map(|n| n.properties.get("name").unwrap().to_string())
+            .collect();
+        names.sort();
+        assert_eq!(
+            names.len(),
+            2,
+            "two 200s and {} nodes on disk",
+            names.len()
+        );
+        assert!(names[0].contains("ada") && names[1].contains("grace"), "{names:?}");
+    }
 }

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -88,6 +88,9 @@ pub struct AppState {
     pub embed_pipeline: Option<Arc<EmbedPipeline>>,
     /// Per-tenant EmbedPipeline cache; invalidated on PATCH /api/tenants/:id
     pub embed_cache: Arc<RwLock<HashMap<String, Arc<EmbedPipeline>>>>,
+    /// Persistence for writes made through `POST /api/query` (#1094). Without it a
+    /// write over HTTP lives only in memory, and every one of them returns success.
+    pub persistence: Option<Arc<crate::persistence::PersistenceManager>>,
 }
 
 /// HTTP server managing the Visualizer API and static assets
@@ -97,12 +100,13 @@ pub struct HttpServer {
     data_path: Option<String>,
     tenants: Option<Arc<TenantManager>>,
     embed_pipeline: Option<Arc<EmbedPipeline>>,
+    persistence: Option<Arc<crate::persistence::PersistenceManager>>,
 }
 
 impl HttpServer {
     /// Create a new HTTP server
     pub fn new(store: Arc<RwLock<GraphStore>>, port: u16) -> Self {
-        Self { store, port, data_path: None, tenants: None, embed_pipeline: None }
+        Self { store, port, data_path: None, tenants: None, embed_pipeline: None, persistence: None }
     }
 
     /// Set the data directory for snapshot persistence (HA-08)
@@ -115,6 +119,12 @@ impl HttpServer {
     /// tenants created via HTTP are immediately visible to `GRAPH.LIST`.
     pub fn with_tenant_manager(mut self, tenants: Arc<TenantManager>) -> Self {
         self.tenants = Some(tenants);
+        self
+    }
+
+    /// Persist writes made through the HTTP query endpoint (#1094).
+    pub fn with_persistence(mut self, pm: Arc<crate::persistence::PersistenceManager>) -> Self {
+        self.persistence = Some(pm);
         self
     }
 
@@ -160,6 +170,7 @@ impl HttpServer {
             tenant_manager: self.tenants.clone(),
             embed_pipeline: self.embed_pipeline.clone(),
             embed_cache: Arc::clone(&embed_cache),
+            persistence: self.persistence.clone(),
         };
 
         let optimize_state = Arc::new(super::optimize::OptimizeState::default());
@@ -241,6 +252,7 @@ mod tests {
             tenant_manager: None,
             embed_pipeline: None,
             embed_cache: Arc::new(RwLock::new(HashMap::new())),
+            persistence: None,
         };
 
         let cloned = state.clone();
@@ -259,6 +271,7 @@ mod tests {
             tenant_manager: None,
             embed_pipeline: None,
             embed_cache: Arc::new(RwLock::new(HashMap::new())),
+            persistence: None,
         };
 
         let cloned = state.clone();
@@ -283,6 +296,7 @@ mod tests {
             tenant_manager: None,
             embed_pipeline: None,
             embed_cache: Arc::new(RwLock::new(HashMap::new())),
+            persistence: None,
         };
 
         let c1 = state.clone();
@@ -305,6 +319,7 @@ mod tests {
             tenant_manager: None,
             embed_pipeline: None,
             embed_cache: Arc::new(RwLock::new(HashMap::new())),
+            persistence: None,
         };
 
         // Write through the state
@@ -343,6 +358,7 @@ mod tests {
             tenant_manager: None,
             embed_pipeline: None,
             embed_cache: Arc::new(RwLock::new(HashMap::new())),
+            persistence: None,
         };
 
         let _app: Router = Router::new()
@@ -362,6 +378,7 @@ mod tests {
             tenant_manager: None,
             embed_pipeline: None,
             embed_cache: Arc::new(RwLock::new(HashMap::new())),
+            persistence: None,
         };
 
         let app = Router::new()

--- a/src/http/vector.rs
+++ b/src/http/vector.rs
@@ -322,6 +322,7 @@ mod tests {
             tenant_manager: None,
             embed_pipeline: None,
             embed_cache: Arc::new(RwLock::new(HashMap::new())),
+            persistence: None,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -615,10 +615,14 @@ async fn start_server() {
     // Start HTTP server for Visualizer API (port from --http-port, default 8080)
     let http_store = Arc::clone(&store);
     let http_tenants = Arc::clone(&shared_tenants);
+    let http_persistence = persistence.clone();
     tokio::spawn(async move {
         let mut http_server = HttpServer::new(http_store, http_port)
             .with_data_path(http_data_path)
             .with_tenant_manager(http_tenants);
+        if let Some(pm) = http_persistence {
+            http_server = http_server.with_persistence(pm);
+        }
         if let Some(ref pipeline) = global_embed_pipeline {
             http_server = http_server.with_embed_pipeline(Arc::clone(pipeline));
         }

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -228,6 +228,108 @@ impl PersistenceManager {
         Ok(())
     }
 
+    /// Persist a statement's changes, as recorded by [`GraphStore::take_write_log`] (#1094).
+    ///
+    /// This replaces reading durability off the *result* of a write query. That older
+    /// call site walked the returned bindings for `Node`/`Edge` values, so what reached
+    /// storage depended on the `RETURN` clause: `CREATE (:Person)` persisted nothing,
+    /// and `DELETE` left the row on disk to be resurrected by the next restart. Every
+    /// write returned success either way.
+    ///
+    /// The log carries ids, not payloads, so the final state of each touched entity is
+    /// read from `store` here. Ids are coalesced to their last operation before anything
+    /// is written: a node set five times in one statement is one write, and one created
+    /// and then deleted is a delete of something never stored, which is a no-op rather
+    /// than a resurrection. An `Upserted` id missing from the store was deleted later in
+    /// the same statement and is skipped for the same reason.
+    ///
+    /// Returns the number of entities written.
+    pub fn apply_mutations(
+        &self,
+        tenant: &str,
+        store: &GraphStore,
+        mutations: &[crate::graph::event::Mutation],
+    ) -> Result<usize, PersistenceError> {
+        use crate::graph::event::Mutation;
+        use std::collections::HashMap;
+
+        // Last operation wins, in order of first appearance. Order matters only for
+        // reading a WAL by eye; correctness comes from each entry carrying final state.
+        let mut order: Vec<(bool, u64)> = Vec::new();
+        let mut last: HashMap<(bool, u64), bool> = HashMap::new(); // (is_edge, id) -> deleted
+        for m in mutations {
+            let (key, deleted) = match *m {
+                Mutation::NodeUpserted(id) => ((false, id.as_u64()), false),
+                Mutation::NodeDeleted(id) => ((false, id.as_u64()), true),
+                Mutation::EdgeUpserted(id) => ((true, id.as_u64()), false),
+                Mutation::EdgeDeleted(id) => ((true, id.as_u64()), true),
+            };
+            if last.insert(key, deleted).is_none() {
+                order.push(key);
+            }
+        }
+
+        let mut written = 0usize;
+        for key in order {
+            let (is_edge, id) = key;
+            let deleted = last[&key];
+            match (is_edge, deleted) {
+                (false, false) => {
+                    // Skipped when absent: deleted later in the same statement.
+                    if let Some(node) = store.get_node(crate::graph::NodeId::new(id)) {
+                        let existed = self.storage.get_node(tenant, id)?.is_some();
+                        let properties = bincode::serialize(&node.properties)?;
+                        self.wal.lock().unwrap().append(WalEntry::CreateNode {
+                            tenant: tenant.to_string(),
+                            node_id: id,
+                            labels: node.labels.iter().map(|l| l.as_str().to_string()).collect(),
+                            properties,
+                        })?;
+                        self.storage.put_node(tenant, node)?;
+                        if !existed {
+                            self.tenants.check_quota(tenant, "nodes")?;
+                            self.tenants.increment_usage(tenant, "nodes", 1)?;
+                        }
+                        written += 1;
+                    }
+                }
+                (false, true) => {
+                    if self.storage.get_node(tenant, id)?.is_some() {
+                        self.persist_delete_node(tenant, id)?;
+                        written += 1;
+                    }
+                }
+                (true, false) => {
+                    if let Some(edge) = store.get_edge(crate::graph::EdgeId::new(id)) {
+                        let existed = self.storage.get_edge(tenant, id)?.is_some();
+                        let properties = bincode::serialize(&edge.properties)?;
+                        self.wal.lock().unwrap().append(WalEntry::CreateEdge {
+                            tenant: tenant.to_string(),
+                            edge_id: id,
+                            source: edge.source.as_u64(),
+                            target: edge.target.as_u64(),
+                            edge_type: edge.edge_type.as_str().to_string(),
+                            properties,
+                        })?;
+                        self.storage.put_edge(tenant, &edge)?;
+                        if !existed {
+                            self.tenants.check_quota(tenant, "edges")?;
+                            self.tenants.increment_usage(tenant, "edges", 1)?;
+                        }
+                        written += 1;
+                    }
+                }
+                (true, true) => {
+                    if self.storage.get_edge(tenant, id)?.is_some() {
+                        self.persist_delete_edge(tenant, id)?;
+                        written += 1;
+                    }
+                }
+            }
+        }
+        Ok(written)
+    }
+
     /// Update node properties
     pub fn persist_update_node_properties(
         &self,

--- a/src/protocol/command.rs
+++ b/src/protocol/command.rs
@@ -153,38 +153,27 @@ impl CommandHandler {
         // Execute query with appropriate method
         let result = if is_write_query {
             let mut store_guard = store.write().await;
-            
+
+            // Record what the statement changes, so persistence does not depend on
+            // what it returns (#1094).
+            if self.persistence.is_some() {
+                store_guard.enable_write_log();
+            }
+
             // Set current tenant for indexing events
             // In a more complex architecture, the store_guard would be isolated
             let res = self.query_engine.execute_mut(&query_str, &mut *store_guard, &graph_name);
 
             // If write succeeded and persistence is enabled, persist the changes
-            if let (Ok(ref batch), Some(ref persist_mgr)) = (&res, &self.persistence) {
-                // Extract created nodes/edges from the result and persist them
-                // The RecordBatch contains Node and Edge values that were created
-                for record in &batch.records {
-                    for (_col, value) in record.bindings().iter() {
-                        match value {
-                            Value::Node(node_id, node) => {
-                                // Persist the created node
-                                if let Err(e) = persist_mgr.persist_create_node(&graph_name, node) {
-                                    warn!("Failed to persist node {:?}: {}", node_id, e);
-                                }
-                            }
-                            Value::Edge(edge_id, edge) => {
-                                // Persist the created edge
-                                if let Err(e) = persist_mgr.persist_create_edge(&graph_name, edge) {
-                                    warn!("Failed to persist edge {:?}: {}", edge_id, e);
-                                }
-                            }
-                            Value::NodeRef(_) | Value::EdgeRef(..) => {
-                                // Refs from read queries — nothing to persist
-                            }
-                            _ => {} // Other value types don't need persistence
-                        }
-                    }
+            if let (Ok(_), Some(ref persist_mgr)) = (&res, &self.persistence) {
+                let mutations = store_guard.take_write_log();
+                match persist_mgr.apply_mutations(&graph_name, &store_guard, &mutations) {
+                    Ok(n) => debug!("Persisted {} entities from {} mutations", n, mutations.len()),
+                    Err(e) => warn!("Failed to persist write: {}", e),
                 }
-                debug!("Write query persisted successfully");
+            } else if self.persistence.is_some() {
+                // The statement failed; do not carry its partial log into the next one.
+                let _ = store_guard.take_write_log();
             }
 
             drop(store_guard);

--- a/tests/write_durability.rs
+++ b/tests/write_durability.rs
@@ -1,0 +1,166 @@
+//! What survives a restart (#1094).
+//!
+//! Durability used to be read off the *result* of a write query: the persist loop in
+//! `src/protocol/command.rs` walked the returned bindings for `Node`/`Edge` values. That
+//! made it a property of the `RETURN` clause — `CREATE (:Person)` with nothing returned
+//! reached no storage, and `DELETE` had no row to describe itself with at all — and the
+//! HTTP path did not persist anything under any clause. Every write returned success.
+//!
+//! These tests drive the write log instead, and each one ends in a real `recover()`, so
+//! what they assert is what a restart would actually find.
+
+use samyama::graph::GraphStore;
+use samyama::persistence::PersistenceManager;
+use samyama::query::QueryEngine;
+
+const T: &str = "default";
+
+struct Db {
+    _dir: tempfile::TempDir,
+    pm: PersistenceManager,
+    engine: QueryEngine,
+    store: GraphStore,
+}
+
+impl Db {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let pm = PersistenceManager::new(dir.path()).unwrap();
+        pm.tenants()
+            .create_tenant(T.to_string(), T.to_string(), None)
+            .ok();
+        let mut store = GraphStore::new();
+        store.enable_write_log();
+        Db { _dir: dir, pm, engine: QueryEngine::new(), store }
+    }
+
+    /// One statement, persisted the way the server persists it.
+    fn write(&mut self, q: &str) {
+        self.engine.execute_mut(q, &mut self.store, T).expect(q);
+        let muts = self.store.take_write_log();
+        self.pm.apply_mutations(T, &self.store, &muts).unwrap();
+    }
+
+    /// What a restart would load.
+    fn restart(&self) -> (Vec<samyama::graph::Node>, Vec<samyama::graph::Edge>) {
+        self.pm.checkpoint().unwrap();
+        self.pm.recover(T).unwrap()
+    }
+}
+
+#[test]
+fn a_create_survives_whether_or_not_it_returns_the_node() {
+    let mut db = Db::new();
+    db.write("CREATE (p:Person {name: \"ada\"}) RETURN p");
+    db.write("CREATE (p:Person {name: \"grace\"})");
+
+    let (nodes, _) = db.restart();
+    let mut names: Vec<String> = nodes
+        .iter()
+        .map(|n| n.properties.get("name").unwrap().to_string())
+        .collect();
+    names.sort();
+    assert_eq!(names.len(), 2, "both creates reached storage");
+    assert!(names[0].contains("ada") && names[1].contains("grace"));
+}
+
+#[test]
+fn a_set_survives_without_a_return_clause() {
+    let mut db = Db::new();
+    db.write("CREATE (p:Person {name: \"ada\"})");
+    db.write("MATCH (p:Person) SET p.name = \"grace\"");
+
+    let (nodes, _) = db.restart();
+    assert_eq!(nodes.len(), 1);
+    let name = nodes[0].properties.get("name").unwrap().to_string();
+    assert!(name.contains("grace"), "stored node still says {name}");
+}
+
+#[test]
+fn a_delete_is_not_resurrected_by_the_restart() {
+    let mut db = Db::new();
+    db.write("CREATE (p:Person {name: \"ada\"})");
+    assert_eq!(db.restart().0.len(), 1);
+
+    db.write("MATCH (p:Person) DELETE p");
+    let (nodes, _) = db.restart();
+    assert!(nodes.is_empty(), "the deleted node came back: {nodes:?}");
+}
+
+#[test]
+fn an_edge_and_its_properties_survive() {
+    let mut db = Db::new();
+    db.write(
+        "CREATE (a:Person {name: \"ada\"})-[:KNOWS {since: 1843}]->(b:Person {name: \"grace\"})",
+    );
+
+    let (nodes, edges) = db.restart();
+    assert_eq!(nodes.len(), 2);
+    assert_eq!(edges.len(), 1, "the edge reached storage");
+    assert_eq!(edges[0].edge_type.as_str(), "KNOWS");
+    assert!(
+        edges[0].properties.get("since").unwrap().to_string().contains("1843"),
+        "edge properties: {:?}",
+        edges[0].properties
+    );
+}
+
+#[test]
+fn deleting_a_node_persists_the_deletion_of_its_edges() {
+    let mut db = Db::new();
+    db.write("CREATE (a:Person {name: \"ada\"})-[:KNOWS]->(b:Person {name: \"grace\"})");
+    assert_eq!(db.restart().1.len(), 1);
+
+    db.write("MATCH (a:Person {name: \"ada\"}) DETACH DELETE a");
+    let (nodes, edges) = db.restart();
+    assert_eq!(nodes.len(), 1, "only ada was deleted");
+    assert!(
+        edges.is_empty(),
+        "the cascade deleted the edge in memory but left it on disk: {edges:?}"
+    );
+}
+
+#[test]
+fn a_node_created_and_deleted_in_the_same_session_leaves_nothing() {
+    let mut db = Db::new();
+    db.write("CREATE (p:Person {name: \"ada\"})");
+    db.write("MATCH (p:Person) DELETE p");
+    db.write("CREATE (p:Person {name: \"grace\"})");
+
+    let (nodes, _) = db.restart();
+    assert_eq!(nodes.len(), 1);
+    assert!(nodes[0].properties.get("name").unwrap().to_string().contains("grace"));
+}
+
+#[test]
+fn repeated_writes_to_one_node_do_not_inflate_the_tenant_count() {
+    // `persist_create_node` increments the tenant's node usage every time it is called,
+    // so an upsert path that re-persists on each SET would report a graph several times
+    // larger than it is, and would hit a quota that was never reached.
+    let mut db = Db::new();
+    db.write("CREATE (p:Person {name: \"ada\"})");
+    for i in 0..5 {
+        db.write(&format!("MATCH (p:Person) SET p.age = {i}"));
+    }
+
+    let usage = db.pm.tenants().get_usage(T).unwrap();
+    assert_eq!(usage.node_count, 1, "five SETs on one node counted as {} nodes", usage.node_count);
+    assert_eq!(db.restart().0.len(), 1);
+}
+
+#[test]
+fn a_failed_statement_does_not_persist_its_partial_log() {
+    let mut db = Db::new();
+    db.write("CREATE (p:Person {name: \"ada\"})");
+
+    // Fails at execution, after the CREATE has already touched the store.
+    let _ = db
+        .engine
+        .execute_mut("CREATE (q:Person {name: \"eve\"}) RETURN nosuchfn(q)", &mut db.store, T);
+    let muts = db.store.take_write_log();
+    // The server drops the log rather than applying it.
+    drop(muts);
+
+    let (nodes, _) = db.restart();
+    assert_eq!(nodes.len(), 1, "only the committed statement is on disk");
+}


### PR DESCRIPTION
Closes #1094.

Writes through `POST /api/query` reached memory only. Six creates, six `200`s, a WAL and a RocksDB directory on disk, and `No persisted tenants found.` on the next start. Durability depended on which of the three documented interfaces made the write, and the interface that lost it said nothing.

### The RESP path was not the working case it looked like

It persisted by walking the *result* of the statement for `Node` and `Edge` values, which makes durability a property of the `RETURN` clause. `tests/write_durability.rs` started as four tests against that loop and two of them failed:

| statement | reached storage |
|---|---|
| `CREATE (p:Person {name:"ada"}) RETURN p` | yes |
| `CREATE (p:Person {name:"ada"})` | **no** |
| `MATCH (p) SET p.name = "grace" RETURN p` | yes, incidentally — the returned node is re-upserted |
| `MATCH (p:Person) DELETE p` | **no** — the row stays on disk and comes back on restart |

So the fix is not to copy that loop into the HTTP handler.

### What this does instead

`GraphStore` records what it changed — `Mutation::{Node,Edge}{Upserted,Deleted}`, **ids only** — and `PersistenceManager::apply_mutations` reads the final state of each touched entity and writes it. Both call sites use it. Recording is opt-in (`enable_write_log`), so an embedded or benchmark store pays neither the allocation nor the push.

Three things the id-only log gets right that a payload log would not:

- **Ids are coalesced to their last operation** before anything is written, so five `SET`s on one node are one write. This matters beyond IO: `persist_create_node` increments the tenant's node usage on *every* call, so a re-persisting upsert path would report a graph several times larger than it is and hit a quota that was never reached. `repeated_writes_to_one_node_do_not_inflate_the_tenant_count` pins that.
- **An `Upserted` id absent from the store at apply time** was deleted later in the same statement, and is skipped rather than resurrected.
- **`DETACH DELETE` cascades through `delete_edge`**, so the edges it removes are journalled by the code that removes them, not by a second place that has to remember to.

### Verification

The issue's own reproduction: server with `--data-path`, three creates over HTTP with **no `RETURN`**, restart → `Tenant 'default': 3 nodes` and all three names back.

- 8 tests in `tests/write_durability.rs`, plus `http_writes_reach_storage` in the handler. All 8 fail if `journal()` is made a no-op — checked.
- `cargo test --workspace --no-fail-fast` (the profile CI runs, i.e. debug): **252 binaries, 4,083 passed, 0 failed**.

### CH-IMPORT now measures the half REL-06 names

REL-06 — "any data visible before restart is visible after, on every ingest path" — is the H1 P0 gate row this sits under, and `examples/import_invariants.rs` compared three paths that all live in **one process**. Between them they could not see a write that reaches memory and never reaches disk, which is why the suite was green throughout this bug. A fourth path now persists per statement, checkpoints, and recovers into a fresh store: 33/33 agree, canary still detected. The harness side is in `samyama-graph-competitor-benchmarks#…`; REL-06 moves 🔴 → 🟢.

Remaining gap, stated in the suite: the CSV loader path is still not compared, and the restart path exercises the persist call the handlers make rather than the handlers themselves.

https://claude.ai/code/session_01QoSJsxd4ZBEU21XjaMbsVL
