### PR TITLE
LOAD CSV (LANG-09): a streaming reading clause behind an import gate

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -454,6 +454,25 @@ async fn start_server() {
         config.data_path = Some(path);
     }
 
+    // Parse --import-dir <dir>: the directory `LOAD CSV` may read under (LANG-09).
+    //
+    // Absent by default, and absent means the clause is refused rather than reading
+    // from the working directory. `LOAD CSV FROM 'file:///etc/passwd'` on a server
+    // reachable over the network is an arbitrary local file read for anyone who can
+    // send a query, so this is a gate that must be opened deliberately.
+    if let Some(dir) = std::env::args()
+        .position(|a| a == "--import-dir")
+        .and_then(|pos| std::env::args().nth(pos + 1))
+    {
+        match samyama::query::csv_source::set_import_root(Some(std::path::Path::new(&dir))) {
+            Ok(()) => println!("LOAD CSV enabled, reading under {}", dir),
+            Err(e) => {
+                eprintln!("--import-dir: {e}");
+                std::process::exit(2);
+            }
+        }
+    }
+
     // Parse --demo flag: social (rich schema) or large (scale stress test)
     let demo_mode: Option<String> = std::env::args()
         .position(|a| a == "--demo")

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -121,6 +121,8 @@ pub struct Query {
     pub foreach_clause: Option<ForeachClause>,
     /// UNWIND clause (optional)
     pub unwind_clause: Option<UnwindClause>,
+    /// `LOAD CSV` clause (optional) — a reading clause, like `unwind_clause`.
+    pub load_csv_clause: Option<LoadCsvClause>,
     /// Every clause of the query, in the order it was written.
     ///
     /// The fields above describe a query by *kind* — all the MATCHes here, the
@@ -271,6 +273,25 @@ pub struct MatchClause {
     pub optional: bool,
 }
 
+/// `LOAD CSV [WITH HEADERS] FROM <expr> AS <var> [FIELDTERMINATOR <str>]` (LANG-09).
+///
+/// A reading clause: one row per CSV record, the way `UNWIND` gives one row per list
+/// element.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LoadCsvClause {
+    /// The source, evaluated per row of the input. A literal in every realistic
+    /// query, but an expression so `LOAD CSV FROM $path` works.
+    pub source: Expression,
+    /// The variable each record is bound to.
+    pub variable: String,
+    /// With headers each record binds as a map keyed by the header row; without, as
+    /// a list. This changes the *shape* of the bound value, so a query written for
+    /// one reads nothing from the other.
+    pub with_headers: bool,
+    /// `FIELDTERMINATOR`. `None` means `,`.
+    pub field_terminator: Option<char>,
+}
+
 /// One clause of a query, as written.
 ///
 /// A flat, ordered alternative to the by-kind fields on [`Query`]. Cypher is a
