### PR TITLE
GRAPH.DELETE deletes the graph, and the tenant counter counts it

### DIFF
--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -379,6 +379,25 @@ impl PersistenceManager {
     }
 
     /// List all tenants that have persisted data in RocksDB
+    /// Drop a graph: its rows, and the usage counted against them.
+    ///
+    /// `GRAPH.DELETE` used to clear memory only (#1110). Three things then went
+    /// wrong together, and all three are this function's job to prevent: the graph
+    /// came back on restart; the id counters had been rewound, so later writes were
+    /// persisted over rows still belonging to the deleted graph; and tenant usage
+    /// kept counting rows nobody could see.
+    ///
+    /// Usage is assigned rather than decremented by a remembered count: after a drop
+    /// the true count is zero whatever the counter had drifted to, and a counter that
+    /// is already wrong cannot be corrected by subtracting from it.
+    pub fn drop_graph(&self, tenant: &str) -> Result<(), PersistenceError> {
+        self.storage.delete_graph(tenant)?;
+        self.storage.flush()?;
+        self.tenants.set_usage(tenant, "nodes", 0)?;
+        self.tenants.set_usage(tenant, "edges", 0)?;
+        Ok(())
+    }
+
     pub fn list_persisted_tenants(&self) -> Result<Vec<String>, PersistenceError> {
         Ok(self.storage.list_persisted_tenants()?)
     }
@@ -395,9 +414,13 @@ impl PersistenceManager {
         let edges = self.storage.scan_edges(tenant)?;
         info!("Recovered {} edges from storage", edges.len());
 
-        // Update resource usage
-        self.tenants.increment_usage(tenant, "nodes", nodes.len())?;
-        self.tenants.increment_usage(tenant, "edges", edges.len())?;
+        // Set, not increment. This used to add the graph's whole size to the
+        // counter on every call, so a second recover for the same tenant counted
+        // every row twice — and the counter gates `check_quota`, so an unchanged
+        // graph drifted toward refusing writes (#1113). What was just read from
+        // storage *is* the count.
+        self.tenants.set_usage(tenant, "nodes", nodes.len())?;
+        self.tenants.set_usage(tenant, "edges", edges.len())?;
 
         Ok((nodes, edges))
     }

--- a/src/persistence/storage.rs
+++ b/src/persistence/storage.rs
@@ -399,6 +399,34 @@ impl PersistentStorage {
         Ok(tenants.into_iter().collect())
     }
 
