### PR TITLE
Export articleRank for parity, with its parameters (ALGO-02)

### DIFF
--- a/examples/algo_parity_export.rs
+++ b/examples/algo_parity_export.rs
@@ -29,6 +29,7 @@ use samyama_graph_algorithms::{
     eigenvector_centrality, harmonic_centrality,
     link_prediction::{score_one, LinkScore},
     average_neighbour_degree, degree_assortativity, diameter, eccentricity, radius,
+    pathfinding_extra::article_rank,
     pathfinding_extra::random_walk,
     articulation_points, bridges, find_cycle, topological_sort, TopoResult,
     community_detect::louvain,
@@ -426,6 +427,19 @@ fn main() {
 
         let mut h2 = serde_json::Map::new();
         let mut put = |k: &str, v: serde_json::Value| { h2.insert(k.to_string(), v); };
+        // ArticleRank (ALGO-02). Deterministic for a given damping and iteration
+        // count, so it has exactly one right answer and belongs in the parity
+        // denominator — "no library ships it" is not the same as "no reference can
+        // exist", and this requirement's exclusion test is the latter.
+        //
+        // The parameters travel with the result. A reference that has to guess them
+        // is comparing two different algorithms, and would disagree for a reason
+        // that says nothing about either implementation.
+        put("article_rank", serde_json::json!({
+            "damping": 0.85,
+            "iterations": 40,
+            "scores": idx(&article_rank(&view, 0.85, 40)),
+        }));
         put("katz", serde_json::to_value(&katz).unwrap());
         put("articulation_points", serde_json::to_value(&artic).unwrap());
         put("bridges", serde_json::to_value(&bridge_pairs).unwrap());


### PR DESCRIPTION
Part of H2 condition 2 (SLT-6 Coverage), which needs ALGO-02 at 1.0.

## Why articleRank belongs in the denominator

ALGO-02 asks that every algorithm **for which a deterministic reference can exist**
is checked against one. `articleRank` is deterministic for a given damping and
iteration count — exactly one right answer. The exclusion test is *"no answer is
uniquely correct"*, not *"no library ships one"*, and NetworkX having no
`article_rank` is the second.

## Parameters travel with the result

`damping` and `iterations` are exported alongside the scores rather than restated in
the comparator. A reference that assumes them is comparing two different algorithms
as soon as a default moves, and would disagree for a reason that says nothing about
either implementation.

## Result

**ALGO-02: 0.9016 → 0.918** (55 → 56 of 61 referenceable algorithms).

The comparator side is in `benchmarks#166`, which writes the reference as a matrix
iteration rather than a transcription of this loop — and found a bug in itself doing
so.

`cargo test --workspace --no-fail-fast`: **257 binaries, 4,106 passed, 0 failed.**

https://claude.ai/code/session_016erf3aJ7MVFwUABw1PXyJf