### PR TITLE
Restore a snapshot, change one property, restart — the rest is no longer lost

### DIFF
--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -275,8 +275,16 @@ impl PersistenceManager {
             let deleted = last[&key];
             match (is_edge, deleted) {
                 (false, false) => {
+                    // `node_materialized`, not `get_node`: a node that arrived by
+                    // snapshot import has an **empty row copy** and holds its
+                    // properties in the column store (#545). Serialising the row
+                    // persisted only the keys a later `SET` happened to write back
+                    // into it, so restore-a-snapshot, update-one-property, restart
+                    // lost every property the update did not touch (#1129).
+                    //
                     // Skipped when absent: deleted later in the same statement.
-                    if let Some(node) = store.get_node(crate::graph::NodeId::new(id)) {
+                    if let Some(node) = store.node_materialized(crate::graph::NodeId::new(id)) {
+                        let node = &node;
                         let existed = self.storage.get_node(tenant, id)?.is_some();
                         let properties = bincode::serialize(&node.properties)?;
                         self.wal.lock().unwrap().append(WalEntry::CreateNode {

--- a/tests/write_durability.rs
+++ b/tests/write_durability.rs
@@ -185,3 +185,66 @@ fn a_partial_failure_leaves_disk_agreeing_with_memory() {
         in_memory
     );
 }
+
+/// Restore a snapshot, change one property, restart: everything else survives.
+///
+/// A node that arrived by snapshot import has an **empty row copy** — its values
+/// live in the column store (#545). `apply_mutations` serialised the row, so it
+/// persisted only the keys a later `SET` had written back into it. Measured before
+/// the fix: a node imported with `{name, age}`, updated with `SET p.age = 37`,
+/// came back from a restart holding `{age: 37}` alone (#1129).
+///
+/// This is the same class as #1094 — durability derived from the wrong view of a
+/// write — and it survived that fix because the write log records *which* node
+/// changed, correctly, while the payload was read from a representation that was
+/// empty for imported nodes.
+#[test]
+fn an_imported_node_keeps_the_properties_a_later_write_did_not_touch() {
+    use samyama::snapshot::{export_tenant, import_tenant};
+
+    let engine = QueryEngine::new();
+    let mut source = GraphStore::new();
+    engine
+        .execute_mut("CREATE (:P {name: \"ada\", age: 36, city: \"London\"})", &mut source, T)
+        .unwrap();
+    let mut bytes = Vec::new();
+    export_tenant(&source, &mut bytes).unwrap();
+
+    let db = Db::new();
+    let mut live = GraphStore::new();
+    import_tenant(&mut live, std::io::Cursor::new(&bytes)).unwrap();
+    live.enable_write_log();
+
+    // The precondition: the import really did leave the row copy empty, so this
+    // test exercises the merge rather than a store that never needed one.
+    let id = live.get_nodes_by_label(&"P".into())[0].id;
+    assert!(
+        live.get_node(id).unwrap().properties.is_empty(),
+        "import now fills the row copy, so this test no longer covers the case it \
+         was written for"
+    );
+
+    engine.execute_mut("MATCH (p:P) SET p.age = 37", &mut live, T).unwrap();
+    let muts = live.take_write_log();
+    db.pm.apply_mutations(T, &live, &muts).expect("persist");
+    db.pm.checkpoint().unwrap();
+
+    let (nodes, _) = db.pm.recover(T).unwrap();
+    assert_eq!(nodes.len(), 1);
+    let props = &nodes[0].properties;
+    assert_eq!(
+        props.get("age"),
+        Some(&samyama::graph::PropertyValue::Integer(37)),
+        "the update itself did not survive"
+    );
+    assert_eq!(
+        props.get("name").map(|v| v.to_string()),
+        Some(samyama::graph::PropertyValue::String("ada".into()).to_string()),
+        "`name` was dropped: the write persisted only what the row copy held"
+    );
+    assert_eq!(
+        props.get("city").map(|v| v.to_string()),
+        Some(samyama::graph::PropertyValue::String("London".into()).to_string()),
+        "`city` was dropped: the write persisted only what the row copy held"
+    );
+}


### PR DESCRIPTION
Closes #1129. Data loss.

## Measured

```
AFTER IMPORT   row = 0 properties,  merged view = 2  (name, age)
client sends   MATCH (p:P) SET p.age = 37
AFTER RESTART  props = {"age": 37}          <- "name" is gone
```

## Cause

A node that arrives by snapshot import has an **empty row copy** — its values are
in the column store (#545, by design). `apply_mutations` built the persisted record
from `store.get_node(id)`, which reads the row. So it wrote only the keys a later
`SET` had put back there, and dropped everything else.

## Why #1094 did not catch it, and was not wrong

That fix made durability depend on **which entity changed** rather than on what the
statement returned. That part holds here: the journal names the right node. The
payload was then read from a representation that is empty for imported nodes.

**The write log was right; the thing it pointed at was not.**

## Scope

- Needs a snapshot import followed by a write. A server that restores from
  `.sgsnap` and then takes traffic is the ordinary case.
- **Silent.** The write succeeds, the response is correct, and the loss appears only
  after a restart.
- Nodes only. Edges keep both representations across an import (measured), so their
  row copy serialises correctly.

## Fix

`apply_mutations` uses `store.node_materialized(id)` — the merge added in #1125 —
so the persisted record carries every property wherever it lives.

The regression test asserts its own precondition (the import really did leave the
row copy empty), so it cannot pass vacuously, and **it fails with the fix
reverted** — verified, not assumed:

```
assertion failed: `name` was dropped: the write persisted only what the row copy held
```

## Left open in #1129

`persist_create_node` and `PersistentStorage::put_node` also serialise
`node.properties` directly. The journal path no longer reaches them, but they take
a `&Node` and cannot merge, so a caller holding a node from an imported graph would
hit the same loss. Either they take the store, or their doc comments say the caller
owns the merge.

`cargo test --workspace --no-fail-fast`: **257 binaries, 4,105 passed, 0 failed.**

https://claude.ai/code/session_016erf3aJ7MVFwUABw1PXyJf