+    /// Remove every node and edge belonging to a tenant.
+    ///
+    /// `GRAPH.DELETE` cleared the in-memory store and left all of this behind
+    /// (#1110), so a restart brought the graph back — and because `clear()` also
+    /// rewinds the id counters, the writes that followed were persisted over ids
+    /// that still belonged to the deleted graph.
+    ///
+    /// A range delete rather than a scan and a loop: a drop should not cost one
+    /// round trip per row, and the keys are `{tenant}:n:{id:016x}`, so the tenant's
+    /// rows are one contiguous range. The upper bound is the prefix with its last
+    /// byte incremented, which is the first key that cannot belong to it.
+    pub fn delete_graph(&self, tenant: &str) -> StorageResult<()> {
+        for (cf_name, kind) in [("nodes", 'n'), ("edges", 'e')] {
+            let cf = self
+                .db
+                .cf_handle(cf_name)
+                .ok_or_else(|| StorageError::ColumnFamily(cf_name.to_string()))?;
+            let from = format!("{}:{}:", tenant, kind).into_bytes();
+            let mut to = from.clone();
+            // ':' + 1. The range is half-open, so this is the first key past the
+            // prefix and no key of the prefix can equal it.
+            *to.last_mut().expect("prefix is never empty") += 1;
+            self.db.delete_range_cf(&cf, from, to)?;
+        }
+        debug!("Dropped every node and edge for tenant {}", tenant);
+        Ok(())
+    }
+
     /// Create node key with tenant prefix
     fn node_key(tenant: &str, node_id: u64) -> Vec<u8> {
         format!("{}:n:{:016x}", tenant, node_id).into_bytes()

--- a/src/persistence/tenant.rs
+++ b/src/persistence/tenant.rs
@@ -503,6 +503,36 @@ impl TenantManager {
         Ok(())
     }
 
+    /// Set resource usage to a known value.
+    ///
+    /// `recover()` used to *increment* by the number of rows it had just read, which
+    /// is right exactly once (#1113). A second call — a diagnostic read, a second
+    /// tenant load — added the whole graph again, and since the counter gates
+    /// `check_quota`, a graph that had not grown drifted toward refusing writes.
+    ///
+    /// A count read from storage is the truth, not a delta to apply to whatever the
+    /// counter happens to hold, so it is assigned.
+    pub fn set_usage(&self, tenant_id: &str, resource: &str, amount: usize) -> TenantResult<()> {
+        let mut usage = self.usage.write().unwrap();
+
+        let tenant_usage = usage
+            .get_mut(tenant_id)
+            .ok_or_else(|| TenantError::NotFound(tenant_id.to_string()))?;
+
+        match resource {
+            "nodes" => tenant_usage.node_count = amount,
+            "edges" => tenant_usage.edge_count = amount,
+            "memory" => tenant_usage.memory_bytes = amount,
+            "storage" => tenant_usage.storage_bytes = amount,
+            "connections" => tenant_usage.active_connections = amount,
+            _ => {}
+        }
+
+        debug!("Set {} for tenant {} to {}", resource, tenant_id, amount);
+
+        Ok(())
+    }
+
     /// Get resource usage for a tenant
     pub fn get_usage(&self, tenant_id: &str) -> TenantResult<ResourceUsage> {
         let usage = self.usage.read().unwrap();

--- a/src/protocol/command.rs
+++ b/src/protocol/command.rs
@@ -227,15 +227,38 @@ impl CommandHandler {
             return RespValue::Error("ERR wrong number of arguments for 'GRAPH.DELETE' command".to_string());
         }
 
-        let _graph_name = match args[1].as_string() {
+        let graph_name = match args[1].as_string() {
             Ok(Some(s)) => s,
             Ok(None) => return RespValue::Error("ERR null graph name".to_string()),
             Err(e) => return RespValue::Error(format!("ERR {}", e)),
         };
+        // The name used to be parsed and thrown away, and then the *whole store*
+        // was cleared -- so `GRAPH.DELETE analytics` also emptied `default`
+        // (#1110). `GRAPH.QUERY` already refuses a name this build does not serve;
+        // a destructive command has more reason to, not less.
+        if graph_name != "default" {
+            return RespValue::Error(format!(
+                "ERR this build serves a single graph ('default'); graph '{}' does not exist. \
+                 The name was previously ignored and the whole store was cleared.",
+                graph_name
+            ));
+        }
 
-        // Clear the graph
+        // Disk first, then memory. The other order leaves a window where a
+        // concurrent write is journalled against ids the drop is about to reuse.
+        if let Some(ref persist_mgr) = self.persistence {
+            if let Err(e) = persist_mgr.drop_graph(&graph_name) {
+                // Do not clear memory after a failed drop: memory and disk would
+                // then disagree, which is the state this command used to leave
+                // behind unconditionally.
+                return RespValue::Error(format!("ERR failed to delete graph: {}", e));
+            }
+        }
+
         let mut store_guard = store.write().await;
         store_guard.clear();
+        // Nothing journalled by `clear()` -- the drop above is the durable half.
+        let _ = store_guard.take_write_log();
         drop(store_guard);
 
         RespValue::SimpleString("OK".to_string())

--- a/tests/graph_delete.rs
+++ b/tests/graph_delete.rs
@@ -1,0 +1,144 @@
+//! What `GRAPH.DELETE` actually deletes (#1110), and what the tenant counter says
+//! afterwards (#1113).
+//!
+//! The handler used to parse the graph name, throw it away, call `GraphStore::clear()`
+//! and return `OK`. Nothing on disk was touched, so a restart brought the graph back —
+//! and `clear()` rewinds the id counters, so the writes that followed were persisted
+//! over ids that still belonged to the deleted graph.
+
+use samyama::graph::GraphStore;
+use samyama::persistence::PersistenceManager;
+use samyama::protocol::{CommandHandler, RespValue};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+fn cmd(parts: &[&str]) -> RespValue {
+    RespValue::Array(
+        parts
+            .iter()
+            .map(|p| RespValue::BulkString(Some(p.as_bytes().to_vec())))
+            .collect(),
+    )
+}
+
+struct Server {
+    _dir: tempfile::TempDir,
+    pm: Arc<PersistenceManager>,
+    handler: CommandHandler,
+    store: Arc<RwLock<GraphStore>>,
+}
+
+impl Server {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let pm = Arc::new(PersistenceManager::new(dir.path()).unwrap());
+        pm.tenants()
+            .create_tenant("default".into(), "default".into(), None)
+            .ok();
+        Server {
+            handler: CommandHandler::new(Some(Arc::clone(&pm))),
+            store: Arc::new(RwLock::new(GraphStore::new())),
+            pm,
+            _dir: dir,
+        }
+    }
+
+    async fn query(&self, q: &str) -> RespValue {
+        self.handler
+            .handle_command(&cmd(&["GRAPH.QUERY", "default", q]), &self.store)
+            .await
+    }
+
+    async fn delete(&self, graph: &str) -> RespValue {
+        self.handler
+            .handle_command(&cmd(&["GRAPH.DELETE", graph]), &self.store)
+            .await
+    }
+
+    /// What a restart would load.
+    fn after_restart(&self) -> Vec<samyama::graph::Node> {
+        self.pm.checkpoint().unwrap();
+        self.pm.recover("default").unwrap().0
+    }
+}
+
+/// The reproduction. Three nodes, a delete, then one node: a restart used to find
+/// **three** — the new node at id 1, and the deleted graph's rows still sitting at
+/// ids 2 and 3, with the row formerly at id 1 silently overwritten by an unrelated
+/// entity. Neither the old graph nor the new one, and no error anywhere.
+#[tokio::test]
+async fn a_deleted_graph_does_not_come_back_around_the_next_write() {
+    let s = Server::new();
+    s.query("CREATE (:Before {tag: \"a\"}), (:Before {tag: \"b\"}), (:Before {tag: \"c\"})")
+        .await;
+    assert_eq!(s.after_restart().len(), 3, "setup did not persist");
+
+    assert_eq!(s.delete("default").await, RespValue::SimpleString("OK".into()));
+    assert_eq!(s.store.read().await.node_count(), 0, "memory not cleared");
+    assert!(s.after_restart().is_empty(), "the delete did not reach disk");
+
+    s.query("CREATE (:After {tag: \"second\"})").await;
+
+    let nodes = s.after_restart();
+    assert_eq!(
+        nodes.len(),
+        1,
+        "a restart found {} nodes: {:?}",
+        nodes.len(),
+        nodes
+            .iter()
+            .map(|n| n.labels.iter().map(|l| l.as_str().to_string()).collect::<Vec<_>>())
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        nodes[0].labels.iter().any(|l| l.as_str() == "After"),
+        "the surviving node is from the deleted graph: {:?}",
+        nodes[0]
+    );
+}
+
+/// The name was parsed into `_graph_name` and discarded, and then the whole store was
+/// cleared — so deleting a graph this build does not serve emptied the one it does.
+/// `GRAPH.QUERY` already refuses an unknown name; a destructive command has more
+/// reason to.
+#[tokio::test]
+async fn deleting_a_graph_that_does_not_exist_does_not_empty_the_one_that_does() {
+    let s = Server::new();
+    s.query("CREATE (:Keep {tag: \"a\"})").await;
+
+    let response = s.delete("analytics").await;
+    assert!(
+        matches!(response, RespValue::Error(_)),
+        "deleting an unknown graph returned {response:?}"
+    );
+    assert_eq!(s.store.read().await.node_count(), 1, "memory was cleared anyway");
+    assert_eq!(s.after_restart().len(), 1, "disk was cleared anyway");
+}
+
+/// #1113: `recover()` used to add the graph's whole size to the tenant counter on
+/// every call, so reading the row count twice doubled it. The counter gates
+/// `check_quota`, so the drift ends in a graph that has not grown refusing writes.
+#[tokio::test]
+async fn reading_the_graph_twice_does_not_double_its_recorded_size() {
+    let s = Server::new();
+    s.query("CREATE (:A {t: 1}), (:A {t: 2}), (:A {t: 3})").await;
+
+    let count = || s.pm.tenants().get_usage("default").unwrap().node_count;
+    assert_eq!(count(), 3);
+    for _ in 0..3 {
+        s.pm.recover("default").unwrap();
+        assert_eq!(count(), 3, "a recover changed the count of an unchanged graph");
+    }
+}
+
+/// A drop sets the counter to the truth rather than subtracting a remembered number
+/// from it, so it lands on zero however far it had drifted beforehand.
+#[tokio::test]
+async fn a_drop_leaves_the_counter_at_zero() {
+    let s = Server::new();
+    s.query("CREATE (:A {t: 1}), (:A {t: 2})").await;
+    s.pm.tenants().increment_usage("default", "nodes", 99).unwrap();
+
+    s.delete("default").await;
+    assert_eq!(s.pm.tenants().get_usage("default").unwrap().node_count, 0);
+}


### PR DESCRIPTION
Closes #1110. Closes #1113.

## Reproduced

Three nodes, `GRAPH.DELETE default`, then one node:

```
memory after the delete:  0 nodes
what a restart found:     3 nodes
    id=1 labels=["After"]  props={"tag": "second"}
    id=2 labels=["Before"] props={"tag": "b"}
    id=3 labels=["Before"] props={"tag": "c"}
```

Neither the old graph nor the new one, and no error at any point.

The handler was nine lines: parse the graph name into `_graph_name`, discard it,
`GraphStore::clear()`, return `OK`. Three defects, together.

| | |
|---|---|
| The name is ignored and the **whole store** is cleared | `GRAPH.DELETE analytics` empties `default`. `GRAPH.QUERY` already refuses a name this build does not serve; a destructive command has more reason to |
| Nothing on disk is touched | The graph comes back on restart. A lost delete is worse than a lost write — it says the data is gone when it is not, which may be the answer the user gave someone else |
| `clear()` rewinds `next_node_id` | The next `CREATE` takes id 1 and `apply_mutations` upserts the persisted row belonging to a *different* entity |

## Fix

`PersistentStorage::delete_graph` does a range delete over the tenant's key prefix
rather than a scan and a loop: keys are `{tenant}:n:{id:016x}`, so a tenant's rows
are one contiguous range and a drop should not cost a round trip per row.

`PersistenceManager::drop_graph` calls it, flushes, and zeroes the usage counters.
**Disk first, then memory** — the other order leaves a window where a concurrent
write is journalled against ids the drop is about to reuse. A failed drop leaves
memory alone rather than clearing it, since memory and disk disagreeing is exactly
the state this command used to produce unconditionally.

## #1113, from the same measurement

```rust
// PersistenceManager::recover
self.tenants.increment_usage(tenant, "nodes", nodes.len())?;
```

`recover()` added the graph's whole size to the tenant counter on **every** call:

```
after CREATE (:A {t: 1})       usage=1  memory=1
  one recover() later          usage=2
after 2 more creates           usage=4  memory=3
  one recover() later          usage=7
```

At boot it runs once per tenant, which is why nothing had caught it. Any second
call permanently inflates a counter that gates `check_quota`, so a graph that has
not grown drifts toward refusing writes, with an error naming a quota the data does
not breach. `TenantManager::set_usage` assigns instead: a count read from storage
is the truth, not a delta to apply to whatever the counter holds. `drop_graph`
assigns zero for the same reason — a counter that has already drifted cannot be
corrected by subtracting from it.

`apply_mutations` was correct throughout; its per-row accounting tracks memory
exactly.

## Worth recording: the probe was measuring itself

The first version read the disk row count with `pm.recover(...)` on each iteration
to print alongside the usage number — so the instrumentation moved the quantity it
was reporting, produced `usage=6` for a graph of 3, and made `apply_mutations` look
like the culprit. The trace above is from after that read was removed.

## Tests

`tests/graph_delete.rs`, driving the real RESP `CommandHandler`:
`a_deleted_graph_does_not_come_back_around_the_next_write`,
`deleting_a_graph_that_does_not_exist_does_not_empty_the_one_that_does`,
`reading_the_graph_twice_does_not_double_its_recorded_size`,
`a_drop_leaves_the_counter_at_zero` (which drifts the counter by 99 first, so it
asserts the assignment and not a lucky subtraction).

`cargo test --workspace --no-fail-fast`: **254 binaries, 4,097 passed, 0 failed.**

https://claude.ai/code/session_016erf3aJ7MVFwUABw1PXyJf