### PR TITLE
Enforce the property-merge contract instead of documenting it

### DIFF
--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -139,6 +139,17 @@ impl PersistenceManager {
     }
 
     /// Persist a node creation
+    /// Persist a node exactly as given.
+    ///
+    /// **The caller owns the property merge.** This serialises `node.properties`,
+    /// the row copy, and a node that arrived by snapshot import has an empty one —
+    /// its values are in the column store (#545). Passing such a node here writes a
+    /// node with no properties and reports success (#1129).
+    ///
+    /// Use `GraphStore::node_materialized(id)` to get a node whose row map holds
+    /// every property wherever it lives, or use `apply_mutations`, which does that
+    /// for you. Today nothing outside this module's own tests calls this; the
+    /// contract is written down so that stays a choice rather than an accident.
     pub fn persist_create_node(&self, tenant: &str, node: &Node) -> Result<(), PersistenceError> {
         // Check tenant quota
         self.tenants.check_quota(tenant, "nodes")?;
@@ -505,6 +516,52 @@ pub type PersistenceResult<T> = Result<T, PersistenceError>;
 
 #[cfg(test)]
 mod tests {
+
+    /// Nothing outside this module's tests may call the persistence functions that
+    /// cannot merge a node's properties.
+    ///
+    /// `persist_create_node` and `PersistentStorage::put_node` serialise the row
+    /// copy. A node from a snapshot import has an empty row copy and its values in
+    /// the column store, so those functions write a node with no properties and
+    /// report success — the loss in #1129, which reached a restart before anything
+    /// noticed. `apply_mutations` merges first; a new caller that does not is the
+    /// way the bug comes back.
+    ///
+    /// A doc comment says the contract. This one enforces it.
+    #[test]
+    fn nothing_persists_a_node_without_merging_its_properties() {
+        let source = include_str!("mod.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("mod.rs has a production region");
+
+        let offenders: Vec<(usize, &str)> = production
+            .lines()
+            .enumerate()
+            .filter(|(_, l)| {
+                l.contains("persist_create_node(") || l.contains(".put_node(")
+            })
+            // The definition itself, and the one call inside it.
+            .filter(|(_, l)| !l.contains("pub fn persist_create_node"))
+            // `apply_mutations` is the merged path — it is fed `node_materialized`.
+            .filter(|(i, _)| {
+                let start = i.saturating_sub(25);
+                !production.lines().collect::<Vec<_>>()[start..*i]
+                    .iter()
+                    .any(|l| l.contains("node_materialized"))
+            })
+            .map(|(i, l)| (i + 1, l.trim()))
+            .collect();
+
+        assert!(
+            offenders.is_empty(),
+            "these persist a node without merging its properties, so a node that \
+             came from a snapshot import is written with none of them and the call \
+             reports success (#1129). Pass `store.node_materialized(id)`, or route \
+             the write through `apply_mutations`: {offenders:?}"
+        );
+    }
     use super::*;
     use crate::graph::{Label, NodeId, EdgeId, EdgeType, PropertyValue, PropertyMap};
     use tempfile::TempDir;

--- a/src/persistence/storage.rs
+++ b/src/persistence/storage.rs
@@ -159,6 +159,13 @@ impl PersistentStorage {
     }
 
     /// Store a node
+    /// Write a node to storage exactly as given.
+    ///
+    /// **The caller owns the property merge**, for the same reason as
+    /// `PersistenceManager::persist_create_node`: this serialises the row copy, and
+    /// a node from a snapshot import has an empty one while its values sit in the
+    /// column store (#545, #1129). A `Node` on its own cannot reach the columns, so
+    /// this function cannot fix it — the caller has to pass a merged node.
     pub fn put_node(&self, tenant: &str, node: &Node) -> StorageResult<()> {
         let cf = self.db.cf_handle("nodes")
             .ok_or_else(|| StorageError::ColumnFamily("nodes".to_string()))?;


### PR DESCRIPTION
Follows #1130, closing the hole it left open in #1129.

## The hole

`persist_create_node` and `PersistentStorage::put_node` serialise `node.properties`
— the row copy. A node from a snapshot import has an empty row copy and its values
in the column store (#545), so these write a node with **no properties** and report
success. That is the loss #1130 fixed on the journal path, and it reached a restart
before anything noticed.

Neither function can fix it itself: both take a `&Node`, and a `Node` cannot reach
the column store. The merge belongs to the caller.

## The fix

- The contract is written on both functions: pass `store.node_materialized(id)`, or
  route through `apply_mutations`.
- A **source-level test** over the production region of `persistence/mod.rs`
  enforces it.

`apply_mutations` is exempt because it is fed `node_materialized`. The test looks
for that call within the preceding lines rather than special-casing a function
name, so a future merged caller passes without being added to an allowlist.

**Verified it can fail.** A hypothetical caller that forwards a `&Node` straight
through is reported by line:

```
these persist a node without merging its properties, so a node that came from a
snapshot import is written with none of them and the call reports success (#1129).
Pass `store.node_materialized(id)`, or route the write through `apply_mutations`:
[(422, "self.persist_create_node(tenant, node)")]
```

Nothing outside this module's own tests calls either function today. The guard is
what keeps that a choice rather than an accident: a doc comment states a contract,
a test holds one.

`cargo test --workspace --no-fail-fast`: **257 binaries, 4,106 passed, 0 failed.**

https://claude.ai/code/session_016erf3aJ7MVFwUABw1PXyJf