### PR TITLE
algo_coverage: one name probed twice is one algorithm

### DIFF
--- a/examples/algo_coverage.rs
+++ b/examples/algo_coverage.rs
@@ -221,6 +221,15 @@ fn main() {
         }
     }
 
+    // One name probed twice is one algorithm. `nodeSimilarity` appears in
+    // CANDIDATES under two call shapes -- `{topK: 3}` and no argument -- because
+    // both are worth probing, and both dispatch, so it was counted twice and
+    // ALGO-01's "algorithms callable from Cypher" read one higher than the
+    // engine ships. The set is also what the name list downstream is built from,
+    // so the count and the list disagreed by exactly this.
+    let mut seen = std::collections::HashSet::new();
+    callable.retain(|n| seen.insert(*n));
+
     let distinct: Vec<&&str> = callable.iter().filter(|n| !ALIASES.contains(n)).collect();
     let json = serde_json::json!({
         "target_h1": 40,


### PR DESCRIPTION
`nodeSimilarity` appears in `CANDIDATES` under two call shapes — `{topK: 3}` and no argument. Both are worth probing and both dispatch, so it was pushed onto `callable` twice and ALGO-01's "algorithms callable from Cypher" read **66** where the engine ships **65**.

The duplicate also split the two censuses this probe feeds: `callable_count` was computed from the list, and the name list downstream from the set. So CH-ALGO-COV reported 66 algorithms and named 65 of them — and CH-ALGO-PARITY divides one by the other, which is what `coverage_census_agrees` has been failing on since it was added. ALGO-02's denominator depended on which of the two a reader picked.

ALGO-01's H1 target is 40, so no requirement status moves.

https://claude.ai/code/session_01QoSJsxd4ZBEU21XjaMbsVL