@@ -283,6 +304,8 @@ pub enum Clause {
     /// A `WHERE` attached to the reading clause before it.
     Where(WhereClause),
     Unwind(UnwindClause),
+    /// `LOAD CSV` — a reading clause, like `Unwind`.
+    LoadCsv(LoadCsvClause),
     With(WithClause),
     Create(CreateClause),
     Merge(MergeClause),
@@ -318,6 +341,7 @@ impl Clause {
             Clause::Match(_) => "MATCH",
             Clause::Where(_) => "WHERE",
             Clause::Unwind(_) => "UNWIND",
+            Clause::LoadCsv(_) => "LOAD CSV",
             Clause::With(_) => "WITH",
             Clause::Create(_) => "CREATE",
             Clause::Merge(_) => "MERGE",
@@ -932,6 +956,7 @@ impl Query {
             params: HashMap::new(),
             foreach_clause: None,
             unwind_clause: None,
+            load_csv_clause: None,
             clauses: Vec::new(),
             needs_clause_pipeline: false,
             extra_unwind_clauses: Vec::new(),

--- a/src/query/csv_source.rs
+++ b/src/query/csv_source.rs
@@ -1,0 +1,179 @@
+//! Where `LOAD CSV` is allowed to read from (LANG-09).
+//!
+//! `LOAD CSV FROM 'file:///etc/passwd'` on a server reachable over the network is an
+//! arbitrary local file read for anyone who can send a query. So this is a gate and
+//! not a warning: with no import root configured the clause is refused outright, and
+//! with one configured a path that resolves outside it is refused by name.
+//!
+//! Resolution is done on the **canonical** path, after symlinks. A check on the
+//! textual path is not a check: `<root>/../../etc/passwd` and a symlink inside the
+//! root both pass it.
+
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+
+/// The directory `LOAD CSV` may read under, or `None` — the default — for "refuse
+/// every source".
+static IMPORT_ROOT: RwLock<Option<PathBuf>> = RwLock::new(None);
+
+/// Point `LOAD CSV` at a directory. `None` disables the clause again.
+///
+/// Canonicalised once here so that every later comparison is between two resolved
+/// paths, and so a root that does not exist is a configuration error rather than a
+/// clause that silently refuses everything.
+pub fn set_import_root(root: Option<&Path>) -> Result<(), CsvSourceError> {
+    let resolved = match root {
+        None => None,
+        Some(p) => Some(
+            p.canonicalize()
+                .map_err(|e| CsvSourceError::UnreadableRoot(p.display().to_string(), e.to_string()))?,
+        ),
+    };
+    *IMPORT_ROOT.write().unwrap() = resolved;
+    Ok(())
+}
+
+/// The configured root, for diagnostics.
+pub fn import_root() -> Option<PathBuf> {
+    IMPORT_ROOT.read().unwrap().clone()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CsvSourceError {
+    /// No import root configured, so the clause is off.
+    NoImportRoot,
+    /// A scheme this build does not fetch.
+    UnsupportedScheme(String),
+    /// Resolved outside the import root.
+    OutsideImportRoot { path: String, root: String },
+    /// The file is not there, or is not readable.
+    Unreadable(String, String),
+    UnreadableRoot(String, String),
+}
+
+impl std::fmt::Display for CsvSourceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CsvSourceError::NoImportRoot => write!(
+                f,
+                "LOAD CSV is disabled: no import directory is configured. Start the \
+                 server with --import-dir <path> to enable it; every source must \
+                 resolve inside that directory"
+            ),
+            CsvSourceError::UnsupportedScheme(s) => write!(
+                f,
+                "LOAD CSV cannot read '{s}' sources; only file:// and plain paths \
+                 under the import directory are supported"
+            ),
+            CsvSourceError::OutsideImportRoot { path, root } => write!(
+                f,
+                "LOAD CSV refused '{path}': it resolves outside the import directory \
+                 '{root}'"
+            ),
+            CsvSourceError::Unreadable(p, e) => write!(f, "LOAD CSV cannot read '{p}': {e}"),
+            CsvSourceError::UnreadableRoot(p, e) => {
+                write!(f, "import directory '{p}' cannot be used: {e}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CsvSourceError {}
+
+/// Resolve a `LOAD CSV` source to a path that may be opened.
+pub fn resolve(source: &str) -> Result<PathBuf, CsvSourceError> {
+    let root = import_root().ok_or(CsvSourceError::NoImportRoot)?;
+
+    let raw = if let Some(rest) = source.strip_prefix("file://") {
+        rest.to_string()
+    } else if let Some((scheme, _)) = source.split_once("://") {
+        // http(s) is deliberately absent. A server that fetches arbitrary URLs on a
+        // client's behalf is an SSRF primitive and deserves its own decision, not an
+        // inheritance from this one.
+        return Err(CsvSourceError::UnsupportedScheme(scheme.to_string()));
+    } else {
+        source.to_string()
+    };
+
+    // Relative paths are relative to the root, not to the process working directory,
+    // which is not something a query author can see.
+    let joined = if Path::new(&raw).is_absolute() {
+        PathBuf::from(&raw)
+    } else {
+        root.join(&raw)
+    };
+
+    // Canonicalise before comparing: `<root>/../../etc/passwd` and a symlink planted
+    // inside the root both pass a textual check.
+    let resolved = joined
+        .canonicalize()
+        .map_err(|e| CsvSourceError::Unreadable(raw.clone(), e.to_string()))?;
+
+    if !resolved.starts_with(&root) {
+        return Err(CsvSourceError::OutsideImportRoot {
+            path: raw,
+            root: root.display().to_string(),
+        });
+    }
+    Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// The global root makes these tests order-dependent, so they run as one.
+    #[test]
+    fn the_gate() {
+        let dir = tempfile::tempdir().unwrap();
+        let inside = dir.path().join("ok.csv");
+        writeln!(std::fs::File::create(&inside).unwrap(), "a,b").unwrap();
+
+        let outside_dir = tempfile::tempdir().unwrap();
+        let outside = outside_dir.path().join("secret.csv");
+        writeln!(std::fs::File::create(&outside).unwrap(), "a,b").unwrap();
+
+        // Off by default: a build that has not been told where to read cannot be
+        // talked into reading anywhere.
+        set_import_root(None).unwrap();
+        assert_eq!(resolve("ok.csv"), Err(CsvSourceError::NoImportRoot));
+        assert_eq!(
+            resolve(&format!("file://{}", outside.display())),
+            Err(CsvSourceError::NoImportRoot)
+        );
+
+        set_import_root(Some(dir.path())).unwrap();
+        assert!(resolve("ok.csv").is_ok(), "a file in the root was refused");
+        assert!(resolve(&format!("file://{}", inside.display())).is_ok());
+
+        // The three ways out of a directory.
+        assert!(matches!(
+            resolve(&format!("file://{}", outside.display())),
+            Err(CsvSourceError::OutsideImportRoot { .. })
+        ));
+        assert!(matches!(
+            resolve("../../etc/passwd"),
+            Err(CsvSourceError::OutsideImportRoot { .. }) | Err(CsvSourceError::Unreadable(..))
+        ));
+        #[cfg(unix)]
+        {
+            let link = dir.path().join("escape.csv");
+            std::os::unix::fs::symlink(&outside, &link).unwrap();
+            assert!(
+                matches!(
+                    resolve("escape.csv"),
+                    Err(CsvSourceError::OutsideImportRoot { .. })
+                ),
+                "a symlink out of the import directory was followed"
+            );
+        }
+
+        assert!(matches!(
+            resolve("https://example.com/x.csv"),
+            Err(CsvSourceError::UnsupportedScheme(_))
+        ));
+
+        set_import_root(None).unwrap();
+    }
+}

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -8,7 +8,7 @@ COMMENT = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ("//" ~ (!"\n" ~ ANY)*) }
 query = { SOI ~ explain_clause? ~ statement ~ (union_clause ~ statement)* ~ ";"? ~ EOI }
 explain_clause = { ^"PROFILE" | ^"EXPLAIN" }
 union_clause = { ^"UNION" ~ ^"ALL"? }
-statement = { show_hierarchy_indexes_stmt | show_indexes_stmt | show_constraints_stmt | drop_hierarchy_index_stmt | drop_index_stmt | create_constraint_stmt | create_vector_index_stmt | create_hierarchy_index_stmt | create_index_stmt | rebuild_hierarchy_index_stmt | call_stmt | foreach_stmt | merge_stmt | unwind_stmt | match_stmt | create_stmt | with_return_stmt | return_stmt }
+statement = { show_hierarchy_indexes_stmt | show_indexes_stmt | show_constraints_stmt | drop_hierarchy_index_stmt | drop_index_stmt | create_constraint_stmt | create_vector_index_stmt | create_hierarchy_index_stmt | create_index_stmt | rebuild_hierarchy_index_stmt | call_stmt | foreach_stmt | merge_stmt | load_csv_stmt | unwind_stmt | match_stmt | create_stmt | with_return_stmt | return_stmt }
 
 // A query as what Cypher actually is: an ordered sequence of clauses.
 //
@@ -25,7 +25,7 @@ statement = { show_hierarchy_indexes_stmt | show_indexes_stmt | show_constraints
 pipeline_query = { SOI ~ explain_clause? ~ pipeline_stmt ~ ";"? ~ EOI }
 pipeline_stmt = { pipeline_clause+ ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
 pipeline_clause = _{
-    optional_match_clause | match_clause | where_clause | unwind_clause |
+    optional_match_clause | match_clause | where_clause | unwind_clause | load_csv_clause |
     with_clause | create_clause | merge_inline | delete_clause |
     foreach_clause | set_clause | remove_clause | call_clause | return_clause
 }
@@ -106,6 +106,14 @@ foreach_stmt = { foreach_clause }
 foreach_clause = { ^"FOREACH" ~ "(" ~ variable ~ in_op ~ expression ~ "|" ~ foreach_body+ ~ ")" }
 foreach_body = _{ set_clause | remove_clause | delete_clause | create_clause }
 unwind_clause = { ^"UNWIND" ~ expression ~ ^"AS" ~ variable }
+// LOAD CSV (LANG-09). A reading clause: it produces one row per record, the way
+// UNWIND produces one row per list element, and everything downstream of it is
+// written against that row.
+//
+// `WITH HEADERS` decides the *shape* of the bound value -- a map keyed by the
+// header row, or a list -- so it is not an optional detail: a query written for
+// one shape reads nothing from the other.
+load_csv_clause = { ^"LOAD" ~ ^"CSV" ~ (^"WITH" ~ ^"HEADERS")? ~ ^"FROM" ~ expression ~ ^"AS" ~ variable ~ (^"FIELDTERMINATOR" ~ string)? }
 merge_inline = { ^"MERGE" ~ pattern ~ (on_create_set | on_match_set)* }
 // A statement that *begins* with UNWIND. UNWIND was already allowed after a MATCH or a
 // WITH, but a leading one had no rule to match, so the batch-write idiom
@@ -115,6 +123,9 @@ merge_inline = { ^"MERGE" ~ pattern ~ (on_create_set | on_match_set)* }
 // `UNWIND [1,2] AS a UNWIND [3,4] AS b` yields four rows — and the TCK leans
 // on the three-way form to enumerate the truth tables for AND/OR/XOR.
 unwind_stmt = { unwind_clause+ ~ ((optional_match_clause | match_clause)+ ~ where_clause?)* ~ (with_clause ~ unwind_clause? ~ ((optional_match_clause | match_clause)+ ~ where_clause?)*)* ~ create_clause? ~ merge_inline? ~ delete_clause? ~ foreach_clause? ~ set_clause* ~ remove_clause* ~ return_clause? ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
+// A statement that *begins* with LOAD CSV, which is where it almost always sits:
+// the clause is a source, so nothing binds before it. Same tail as `unwind_stmt`.
+load_csv_stmt = { load_csv_clause ~ ((optional_match_clause | match_clause)+ ~ where_clause?)* ~ (with_clause ~ unwind_clause? ~ ((optional_match_clause | match_clause)+ ~ where_clause?)*)* ~ create_clause? ~ merge_inline? ~ delete_clause? ~ foreach_clause? ~ set_clause* ~ remove_clause* ~ return_clause? ~ order_by_clause? ~ skip_clause? ~ limit_clause? }
 match_clause = { ^"MATCH" ~ pattern }
 optional_match_clause = { ^"OPTIONAL" ~ ^"MATCH" ~ pattern }
 where_clause = { ^"WHERE" ~ expression }

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -15692,6 +15692,163 @@ impl PhysicalOperator for UnwindOperator {
     }
 }
 
+/// `LOAD CSV` — one row per CSV record (LANG-09).
+///
+/// Streams. The obvious alternative is to desugar `LOAD CSV ... AS row` into
+/// `UNWIND <the whole file> AS row`, which needs no operator at all and inherits
+/// every UNWIND optimisation — but `UnwindOperator` materialises its list into a
+/// `Vec<Record>`, one clone per row, so a bulk-ingest clause would hold the entire
+/// file *and* a record per line in memory. This holds a `csv::Reader` and yields one
+/// record at a time, which is the only version that can honestly use the word bulk.
+///
+/// The reader is opened lazily, on the first `next()`, so a query that is planned
+/// and never pulled does not touch the filesystem, and `reset()` can drop it.
+pub struct LoadCsvOperator {
+    input: OperatorBox,
+    clause: crate::query::ast::LoadCsvClause,
+    /// The row this file is being read for. `LOAD CSV` is a source and its input is
+    /// a single empty row in every realistic query, but the operator is written for
+    /// the general case rather than assuming it.
+    current: Option<Record>,
+    reader: Option<csv::Reader<std::fs::File>>,
+    headers: Vec<String>,
+    exhausted: bool,
+}
+
+impl LoadCsvOperator {
+    pub fn new(input: OperatorBox, clause: crate::query::ast::LoadCsvClause) -> Self {
+        Self {
+            input,
+            clause,
+            current: None,
+            reader: None,
+            headers: Vec::new(),
+            exhausted: false,
+        }
+    }
+
+    fn open(&mut self, record: &Record, store: &GraphStore) -> ExecutionResult<()> {
+        let source = match eval_expression(&self.clause.source, record, store)? {
+            Value::Property(PropertyValue::String(s)) => s,
+            other => {
+                return Err(ExecutionError::TypeError(format!(
+                    "LOAD CSV FROM expects a string path, got {other:?}"
+                )))
+            }
+        };
+        let path = crate::query::csv_source::resolve(&source)
+            .map_err(|e| ExecutionError::RuntimeError(e.to_string()))?;
+        let file = std::fs::File::open(&path)
+            .map_err(|e| ExecutionError::RuntimeError(format!("LOAD CSV cannot open '{}': {e}", path.display())))?;
+
+        let mut reader = csv::ReaderBuilder::new()
+            .delimiter(self.clause.field_terminator.unwrap_or(',') as u8)
+            .has_headers(self.clause.with_headers)
+            // A ragged row is an error, not a row with some fields missing. Without
+            // headers the row is a list and a short one changes what `row[3]` means.
+            .flexible(false)
+            .from_reader(file);
+
+        self.headers = if self.clause.with_headers {
+            reader
+                .headers()
+                .map_err(|e| ExecutionError::RuntimeError(format!("LOAD CSV cannot read the header row: {e}")))?
+                .iter()
+                .map(|h| h.trim().to_string())
+                .collect()
+        } else {
+            Vec::new()
+        };
+        self.reader = Some(reader);
+        Ok(())
+    }
+
+    /// A field becomes a string. Cypher's `LOAD CSV` does not infer types — every
+    /// field arrives as a string and the query converts with `toInteger`/`toFloat` —
+    /// and guessing here would make `007` an integer and lose the zeros, silently,
+    /// in an ingest path.
+    fn field(raw: &str) -> Value {
+        Value::Property(PropertyValue::String(raw.to_string()))
+    }
+}
+
+impl PhysicalOperator for LoadCsvOperator {
+    fn next_mut(&mut self, store: &mut GraphStore, tenant_id: &str) -> ExecutionResult<Option<Record>> {
+        drain_input_for_write(&mut self.input, store, tenant_id)?;
+        self.next(store)
+    }
+
+    fn children_mut(&mut self) -> Vec<&mut OperatorBox> {
+        vec![&mut self.input]
+    }
+
+    fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        loop {
+            if self.reader.is_none() {
+                if self.exhausted {
+                    return Ok(None);
+                }
+                let record = match self.input.next(store)? {
+                    Some(r) => r,
+                    None => {
+                        self.exhausted = true;
+                        return Ok(None);
+                    }
+                };
+                self.open(&record, store)?;
+                self.current = Some(record);
+            }
+
+            let reader = self.reader.as_mut().expect("opened above");
+            let mut row = csv::StringRecord::new();
+            let more = reader
+                .read_record(&mut row)
+                .map_err(|e| ExecutionError::RuntimeError(format!("LOAD CSV: {e}")))?;
+            if !more {
+                // This file is done; the next input row, if any, opens the next one.
+                self.reader = None;
+                self.current = None;
+                continue;
+            }
+
+            let value = if self.clause.with_headers {
+                let mut map = std::collections::BTreeMap::new();
+                for (i, header) in self.headers.iter().enumerate() {
+                    map.insert(header.clone(), Self::field(row.get(i).unwrap_or("")));
+                }
+                Value::Map(map)
+            } else {
+                Value::List(row.iter().map(Self::field).collect())
+            };
+
+            let mut out = self.current.clone().unwrap_or_default();
+            out.bind(self.clause.variable.clone(), value);
+            return Ok(Some(out));
+        }
+    }
+
+    fn reset(&mut self) {
+        self.input.reset();
+        self.reader = None;
+        self.current = None;
+        self.headers.clear();
+        self.exhausted = false;
+    }
+
+    fn describe(&self) -> OperatorDescription {
+        OperatorDescription {
+            name: "LoadCsv".to_string(),
+            details: format!(
+                "{} AS {}{}",
+                format_expression(&self.clause.source),
+                self.clause.variable,
+                if self.clause.with_headers { " (with headers)" } else { "" }
+            ),
+            children: vec![self.input.describe()],
+        }
+    }
+}
+
 /// MERGE operator - upsert: match or create pattern
 pub struct MergeOperator {
     /// Upstream rows, when this MERGE runs inside a clause pipeline.

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -1288,9 +1288,15 @@ impl QueryPlanner {
         // no MATCH but is still row-driven, and planning it as a CREATE-only statement runs
         // it once with nothing bound. It falls through to the general pipeline, where the
         // Unwind feeds the create.
+        //
+        // `LOAD CSV` is the same shape and needed the same exclusion: without it
+        // `LOAD CSV ... AS row CREATE (:P {n: row.name})` was planned as a bare CREATE
+        // and failed with "`n` refers to a variable that is not bound here", the file
+        // never opened.
         if query.match_clauses.is_empty()
             && query.call_clause.is_none()
             && !Self::has_any_unwind(query)
+            && query.load_csv_clause.is_none()
         {
             if let Some(create_clause) = &query.create_clause {
                 let mut plan = self.plan_create_only(create_clause)?;
@@ -1771,6 +1777,19 @@ impl QueryPlanner {
         let unwind_before_barrier = query.unwind_leading
             || query.with_clause.is_some()
             || !query.extra_with_stages.is_empty();
+
+        // `LOAD CSV` is a source: it opens the file and produces the rows the rest of
+        // the query is written against, so it goes at the bottom of the pipeline, the
+        // same place a leading UNWIND goes.
+        if let Some(load) = &query.load_csv_clause {
+            use crate::query::executor::operator::{LoadCsvOperator, SingleRowOperator};
+            let base: OperatorBox = match operator.take() {
+                Some(op) => op,
+                None => Box::new(SingleRowOperator::new()),
+            };
+            operator = Some(Box::new(LoadCsvOperator::new(base, load.clone())));
+            known_vars.insert(load.variable.clone());
+        }
 
         if unwind_before_barrier {
             if let Some(unwind) = leading_unwind {
@@ -6224,7 +6243,12 @@ impl QueryPlanner {
         // hardest part of the planner.
         let split = clauses
             .iter()
-            .position(|c| !matches!(c, Clause::Match(_) | Clause::Where(_) | Clause::Unwind(_)))
+            .position(|c| {
+                !matches!(
+                    c,
+                    Clause::Match(_) | Clause::Where(_) | Clause::Unwind(_) | Clause::LoadCsv(_)
+                )
+            })
             .unwrap_or(clauses.len());
 
         let mut operator: OperatorBox = if split == 0 {
@@ -6245,6 +6269,7 @@ impl QueryPlanner {
                             prefix.extra_unwind_clauses.push(u.clone());
                         }
                     }
+                    Clause::LoadCsv(l) => prefix.load_csv_clause = Some(l.clone()),
                     _ => unreachable!("split stops at the first non-reading clause"),
                 }
             }
@@ -6268,6 +6293,7 @@ impl QueryPlanner {
                     }
                 }
                 Clause::Unwind(u) => { bound.insert(u.variable.clone()); }
+                Clause::LoadCsv(l) => { bound.insert(l.variable.clone()); }
                 _ => {}
             }
         }
@@ -6410,6 +6436,16 @@ impl QueryPlanner {
                             _ => String::new(),
                         }))
                         .collect();
+                }
+                // A `LOAD CSV` after the reading prefix -- `WITH ... LOAD CSV ...`.
+                // Without this arm it would fall through the wildcard below and
+                // silently bind nothing, which is how a clause gets added to one AST
+                // shape and not the other.
+                Clause::LoadCsv(l) => {
+                    operator = Box::new(
+                        crate::query::executor::operator::LoadCsvOperator::new(operator, l.clone()),
+                    );
+                    bound.insert(l.variable.clone());
                 }
                 Clause::Unwind(u) => {
                     operator = Box::new(UnwindOperator::new(
@@ -7948,6 +7984,7 @@ mod tests {
 
         // Build a query manually with no MATCH and no CREATE
         let query = crate::query::ast::Query {
+            load_csv_clause: None,
             match_clauses: vec![],
             where_clause: None,
             return_clause: None,

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -75,6 +75,7 @@ pub mod parser;
 pub mod star;
 pub mod validate;
 pub mod executor;
+pub mod csv_source;
 
 use std::num::NonZeroUsize;
 use std::sync::Mutex;

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -204,6 +204,9 @@ fn parse_clause_pipeline(input: &str) -> ParseResult<Query> {
                             Rule::unwind_clause => {
                                 query.clauses.push(Clause::Unwind(parse_unwind_clause(c)?));
                             }
+                            Rule::load_csv_clause => {
+                                query.clauses.push(Clause::LoadCsv(parse_load_csv_clause(c)?));
+                            }
                             Rule::with_clause => {
                                 query.clauses.push(Clause::With(parse_with_clause(c)?));
                             }
@@ -532,6 +535,11 @@ fn parse_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -> Pars
                         query.foreach_clause = Some(parse_foreach_clause(fe)?);
                     }
                 }
+            }
+            Rule::load_csv_stmt => {
+                // Same clause set again -- `parse_match_statement` dispatches on each
+                // inner rule, and `load_csv_clause` is one of the rules it knows.
+                parse_match_statement(inner, query)?;
             }
             Rule::match_stmt | Rule::unwind_stmt => {
                 // Same clause set, so the same builder applies -- it already dispatches on
@@ -1155,6 +1163,9 @@ fn parse_match_statement(pair: pest::iterators::Pair<Rule>, query: &mut Query) -
                     query.extra_unwind_clauses.push(u);
                 }
             }
+            Rule::load_csv_clause => {
+                query.load_csv_clause = Some(parse_load_csv_clause(inner)?);
+            }
             Rule::merge_inline => {
                 query.merge_clause = Some(parse_merge_clause(inner)?);
             }
@@ -1421,6 +1432,53 @@ fn parse_unwind_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<UnwindC
     Ok(UnwindClause {
         expression: expression.ok_or_else(|| ParseError::SemanticError("UNWIND missing expression".to_string()))?,
         variable: variable.ok_or_else(|| ParseError::SemanticError("UNWIND missing AS variable".to_string()))?,
+    })
+}
+
+/// `LOAD CSV [WITH HEADERS] FROM <expr> AS <var> [FIELDTERMINATOR <str>]`.
+///
+/// `WITH HEADERS` has no token of its own in the parse tree — it is a bare keyword
+/// pair — so it is read off the clause text rather than from a child pair.
+fn parse_load_csv_clause(pair: pest::iterators::Pair<Rule>) -> ParseResult<LoadCsvClause> {
+    let text = pair.as_str().to_string();
+    let mut source = None;
+    let mut variable = None;
+    let mut field_terminator = None;
+
+    for inner in pair.into_inner() {
+        match inner.as_rule() {
+            Rule::expression => source = Some(parse_expression(inner)?),
+            Rule::variable => variable = Some(inner.as_str().to_string()),
+            Rule::string => {
+                let raw = inner.as_str();
+                let unquoted = &raw[1..raw.len().saturating_sub(1)];
+                let mut chars = unquoted.chars();
+                let (first, rest) = (chars.next(), chars.next());
+                match (first, rest) {
+                    (Some(c), None) => field_terminator = Some(c),
+                    _ => {
+                        return Err(ParseError::SemanticError(format!(
+                            "FIELDTERMINATOR must be a single character, got {raw}"
+                        )))
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Uppercased once: the keyword is case-insensitive in the grammar, so matching
+    // the written case would accept `WITH HEADERS` and quietly ignore `with headers`.
+    let upper = text.to_uppercase();
+    let with_headers = upper.contains("WITH") && upper.contains("HEADERS");
+
+    Ok(LoadCsvClause {
+        source: source
+            .ok_or_else(|| ParseError::SemanticError("LOAD CSV missing FROM source".to_string()))?,
+        variable: variable
+            .ok_or_else(|| ParseError::SemanticError("LOAD CSV missing AS variable".to_string()))?,
+        with_headers,
+        field_terminator,
     })
 }
 

--- a/src/query/star.rs
+++ b/src/query/star.rs
@@ -182,6 +182,7 @@ fn expand_stars_pipeline(clauses: &mut [Clause]) -> bool {
                 // FOREACH binds only inside its own body.
             }
             Clause::Unwind(u) => push_unique(&mut scope, &u.variable),
+            Clause::LoadCsv(l) => push_unique(&mut scope, &l.variable),
             Clause::Call(call) => {
                 for item in &call.yield_items {
                     push_unique(&mut scope, item.alias.as_ref().unwrap_or(&item.name));

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -434,6 +434,9 @@ fn write_patterns(query: &Query) -> Vec<(WriteKind, &crate::query::ast::Pattern,
                 Clause::Unwind(uc) => {
                     bound.insert(uc.variable.clone());
                 }
+                Clause::LoadCsv(lc) => {
+                    bound.insert(lc.variable.clone());
+                }
                 Clause::Create(cc) => {
                     out.push((WriteKind::Create, &cc.pattern, bound.clone()));
                     pattern_variables(&cc.pattern, &mut bound);
@@ -1015,6 +1018,7 @@ fn validate_order_by_in_scope(query: &Query) -> Result<(), ValidationError> {
             Clause::Create(cc) => { pattern_vars(&cc.pattern, &mut scope); seen_any_binding = true; }
             Clause::Merge(mc) => { pattern_vars(&mc.pattern, &mut scope); seen_any_binding = true; }
             Clause::Unwind(u) => { scope.insert(u.variable.clone()); seen_any_binding = true; }
+            Clause::LoadCsv(l) => { scope.insert(l.variable.clone()); seen_any_binding = true; }
             Clause::With(wc) => {
                 let projected = projected_names(&wc.items);
                 if let Some(ob) = &wc.order_by {
@@ -1169,6 +1173,7 @@ fn all_expressions(query: &Query) -> Vec<&Expression> {
                 Clause::With(w) => push_items(&w.items, &mut out),
                 Clause::Where(w) => out.push(&w.predicate),
                 Clause::Unwind(u) => out.push(&u.expression),
+                Clause::LoadCsv(l) => out.push(&l.source),
                 _ => {}
             }
         }
@@ -1379,6 +1384,7 @@ fn validate_pattern_predicate_vars(query: &Query) -> Result<(), ValidationError>
                 Clause::Create(cc) => pattern_vars(&cc.pattern, &mut bound),
                 Clause::Merge(mc) => pattern_vars(&mc.pattern, &mut bound),
                 Clause::Unwind(u) => { bound.insert(u.variable.clone()); }
+                Clause::LoadCsv(l) => { bound.insert(l.variable.clone()); }
                 Clause::With(w) => bound = projected_names(&w.items),
                 Clause::Where(w) => walk(&w.predicate, &bound)?,
                 _ => {}
@@ -1393,6 +1399,9 @@ fn validate_pattern_predicate_vars(query: &Query) -> Result<(), ValidationError>
     }
     if let Some(u) = &query.unwind_clause {
         bound.insert(u.variable.clone());
+    }
+    if let Some(l) = &query.load_csv_clause {
+        bound.insert(l.variable.clone());
     }
     for u in &query.extra_unwind_clauses {
         bound.insert(u.variable.clone());
@@ -1578,6 +1587,9 @@ fn validate_delete_targets(query: &Query) -> Result<(), ValidationError> {
         if let Some(u) = &query.unwind_clause {
             out.insert(u.variable.clone());
         }
+        if let Some(l) = &query.load_csv_clause {
+            out.insert(l.variable.clone());
+        }
         for u in &query.extra_unwind_clauses {
             out.insert(u.variable.clone());
         }
@@ -1603,6 +1615,9 @@ fn validate_delete_targets(query: &Query) -> Result<(), ValidationError> {
                 Clause::Merge(mc) => pattern_vars(&mc.pattern, &mut out),
                 Clause::Unwind(u) => {
                     out.insert(u.variable.clone());
+                }
+                Clause::LoadCsv(l) => {
+                    out.insert(l.variable.clone());
                 }
                 Clause::With(w) => out.extend(projected_names(&w.items)),
                 _ => {}
@@ -1750,6 +1765,10 @@ fn validate_variables_are_bound(query: &Query) -> Result<(), ValidationError> {
             bound.insert(u.variable.clone());
             binders(&u.expression, bound);
         }
+        if let Some(l) = &query.load_csv_clause {
+            bound.insert(l.variable.clone());
+            binders(&l.source, bound);
+        }
         if let Some(f) = &query.foreach_clause {
             bound.insert(f.variable.clone());
             for c in &f.create_clauses {
@@ -1772,6 +1791,10 @@ fn validate_variables_are_bound(query: &Query) -> Result<(), ValidationError> {
                 Clause::Unwind(u) => {
                     bound.insert(u.variable.clone());
                     binders(&u.expression, bound);
+                }
+                Clause::LoadCsv(l) => {
+                    bound.insert(l.variable.clone());
+                    binders(&l.source, bound);
                 }
                 Clause::Foreach(f) => {
                     bound.insert(f.variable.clone());

--- a/tests/load_csv.rs
+++ b/tests/load_csv.rs
@@ -1,0 +1,138 @@
+//! `LOAD CSV` (LANG-09).
+//!
+//! The clause is off unless an import directory is configured, so most of these set
+//! one first. That is not test scaffolding: `LOAD CSV FROM 'file:///etc/passwd'` on a
+//! server reachable over the network is an arbitrary local file read, so the gate is
+//! the feature's first property rather than an option on it.
+
+use samyama::graph::GraphStore;
+use samyama::query::csv_source::set_import_root;
+use samyama::query::QueryEngine;
+use std::io::Write;
+
+const T: &str = "default";
+
+fn write_csv(dir: &std::path::Path, name: &str, body: &str) -> std::path::PathBuf {
+    let p = dir.join(name);
+    write!(std::fs::File::create(&p).unwrap(), "{body}").unwrap();
+    p
+}
+
+/// One test, because the import root is process-global and these would otherwise
+/// race each other into whichever directory ran last.
+#[test]
+fn load_csv_end_to_end() {
+    let dir = tempfile::tempdir().unwrap();
+    write_csv(
+        dir.path(),
+        "people.csv",
+        "name,city\nada,London\n\"Doe, Jane\",Pune\n",
+    );
+    write_csv(dir.path(), "semi.csv", "name;city\nalan;Wilmslow\n");
+    let engine = QueryEngine::new();
+
+    // ---- the gate ----
+    set_import_root(None).unwrap();
+    let mut store = GraphStore::new();
+    let err = engine
+        .execute_mut(
+            "LOAD CSV WITH HEADERS FROM 'people.csv' AS row CREATE (:P {n: row.name})",
+            &mut store,
+            T,
+        )
+        .expect_err("LOAD CSV ran with no import directory configured");
+    assert!(
+        err.to_string().contains("no import directory"),
+        "refused for the wrong reason: {err}"
+    );
+    assert_eq!(store.node_count(), 0);
+
+    set_import_root(Some(dir.path())).unwrap();
+
+    // ---- WITH HEADERS binds a map, and the CSV is really parsed ----
+    let mut store = GraphStore::new();
+    engine
+        .execute_mut(
+            "LOAD CSV WITH HEADERS FROM 'people.csv' AS row CREATE (:P {n: row.name, c: row.city})",
+            &mut store,
+            T,
+        )
+        .unwrap();
+    assert_eq!(store.node_count(), 2);
+    let names: std::collections::BTreeSet<String> = store
+        .get_nodes_by_label(&"P".into())
+        .iter()
+        .filter_map(|n| match n.properties.get("n") {
+            Some(samyama::graph::PropertyValue::String(s)) => Some(s.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        names.contains("Doe, Jane"),
+        "the quoted comma was split into two fields: {names:?}"
+    );
+    assert!(names.contains("ada"), "{names:?}");
+
+    // ---- without headers the row is a list ----
+    let mut store = GraphStore::new();
+    let rows = engine
+        .execute("LOAD CSV FROM 'people.csv' AS row RETURN row", &store)
+        .unwrap();
+    assert_eq!(
+        rows.records.len(),
+        3,
+        "without WITH HEADERS the header line is data, so all three lines are rows"
+    );
+    let _ = &mut store;
+
+    // ---- FIELDTERMINATOR ----
+    let rows = engine
+        .execute(
+            "LOAD CSV WITH HEADERS FROM 'semi.csv' AS row FIELDTERMINATOR ';' RETURN row",
+            &GraphStore::new(),
+        )
+        .unwrap();
+    assert_eq!(rows.records.len(), 1);
+
+    // ---- escaping the import directory ----
+    let outside = tempfile::tempdir().unwrap();
+    write_csv(outside.path(), "secret.csv", "a\n1\n");
+    let err = engine
+        .execute(
+            &format!(
+                "LOAD CSV FROM 'file://{}' AS row RETURN row",
+                outside.path().join("secret.csv").display()
+            ),
+            &GraphStore::new(),
+        )
+        .expect_err("read a file outside the import directory");
+    assert!(err.to_string().contains("outside the import directory"), "{err}");
+
+    // ---- http is refused rather than fetched ----
+    let err = engine
+        .execute(
+            "LOAD CSV FROM 'https://example.com/x.csv' AS row RETURN row",
+            &GraphStore::new(),
+        )
+        .expect_err("fetched an http source");
+    assert!(err.to_string().contains("cannot read 'https' sources"), "{err}");
+
+    // ---- fields arrive as strings, not guessed types ----
+    write_csv(dir.path(), "zeros.csv", "code\n007\n");
+    let mut store = GraphStore::new();
+    engine
+        .execute_mut(
+            "LOAD CSV WITH HEADERS FROM 'zeros.csv' AS row CREATE (:Z {code: row.code})",
+            &mut store,
+            T,
+        )
+        .unwrap();
+    let z = store.get_nodes_by_label(&"Z".into())[0].properties.get("code").cloned();
+    assert_eq!(
+        z,
+        Some(samyama::graph::PropertyValue::String("007".into())),
+        "a field was type-guessed, which loses the leading zeros"
+    );
+
+    set_import_root(None).unwrap();
+}


### PR DESCRIPTION
LANG-09's H1 target read `none` in `02-query-language.md`, and there were no hits
for `LOAD CSV` / `LoadCsv` anywhere in `src/`. This is the clause.

```cypher
LOAD CSV WITH HEADERS FROM 'people.csv' AS row CREATE (:P {n: row.name, c: row.city})
LOAD CSV FROM 'rows.csv' AS row FIELDTERMINATOR ';' RETURN row
```

Both AST shapes, and it reuses the RFC 4180 reader #1108 put behind
`/api/import/csv`, so quoting, escapes, embedded newlines and ragged rows behave
identically however the data arrives rather than becoming a second CSV dialect.

## The gate is the feature's first property

`LOAD CSV FROM 'file:///etc/passwd'` on a server reachable over the network is an
arbitrary local file read for anyone who can send a query. So:

- **Off by default.** With no `--import-dir` the clause is refused, naming the
  flag. There is no implicit default of "the working directory" — that is the same
  hole with a friendlier name.
- **Resolved on the canonical path.** A textual check is not a check:
  `<root>/../../etc/passwd` and a symlink planted inside the root both pass one.
  All three escapes are tested, the symlink included.
- **`https://` is refused, not fetched.** A server that retrieves arbitrary URLs on
  a client's behalf is an SSRF primitive and deserves its own decision rather than
  inheriting this one.

## Streaming, not desugaring to UNWIND

Rewriting `LOAD CSV ... AS row` into `UNWIND <the whole file> AS row` needs no new
operator and inherits every UNWIND optimisation, which is exactly why it is worth
saying no to: `UnwindOperator` materialises its list into a `Vec<Record>`, one
clone per row, so a bulk-ingest clause would hold the entire file *and* a record
per line in memory. `LoadCsvOperator` holds a `csv::Reader` and yields one record
at a time, opening lazily on the first `next()`.

## One deliberate semantic

Fields arrive as **strings**; nothing is type-guessed. `007` stays `"007"` —
inferring would drop the leading zeros silently, in an ingest path — and this
matches `LOAD CSV` elsewhere, where the query converts with `toInteger`/`toFloat`.

## Two notes on the integration

**The planner had already written down the bug.** Its CREATE-only fast path says a
leading UNWIND must be excluded because such a statement "has no MATCH but is still
row-driven, and planning it as a CREATE-only statement runs it once with nothing
bound." `LOAD CSV` is that shape. Without the same exclusion,
`LOAD CSV ... CREATE (:P {n: row.name})` failed with "`n` refers to a variable that
is not bound here" — and the file was never opened.

**The compiler caught 1 of 14 integration points.** Adding `Clause::LoadCsv`
produced a single non-exhaustive-match error; every other site matches with a
wildcard, so a new reading clause silently binds nothing and fails far from the
cause. All thirteen `Clause::Unwind` sites were walked and decided explicitly (six
in `validate.rs`, one in `star.rs`, four in `planner.rs`), plus the by-kind
equivalents that hang off `Query` rather than the clause list — that split is why
`row` read as unbound on the first probe while the grammar parsed cleanly.

## Tests

`tests/load_csv.rs` end-to-end through the engine, and `csv_source::tests::the_gate`
for the resolver. Both run as single tests on purpose: the import root is
process-global, so split tests would race each other into whichever directory ran
last.

`cargo test --workspace --no-fail-fast`: **255 binaries, 4,100 passed, 0 failed.**

Not benchmarked as an ingest-throughput feature, per #1098: the bottleneck is
`&mut GraphStore` (#503), and measuring a format path against it would prove
something about the mutex instead.

https://claude.ai/code/session_016erf3aJ7MVFwUABw1PXyJf