### PR TITLE
LINT-RATCHET: show what it is counting

### DIFF
--- a/scripts/check_lint_ratchet.sh
+++ b/scripts/check_lint_ratchet.sh
@@ -16,8 +16,23 @@ set -uo pipefail
 
 CEILING="${1:-769}"
 
-count=$(cargo clippy --workspace --all-targets 2>&1 | grep -cE "^warning")
+# Two different things start with "warning:" — individual lints, and cargo's
+# per-crate summary ("warning: `samyama` (lib) generated 64 warnings"). The count
+# below includes both, which is what the ceiling was set against, so it stays that
+# way until the ceiling is re-measured on CI in the same commit.
+#
+# It is worth knowing that the two move independently. The summary count is one
+# line per *crate that emitted anything*, so it shifts with toolchain version and
+# with how the workspace is split, neither of which is lint debt. Measured on
+# 2026-09-07 with rustc 1.96.1: 945 total = 799 lints + 146 summaries, while CI on
+# `stable` passed the 769 ceiling on the same commit. A number that differs between
+# a developer's machine and CI teaches people to ignore it, so both are printed.
+raw=$(cargo clippy --workspace --all-targets 2>&1)
+count=$(echo "$raw" | grep -cE "^warning")
+lints=$(echo "$raw" | grep -E "^warning" | grep -vc "generated")
+summaries=$((count - lints))
 echo "clippy warnings: $count (ceiling $CEILING)"
+echo "  of which lints: $lints, per-crate summaries: $summaries"
 
 if [ "$count" -gt "$CEILING" ]; then
   echo "FAIL: $((count - CEILING)) more clippy warnings than the ceiling."


### PR DESCRIPTION
Part of #1134.

## The disagreement

Same commit, two answers:

```
local (rustc 1.96.1)   clippy warnings: 945 (ceiling 769)  -> FAIL
CI (stable)            LINT-RATCHET                        -> pass
```

## Cause

Two different things start with `warning:` in cargo's output:

- an individual lint — `warning: variable does not need to be mutable`
- a per-crate summary — ``warning: `samyama` (lib) generated 64 warnings``

`grep -cE "^warning"` counts both:

```
clippy warnings: 945 (ceiling 769)
  of which lints: 799, per-crate summaries: 146
```

The summary count is one line per *crate that emitted anything*, so it moves with
the toolchain version and with how the workspace splits into compilation units.
Neither of those is lint debt.

## Why this matters more than the 176

A local script that fails while CI passes is worse than no local script: it trains
people to run it, see red, and ignore it. The ratchet exists so someone notices
before pushing.

It also cost me a wrong claim earlier today — I reported the ratchet as "already
breached by 156 before my work" from the local number. Local artefact. Withdrawn.

## What this changes, and what it does not

Prints the breakdown. **Leaves the pass/fail computation alone.** The 769 ceiling
was set against the combined number, so changing the counter without re-measuring
the ceiling in the same commit would either break the build or install a ceiling
nobody measured.

The real fix — count lints only, with the ceiling read off a CI run in the same
commit — is #1134.

https://claude.ai/code/session_016erf3aJ7MVFwUABw1PXyJf