### PR TITLE
Where the bytes are, and why freeing them does not help

### DIFF
--- a/benches/memory_footprint.rs
+++ b/benches/memory_footprint.rs
@@ -182,6 +182,34 @@ fn measure_real_dataset(dir: &std::path::Path, json_out: Option<String>) -> () {
     };
     let after_load = live_heap();
 
+    // What a bulk load leaves behind in `Vec` slack, and what returning it is worth.
+    // Reported as its own line rather than folded into the total: a load that never
+    // shrinks is the state the engine ships in today, so both numbers are real.
+    let before_shrink = live_heap();
+    let rss_before_shrink = rss();
+    store.shrink_to_fit();
+    let after_shrink = live_heap();
+    let rss_after_shrink = rss();
+
+    // Does the allocator give the pages back?
+    //
+    // `shrink_to_fit` and CSR compaction both cut live heap and left RSS where it
+    // was, which is the difference between "freed" and "returned". glibc keeps freed
+    // arenas mapped; `malloc_trim` is the ask. If this moves RSS, the reclamations
+    // are worth something against a *resident* target; if it does not, the footprint
+    // has to be avoided at allocation time instead of reclaimed afterwards.
+    #[cfg(target_env = "gnu")]
+    let rss_after_trim = {
+        unsafe extern "C" {
+            fn malloc_trim(pad: usize) -> i32;
+        }
+        let returned = unsafe { malloc_trim(0) };
+        eprintln!("malloc_trim returned {returned}");
+        rss()
+    };
+    #[cfg(not(target_env = "gnu"))]
+    let rss_after_trim = rss();
+
     // The planner's view, built here rather than lazily at first query, so the number
     // includes what a served graph actually holds.
     let _stats = store.statistics();
