### PR TITLE
Which statements are writes is decided by the parser, not by two keyword lists

### DIFF
--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -286,18 +286,13 @@ pub async fn query_handler(
             .into_response();
     }
 
-    // Check if query is write or read
-    let query_upper = payload.query.trim().to_uppercase();
-    let is_write = query_upper.starts_with("CREATE") ||
-                   query_upper.starts_with("SET") ||
-                   query_upper.starts_with("DELETE") ||
-                   query_upper.starts_with("MERGE") ||
-                   (query_upper.starts_with("MATCH") &&
-                    (query_upper.contains(" CREATE ") || query_upper.contains(" SET ") ||
-                     query_upper.contains(" DELETE ") || query_upper.contains(" MERGE ") ||
-                     query_upper.contains(" REMOVE ") ||
-                     query_upper.ends_with(" CREATE") || query_upper.ends_with(" SET") ||
-                     query_upper.ends_with(" DELETE") || query_upper.ends_with(" MERGE")));
+    // Asked of the parser, not of the query text. Two string matchers used to
+    // answer this, one per transport, and they disagreed: this one only looked
+    // past the first keyword when the statement began with `MATCH`, so
+    // `UNWIND [1] AS x CREATE (:X)` was sent to the read-only executor and came
+    // back 400 (#1111). A statement that does not parse is treated as a read and
+    // fails with its parse error a beat later, which is where it failed before.
+    let is_write = state.engine.statement_is_write(&payload.query).unwrap_or(false);
 
     let snapshot_version: u64;
     let (result, full_props) = if is_write {
@@ -2162,6 +2157,33 @@ mod tests {
             0,
             "the rows before the ragged one were committed anyway"
         );
+    }
+
+    /// `UNWIND $rows AS row CREATE (...)` is the standard parameterised bulk insert
+    /// and it was refused over HTTP with a 400: the write check only looked past the
+    /// first keyword when the statement began with `MATCH`, so this went to the
+    /// read-only executor (#1111). Two shapes here, both previously rejected, and
+    /// each is checked all the way to what a restart would find.
+    #[tokio::test]
+    async fn writes_that_do_not_begin_with_match_reach_storage() {
+        for (query, expected) in [
+            ("UNWIND [1, 2, 3] AS x CREATE (:X {v: x})", 3),
+            ("WITH 7 AS x CREATE (:X {v: x})", 1),
+        ] {
+            let (state, pm, _dir) = state_with_persistence();
+            let app = Router::new()
+                .route("/api/query", post(query_handler))
+                .with_state(state.clone());
+
+            let body = serde_json::json!({"query": query, "graph": "default"}).to_string();
+            let (status, json) = post_query(app, &body).await;
+            assert_eq!(status, StatusCode::OK, "{query} -> {json}");
+
+            assert_eq!(state.store.read().await.node_count(), expected, "{query}");
+            pm.checkpoint().unwrap();
+            let (nodes, _) = pm.recover("default").unwrap();
+            assert_eq!(nodes.len(), expected, "{query} returned 200 and a restart found {} nodes", nodes.len());
+        }
     }
 
     /// The miss in #1106 was not that five handlers each forgot to persist. It was

