### PR TITLE
PERF-10 measured on the dataset it is specified for, not a proxy

### DIFF
--- a/benches/memory_footprint.rs
+++ b/benches/memory_footprint.rs
@@ -22,6 +22,11 @@
 //!   cargo bench --bench memory_footprint -- --scale 200000
 
 use samyama::graph::GraphStore;
+
+// The LDBC loader, shared with `ldbc_benchmark` rather than re-implemented: a second
+// loader would measure a second graph, and the point is to measure the one the
+// benchmark builds.
+mod ldbc_common;
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -154,6 +159,124 @@ struct Phase {
     heap_delta: usize,
 }
 
+/// Load a real LDBC SNB export and report its footprint (PERF-10 as specified).
+///
+/// RSS is the figure the spec names, and it is the honest one for "resident": the
+/// live-heap number ignores allocator fragmentation and the return of freed pages,
+/// both of which a customer pays for. Both are reported, with their ratio, because a
+/// large gap between them is itself the finding — it says the cost is in the
+/// allocator rather than in the data structures.
+fn measure_real_dataset(dir: &std::path::Path, json_out: Option<String>) -> () {
+    let base_heap = live_heap();
+    let base_rss = rss();
+    let hist_base = hist_snapshot();
+    let t = std::time::Instant::now();
+
+    let mut store = GraphStore::new();
+    let loaded = match ldbc_common::load_dataset(&mut store, dir) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("could not load {}: {e}", dir.display());
+            std::process::exit(1);
+        }
+    };
+    let after_load = live_heap();
+
+    // The planner's view, built here rather than lazily at first query, so the number
+    // includes what a served graph actually holds.
+    let _stats = store.statistics();
+    let after_stats = live_heap();
+    let final_rss = rss();
+    let hist_end = hist_snapshot();
+    let elapsed = t.elapsed();
+
+    let nodes = loaded.total_nodes;
+    let edges = loaded.total_edges;
+    let heap = after_stats.saturating_sub(base_heap);
+    let rss_delta = match (base_rss, final_rss) {
+        (Some(b), Some(f)) => f.saturating_sub(b) as i64,
+        _ => -1,
+    };
+
+    println!("PERF-10 — real dataset at {}", dir.display());
+    println!("{}", "-".repeat(78));
+    println!("{:<28} {:>16}", "nodes", nodes);
+    println!("{:<28} {:>16}", "edges", edges);
+    println!("{:<28} {:>16}", "load seconds", elapsed.as_secs());
+    println!("{:<28} {:>16}", "live heap (bytes)", heap);
+    println!("{:<28} {:>16}", "RSS delta (bytes)", rss_delta);
+    println!("{:<28} {:>16}", "statistics (bytes)", after_stats.saturating_sub(after_load));
+    if edges > 0 {
+        println!("{:<28} {:>16.1}", "heap bytes/edge", heap as f64 / edges as f64);
+        if rss_delta >= 0 {
+            println!("{:<28} {:>16.1}", "RSS bytes/edge  <- PERF-10", rss_delta as f64 / edges as f64);
+        }
+    }
+    if heap > 0 && rss_delta > 0 {
+        println!("{:<28} {:>16.2}", "RSS / heap", rss_delta as f64 / heap as f64);
+    }
+
+    // Which allocation sizes the load made. **These are calls, not live blocks** --
+    // most are transient parsing churn -- so the histogram measures allocator
+    // pressure during load and says nothing directly about residency. Read together
+    // with `RSS / heap` it is still decisive in one direction: a load dominated by
+    // tiny allocations that nonetheless ends at RSS ~= live heap has *not* paid
+    // per-allocation overhead in resident bytes, which rules the allocator out and
+    // points at the data itself. One `load_dataset` call builds nodes and edges
+    // together, so the phase split the synthetic path reports is not available here.
+    println!("\nallocation sizes during load (calls, not live blocks)");
+    println!("{:<16} {:>14} {:>12}", "size", "count", "share");
+    let total: usize = (0..BUCKETS).map(|i| hist_end[i].saturating_sub(hist_base[i])).sum();
+    for i in 0..BUCKETS {
+        let n = hist_end[i].saturating_sub(hist_base[i]);
+        if n == 0 {
+            continue;
+        }
+        let label = if i + 1 >= BUCKETS { format!(">={}", 1usize << i) } else { format!("{}..{}", 1usize << i, (1usize << (i + 1)) - 1) };
+        println!("{:<16} {:>14} {:>11.1}%", label, n, 100.0 * n as f64 / total.max(1) as f64);
+    }
+
+    if let Some(path) = json_out {
+        let commit = std::process::Command::new("git")
+            .args(["rev-parse", "--short", "HEAD"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .unwrap_or_else(|| "unknown".into());
+        let name = dir.file_name().map(|s| s.to_string_lossy().to_string()).unwrap_or_default();
+        let body = format!(
+            "{{
+  \"suite\": \"memory-footprint\",
+  \"requirement_ids\": [\"PERF-10\"],
+  \"run_id\": \"footprint-{commit}-{name}\",
+  \"engine\": {{\"name\": \"samyama\", \"version\": \"{}\", \"commit\": \"{commit}\"}},
+  \"hardware\": {{\"note\": \"single process; RSS is host-dependent, heap bytes are not\"}},
+  \"dataset\": {{\"name\": \"{name}\", \"nodes\": {nodes}, \"edges\": {edges}, \"synthetic\": false}},
+  \"measurements\": {{
+    \"live_heap_bytes\": {heap},
+    \"rss_delta_bytes\": {rss_delta},
+    \"load_seconds\": {},
+    \"bytes_per_node_heap\": {:.2},
+    \"bytes_per_edge_heap\": {:.2},
+    \"bytes_per_edge_rss\": {:.2}
+  }}
+}}
+",
+            env!("CARGO_PKG_VERSION"),
+            elapsed.as_secs(),
+            if nodes > 0 { heap as f64 / nodes as f64 } else { 0.0 },
+            if edges > 0 { heap as f64 / edges as f64 } else { 0.0 },
+            if edges > 0 && rss_delta >= 0 { rss_delta as f64 / edges as f64 } else { -1.0 },
+        );
+        if let Err(e) = std::fs::write(&path, body) {
+            eprintln!("could not write {path}: {e}");
+        } else {
+            println!("\n-> {path}");
+        }
+    }
+}
+
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     let arg = |flag: &str| -> Option<String> {
@@ -173,6 +296,19 @@ fn main() {
     let compact_every: usize = arg("--compact-every")
         .and_then(|s| s.parse().ok())
         .unwrap_or(0);
+
+    // PERF-10 is specified on SNB SF10 — "≤128 B/edge resident" — and the synthetic
+    // graph above is a proxy for it whose value moves 4.5x across degree 2..16. So a
+    // number from it can bound nothing: the spec's target is a property of a
+    // particular dataset, and the only way to report against that target is to load
+    // that dataset.
+    //
+    // This path loads a real SNB export with the same loader the LDBC benchmark uses
+    // and reports the same allocator and RSS figures. Nothing else in the bench
+    // changes, so the synthetic and real numbers stay comparable.
+    if let Some(dir) = arg("--ldbc-data") {
+        return measure_real_dataset(std::path::Path::new(&dir), arg("--json"));
+    }
 
     println!(
         "Memory footprint — {scale} nodes, target degree {avg_degree}{}",


### PR DESCRIPTION
PERF-10 is **"≤128 B/edge resident on SNB SF10"**. `CH-MEM-01` measured a
*synthetic* graph, and its own envelope has always said what that costs:

> `bytes_per_edge_sf10` — **unmeasured** — "PERF-10 as specified. SF10 has not
> been re-measured since the SF1 run of 479.6 B/edge."

A proxy whose value moves **4.5× across degree 2–16** cannot report against a
target written for one dataset, so the requirement stayed unmeasured however often
the bench ran. `--ldbc-data <dir>` loads a real SNB export through
`ldbc_common::load_dataset` — the same loader `ldbc_benchmark` uses, so it is the
same graph the benchmark builds — and reports the same allocator and RSS figures.

## Measured

| | real SF1 | **real SF10** |
|---|---|---|
| nodes | 3,181,724 | 29,987,835 |
| edges | 17,256,038 | 176,623,433 |
| RSS delta | 9.2 GB | **92.0 GB** |
| **RSS bytes/edge** | 535.0 | **521.1** |
| heap bytes/edge | 493.6 | 471.0 |
| heap bytes/node | 2,677 | 2,774 |
| RSS / heap | 1.08 | 1.11 |

SF10 measured on a 246 GB spot instance; vm-1's 46 GB cannot hold it.

**PERF-10 = 521.1 B/edge against a 256 H1 target — 2.0× over, and 4.1× the 128
spec goal.** This confirms rather than contradicts the charter's Fact 3, whose
"~95 GB resident for SF10" now reads 92.0 GB, within 3%.

## What the numbers narrow down

- **RSS/heap is 1.08 at SF1 and 1.11 at SF10.** The resident cost is live data,
  not allocator slack, at both scales. A smaller footprint has to come from the
  data structures — do not go and tune the allocator.
- **2,774 B/node against 5.9 edges/node.** The footprint is *node-side*. A
  per-edge target is being missed by per-node cost, and dividing one by the other
  hides which, so both are reported.
- **The metric is scale-invariant** — 535 → 521 B/edge, 2,677 → 2,774 B/node
  across a 10× dataset. That is the operationally useful part: **SF1 is a valid
  proxy for SF10 for this requirement**, so footprint work can be iterated in a
  30-second load on a workstation instead of an 8-minute load on a 246 GB machine.
  The proxy that does not work is the synthetic one, because its degree is a free
  parameter and SNB's is not.

## A wrong inference this nearly published

The allocation-size histogram is extended to this path. The SF1 load makes **293M
allocations, two-thirds of them under 16 bytes**, which reads as damning
per-allocation overhead. It is not: those are *calls*, mostly transient parsing
churn, and RSS ≈ live heap proves the overhead was never paid in resident bytes.
Read alone it sends you to the allocator; read beside `RSS / heap` it rules the
allocator out. The output is now labelled **"calls, not live blocks"** with that
reasoning attached, because I made the wrong reading first.

## Harness

`CH-MEM-01` takes the real path when `--ldbc-data` is given, and keeps the
synthetic path otherwise. A non-SF10 export is reported as itself and marked
`partial` rather than judged: it is a real measurement of a real dataset and still
not the one the requirement names.

`cargo test --workspace --no-fail-fast`: **255 binaries, 4,100 passed, 0 failed.**
Synthetic path unchanged and verified.

https://claude.ai/code/session_016erf3aJ7MVFwUABw1PXyJf