@@ -210,6 +238,13 @@ fn measure_real_dataset(dir: &std::path::Path, json_out: Option<String>) -> () {
     println!("{:<28} {:>16}", "live heap (bytes)", heap);
     println!("{:<28} {:>16}", "RSS delta (bytes)", rss_delta);
     println!("{:<28} {:>16}", "statistics (bytes)", after_stats.saturating_sub(after_load));
+    println!("{:<28} {:>16}", "returned by shrink_to_fit", before_shrink.saturating_sub(after_shrink));
+    if let (Some(a), Some(b), Some(c)) = (rss_before_shrink, rss_after_shrink, rss_after_trim) {
+        println!("{:<28} {:>16}", "  RSS before shrink", a);
+        println!("{:<28} {:>16}", "  RSS after shrink", b);
+        println!("{:<28} {:>16}", "  RSS after malloc_trim", c);
+        println!("{:<28} {:>16}", "  RSS actually returned", a.saturating_sub(c));
+    }
     if edges > 0 {
         println!("{:<28} {:>16.1}", "heap bytes/edge", heap as f64 / edges as f64);
         if rss_delta >= 0 {
@@ -262,54 +297,51 @@ fn measure_real_dataset(dir: &std::path::Path, json_out: Option<String>) -> () {
         let label_cost = label_count * STRING_HANDLE + label_bytes;
         let label_interned = label_count * std::mem::size_of::<u32>()
             + distinct_labels.iter().map(|l| l.len() + STRING_HANDLE).sum::<usize>();
+        let recoverable = key_cost.saturating_sub(key_interned)
+            + label_cost.saturating_sub(label_interned);
 
-        // Interning is a real win and not the main one, so the structural sizes have
-        // to be reported too: the container overhead per node is paid once per node
-        // whatever the strings cost.
-        let node_struct = std::mem::size_of::<samyama::graph::Node>();
-        let pv = std::mem::size_of::<samyama::graph::PropertyValue>();
-        let mut prop_capacity = 0usize;
-        let mut label_capacity = 0usize;
-        for node in store.all_nodes() {
-            prop_capacity += node.properties.capacity();
-            label_capacity += node.labels.capacity();
-        }
-        // hashbrown: one control byte per slot plus the slot itself.
-        let prop_table = prop_capacity * (STRING_HANDLE + pv + 1);
-        let label_table = label_capacity * (STRING_HANDLE + 1);
+        // The store's own decomposition, rather than a second walk here that could
+        // drift from it. Capacity, not length: slack is resident.
+        let report = store.memory_report();
+        node_side_bytes = report.node_versions + report.node_properties + report.node_labels;
 
-        println!("\nwhat is in a node");
-        println!("{:<34} {:>16}", "sizeof(Node)", node_struct);
-        println!("{:<34} {:>16}", "sizeof(PropertyValue)", pv);
-        println!("{:<34} {:>16}", "Node structs total", node_struct * nodes);
-        println!("{:<34} {:>16}", "property table slots", prop_capacity);
-        println!("{:<34} {:>16}", "property tables total", prop_table);
-        println!("{:<34} {:>16}", "label table slots", label_capacity);
-        println!("{:<34} {:>16}", "label tables total", label_table);
-        node_side_bytes = node_struct * nodes + prop_table + label_table;
-        if heap > 0 {
+        println!("\nwhere the bytes are (structural walk, largest first)");
+        println!("{:<30} {:>16} {:>10}", "structure", "bytes", "share");
+        for (name, bytes) in report.lines() {
+            if bytes == 0 {
+                continue;
+            }
             println!(
-                "{:<34} {:>15.1}%",
-                "  node side as share of heap",
-                100.0 * (node_struct * nodes + prop_table + label_table) as f64 / heap as f64
+                "{:<30} {:>16} {:>9.1}%",
+                name,
+                bytes,
+                if heap > 0 { 100.0 * bytes as f64 / heap as f64 } else { 0.0 }
             );
         }
-        println!("{:<34} {:>16}", "property entries", entries);
-        println!("{:<34} {:>16}", "distinct property keys", distinct_keys.len());
-        println!("{:<34} {:>16}", "labels held", label_count);
-        println!("{:<34} {:>16}", "distinct labels", distinct_labels.len());
-        println!("{:<34} {:>16}", "string property value bytes", value_bytes);
-        println!("{:<34} {:>16}", "key handles + buffers", key_cost);
-        println!("{:<34} {:>16}", "  same, interned", key_interned);
-        println!("{:<34} {:>16}", "label handles + buffers", label_cost);
-        println!("{:<34} {:>16}", "  same, interned", label_interned);
-        let recoverable = key_cost.saturating_sub(key_interned) + label_cost.saturating_sub(label_interned);
-        println!("{:<34} {:>16}", "recoverable by interning", recoverable);
+        println!(
+            "{:<30} {:>16} {:>9.1}%",
+            "attributed",
+            report.attributed(),
+            if heap > 0 { 100.0 * report.attributed() as f64 / heap as f64 } else { 0.0 }
+        );
+        println!(
+            "{:<30} {:>16}",
+            "unattributed (indexes, etc.)",
+            heap.saturating_sub(report.attributed())
+        );
+
+        println!("\nrepetition (what interning would remove)");
+        println!("{:<30} {:>16}", "property entries", entries);
+        println!("{:<30} {:>16}", "distinct property keys", distinct_keys.len());
+        println!("{:<30} {:>16}", "labels held", label_count);
+        println!("{:<30} {:>16}", "distinct labels", distinct_labels.len());
+        println!("{:<30} {:>16}", "string property value bytes", value_bytes);
+        println!("{:<30} {:>16}", "recoverable by interning", recoverable);
         if heap > 0 {
-            println!("{:<34} {:>15.1}%", "  as a share of live heap", 100.0 * recoverable as f64 / heap as f64);
+            println!("{:<30} {:>15.1}%", "  as a share of live heap", 100.0 * recoverable as f64 / heap as f64);
         }
         if edges > 0 {
-            println!("{:<34} {:>16.1}", "  bytes/edge it would remove", recoverable as f64 / edges as f64);
+            println!("{:<30} {:>16.1}", "  bytes/edge it would remove", recoverable as f64 / edges as f64);
         }
     }
 

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -378,6 +378,11 @@ impl FrozenAdjacencyStore {
 
     fn edge_count(&self) -> usize { self.total_edges }
 
+    /// Resident bytes across every segment (capacity, not length).
+    fn heap_bytes(&self) -> usize {
+        self.segments.iter().map(FrozenAdjacency::heap_bytes).sum()
+    }
+
     fn node_capacity(&self) -> usize {
         self.segments.iter().map(|s| s.node_capacity()).max().unwrap_or(0)
     }
@@ -507,6 +512,12 @@ pub struct FrozenAdjacency {
 }
 
 impl FrozenAdjacency {
+    /// Resident bytes of the offset table and the packed entries.
+    fn heap_bytes(&self) -> usize {
+        self.offsets.capacity() * std::mem::size_of::<u32>()
+            + self.edges.capacity() * std::mem::size_of::<(NodeId, EdgeId)>()
+    }
+
     /// Create an empty frozen tier
     fn empty() -> Self {
         Self { offsets: vec![0], edges: Vec::new() }
@@ -662,6 +673,71 @@ pub struct Transaction {
 pub struct EdgeVersionEntry {
     pub version: u64,
     pub properties: PropertyMap,
+}
+
+/// Where a loaded graph's bytes are, by structure (`GraphStore::memory_report`).
+///
+/// Every field is heap bytes at **capacity**, since slack is resident. The point of
+/// the type is that it decomposes rather than normalises: a `bytes/edge` figure
+/// cannot say which structure to change and these can.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MemoryReport {
+    /// Node arena including MVCC version chains — one `Vec<Node>` per node id.
+    pub node_versions: usize,
+    /// Node property tables, their key strings and their string values.
+    pub node_properties: usize,
+    /// Node label sets and their strings.
+    pub node_labels: usize,
+    /// `EdgeId -> (source, target)`.
+    pub edge_endpoints: usize,
+    /// `EdgeId -> type index`.
+    pub edge_type_ids: usize,
+    /// Sparse edge property maps.
+    pub edge_properties: usize,
+    /// Mutable `Vec<Vec<..>>` adjacency, both directions.
+    pub adjacency_write_buffer: usize,
+    /// Frozen CSR segments, both directions.
+    pub adjacency_frozen: usize,
+    /// `label -> nodes`.
+    pub label_index: usize,
+    /// `edge type -> edges`.
+    pub edge_type_index: usize,
+}
+
+impl MemoryReport {
+    /// Everything the walk attributes. Deliberately not called `total`: the vector,
+    /// property and hierarchy index managers are behind `Arc` and are not walked, so
+    /// this is a floor on the graph's footprint and not the process's.
+    pub fn attributed(&self) -> usize {
+        self.node_versions
+            + self.node_properties
+            + self.node_labels
+            + self.edge_endpoints
+            + self.edge_type_ids
+            + self.edge_properties
+            + self.adjacency_write_buffer
+            + self.adjacency_frozen
+            + self.label_index
+            + self.edge_type_index
+    }
+
+    /// Named lines, largest first — the order someone reading it wants.
+    pub fn lines(&self) -> Vec<(&'static str, usize)> {
+        let mut v = vec![
+            ("node versions (arena)", self.node_versions),
+            ("node properties", self.node_properties),
+            ("node labels", self.node_labels),
+            ("edge endpoints", self.edge_endpoints),
+            ("edge type ids", self.edge_type_ids),
+            ("edge properties", self.edge_properties),
+            ("adjacency: write buffer", self.adjacency_write_buffer),
+            ("adjacency: frozen CSR", self.adjacency_frozen),
+            ("label index", self.label_index),
+            ("edge type index", self.edge_type_index),
+        ];
+        v.sort_by(|a, b| b.1.cmp(&a.1));
+        v
+    }
 }
 
 #[derive(Debug)]
@@ -905,6 +981,130 @@ impl GraphStore {
     fn journal(&mut self, m: crate::graph::event::Mutation) {
         if let Some(log) = &mut self.write_log {
             log.push(m);
+        }
+    }
+
+    /// Return capacity the graph is not using.
+    ///
+    /// `Vec` grows by doubling, so a bulk load leaves the edge arrays at up to 2x
+    /// the size they need. Measured on LDBC SF1: `edge_endpoints` and
+    /// `edge_type_ids` both sit at **1.94x** their length — 293 MB, 3.4% of live
+    /// heap, held and never read (#1118).
+    ///
+    /// Caller-driven rather than automatic, because it reallocates and copies: the
+    /// right moment is the end of a load, not the middle of one. Incremental writers
+    /// should not call it at all — they would pay a copy per growth step and get the
+    /// slack straight back.
+    pub fn shrink_to_fit(&mut self) {
+        self.edge_endpoints.shrink_to_fit();
+        self.edge_type_ids.shrink_to_fit();
+        self.nodes.shrink_to_fit();
+        for chain in &mut self.nodes {
+            chain.shrink_to_fit();
+        }
+        // The adjacency write buffer, per node. Not the frozen segments: those are
+        // built at exactly their size already.
+        self.outgoing.shrink_to_fit();
+        self.incoming.shrink_to_fit();
+        for v in self.outgoing.iter_mut().chain(self.incoming.iter_mut()) {
+            v.shrink_to_fit();
+        }
+        self.free_node_ids.shrink_to_fit();
+        self.free_edge_ids.shrink_to_fit();
+    }
+
+    /// Bytes held by each of the store's structures, walked rather than divided.
+    ///
+    /// A per-node or per-edge figure is a **normalisation, not a decomposition**:
+    /// `live_heap / nodes` divides the whole graph by the node count and reads high
+    /// whatever the memory is actually in, which is how PERF-10 acquired the claim
+    /// that its footprint was node-side when node-side is 28% of it (#1118). A
+    /// number that is going to send someone to a particular structure has to be
+    /// produced by looking at that structure.
+    ///
+    /// Capacity, not length: slack in a `Vec` is resident. Nested containers are
+    /// walked, so this is O(nodes + edges) and is a diagnostic rather than
+    /// something to call per query.
+    ///
+    /// Heap only. The `Arc`-held index managers report their own sizes if they can;
+    /// what is not attributed here is named in `unattributed_note` rather than
+    /// silently folded into another line.
+    pub fn memory_report(&self) -> MemoryReport {
+        let node_versions: usize = self
+            .nodes
+            .iter()
+            .map(|v| v.capacity() * std::mem::size_of::<Node>() + std::mem::size_of::<Vec<Node>>())
+            .sum();
+        let mut node_properties = 0usize;
+        let mut node_labels = 0usize;
+        for chain in &self.nodes {
+            for n in chain {
+                node_properties += n.properties.capacity()
+                    * (std::mem::size_of::<String>() + std::mem::size_of::<PropertyValue>() + 1);
+                for (k, v) in n.properties.iter() {
+                    node_properties += k.len();
+                    if let PropertyValue::String(sv) = v {
+                        node_properties += sv.len();
+                    }
+                }
+                node_labels += n.labels.capacity() * (std::mem::size_of::<Label>() + 1);
+                for l in n.labels.iter() {
+                    node_labels += l.as_str().len();
+                }
+            }
+        }
+
+        let write_buffer: usize = self
+            .outgoing
+            .iter()
+            .chain(self.incoming.iter())
+            .map(|v| {
+                v.capacity() * std::mem::size_of::<(NodeId, EdgeId)>()
+                    + std::mem::size_of::<Vec<(NodeId, EdgeId)>>()
+            })
+            .sum();
+        let frozen = self.frozen_outgoing.heap_bytes() + self.frozen_incoming.heap_bytes();
+
+        let edge_endpoints = self.edge_endpoints.capacity()
+            * std::mem::size_of::<(NodeId, NodeId)>();
+        let edge_type_ids = self.edge_type_ids.capacity() * std::mem::size_of::<u16>();
+        let mut edge_properties = self.edge_properties.capacity()
+            * (std::mem::size_of::<EdgeId>() + std::mem::size_of::<PropertyMap>() + 1);
+        for props in self.edge_properties.values() {
+            edge_properties += props.capacity()
+                * (std::mem::size_of::<String>() + std::mem::size_of::<PropertyValue>() + 1);
+            for (k, v) in props.iter() {
+                edge_properties += k.len();
+                if let PropertyValue::String(sv) = v {
+                    edge_properties += sv.len();
+                }
+            }
+        }
+
+        let mut label_index = self.label_index.capacity()
+            * (std::mem::size_of::<Label>() + std::mem::size_of::<HashSet<NodeId>>() + 1);
+        for (l, set) in self.label_index.iter() {
+            label_index += l.as_str().len()
+                + set.capacity() * (std::mem::size_of::<NodeId>() + 1);
+        }
+        let mut edge_type_index = self.edge_type_index.capacity()
+            * (std::mem::size_of::<EdgeType>() + std::mem::size_of::<HashSet<EdgeId>>() + 1);
+        for (t, set) in self.edge_type_index.iter() {
+            edge_type_index += t.as_str().len()
+                + set.capacity() * (std::mem::size_of::<EdgeId>() + 1);
+        }
+
+        MemoryReport {
+            node_versions,
+            node_properties,
+            node_labels,
+            edge_endpoints,
+            edge_type_ids,
+            edge_properties,
+            adjacency_write_buffer: write_buffer,
+            adjacency_frozen: frozen,
+            label_index,
+            edge_type_index,
         }
     }
 


### PR DESCRIPTION
Closes #1119.

## `GraphStore::memory_report()`

Walks the store's structures and reports bytes **at capacity**, because slack is
resident. It exists because a per-node or per-edge figure is a *normalisation, not
a decomposition* — `heap / nodes` divides the whole graph by the node count and
reads high whatever the memory is in, which is exactly how #1117 acquired the
claim that this footprint was node-side when node-side is 28% of it. Public, so it
can serve ops diagnostics rather than only this bench.

LDBC SF1, after `shrink_to_fit`:

| structure | bytes | share |
|---|---|---|
| node properties | 2,109 MB | 26.8% |
| edge properties | 1,435 MB | 18.2% |
| adjacency: write buffer | 705 MB | 8.9% |
| node versions (arena) | 484 MB | 6.1% |
| edge endpoints | 276 MB | 3.5% |
| node labels | 258 MB | 3.3% |
| edge type index | 237 MB | 3.0% |
| **attributed** | **5,589 MB** | **71.0%** |
| unattributed | 2,288 MB | (Arc-held index managers) |

**Properties are 45% of the heap; adjacency is 9%** — the opposite of where I
expected to end up. `attributed()` is deliberately not called `total`: the vector,
property and hierarchy index managers are behind `Arc` and are not walked, so the
remainder is named rather than folded into another line.

## `shrink_to_fit()`

Returns the doubling slack a bulk load leaves — `edge_endpoints` and
`edge_type_ids` both sat at **1.94×** their length. Caller-driven because it
reallocates: the right moment is the end of a load, and an incremental writer
would pay a copy per growth step and get the slack straight back.

## The finding that inverts the plan

```
shrink_to_fit freed       641,014,682 bytes of live heap
  RSS before shrink     9,235,460,096
  RSS after shrink      9,235,591,168   (+131 KB — nothing returned)
  RSS after malloc_trim 9,178,894,336
  RSS actually returned     56,565,760   = 8.8% of what was freed
PERF-10                      535.0 → 531.8 B/edge   = 0.6%
```

CSR compaction says the same from the other side: **−2.9% live heap, +6.3% RSS**.
Freed blocks are interleaved with live ones, so glibc keeps the arenas mapped and
`malloc_trim` recovers only whole free pages.

PERF-10 is specified on **resident** bytes, so every reclamation-after-the-fact is
worth about a tenth of its apparent size:

| candidate | live heap | RSS |
|---|---|---|
| intern keys and labels | −615 MB | ~−54 MB (at the measured 8.8%) |
| `shrink_to_fit` | −641 MB | **−57 MB** (measured) |
| CSR compaction | −250 MB | **+578 MB** (measured) |

~1.5 GB of "obvious wins" buys about **1%** of a requirement that needs **2×**.
**The footprint has to be avoided at allocation time, not reclaimed afterwards** —
a smaller `PropertyValue` (56 bytes × 19.0M entries), keys interned *at insert*,
CSR built directly rather than compacted into, and node properties in the columnar
store the LDBC path does not use.

The bench now prints RSS before shrink, after shrink and after `malloc_trim`, so
the difference between *freed* and *returned* is visible in the artifact instead of
being something the reader has to already know.

`cargo test --workspace --no-fail-fast`: **255 binaries, 4,100 passed, 0 failed.**

https://claude.ai/code/session_016erf3aJ7MVFwUABw1PXyJf