### PR TITLE
Document /api/import/parquet and /api/query/export — CI has been red since they shipped

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -121,6 +121,116 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /api/import/parquet:
+    post:
+      operationId: importParquet
+      summary: Import nodes from a Parquet file
+      description: |
+        Upload a Parquet file to create one node per row, with the file's columns as
+        properties. Nodes only: an edge needs identity resolution — a `source` column
+        names *something*, and which property it names is a decision the file cannot
+        make — so that belongs in `LOAD PARQUET`, where the mapping is written in the
+        query.
+      parameters:
+        - name: label
+          in: query
+          required: true
+          schema:
+            type: string
+          description: |
+            The label every created node gets. Required rather than inferred: a Parquet
+            file carries a schema, not a label, and taking one from the filename would
+            make the import depend on what the file was called.
+        - name: graph
+          in: query
+          required: false
+          schema:
+            type: string
+            default: default
+          description: Target graph/tenant name
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: Parquet file content
+      responses:
+        '200':
+          description: Import successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    examples:
+                      - ok
+                  stats:
+                    type: object
+                    description: Rows read and nodes created
+        '400':
+          description: Missing file field, unreadable Parquet, or unknown graph
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/query/export:
+    post:
+      operationId: exportQuery
+      summary: A read query's result as Arrow IPC or Parquet
+      description: |
+        Runs a read query and returns the result as a binary columnar stream rather
+        than JSON. `arrow` is the default because it needs no intermediate file at
+        either end.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - query
+              properties:
+                query:
+                  type: string
+                  description: The Cypher read query
+                graph:
+                  type: string
+                  default: default
+                  description: Target graph/tenant name
+                format:
+                  type: string
+                  enum: [arrow, parquet]
+                  default: arrow
+                  description: Output encoding
+      responses:
+        '200':
+          description: The result set
+          content:
+            application/vnd.apache.arrow.stream:
+              schema:
+                type: string
+                format: binary
+            application/vnd.apache.parquet:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Unknown format, unknown graph, or a query that does not run
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /api/import/json:
     post:
       operationId: importJson


### PR DESCRIPTION
## The failure

CH-API compares the routes the server registers against `api/openapi.yaml`:

```
documented endpoints  16
served endpoints      18
served but undocumented: ["/api/import/parquet", "/api/query/export"]

API contract broken:
  - 2 served endpoint(s) missing from the document
```

**Both are mine, from #1102.** I ran the test suite before merging that; CH-API is
a CI-only gate, so the failure appeared after the merge and stayed.

## One red gate hides the rest

The job stops at the first failing step, so since #1102 these have not run at all:

- CH-TCK — the openCypher pass count may not decrease
- CH-DETERM-THREADS
- The release-gate check
- LINT-RATCHET
- CH-ALGO-PARITY

That is worth more attention than this fix. A gate sequence that halts on the first
failure means one stale red makes every gate behind it invisible, and nothing
reports the difference between "passed" and "never ran".

## The fix

Both entries describe the handlers as written, including the parts that are
decisions rather than details:

- `label` is a **required query parameter** on the Parquet import, because a Parquet
  file carries a schema and not a label — taking one from the filename would make
  the import depend on what the file was called.
- The import is **nodes-only**: an edge needs identity resolution that the file
  cannot supply.
- `format` on the export defaults to `arrow`, which needs no intermediate file at
  either end.

```
documented endpoints  18
served endpoints      18
agreeing              18
the document and the server agree
```

`cargo test --workspace --no-fail-fast`: **257 binaries, 4,106 passed, 0 failed.**

https://claude.ai/code/session_016erf3aJ7MVFwUABw1PXyJf