### PR TITLE
`RETURN n` gave back empty nodes on an imported graph

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -4277,6 +4277,32 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
     /// wins on conflict. This is what the Cypher `RETURN n.<prop>` path sees;
     /// callers that iterate only `node.properties` miss ColumnStore-backed scalars
     /// (name/title/ids from stub/bulk loads and v2 snapshot import).
+    /// A node with its properties filled in from wherever they live.
+    ///
+    /// After a snapshot import the row copy is **empty by design** and the values
+    /// are in the column store (#545), so cloning the row alone hands back a node
+    /// with `properties: {}`. Reading a single property already consulted the
+    /// columns first, which is why `RETURN n.name` was right on an imported graph
+    /// while `RETURN n` returned an empty property bag for every node (#1125) — one
+    /// of the pair was moved to the columnar store and the other was not.
+    ///
+    /// The merge runs only when the columns hold a key the row does not, so a graph
+    /// built by `CREATE` — where `set_node_property` writes both — pays a key scan
+    /// and no rebuild.
+    pub fn node_materialized(&self, id: NodeId) -> Option<Node> {
+        let mut node = self.get_node(id)?.clone();
+        let idx = id.as_u64() as usize;
+        if self
+            .node_columns
+            .get_property_keys(idx)
+            .iter()
+            .any(|k| !node.properties.contains_key(k))
+        {
+            node.properties = self.node_properties_full(id);
+        }
+        Some(node)
+    }
+
     pub fn node_properties_full(&self, id: NodeId) -> HashMap<String, PropertyValue> {
         let mut out: HashMap<String, PropertyValue> = HashMap::new();
         if let Some(node) = self.get_node(id) {

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -8090,8 +8090,11 @@ impl ProjectOperator {
                 // "Edge not found" (#905). A *property* read of the same
                 // reference does fail -- see `read_property`.
                 match val {
-                    Value::NodeRef(id) => Ok(match store.get_node(id) {
-                        Some(node) => Value::Node(id, Box::new(node.clone())),
+                    // `node_materialized`, not `get_node`: after an import the row
+                    // copy of the properties is empty and the values are in the
+                    // column store (#1125).
+                    Value::NodeRef(id) => Ok(match store.node_materialized(id) {
+                        Some(node) => Value::Node(id, Box::new(node)),
                         None => Value::NodeRef(id),
                     }),
                     Value::EdgeRef(id, src, dst, ref ty) => Ok(match store.get_edge(id) {

--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -498,8 +498,10 @@ impl Value {
     pub fn materialize_node(self, store: &GraphStore) -> Self {
         match self {
             Value::NodeRef(id) => {
-                if let Some(node) = store.get_node(id) {
-                    Value::Node(id, Box::new(node.clone()))
+                // One implementation of the merge, on the store — see
+                // `node_materialized` for why the row copy alone is not enough.
+                if let Some(node) = store.node_materialized(id) {
+                    Value::Node(id, Box::new(node))
                 } else {
                     Value::Null
                 }

--- a/tests/query_parity_after_import.rs
+++ b/tests/query_parity_after_import.rs
@@ -1,0 +1,174 @@
+//! The same query, the same answer, before and after a snapshot round trip.
+//!
+//! After an import, `node.properties` is **empty by design** — values live in the
+//! columnar store (`snapshot_preserves_properties.rs`, #545). Every reader that
+//! goes through `node_properties_full()` or the column store is fine; there are
+//! ~122 sites in `src/` that read `.properties` directly, and each one of those
+//! answers a different question on an imported graph than on a built one.
+//!
+//! Auditing 122 call sites finds the ones I think to look at. Asking the engine the
+//! same question twice finds the ones I do not: this builds a graph, records the
+//! answer to a corpus of queries, round-trips it through a snapshot, and asks
+//! again. A divergence is a reader that has not been moved.
+//!
+//! This is the metamorphic shape LANG-05 asks for, applied to storage rather than
+//! to query rewriting: the transformation is "persist and reload", which the
+//! specification requires to preserve every answer.
+
+use samyama::graph::GraphStore;
+use samyama::query::QueryEngine;
+use samyama::snapshot::{export_tenant, import_tenant};
+
+const T: &str = "default";
+
+/// A graph with every property type the columnar store treats differently: typed
+/// columns (int, float, string, bool) and the `Other` fallback (array, map,
+/// temporal), plus a node with no properties and one with a property only it has.
+const BUILD: &str = r#"
+CREATE (:Person {name: "ada", age: 36, score: 1.5, active: true});
+CREATE (:Person {name: "grace", age: 45, score: 2.5, active: false});
+CREATE (:Person {name: "alan", age: 41, score: 3.5, active: true, nickname: "prof"});
+CREATE (:Empty);
+CREATE (:Odd {tags: ["a", "b"], when: date("2026-09-06")});
+MATCH (a:Person {name: "ada"}), (b:Person {name: "grace"}) CREATE (a)-[:KNOWS {since: 2020}]->(b);
+MATCH (a:Person {name: "grace"}), (b:Person {name: "alan"}) CREATE (a)-[:KNOWS {since: 2021}]->(b);
+"#;
+
+/// Every query here must answer identically on both stores. They are chosen to
+/// exercise the reader paths separately: whole-node return, single property,
+/// property in a predicate, aggregation over a property, `keys()`, `properties()`,
+/// ordering by a property, and a traversal carrying an edge property.
+const QUERIES: &[&str] = &[
+    "MATCH (n:Person) RETURN n.name ORDER BY n.name",
+    "MATCH (n:Person) RETURN n ORDER BY n.name",
+    "MATCH (n:Person) WHERE n.age > 40 RETURN n.name ORDER BY n.name",
+    "MATCH (n:Person) RETURN count(n)",
+    "MATCH (n:Person) RETURN sum(n.age)",
+    "MATCH (n:Person) RETURN avg(n.score)",
+    "MATCH (n:Person) WHERE n.active = true RETURN n.name ORDER BY n.name",
+    "MATCH (n:Person {name: \"alan\"}) RETURN keys(n)",
+    "MATCH (n:Person {name: \"alan\"}) RETURN properties(n)",
+    "MATCH (n:Person {name: \"alan\"}) RETURN n.nickname",
+    "MATCH (n:Person) RETURN n.name ORDER BY n.age DESC",
+    "MATCH (n:Empty) RETURN keys(n)",
+    "MATCH (n:Odd) RETURN n.tags",
+    "MATCH (a)-[r:KNOWS]->(b) RETURN a.name, r.since, b.name ORDER BY a.name",
+    "MATCH (n) RETURN count(n)",
+    "MATCH (n:Person) WHERE n.name STARTS WITH \"a\" RETURN n.name ORDER BY n.name",
+];
+
+/// Canonicalise the brace-delimited groups a `Debug` rendering produces for maps
+/// and property bags, whose iteration order is not part of the answer.
+///
+/// Without this the check reports `RETURN properties(n)` as a divergence because
+/// the same five entries come back in a different order — a false positive that
+/// would train a reader to ignore the test.
+fn canonical(s: &str) -> String {
+    // Node timestamps are struct metadata, not query answers, and a snapshot round
+    // trip resets them to 0 — a real gap, filed separately (#1124), and not one this
+    // check is about. Masked rather than left in, because a check that fails for a
+    // reason it is not testing gets muted.
+    let masked = mask_timestamps(s);
+    let s = masked.as_str();
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(open) = rest.find('{') {
+        out.push_str(&rest[..=open]);
+        rest = &rest[open + 1..];
+        let Some(close) = rest.find('}') else {
+            break;
+        };
+        let (inner, after) = rest.split_at(close);
+        // Only flat groups: a nested brace means the split below would cut a value
+        // in half, so it is left alone rather than mangled.
+        if inner.contains('{') {
+            out.push_str(inner);
+        } else {
+            let mut parts: Vec<&str> = inner.split(", ").collect();
+            parts.sort_unstable();
+            out.push_str(&parts.join(", "));
+        }
+        rest = after;
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Replace `created_at: <n>` / `updated_at: <n>` with a placeholder.
+fn mask_timestamps(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(pos) = rest.find("_at: ") {
+        out.push_str(&rest[..pos + 5]);
+        rest = &rest[pos + 5..];
+        let end = rest.find(|c: char| !c.is_ascii_digit()).unwrap_or(rest.len());
+        out.push_str("<ts>");
+        rest = &rest[end..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// A result rendered as a comparable string. Column order and row order are part of
+/// the answer, so nothing is sorted there — the queries that need an order say so.
+fn answer(engine: &QueryEngine, store: &GraphStore, q: &str) -> String {
+    match engine.execute(q, store) {
+        Ok(batch) => {
+            let mut out = String::new();
+            out.push_str(&batch.columns.join("|"));
+            for rec in &batch.records {
+                out.push('\n');
+                let cells: Vec<String> = batch
+                    .columns
+                    .iter()
+                    .map(|c| canonical(&format!("{:?}", rec.get(c))))
+                    .collect();
+                out.push_str(&cells.join("|"));
+            }
+            out
+        }
+        Err(e) => format!("ERR {e}"),
+    }
+}
+
+#[test]
+fn every_query_answers_the_same_after_a_snapshot_round_trip() {
+    let engine = QueryEngine::new();
+
+    let mut built = GraphStore::new();
+    for stmt in BUILD.split(';').map(str::trim).filter(|s| !s.is_empty()) {
+        engine
+            .execute_mut(stmt, &mut built, T)
+            .unwrap_or_else(|e| panic!("setup failed: {stmt}\n{e}"));
+    }
+    assert!(built.node_count() >= 5, "setup built nothing to compare");
+
+    let mut bytes = Vec::new();
+    export_tenant(&built, &mut bytes).expect("export");
+    let mut imported = GraphStore::new();
+    import_tenant(&mut imported, std::io::Cursor::new(&bytes)).expect("import");
+    assert_eq!(
+        imported.node_count(),
+        built.node_count(),
+        "the round trip lost nodes, so any answer comparison below is moot"
+    );
+
+    let mut diffs = Vec::new();
+    for q in QUERIES {
+        let before = answer(&engine, &built, q);
+        let after = answer(&engine, &imported, q);
+        if before != after {
+            diffs.push(format!("--- {q}\n  built:    {before}\n  imported: {after}"));
+        }
+    }
+
+    assert!(
+        diffs.is_empty(),
+        "{} of {} queries answer differently after a snapshot round trip. \
+         Each one is a reader of `Node.properties` that has not moved to the \
+         columnar store or `node_properties_full()` (#545):\n\n{}",
+        diffs.len(),
+        QUERIES.len(),
+        diffs.join("\n\n")
+    );
+}


### PR DESCRIPTION
## The bug

After a snapshot import the row copy of a node's properties is **empty by design**
— the values live in the column store (#545). Reading a *single* property already
consulted the columns first, so this was correct:

```cypher
MATCH (n:Person) RETURN n.name    -- "ada"
```

while the sibling path cloned the row and stopped there:

```cypher
MATCH (n:Person) RETURN n         -- properties: {}   for every node
```

One of the pair had been moved to columnar storage and the other had not.

## The reason it lasted

Not that a reader was missed — there are **~122 direct readers of
`Node.properties`** in `src/` and any of them could be next. It is that nothing
asked the two stores the same question. A graph built by `CREATE` and the same
graph after a round trip disagreed, silently.

`tests/query_parity_after_import.rs` asks. It builds a graph covering every kind of
column the store treats differently — typed (`Int`/`Float`/`String`/`Bool`) and the
`Other` fallback (array, temporal), plus a node with no properties and a property
only one node has — records the answer to **16 queries**, round-trips through a
snapshot, and asks again.

It found this on its first run, and **it fails again if the fix is removed**
(verified, not assumed).

This is the metamorphic shape LANG-05 asks for, applied to storage rather than to
query rewriting: the transformation is "persist and reload", which the
specification requires to preserve every answer. Auditing 122 call sites finds the
ones I think to look at; asking the engine the same question twice finds the ones I
do not.

## The fix

`GraphStore::node_materialized()` — one merge, used by both call sites. It runs
only when the columns hold a key the row does not, so a graph built by `CREATE`,
where `set_node_property` writes both, pays a key scan and no rebuild.

## Two things the check deliberately does not claim

- **Map iteration order is canonicalised** before comparing. It differs between the
  two stores and is not part of an answer; leaving it in reported a false
  divergence on `properties(n)`, which is how a test teaches people to ignore it.
- **Node `created_at`/`updated_at` are masked.** A round trip resets them to 0 —
  a real gap, filed as #1124, and a snapshot-*format* decision rather than a
  query-correctness one. The mask carries a comment pointing there, so removing it
  is the natural last step of that issue.

`cargo test --workspace --no-fail-fast`: **256 binaries, 4,101 passed, 0 failed.**

https://claude.ai/code/session_016erf3aJ7MVFwUABw1PXyJf