--- a/src/protocol/command.rs
+++ b/src/protocol/command.rs
@@ -139,16 +139,13 @@ impl CommandHandler {
 
         debug!("Executing query: {}", query_str);
 
-        // Check if this is a write query (CREATE, DELETE, SET, MERGE)
-        let query_upper = query_str.trim().to_uppercase();
-        let is_write_query = query_upper.starts_with("CREATE")
-            || query_upper.starts_with("DELETE")
-            || query_upper.starts_with("SET")
-            || query_upper.starts_with("MERGE")
-            || query_upper.contains(" CREATE ")
-            || query_upper.contains(" DELETE ")
-            || query_upper.contains(" SET ")
-            || query_upper.contains(" MERGE ");
+        // Asked of the parser, not of the query text. This used to be a list of
+        // keywords that had no `REMOVE` in it, while the HTTP server kept a
+        // different list with different holes (#1111).
+        let is_write_query = self
+            .query_engine
+            .statement_is_write(&query_str)
+            .unwrap_or(false);
 
         // Execute query with appropriate method
         let result = if is_write_query {
@@ -205,7 +202,18 @@ impl CommandHandler {
         args: &[RespValue],
         store: &Arc<RwLock<GraphStore>>,
     ) -> RespValue {
-        // For now, same as GRAPH.QUERY (we don't enforce read-only yet)
+        // The command exists so a caller can send reads somewhere a write must not
+        // land — a replica, a reader pool. It used to delegate straight to
+        // `GRAPH.QUERY`, with a comment saying read-only was not enforced, so the
+        // guarantee in the name was not one (#1111). Now that the parser decides
+        // what a write is, refusing one here is a single check.
+        if let Some(Ok(Some(query))) = args.get(2).map(|a| a.as_string()) {
+            if self.query_engine.statement_is_write(&query).unwrap_or(false) {
+                return RespValue::Error(
+                    "ERR GRAPH.RO_QUERY was given a write; use GRAPH.QUERY".to_string(),
+                );
+            }
+        }
         self.handle_graph_query(args, store).await
     }
 

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -854,6 +854,55 @@ pub struct OrderByItem {
 
 impl Query {
     /// Create a new empty query
+    /// Whether executing this statement can change the graph.
+    ///
+    /// The servers used to answer this by matching strings against the query text,
+    /// once per transport and differently each time (#1111): the RESP list had no
+    /// `REMOVE`, and the HTTP list only looked past the first keyword when the
+    /// statement began with `MATCH`, so `UNWIND [1] AS x CREATE (:X)` — the
+    /// canonical parameterised bulk insert — was routed to the read-only executor
+    /// and refused with a 400.
+    ///
+    /// Both AST shapes are checked. `clauses` is the pipeline shape and the by-kind
+    /// fields are the other, and a statement populates one or the other; missing
+    /// either half is how a rule silently applies to only some queries.
+    ///
+    /// DDL counts as a write. `CREATE INDEX` and friends need `&mut GraphStore` for
+    /// the same reason `CREATE` does, and routing them to the read path fails at
+    /// execution rather than at the door.
+    ///
+    /// `union_queries` and `call_subquery` are checked recursively: a read query
+    /// whose subquery writes is a write.
+    pub fn is_write(&self) -> bool {
+        if self.clauses.iter().any(Clause::is_write) {
+            return true;
+        }
+        if self.create_clause.is_some()
+            || self.delete_clause.is_some()
+            || self.merge_clause.is_some()
+            || self.foreach_clause.is_some()
+            || !self.set_clauses.is_empty()
+            || !self.remove_clauses.is_empty()
+        {
+            return true;
+        }
+        // Schema changes mutate the store too.
+        if self.create_index_clause.is_some()
+            || self.drop_index_clause.is_some()
+            || self.create_vector_index_clause.is_some()
+            || self.create_constraint_clause.is_some()
+            || self.create_hierarchy_index_clause.is_some()
+            || self.drop_hierarchy_index.is_some()
+            || self.rebuild_hierarchy_index.is_some()
+        {
+            return true;
+        }
+        if self.union_queries.iter().any(|(q, _all)| q.is_write()) {
+            return true;
+        }
+        self.call_subquery.as_deref().is_some_and(|q| q.is_write())
+    }
+
     pub fn new() -> Self {
         Self {
             match_clauses: Vec::new(),

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -210,6 +210,22 @@ impl QueryEngine {
         Ok(query)
     }
 
+    /// Whether this statement can change the graph, answered by the parser.
+    ///
+    /// The servers each matched strings against the query text to decide which
+    /// executor to use, and the two lists disagreed (#1111). The AST already knows,
+    /// and `cached_parse` means asking it costs a cache lookup on the second and
+    /// later sight of a statement — the same parse the execute call is about to do.
+    ///
+    /// A statement that does not parse is not classified here. The caller gets the
+    /// parse error, which is the same error it would have got a beat later.
+    pub fn statement_is_write(
+        &self,
+        query_str: &str,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        Ok(self.cached_parse(query_str)?.is_write())
+    }
+
     /// Parse and execute a read-only Cypher query (MATCH, RETURN, etc.)
     pub fn execute(
         &self,

--- a/tests/write_detection.rs
+++ b/tests/write_detection.rs
@@ -1,0 +1,99 @@
+//! Which statements are writes (#1111).
+//!
+//! Each server used to decide this by matching strings against the query text, with
+//! a different list of keywords per transport. The RESP list had no `REMOVE`; the
+//! HTTP list only looked past the first keyword when the statement began with
+//! `MATCH`, so `UNWIND [1] AS x CREATE (:X)` — the canonical parameterised bulk
+//! insert — was routed to the read-only executor and refused with a 400.
+//!
+//! `Query::is_write()` replaces both. It is a second implementation of a judgement
+//! the planner also makes, so the first test here is that the two agree; without it
+//! this file would be documenting a third list rather than removing two.
+
+use samyama::graph::GraphStore;
+use samyama::query::QueryEngine;
+
+/// Statements whose classification is not in doubt, including every shape the two
+/// string matchers disagreed about.
+const WRITES: &[&str] = &[
+    "CREATE (:X {v: 1})",
+    "MATCH (n:X) SET n.v = 2",
+    "MATCH (n:X) DELETE n",
+    "MATCH (n:X) DETACH DELETE n",
+    "MATCH (n:X) REMOVE n.v",
+    "MERGE (:X {v: 1})",
+    // Rejected with a 400 over HTTP before this change: not `MATCH`-prefixed.
+    "UNWIND [1] AS x CREATE (:X {v: x})",
+    "WITH 1 AS x CREATE (:X {v: x})",
+    "FOREACH (x IN [1] | CREATE (:X {v: x}))",
+    "MATCH (n:X) WITH n LIMIT 1 SET n.v = 3",
+];
+
+const READS: &[&str] = &[
+    "MATCH (n:X) RETURN n",
+    "RETURN 1",
+    "MATCH (n:X) WHERE n.v > 1 RETURN count(n)",
+    "UNWIND [1, 2] AS x RETURN x",
+    "WITH 1 AS x RETURN x",
+    // The text says DELETE; the statement does not.
+    "MATCH (n:X) WHERE n.note = \"please DELETE this\" RETURN n",
+];
+
+fn engine() -> QueryEngine {
+    QueryEngine::new()
+}
+
+#[test]
+fn writes_are_writes_and_reads_are_reads() {
+    let e = engine();
+    for q in WRITES {
+        assert!(e.statement_is_write(q).unwrap(), "classified as a read: {q}");
+    }
+    for q in READS {
+        assert!(!e.statement_is_write(q).unwrap(), "classified as a write: {q}");
+    }
+}
+
+/// The read-only executor refuses a write with a typed error, so a statement this
+/// module calls a read must actually run there. That is the property the string
+/// matchers broke: `UNWIND [1] AS x CREATE (:X)` was called a read and came back
+/// `WriteInReadTransaction`, which is the planner disagreeing after the fact.
+#[test]
+fn nothing_classified_as_a_read_is_refused_by_the_read_executor() {
+    let e = engine();
+    let store = GraphStore::new();
+    for q in READS {
+        if let Err(err) = e.execute(q, &store) {
+            assert!(
+                !err.to_string().contains("WriteInReadTransaction"),
+                "classified as a read and refused as a write: {q} ({err})"
+            );
+        }
+    }
+}
+
+/// And the converse: every statement called a write is one the read executor
+/// refuses. A write misfiled as a read is the expensive direction — before #1107 it
+/// would also have skipped the mutation journal.
+#[test]
+fn everything_classified_as_a_write_is_refused_by_the_read_executor() {
+    let e = engine();
+    let store = GraphStore::new();
+    for q in WRITES {
+        let err = e
+            .execute(q, &store)
+            .err()
+            .unwrap_or_else(|| panic!("the read executor accepted a write: {q}"));
+        assert!(
+            err.to_string().contains("WriteInReadTransaction"),
+            "{q} failed for another reason, so this asserts nothing: {err}"
+        );
+    }
+}
+
+/// A statement that does not parse is not a write, and is not an error *here*: the
+/// caller gets the parse error from execution, which is where it got it before.
+#[test]
+fn an_unparseable_statement_is_not_classified() {
+    assert!(engine().statement_is_write("MATCH ((( RETURN").is_err());
+}


### PR DESCRIPTION
Closes #1111.

## Measured, not inferred

Against the real handler, before this change:

```
POST /api/query  UNWIND [1] AS x CREATE (:X {v: x})    -> 400  WriteInReadTransaction
POST /api/query  WITH 1 AS x CREATE (:X {v: x})        -> 400  WriteInReadTransaction
POST /api/query  FOREACH (x IN [1] | CREATE (:X))      -> 400  WriteInReadTransaction
```

`UNWIND $rows AS row CREATE (...)` is the canonical parameterised bulk insert in
Cypher and it could not be sent over the HTTP API at all.

The cause is that each server matched strings against the query text, with a
different list per transport:

| statement | HTTP before | RESP before |
|---|---|---|
| `MATCH (n) REMOVE n.age` | write | **read** — no `REMOVE` in the RESP list |
| `UNWIND [1] AS x CREATE (:X)` | **read** — not `MATCH`-prefixed | write |
| `WITH 1 AS x CREATE (:X)` | **read** | write |
| `FOREACH (x IN [1] \| CREATE (:X))` | **read** | write |
| `MATCH (n) WHERE n.note = "please DELETE this" RETURN n` | write | write — a read taking the write lock |

The one piece of luck is that the failure is loud: the read-only executor refuses
rather than quietly doing nothing. Had it not, these would have been 200s with the
data dropped, and since #1107 the journal would not have run either.

## Fix

`Query::is_write()` answers from the AST — over **both** AST shapes (the clause
pipeline and the by-kind fields; a rule written for one silently no-ops the
other), recursively through `UNION` and `CALL` subqueries, and counting DDL as a
write because `CREATE INDEX` needs `&mut GraphStore` for the same reason `CREATE`
does.

`QueryEngine::statement_is_write` wraps it on `cached_parse`, so asking costs an
LRU lookup on the second and later sight of a statement — the same parse the
execute call is about to do. Both keyword lists are **deleted**, not merged: every
row in that table is a case somebody did not think of, and a longer list only
moves the next one further out.

## Why this is not a third divergent list

The planner already decides `ExecutionPlan::is_write`, at more than a dozen
construction sites, so a new predicate is only safe if the two agree. Rather than
mirror the planner's rule (which is how there came to be two lists), the tests
assert the agreement against the executor itself:

- `everything_classified_as_a_write_is_refused_by_the_read_executor` — and fails
  loudly if the statement errors for any *other* reason, so it cannot pass
  vacuously.
- `nothing_classified_as_a_read_is_refused_by_the_read_executor`.

Plus `writes_that_do_not_begin_with_match_reach_storage`, which takes the two
previously-rejected shapes through the real router and on to what a `recover()`
would find.

## `GRAPH.RO_QUERY` gets the guarantee in its name

It delegated to `GRAPH.QUERY` under a comment saying read-only was not enforced,
so a write sent to a reader endpoint was accepted — the command exists precisely
so a caller can route reads where a write must not land. With the parser deciding,
refusing one is a single check.

## Tests

`cargo test --workspace --no-fail-fast` (the debug profile CI uses): **253
binaries, 4,093 passed, 0 failed.**

https://claude.ai/code/session_016erf3aJ7MVFwUABw1PXyJf