### PR TITLE
Every mutating HTTP path is durable, and disk agrees with memory

### DIFF
--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -199,13 +199,12 @@ pub async fn import_parquet_handler(
             .into_response();
     };
 
-    let mut store_guard = state.store.write().await;
-    match crate::export::import::parquet_to_nodes(
-        &mut store_guard,
-        &params.graph,
-        &params.label,
-        data,
-    ) {
+    let outcome = state
+        .mutate(&params.graph, |store| {
+            crate::export::import::parquet_to_nodes(store, &params.graph, &params.label, data)
+        })
+        .await;
+    match outcome {
         Ok(stats) => (StatusCode::OK, Json(json!({ "status": "ok", "stats": stats })))
             .into_response(),
         Err(e) => (
@@ -302,27 +301,19 @@ pub async fn query_handler(
 
     let snapshot_version: u64;
     let (result, full_props) = if is_write {
-        let mut store_guard = state.store.write().await;
-        // Record the changes so they can be persisted: a write here used to reach
+        // `mutate` records the changes and persists them: a write here used to reach
         // memory only, and returned 200 all the same (#1094).
-        if state.persistence.is_some() {
-            store_guard.enable_write_log();
-        }
-        let result = state.engine.execute_mut(&payload.query, &mut *store_guard, &payload.graph);
-        if let Some(pm) = &state.persistence {
-            let mutations = store_guard.take_write_log();
-            if result.is_ok() {
-                match pm.apply_mutations(&payload.graph, &store_guard, &mutations) {
-                    Ok(n) => tracing::debug!("Persisted {} entities from {} mutations", n, mutations.len()),
-                    Err(e) => tracing::warn!("Failed to persist HTTP write: {}", e),
-                }
-            }
-        }
-        snapshot_version = store_guard.current_version;
-        let props = result
-            .as_ref()
-            .map(|b| merged_node_properties(b, &store_guard))
-            .unwrap_or_default();
+        let (result, version, props) = state
+            .mutate(&payload.graph, |store| {
+                let result = state.engine.execute_mut(&payload.query, store, &payload.graph);
+                let props = result
+                    .as_ref()
+                    .map(|b| merged_node_properties(b, store))
+                    .unwrap_or_default();
+                (result, store.current_version, props)
+            })
+            .await;
+        snapshot_version = version;
         (result, props)
     } else {
         let store_guard = state.store.read().await;
@@ -796,8 +787,8 @@ pub async fn import_csv_handler(
     let headers: Vec<&str> = header_line.split(delimiter as char).collect();
     let id_col_idx = id_column.as_ref().and_then(|id_col| headers.iter().position(|h| h.trim() == id_col.as_str()));
 
-    let mut store_guard = state.store.write().await;
     let mut count = 0usize;
+    state.mutate(&graph, |store_guard| {
     let mut id_map: HashMap<String, crate::graph::NodeId> = HashMap::new();
 
     for line in lines {
@@ -836,6 +827,8 @@ pub async fn import_csv_handler(
         }
         count += 1;
     }
+    let _ = id_map;
+    }).await;
 
     Json(json!({
         "status": "ok",
@@ -864,9 +857,8 @@ pub async fn import_json_handler(
         return (axum::http::StatusCode::BAD_REQUEST, Json(json!({ "error": "Missing 'label' field" }))).into_response();
     }
 
-    let mut store_guard = state.store.write().await;
     let mut count = 0usize;
-
+    state.mutate(&payload.graph, |store_guard| {
     for node_json in &payload.nodes {
         let node_id = store_guard.create_node(payload.label.as_str());
 
@@ -891,6 +883,7 @@ pub async fn import_json_handler(
         }
         count += 1;
     }
+    }).await;
 
     Json(json!({
         "status": "ok",
@@ -980,6 +973,10 @@ pub async fn restore_snapshot_handler(
         }
     };
 
+    // persistence: the snapshot bytes are committed to `data_path/snapshots` below
+    // and reloaded by `restore_persisted_snapshots` at boot (HA-08), so this path
+    // does not go through the mutation journal -- one journal entry per node of a
+    // hundred-million-node snapshot is not the right shape for it.
     let mut store_guard = state.store.write().await;
     let cursor = std::io::Cursor::new(&data);
     let dedup_keys: Vec<String> = params
@@ -1097,15 +1094,20 @@ pub async fn enrich_handler(
     }
 
     // Write phase: quarantine.
-    let mut filled = 0usize;
-    {
-        let mut store = state.store.write().await;
-        for o in &outcomes {
-            if enrich::quarantine(&mut store, o).is_ok() {
-                filled += 1;
+    // `/api/enrich` is single-graph by design -- `EnrichRequest` carries no graph and
+    // the policy is global -- so the tenant is the default one. A per-graph enrich
+    // would have to thread the name through here as well.
+    let filled = state
+        .mutate("default", |store| {
+            let mut filled = 0usize;
+            for o in &outcomes {
+                if enrich::quarantine(store, o).is_ok() {
+                    filled += 1;
+                }
             }
-        }
-    }
+            filled
+        })
+        .await;
 
     (
         StatusCode::OK,
@@ -1131,10 +1133,10 @@ pub async fn verify_handler(
         };
         enrich::collect_result_nodes(&batch)
     };
-    let report = {
-        let mut store = state.store.write().await;
-        enrich::verify(&cfg, &mut store, &node_ids)
-    };
+    // Single-graph, as `/api/enrich` is.
+    let report = state
+        .mutate("default", |store| enrich::verify(&cfg, store, &node_ids))
+        .await;
     (StatusCode::OK, Json(report)).into_response()
 }
 
@@ -1990,5 +1992,99 @@ mod tests {
             names.len()
         );
         assert!(names[0].contains("ada") && names[1].contains("grace"), "{names:?}");
+    }
+
+    /// Build an `AppState` backed by a real `PersistenceManager`, and hand back the
+    /// manager so a test can ask what a restart would load.
+    fn state_with_persistence() -> (
+        AppState,
+        std::sync::Arc<crate::persistence::PersistenceManager>,
+        tempfile::TempDir,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let pm = std::sync::Arc::new(
+            crate::persistence::PersistenceManager::new(dir.path()).unwrap(),
+        );
+        pm.tenants()
+            .create_tenant("default".to_string(), "default".to_string(), None)
+            .ok();
+        let state = AppState {
+            store: Arc::new(RwLock::new(GraphStore::new())),
+            engine: Arc::new(QueryEngine::new()),
+            data_path: None,
+            tenant_manager: None,
+            embed_pipeline: None,
+            embed_cache: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            persistence: Some(std::sync::Arc::clone(&pm)),
+        };
+        (state, pm, dir)
+    }
+
+    /// `/api/import/json` is an ingest path, and REL-06 is about ingest paths. It
+    /// wrote to memory and returned `{"status":"ok"}` with nothing on disk (#1106).
+    #[tokio::test]
+    async fn json_import_reaches_storage() {
+        let (state, pm, _dir) = state_with_persistence();
+        let app = Router::new()
+            .route("/api/import/json", post(import_json_handler))
+            .with_state(state.clone());
+
+        let body = r#"{"label":"Person","nodes":[{"name":"ada"},{"name":"grace"}]}"#;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/import/json")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        assert_eq!(state.store.read().await.node_count(), 2, "imported into memory");
+        pm.checkpoint().unwrap();
+        let (nodes, _) = pm.recover("default").unwrap();
+        assert_eq!(nodes.len(), 2, "the import returned ok and a restart found {} nodes", nodes.len());
+    }
+
+    /// The miss in #1106 was not that five handlers each forgot to persist. It was
+    /// that each one took the write lock itself, so there was nowhere for the fix to
+    /// live and nothing for a new handler to inherit. `AppState::mutate` is that
+    /// place; this test is what keeps handlers in it.
+    ///
+    /// A handler that genuinely must not go through `mutate` says so on the line,
+    /// with the mechanism that makes it durable instead.
+    #[test]
+    fn no_handler_takes_the_write_lock_outside_mutate() {
+        let source = include_str!("handler.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("handler.rs has a production region");
+
+        let lines: Vec<&str> = production.lines().collect();
+        let offenders: Vec<(usize, &str)> = lines
+            .iter()
+            .enumerate()
+            .filter(|(_, l)| l.contains("store.write().await"))
+            // The waiver is a `persistence:` note in the comment block above the
+            // line, so it has room to say *how* the path is durable instead.
+            .filter(|(i, _)| {
+                !lines[i.saturating_sub(6)..*i]
+                    .iter()
+                    .any(|c| c.trim_start().starts_with("//") && c.contains("persistence:"))
+            })
+            .map(|(i, l)| (i + 1, l.trim()))
+            .collect();
+
+        assert!(
+            offenders.is_empty(),
+            "these take the write lock directly, so whatever they change is not \
+             journalled and does not survive a restart. Route them through \
+             `AppState::mutate`, or write a `// persistence: <how>` note above the line if \
+             the path is durable by another mechanism: {offenders:?}"
+        );
     }
 }

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -88,9 +88,47 @@ pub struct AppState {
     pub embed_pipeline: Option<Arc<EmbedPipeline>>,
     /// Per-tenant EmbedPipeline cache; invalidated on PATCH /api/tenants/:id
     pub embed_cache: Arc<RwLock<HashMap<String, Arc<EmbedPipeline>>>>,
-    /// Persistence for writes made through `POST /api/query` (#1094). Without it a
-    /// write over HTTP lives only in memory, and every one of them returns success.
+    /// Persistence for writes made over HTTP (#1094, #1106). Without it a write
+    /// lives only in memory, and every one of them returns success.
     pub persistence: Option<Arc<crate::persistence::PersistenceManager>>,
+}
+
+impl AppState {
+    /// Take the write lock, run a mutation, and persist whatever it changed.
+    ///
+    /// Every HTTP path that mutates the graph goes through here. Five did not
+    /// (#1106) — Parquet, CSV and JSON import, `/api/enrich` and `/api/verify` all
+    /// wrote to memory and returned 200 with nothing on disk — and the shape of the
+    /// miss is why this is a method and not a fourth copy of the same six lines:
+    /// each handler took the lock itself, so the fix to `query_handler` was not
+    /// something the others could inherit.
+    ///
+    /// The log is applied on the outcome of the *store*, not of `body`. A statement
+    /// that fails partway does not undo the rows it already wrote — the engine has
+    /// no statement rollback (LANG-07) — and REL-06 does not let disk disagree with
+    /// memory about rows that are visible.
+    ///
+    /// `GraphStore` is passed by `&mut` rather than the guard so that a body cannot
+    /// hold the lock past the persist.
+    pub async fn mutate<T>(
+        &self,
+        graph: &str,
+        body: impl FnOnce(&mut GraphStore) -> T,
+    ) -> T {
+        let mut store = self.store.write().await;
+        if self.persistence.is_some() {
+            store.enable_write_log();
+        }
+        let out = body(&mut store);
+        if let Some(pm) = &self.persistence {
+            let mutations = store.take_write_log();
+            match pm.apply_mutations(graph, &store, &mutations) {
+                Ok(n) => tracing::debug!("persisted {n} entities from {} mutations", mutations.len()),
+                Err(e) => tracing::warn!("failed to persist {} mutations: {e}", mutations.len()),
+            }
+        }
+        out
+    }
 }
 
 /// HTTP server managing the Visualizer API and static assets

--- a/src/protocol/command.rs
+++ b/src/protocol/command.rs
@@ -164,16 +164,18 @@ impl CommandHandler {
             // In a more complex architecture, the store_guard would be isolated
             let res = self.query_engine.execute_mut(&query_str, &mut *store_guard, &graph_name);
 
-            // If write succeeded and persistence is enabled, persist the changes
-            if let (Ok(_), Some(ref persist_mgr)) = (&res, &self.persistence) {
+            // Persist on the outcome of the *store*, not of the statement. A
+            // statement that fails partway does not undo the rows it already wrote
+            // -- the engine has no statement rollback (LANG-07) -- so skipping the
+            // log on error left those rows visible in memory and absent from disk,
+            // which is the REL-06 violation rather than the guard against one
+            // (#1106).
+            if let Some(ref persist_mgr) = self.persistence {
                 let mutations = store_guard.take_write_log();
                 match persist_mgr.apply_mutations(&graph_name, &store_guard, &mutations) {
                     Ok(n) => debug!("Persisted {} entities from {} mutations", n, mutations.len()),
                     Err(e) => warn!("Failed to persist write: {}", e),
                 }
-            } else if self.persistence.is_some() {
-                // The statement failed; do not carry its partial log into the next one.
-                let _ = store_guard.take_write_log();
             }
 
             drop(store_guard);

--- a/tests/write_durability.rs
+++ b/tests/write_durability.rs
@@ -148,19 +148,40 @@ fn repeated_writes_to_one_node_do_not_inflate_the_tenant_count() {
     assert_eq!(db.restart().0.len(), 1);
 }
 
+/// A statement that fails partway does not undo what it already wrote — the engine
+/// has no statement rollback (LANG-07: transactions are "none"). So the question is
+/// not whether to persist a failed statement's log but whether disk is allowed to
+/// disagree with memory, and REL-06 says it is not.
+///
+/// `UNWIND [1, 2, 0] AS n CREATE (:M {v: 10 / n})` errors on the last row with rows
+/// already in the store. Dropping the log there left memory holding rows that a
+/// restart threw away.
 #[test]
-fn a_failed_statement_does_not_persist_its_partial_log() {
+fn a_partial_failure_leaves_disk_agreeing_with_memory() {
     let mut db = Db::new();
-    db.write("CREATE (p:Person {name: \"ada\"})");
 
-    // Fails at execution, after the CREATE has already touched the store.
-    let _ = db
-        .engine
-        .execute_mut("CREATE (q:Person {name: \"eve\"}) RETURN nosuchfn(q)", &mut db.store, T);
+    let result = db.engine.execute_mut(
+        "UNWIND [1, 2, 0] AS n CREATE (:M {v: 10 / n})",
+        &mut db.store,
+        T,
+    );
+    assert!(result.is_err(), "the statement is supposed to fail");
+    // How many rows got through before the error is an evaluation-order detail and
+    // not what this test is about; that any did is the whole point.
+    let in_memory = db.store.node_count();
+    assert!(in_memory > 0, "the failure left nothing visible, so there is nothing to lose");
+
+    // Persisted the way the server persists it: on the outcome of the *store*, not
+    // the outcome of the statement.
     let muts = db.store.take_write_log();
-    // The server drops the log rather than applying it.
-    drop(muts);
+    db.pm.apply_mutations(T, &db.store, &muts).expect("persist");
 
     let (nodes, _) = db.restart();
-    assert_eq!(nodes.len(), 1, "only the committed statement is on disk");
+    assert_eq!(
+        nodes.len(),
+        in_memory,
+        "restart found {} of the {} rows the failed statement left visible",
+        nodes.len(),
+        in_memory
+    );
 }


### PR DESCRIPTION
Closes #1106.

## What was wrong

#1094 fixed `POST /api/query` and the RESP path. Five other handlers mutate the
graph and none of them persisted:

| endpoint | reached disk before |
|---|---|
| `POST /api/import/parquet` | no — shipped in #1102, the day the row was marked green |
| `POST /api/import/csv` | no |
| `POST /api/import/json` | no |
| `POST /api/enrich` | no |
| `POST /api/verify` | no |
| `POST /api/snapshot/restore` | yes, by a different mechanism (HA-08) |

All five returned 200. REL-06 is "any data visible before restart is visible
after, **on every ingest path**".

## The shape of the miss

Not five oversights. Each handler takes the write lock itself, so the fix to
`query_handler` was six lines that lived inside `query_handler` — there was
nowhere for it to live that the others could inherit from. The gap note written
with the green row said so and was read as a caveat:

> the restart path exercises the persist call the handlers make rather than the
> handlers themselves

So the fix is one place plus a guard, not five patches:

- `AppState::mutate(graph, body)` takes the lock, enables the journal, runs the
  body, applies the log. Every mutating handler goes through it, `query_handler`
  included — it no longer keeps its own copy.
- `no_handler_takes_the_write_lock_outside_mutate` reads the production region of
  `handler.rs` and fails on any line taking the write lock outside `mutate`,
  unless the comment block above it carries a `// persistence: <how>` note saying
  what makes that path durable instead. Snapshot restore is the one waiver.
  **That guard, not the list of five, is the claim.** It failed on the first run
  and passed once the waiver was written, so it is a check that can fail.

## The second bug

The #1094 fix dropped the mutation log when the statement returned `Err`. That
reads as obviously right and is not — the engine has no statement rollback
(LANG-07 records transactions as "none"), so a partial failure leaves its rows
visible:

```
UNWIND [1, 2, 0] AS n CREATE (:M {v: 10 / n})
  -> Err
  -> 3 nodes in memory
  -> 5 mutations journalled
  -> 0 nodes on disk
```

Discarding the log there is not a guard against a REL-06 violation, it is one.
Durability mirrors memory, not intent. Both servers now persist on the outcome of
the store. The test that asserted the old behaviour was asserting the defect; it
now asserts that disk and memory agree after a partial failure.

## Tests

`cargo test --workspace --no-fail-fast` (the debug profile CI uses): **252
binaries, 0 failures.** New: `json_import_reaches_storage` (end-to-end through a
real `recover()`), `no_handler_takes_the_write_lock_outside_mutate`,
`a_partial_failure_leaves_disk_agreeing_with_memory`.

Spec updated in samyama-cloud (`03-reliability-operability.md`), which now records
that the row was marked green before it was true.

https://claude.ai/code/session_016erf3aJ7MVFwUABw1PXyJf