### PR TITLE
Node properties are stored twice, and nothing was measuring the second copy

### DIFF
--- a/src/graph/storage/columnar.rs
+++ b/src/graph/storage/columnar.rs
@@ -100,6 +100,25 @@ pub fn dense_is_smaller(span: usize, entries: usize, elem_bytes: usize) -> bool 
     dense_bits < sparse_bits
 }
 
+impl<T> ColumnData<T> {
+    /// Resident bytes at capacity. `elem` is `size_of::<T>()`; `owned` reports what
+    /// each element owns beyond that, which is the string contents for a `String`
+    /// column and nothing for the scalar ones.
+    pub fn heap_bytes(&self, elem: usize, owned: impl Fn(&T) -> usize) -> usize {
+        match self {
+            ColumnData::Sparse(m) => {
+                m.capacity() * (std::mem::size_of::<usize>() + elem + 1)
+                    + m.values().map(&owned).sum::<usize>()
+            }
+            ColumnData::Dense { values, present, .. } => {
+                values.capacity() * elem
+                    + present.capacity() * std::mem::size_of::<u64>()
+                    + values.iter().map(&owned).sum::<usize>()
+            }
+        }
+    }
+}
+
 impl<T: Clone + Default> ColumnData<T> {
     fn new() -> Self {
         ColumnData::Sparse(FxHashMap::default())
@@ -369,6 +388,41 @@ pub enum Column {
 }
 
 impl Column {
+    /// Resident bytes of this column's data, at capacity.
+    pub fn heap_bytes(&self) -> usize {
+        match self {
+            Column::Int(d) => d.heap_bytes(std::mem::size_of::<i64>(), |_| 0),
+            Column::Float(d) => d.heap_bytes(std::mem::size_of::<f64>(), |_| 0),
+            Column::Bool(d) => d.heap_bytes(std::mem::size_of::<bool>(), |_| 0),
+            Column::String(d) => d.heap_bytes(std::mem::size_of::<String>(), |s: &String| s.len()),
+            Column::Other(m) => {
+                m.capacity()
+                    * (std::mem::size_of::<usize>() + std::mem::size_of::<PropertyValue>() + 1)
+                    + m.values().map(property_value_heap).sum::<usize>()
+            }
+        }
+    }
+}
+
+/// Heap a `PropertyValue` owns beyond its own 56 bytes.
+fn property_value_heap(v: &PropertyValue) -> usize {
+    match v {
+        PropertyValue::String(s) => s.len(),
+        PropertyValue::Array(a) => {
+            a.capacity() * std::mem::size_of::<PropertyValue>()
+                + a.iter().map(property_value_heap).sum::<usize>()
+        }
+        PropertyValue::Vector(v) => v.capacity() * std::mem::size_of::<f32>(),
+        PropertyValue::Map(m) => {
+            m.capacity() * (std::mem::size_of::<String>() + std::mem::size_of::<PropertyValue>() + 1)
+                + m.iter().map(|(k, v)| k.len() + property_value_heap(v)).sum::<usize>()
+        }
+        PropertyValue::ZonedDateTime { zone: Some(z), .. } => z.len(),
+        _ => 0,
+    }
+}
+
+impl Column {
     pub fn new_int() -> Self { Column::Int(ColumnData::new()) }
     pub fn new_float() -> Self { Column::Float(ColumnData::new()) }
     pub fn new_string() -> Self { Column::String(ColumnData::new()) }
@@ -515,6 +569,22 @@ pub struct ColumnStore {
 impl ColumnStore {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Resident bytes across every column (capacity, not length).
+    ///
+    /// Reported so `GraphStore::memory_report` can attribute the columnar half of
+    /// property storage instead of leaving it in an unexplained remainder — every
+    /// property is currently written here *and* to the row `Node.properties`, and a
+    /// duplication nobody can see the size of is one nobody removes.
+    pub fn heap_bytes(&self) -> usize {
+        let mut total = self.names.iter().map(|n| n.len() + std::mem::size_of::<String>()).sum::<usize>();
+        total += self.index.capacity() * (std::mem::size_of::<String>() + std::mem::size_of::<ColumnId>() + 1);
+        for (name, col) in self.names.iter().zip(self.columns.iter()) {
+            total += name.len();
+            total += col.heap_bytes();
+        }
+        total
     }
 
     /// The id of a property's column, if it has one.

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -682,6 +682,12 @@ pub struct EdgeVersionEntry {
 /// cannot say which structure to change and these can.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MemoryReport {
+    /// Columnar node properties. Written on **every** `set_node_property`
+    /// alongside the row copy in `node_properties`, so the two lines are the same
+    /// data twice (#1123).
+    pub node_columns: usize,
+    /// Columnar edge properties, likewise duplicated with `edge_properties`.
+    pub edge_columns: usize,
     /// Node arena including MVCC version chains — one `Vec<Node>` per node id.
     pub node_versions: usize,
     /// Node property tables, their key strings and their string values.
@@ -709,7 +715,9 @@ impl MemoryReport {
     /// property and hierarchy index managers are behind `Arc` and are not walked, so
     /// this is a floor on the graph's footprint and not the process's.
     pub fn attributed(&self) -> usize {
-        self.node_versions
+        self.node_columns
+            + self.edge_columns
+            + self.node_versions
             + self.node_properties
             + self.node_labels
             + self.edge_endpoints
@@ -724,12 +732,14 @@ impl MemoryReport {
     /// Named lines, largest first — the order someone reading it wants.
     pub fn lines(&self) -> Vec<(&'static str, usize)> {
         let mut v = vec![
+            ("node properties (columnar)", self.node_columns),
+            ("edge properties (columnar)", self.edge_columns),
             ("node versions (arena)", self.node_versions),
-            ("node properties", self.node_properties),
+            ("node properties (row)", self.node_properties),
             ("node labels", self.node_labels),
             ("edge endpoints", self.edge_endpoints),
             ("edge type ids", self.edge_type_ids),
-            ("edge properties", self.edge_properties),
+            ("edge properties (row)", self.edge_properties),
             ("adjacency: write buffer", self.adjacency_write_buffer),
             ("adjacency: frozen CSR", self.adjacency_frozen),
             ("label index", self.label_index),
@@ -1095,6 +1105,8 @@ impl GraphStore {
         }
 
         MemoryReport {
+            node_columns: self.node_columns.heap_bytes(),
+            edge_columns: self.edge_columns.heap_bytes(),
             node_versions,
             node_properties,
             node_labels,


### PR DESCRIPTION
Follows #1121, and corrects its plan.

`set_node_property` writes the columnar store **and** the row `Node.properties`:

```rust
// Update columnar storage (always latest)
self.node_columns.set_property(idx, &key_str, val.clone());
```

Nothing attributed the columnar half, so 2.3 GB sat in "unattributed (indexes,
etc.)" and the two copies could not be compared — only one of them had a number.

## Measured

`ColumnStore::heap_bytes` (with `Column`/`ColumnData` beneath it) reports bytes at
capacity including what each element owns. Real LDBC SF1:

```
node properties (row)         2,108,615,887   26.8%
node properties (columnar)      944,598,850   12.0%
edge properties (row)         1,434,932,335   18.2%
edge properties (columnar)                0
attributed                    6,533,114,268   82.9%   (was 71.0%)
```

**3,054 MB holds the same node properties twice.**

## What it changes

The PERF-10 plan goes from *"migrate to columnar and save 1,436 MB"* to
**"delete the row copy and save 2,109 MB — 26.8% of live heap, 122 B/edge"**,
using a representation that is already maintained on every write. That is the
largest single item on the ledger and the cheapest to reach.

Edges are the opposite case: `edge_columns` is empty, so for them it really is a
migration and the ~975 MB estimate is still unconfirmed.

## Two corrections, both mine

1. **My cost model was optimistic by 40%.** I predicted 673 MB for columnar node
   properties using the engine's own `dense_is_smaller`; the measured store is
   **945 MB**, because I modelled neither `Column::Other` nor string-column density
   properly. Borrowing a cost model is not the same as measuring the thing.
2. **The duplication was invisible for want of a number, not a comment** — the code
   says plainly that it writes both. What was missing was a figure next to it.

The lines are now named `node properties (row)` / `node properties (columnar)` so
the pair reads as a pair.

`cargo test --workspace --no-fail-fast`: **255 binaries, 4,100 passed, 0 failed.**

https://claude.ai/code/session_016erf3aJ7MVFwUABw1PXyJf