### PR TITLE
Index nodes from the properties given, not from the row copy

### DIFF
--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -1451,6 +1451,14 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
             self.node_columns.set_property(idx, key, value.clone());
         }
 
+        // Kept before the move so the index event below is built from the
+        // properties *as given* rather than read back off the node. Reading them
+        // back ties indexing to the row copy: with the row empty — which is what a
+        // snapshot-imported graph looks like, and what removing the duplication in
+        // #1123 would make every graph look like — the event carries nothing and
+        // the index silently never learns the values (#1132).
+        let indexed_properties = properties.clone();
+
         let mut node = Node::new_with_properties(node_id, labels.clone(), properties);
         node.version = self.current_version;
 
@@ -1481,15 +1489,15 @@ NodeDeleted { tenant_id: _, id, labels, properties } => {
                 tenant_id: tenant_id.to_string(),
                 id: node_id,
                 labels: node.labels.iter().cloned().collect(),
-                properties: node.properties.clone(),
+                properties: indexed_properties,
             });
-        } else if !node.properties.is_empty() {
+        } else if !indexed_properties.is_empty() {
             self.handle_index_event(
                 crate::graph::event::IndexEvent::NodeCreated {
                     tenant_id: tenant_id.to_string(),
                     id: node_id,
                     labels: node.labels.iter().cloned().collect(),
-                    properties: node.properties.clone(),
+                    properties: indexed_properties,
                 },
                 None,
             );


### PR DESCRIPTION
Preparation for #1123, and worth having on its own.

## What

`create_node_with_properties` built its `NodeCreated` index event by reading
`node.properties` back off the node it had just constructed. That ties indexing to
the **row copy** — one of two representations, and not the authoritative one.

## Measured

The row copy suppressed at the point of construction, which is what removing the
duplication in #1123 would do to every graph:

| | failures |
|---|---|
| row copy disabled, before this change | **5** |
| row copy disabled, after this change | **2** |

The three this fixes are `test_property_index_usage`, `test_property_index_range`
and `test_vector_call_query`. With an empty row the event carried nothing, the
property and vector indexes never learned the values, and
`MATCH (n:Person) WHERE n.id = 50` returned **0 rows** instead of 1 — silently, because
an index that was never told about a value looks exactly like a value that is not
there.

## No new test, and why

Behaviour is unchanged on current `main`: the row copy is always populated on this
path today, so **no new test can fail**, and I am not adding one that cannot. The
guard is the pair of remaining failures under the experiment —
`test_create_node_with_properties`, which asserts the row copy on purpose, and
`test_vector_search_integration`. Those are the work still to do before #1123 can
land, and they are now the whole of it.

## Why it stands alone

Reading state back out of a structure to describe a change you already hold is how
two representations get coupled in the first place. The properties were in hand;
the event should carry them.

`cargo test --workspace --no-fail-fast`: **257 binaries, 4,106 passed, 0 failed.**

https://claude.ai/code/session_016erf3aJ7MVFwUABw1PXyJf