### PR TITLE
A lower bound of 0 no longer collapses the path multiset

### DIFF
--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -7626,7 +7626,13 @@ impl VarLengthExpandOperator {
             edges.push(eid);
             let depth = path.len();
 
-            if depth >= self.min_hops && self.emit_ok(nb, store) {
+            // Both bounds. `depth >= min_hops` alone was sufficient while this
+            // path was reachable only for `min_hops >= 1`, because the
+            // `depth < max_hops` descend guard below then implied the upper bound.
+            // At `*0..0` it does not: depth 1 satisfies `1 >= 0` and is emitted
+            // before anything checks it against `max_hops == 0`. Stated as the
+            // interval it is, rather than relying on a guard elsewhere (#1140).
+            if depth >= self.min_hops && depth <= self.max_hops && self.emit_ok(nb, store) {
                 trails += 1;
                 if trails > MAX_TRAILS {
                     return Err(ExecutionError::PlanningError(format!(
@@ -7762,10 +7768,35 @@ impl VarLengthExpandOperator {
         // nodes, and IC6 needs the pinned-target walk to stay cheap. Both have
         // `min_hops == 1`, as does every LDBC pattern, so the enumeration is
         // taken only where the BFS is not merely lossy but wrong.
-        // `min_hops == 0` stays on the BFS: `expand_trails` walks outward from
-        // the source and has no way to emit the source itself, so routing
-        // `*0..n` into it silently drops the zero-length match — caught by
-        // `zero_hops_includes_the_target_itself`.
+        // `min_hops == 0` used to stay on the BFS, because `expand_trails` walks
+        // outward from the source and cannot emit the source itself — routing
+        // `*0..n` into it dropped the zero-length match, which
+        // `zero_hops_includes_the_target_itself` catches.
+        //
+        // That reasoning was right about `expand_trails` and wrong about the
+        // conclusion. Staying on the BFS means `*0..n` gets first-reach dedup with
+        // the multiplicity guard never consulted, so `(a)-[:E*0..2]->(y)` over two
+        // parallel `a->b` edges answered `a, b, c` where the correct multiset is
+        // `a, b, b, c, c` — while `*1..2` on the same graph was right (#1140). A
+        // silent wrong answer through an interface reporting success.
+        //
+        // The fix is the invariant rather than a second traversal:
+        //
+        //     A(0, n)  ==  A(0, 0)  union  A(1, n)      as multisets
+        //
+        // true under every ISO/IEC 39075 path mode — WALK, TRAIL, ACYCLIC and
+        // SIMPLE — because a path has exactly one length and no restrictor mentions
+        // the quantifier bounds. `A(0,0)` is the single zero-length match, emitted
+        // here; `A(1,n)` is what `expand_trails` already computes, since its emit
+        // test is `depth >= min_hops` and its first depth is 1. So the two halves
+        // cannot diverge again: there is only one traversal.
+        if self.enumerate_trails && self.min_hops == 0 {
+            if self.emit_ok(source_id, store) {
+                let empty = std::collections::HashMap::new();
+                self.buffer(record, source_id, &empty, source_id, store);
+            }
+            return self.expand_trails(record, source_id, store);
+        }
         if self.min_hops >= 2 || (self.enumerate_trails && self.min_hops >= 1) {
             return self.expand_trails(record, source_id, store);
         }

--- a/tests/varlen_zero_lower_bound.rs
+++ b/tests/varlen_zero_lower_bound.rs
@@ -1,0 +1,140 @@
+//! `A(0, n)` equals `A(0, 0)` union `A(1, n)`, as multisets (#1140).
+//!
+//! A variable-length pattern with lower bound 0 returned one row per distinct end
+//! node instead of one row per path: `(a)-[:E*0..2]->(y)` over two parallel `a->b`
+//! edges answered `a, b, c` where the correct multiset is `a, b, b, c, c`. The query
+//! succeeded; only the answer was wrong.
+//!
+//! The identity asserted here holds under **every** ISO/IEC 39075 path mode — WALK,
+//! TRAIL, ACYCLIC and SIMPLE — because a path has exactly one length and no
+//! restrictor mentions the quantifier bounds. So this is a conformance property, not
+//! a commitment to one semantics: whatever `*1..n` means, `*0..n` must be that plus
+//! the zero-length match.
+//!
+//! Asserted as a relation between two of the engine's own answers rather than
+//! against a table of expected values. A table encodes what I believed on the day I
+//! wrote it; this stays true when the path semantics change, and it is the shape a
+//! metamorphic suite uses.
+
+use samyama::graph::GraphStore;
+use samyama::query::QueryEngine;
+
+const T: &str = "default";
+
+/// The reproducer's graph: `a =e1,e2=> b -e3-> c -e4-> a`.
+///
+/// The two parallel `a->b` edges are the point. With one edge per pair, first-reach
+/// deduplication and correct multiset semantics agree on every query here, and the
+/// bug is invisible.
+const PARALLEL: &[(&str, &str)] = &[("a", "b"), ("a", "b"), ("b", "c"), ("c", "a")];
+
+/// A diamond: two distinct 2-hop routes from `a` to `d`.
+const DIAMOND: &[(&str, &str)] = &[("a", "b"), ("a", "c"), ("b", "d"), ("c", "d")];
+
+/// A triangle, the shape the multiplicity guard's own doc comment cites.
+const TRIANGLE: &[(&str, &str)] = &[("a", "b"), ("b", "c"), ("c", "a")];
+
+fn build(edges: &[(&str, &str)]) -> GraphStore {
+    let engine = QueryEngine::new();
+    let mut store = GraphStore::new();
+    let mut names: Vec<&str> = edges.iter().flat_map(|&(a, b)| [a, b]).collect();
+    names.sort_unstable();
+    names.dedup();
+    for n in names {
+        engine
+            .execute_mut(&format!("CREATE (:N {{eid: \"{n}\"}})"), &mut store, T)
+            .unwrap();
+    }
+    for &(a, b) in edges {
+        engine
+            .execute_mut(
+                &format!(
+                    "MATCH (x:N {{eid: \"{a}\"}}), (y:N {{eid: \"{b}\"}}) CREATE (x)-[:E]->(y)"
+                ),
+                &mut store,
+                T,
+            )
+            .unwrap();
+    }
+    store
+}
+
+/// End-node ids for a pattern, sorted — a multiset, since order is not the claim.
+fn ends(store: &GraphStore, pattern: &str) -> Vec<String> {
+    let engine = QueryEngine::new();
+    let q = format!("MATCH (x:N {{eid: \"a\"}})-[:E{pattern}]->(y) RETURN y.eid");
+    let batch = engine.execute(&q, store).unwrap_or_else(|e| panic!("{q}: {e}"));
+    let mut out: Vec<String> = batch
+        .records
+        .iter()
+        .map(|r| format!("{:?}", r.get("y.eid")))
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn zero_lower_bound_is_the_zero_length_match_plus_the_one_bounded_form() {
+    for (name, edges) in [
+        ("parallel", PARALLEL),
+        ("diamond", DIAMOND),
+        ("triangle", TRIANGLE),
+    ] {
+        let store = build(edges);
+        let zero = ends(&store, "*0..0");
+        assert_eq!(zero.len(), 1, "{name}: *0..0 is the source and nothing else");
+
+        for n in 1..=4 {
+            let actual = ends(&store, &format!("*0..{n}"));
+            let mut expected = zero.clone();
+            expected.extend(ends(&store, &format!("*1..{n}")));
+            expected.sort();
+            assert_eq!(
+                actual, expected,
+                "{name}: *0..{n} must be *0..0 plus *1..{n} as a multiset. \
+                 Got {} rows, expected {}. A lower bound of 0 taking a different \
+                 traversal from a lower bound of 1 is how these diverge.",
+                actual.len(),
+                expected.len()
+            );
+        }
+    }
+}
+
+/// The parallel-edge case with its numbers written down, so a reader can see what
+/// the property above is worth without running it.
+///
+/// This is the reproducer from #1140. Kept alongside the property, not instead of
+/// it: the property is what survives a change in path semantics, and this is what
+/// makes the property legible.
+#[test]
+fn the_reported_case_answers_one_row_per_path() {
+    let store = build(PARALLEL);
+    for (pattern, rows) in [
+        ("*0..0", 1), // a
+        ("*0..1", 3), // a, b, b
+        ("*0..2", 5), // a, b, b, c, c
+        ("*1..1", 2), // b, b
+        ("*1..2", 4), // b, b, c, c
+        ("*2..2", 2), // c, c
+    ] {
+        assert_eq!(
+            ends(&store, pattern).len(),
+            rows,
+            "{pattern} over two parallel a->b edges"
+        );
+    }
+}
+
+/// An empty interval matches nothing, and `*0..0` is not empty.
+///
+/// `expand_trails` emits on `depth >= min_hops` and used to rely on the descend
+/// guard for the upper bound, which held only while `min_hops >= 1`. Routing
+/// `*0..0` there emitted every depth-1 neighbour — three rows for a one-row answer.
+#[test]
+fn an_empty_interval_matches_nothing_and_zero_zero_matches_the_source() {
+    let store = build(PARALLEL);
+    assert_eq!(ends(&store, "*0..0").len(), 1);
+    assert_eq!(ends(&store, "*1..0").len(), 0, "*1..0 is empty");
+    assert_eq!(ends(&store, "*2..1").len(), 0, "*2..1 is empty");
+}


### PR DESCRIPTION
Closes #1140. P0: silently wrong through an interface reporting success.

## Reproduced exactly as filed

`a =e1,e2=> b -e3-> c -e4-> a`, start `a`, `RETURN y.eid`:

| pattern | before | after | correct |
|---|---:|---:|---|
| `*0..0` | 1 | 1 | `a` |
| `*0..1` | 2 | **3** | `a, b, b` |
| `*0..2` | 3 | **5** | `a, b, b, c, c` |
| `*0..3` | 3 | **7** | `a, a, a, b, b, c, c` |
| `*1..1` | 2 | 2 | `b, b` |
| `*1..2` | 4 | 4 | `b, b, c, c` |
| `*1..3` | 6 | 6 | `a, a, b, b, c, c` |

One correction to the issue's table: `*0..3` is **7** rows, not 6. The listed
expectation `a, a, b, b, c, c` is `A(1,3)` and omits the zero-length match — by the
issue's own invariant, `A(0,3) = A(0,0) + A(1,3) = 1 + 6`.

## Cause — documented in the code that caused it

```rust
// `min_hops == 0` stays on the BFS: `expand_trails` walks outward from
// the source and has no way to emit the source itself, so routing
// `*0..n` into it silently drops the zero-length match
```

Right about `expand_trails`, wrong about the conclusion. Staying on the BFS means
`*0..n` gets first-reach deduplication with `multiplicity_is_observable` **never
consulted** — confirming the issue's reading exactly: the guard was not returning a
wrong verdict, it was not being asked.

Neither named candidate site was the cause. The `min_hops <= 1` case at ~3735 is a
pinned-target optimisation that needs a resolved target; the routing condition in
`VarLengthExpandOperator` is.

## Fix — the invariant, not a third traversal

```
A(0, n)  ==  A(0, 0)  union  A(1, n)      as multisets
```

`A(0,0)` is emitted directly; `A(1,n)` is what `expand_trails` already computes,
since its emit test is `depth >= min_hops` and its first depth is 1. One traversal,
so the two halves cannot diverge again — which is what the issue asked for.

## A second defect it exposed immediately

`*0..0` then returned **three** rows. `expand_trails` emits on `depth >= min_hops`
and relied on the `depth < max_hops` descend guard for its upper bound — which
holds only while `min_hops >= 1`. At `*0..0`, depth 1 satisfies `1 >= 0` and is
emitted before anything compares it to `max_hops == 0`. Now stated as the interval
it is.

## Tested as a property

`A(0,n) == A(0,0) + A(1,n)` over three graphs — parallel edges, diamond, triangle —
for n in 1..=4. A table encodes what I believed on the day I wrote it; the relation
stays true if the path semantics change, and it is the shape #1142 asks for. The
reported case is pinned alongside with its numbers so the property is legible.

Also pinned: `*1..0` and `*2..1` match nothing, and `*0..0` is not an empty
interval.

## Verification

- **TCK unchanged**: 3760 pass, **0 wrong results**, 3 errored (Temporal10,
  ExistentialSubquery2 — unrelated to paths), pass rate 0.9992 — identical to the
  recorded baseline.
- `cargo test --workspace --no-fail-fast`: 258 binaries, 4,111 passed, 0 failed.