### PR TITLE
GQL path restrictors and selectors

### DIFF
--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -362,6 +362,99 @@ pub struct Pattern {
     pub paths: Vec<PathPattern>,
 }
 
+/// Which paths are candidates, before any selector applies (ISO/IEC 39075:2024).
+///
+/// The four modes differ only in what a path may repeat:
+///
+/// | mode | may repeat an edge | may repeat a node |
+/// |---|---|---|
+/// | `Walk` | yes | yes |
+/// | `Trail` | no | yes |
+/// | `Acyclic` | no | no |
+/// | `Simple` | no | no, except first and last may coincide |
+///
+/// `Trail` is the default and is what openCypher's relationship-uniqueness rule
+/// already required, so an unannotated pattern keeps its current meaning exactly.
+/// Naming it is the point: the executor already chose between a first-reach BFS and
+/// a trail enumerator by inferring intent from query shape, and the inference is
+/// what #1140 was a bug in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PathRestrictor {
+    /// No restriction. Unbounded under `ALL` is forbidden by the standard, since
+    /// the answer is infinite on any graph with a cycle.
+    Walk,
+    /// No repeated edge. openCypher's rule, and this dialect's historical default.
+    #[default]
+    Trail,
+    /// No repeated node. Not expressible by any Cypher rewrite.
+    Acyclic,
+    /// No repeated node, except that the first and last may coincide — so a cycle
+    /// is a simple path and nothing shorter than the whole path is.
+    Simple,
+}
+
+impl PathRestrictor {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PathRestrictor::Walk => "WALK",
+            PathRestrictor::Trail => "TRAIL",
+            PathRestrictor::Acyclic => "ACYCLIC",
+            PathRestrictor::Simple => "SIMPLE",
+        }
+    }
+
+    /// Whether the restriction is prefix-closed — decidable while extending a path.
+    ///
+    /// `Trail` and `Acyclic` are: a prefix of a legal path is legal, so a traversal
+    /// can prune the moment it is violated. `Simple` is **not**, in the same way: a
+    /// prefix whose first and last nodes coincide is legal only if the path stops
+    /// there, so pruning on the full condition would reject paths that become legal
+    /// again. `Simple` prunes on the interior condition only and checks the
+    /// endpoint exemption at emit time.
+    pub fn is_prefix_closed(self) -> bool {
+        !matches!(self, PathRestrictor::Simple)
+    }
+}
+
+/// Which of the candidate paths to return, per endpoint pair (ISO/IEC 39075:2024).
+///
+/// Applied *after* the restrictor, and partitioning on the endpoint pair rather
+/// than filtering: `ANY` returns one path per pair, not one path overall.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PathSelector {
+    /// Every match. The default.
+    #[default]
+    All,
+    /// One match per endpoint pair, unspecified which. The standard permits any
+    /// choice, so returning whichever is found first is conforming.
+    Any,
+    /// Every match of minimum length, per endpoint pair.
+    AllShortest,
+    /// One match of minimum length per endpoint pair.
+    AnyShortest,
+}
+
+impl PathSelector {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PathSelector::All => "ALL",
+            PathSelector::Any => "ANY",
+            PathSelector::AllShortest => "ALL SHORTEST",
+            PathSelector::AnyShortest => "ANY SHORTEST",
+        }
+    }
+
+    /// Whether only minimum-length paths are wanted.
+    pub fn is_shortest(self) -> bool {
+        matches!(self, PathSelector::AllShortest | PathSelector::AnyShortest)
+    }
+
+    /// Whether one path per endpoint pair suffices.
+    pub fn is_single(self) -> bool {
+        matches!(self, PathSelector::Any | PathSelector::AnyShortest)
+    }
+}
+
 /// Path type for path patterns (normal, shortest, allShortest)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PathType {
@@ -377,6 +470,11 @@ pub struct PathPattern {
     pub path_variable: Option<String>,
     /// Path type (Normal, Shortest, AllShortest)
     pub path_type: PathType,
+    /// GQL path restrictor: which paths are candidates. `Trail` by default, which
+    /// is what an unannotated pattern has always meant here.
+    pub restrictor: PathRestrictor,
+    /// GQL path selector: which candidates to return per endpoint pair.
+    pub selector: PathSelector,
     /// Start node
     pub start: NodePattern,
     /// Edges and nodes

--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -181,7 +181,21 @@ create_stmt = { create_clause+ ~ return_clause? ~ order_by_clause? ~ skip_clause
 
 // Pattern matching
 pattern = { named_path ~ ("," ~ named_path)* }
-named_path = { (variable ~ "=" ~ shortest_path_call) | (variable ~ "=" ~ path) | shortest_path_call | path }
+named_path = { (variable ~ "=" ~ shortest_path_call) | (variable ~ "=" ~ path_modes ~ path) | (variable ~ "=" ~ path) | shortest_path_call | (path_modes ~ path) | path }
+
+// GQL path selectors and restrictors (ISO/IEC 39075:2024), as a prefix on a path
+// pattern: `MATCH ALL SHORTEST ACYCLIC (a)-[:R*1..3]->(b)`.
+//
+// Selector first, then restrictor, which is the standard's order: the restrictor
+// says which paths are candidates and the selector picks among them per endpoint
+// pair. Both optional and both independently useful.
+path_modes = { (path_selector ~ path_restrictor?) | path_restrictor }
+// **Longest alternative first.** PEG takes the first match and does not backtrack
+// into a longer one, so `ALL` before `ALL SHORTEST` would consume the `ALL` and
+// leave `SHORTEST` to fail as a node pattern -- the ordering trap that has bitten
+// this grammar before.
+path_selector = { (^"ALL" ~ ^"SHORTEST") | (^"ANY" ~ ^"SHORTEST") | ^"ANY" | ^"ALL" }
+path_restrictor = { ^"WALK" | ^"TRAIL" | ^"ACYCLIC" | ^"SIMPLE" }
 path = { node ~ (edge_pattern ~ node)* }
 
 // shortestPath / allShortestPaths wrapping a pattern

--- a/src/query/error_code.rs
+++ b/src/query/error_code.rs
@@ -102,3 +102,9 @@ pub const CLAUSE_CONFLICT: &str = "Samyama.ClientError.Statement.ClauseConflict"
 /// A CREATE or MERGE pattern the language does not permit -- an untyped
 /// relationship, an undirected one, a variable-length one.
 pub const INVALID_WRITE_PATTERN: &str = "Samyama.ClientError.Statement.InvalidWritePattern";
+
+/// A read pattern that is well-formed but has no finite answer, e.g. an unbounded
+/// `WALK` under `ALL` (#1141). Distinct from a write-pattern error: nothing is
+/// being written, and nothing needs rebinding or retyping — the combination of
+/// restrictor, selector and quantifier is what cannot be served.
+pub const INVALID_PATTERN: &str = "Samyama.ClientError.Statement.InvalidPattern";

--- a/src/query/executor/logical_plan.rs
+++ b/src/query/executor/logical_plan.rs
@@ -442,6 +442,8 @@ mod tests {
 
     fn make_path(start_var: &str, start_labels: Vec<Label>, segments: Vec<PathSegment>) -> PathPattern {
         PathPattern {
+            restrictor: Default::default(),
+            selector: Default::default(),
             path_variable: None,
             path_type: PathType::Normal,
             start: NodePattern {

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -6999,6 +6999,9 @@ impl PhysicalOperator for ExpandOperator {
 /// unrestricted, matching Cypher). An optional `path_variable` is materialized
 /// with the BFS route (shortest path source→target).
 pub struct VarLengthExpandOperator {
+    /// GQL path restrictor. `Trail` is the default and is what this operator has
+    /// always enforced, so an unannotated pattern is unchanged (#1141).
+    restrictor: crate::query::ast::PathRestrictor,
     input: OperatorBox,
     source_var: String,
     target_var: String,
@@ -7041,6 +7044,17 @@ pub struct VarLengthExpandOperator {
     edge_properties: std::collections::HashMap<String, PropertyValue>,
     /// Output records buffered for the current input record.
     pending: std::collections::VecDeque<Record>,
+    /// `(end node, path length)` for each entry of `pending`, in lockstep.
+    ///
+    /// The GQL selectors partition on the endpoint pair and then choose by length,
+    /// so applying one needs both facts and a `Record` carries neither reliably —
+    /// the path variable is bound only when the pattern names it. Recorded at the
+    /// single sink every walk goes through, so the two cannot fall out of step
+    /// (#1141).
+    pending_ends: std::collections::VecDeque<(NodeId, usize)>,
+    /// GQL path selector, applied once the expansion for one input record is
+    /// complete. `All` is the default and skips the pass entirely.
+    selector: crate::query::ast::PathSelector,
     /// `edge_types` resolved to interned ids, cached after the first use.
     ///
     /// Resolving is a hash lookup per type against the store, and the answer
@@ -7139,12 +7153,15 @@ impl VarLengthExpandOperator {
             target_labels: Vec::new(),
             direction,
             min_hops,
+            restrictor: crate::query::ast::PathRestrictor::default(),
             max_hops,
             path_variable: None,
             rel_variable: None,
             reversed_walk: false,
             edge_properties: std::collections::HashMap::new(),
             pending: std::collections::VecDeque::new(),
+            pending_ends: std::collections::VecDeque::new(),
+            selector: crate::query::ast::PathSelector::default(),
             type_ids: None,
             pinned_target: None,
             target_reach: None,
@@ -7444,6 +7461,34 @@ impl VarLengthExpandOperator {
 
     /// Enumerate trails rather than walking shortest paths, because the query
     /// can observe how many times a node is reached. See `enumerate_trails`.
+    /// Set the GQL path selector (#1141).
+    ///
+    /// A selector other than `All` needs every candidate path before it can choose
+    /// among them, so it turns enumeration on: the first-reach BFS keeps one path
+    /// per end node and cannot answer `ALL SHORTEST` at all.
+    pub fn with_selector(mut self, selector: crate::query::ast::PathSelector) -> Self {
+        self.selector = selector;
+        if selector != crate::query::ast::PathSelector::All {
+            self.enumerate_trails = true;
+        }
+        self
+    }
+
+    /// Set the GQL path restrictor (#1141).
+    ///
+    /// `Acyclic`, `Simple` and `Walk` all imply enumeration: each is a statement
+    /// about whole paths, and the first-reach BFS cannot express any of them — it
+    /// keeps one path per end node and so cannot tell a repeated node from a
+    /// repeated visit. Setting a non-default restrictor therefore turns enumeration
+    /// on rather than relying on the caller to remember.
+    pub fn with_restrictor(mut self, restrictor: crate::query::ast::PathRestrictor) -> Self {
+        self.restrictor = restrictor;
+        if restrictor != crate::query::ast::PathRestrictor::Trail {
+            self.enumerate_trails = true;
+        }
+        self
+    }
+
     pub fn with_trail_enumeration(mut self) -> Self {
         self.enumerate_trails = true;
         self
@@ -7598,11 +7643,14 @@ impl VarLengthExpandOperator {
 
         // Not a closure over `self`: `buffer` below needs `&mut self`, and a
         // captured `&self` would still be alive.
+        // `WALK` may reuse an edge; every other restrictor may not. Decided once
+        // here rather than inside the loop, so the common case pays nothing.
+        let reuse_edges = self.restrictor == crate::query::ast::PathRestrictor::Walk;
         macro_rules! collect {
             ($cur:expr, $used:expr) => {{
                 let mut out = Vec::new();
                 self.for_each_neighbor($cur, type_filter, store, |nb, eid| {
-                    if !$used.contains(&eid) {
+                    if reuse_edges || !$used.contains(&eid) {
                         out.push((nb, eid));
                     }
                 });
@@ -7622,6 +7670,29 @@ impl VarLengthExpandOperator {
                 }
                 continue;
             };
+            // Node restrictors (#1141). `Trail` and `Walk` say nothing about nodes,
+            // so they skip this entirely.
+            //
+            // `Acyclic` forbids any repeat, including the source. `Simple` forbids a
+            // repeat of an interior node but permits returning to the source — a
+            // cycle is a simple path — and a path that has done so may not continue,
+            // which is handled at the descend guard below rather than here. That
+            // asymmetry is why `Simple` is not prefix-closed: rejecting `nb ==
+            // source` outright would refuse every cycle, and accepting it without
+            // stopping would admit paths through the source.
+            match self.restrictor {
+                crate::query::ast::PathRestrictor::Acyclic => {
+                    if nb == source_id || path.iter().any(|&(n, _)| n == nb) {
+                        continue;
+                    }
+                }
+                crate::query::ast::PathRestrictor::Simple => {
+                    if path.iter().any(|&(n, _)| n == nb) {
+                        continue;
+                    }
+                }
+                _ => {}
+            }
             path.push((nb, eid));
             edges.push(eid);
             let depth = path.len();
@@ -7661,7 +7732,12 @@ impl VarLengthExpandOperator {
                 self.buffer_trail(record, nb, trail_nodes, trail_edges, store);
             }
 
-            if depth < self.max_hops {
+            // A `Simple` path that has returned to its source is complete: extending
+            // it would put the source in the interior, which `Simple` forbids. So it
+            // is emitted above and not descended from.
+            let simple_closed = self.restrictor == crate::query::ast::PathRestrictor::Simple
+                && nb == source_id;
+            if depth < self.max_hops && !simple_closed {
                 stack.push(collect!(nb, edges));
             } else {
                 path.pop();
@@ -7673,7 +7749,65 @@ impl VarLengthExpandOperator {
 
     /// BFS from the source bound in `record`, buffering one output record per
     /// distinct reachable target in `[min_hops, max_hops]`.
+    /// Expand one input record, then apply the GQL path selector to what it
+    /// produced (#1141).
+    ///
+    /// The selector partitions on the endpoint pair and chooses within each part,
+    /// so it cannot be applied while walking: `ALL SHORTEST` does not know which
+    /// length is shortest until the walk is done. Applied per input record rather
+    /// than per operator, because the pair is `(this record's source, end)` and two
+    /// input rows are two different partitions.
     fn expand_from(&mut self, record: &Record, store: &GraphStore) -> ExecutionResult<()> {
+        let first_new = self.pending.len();
+        let result = self.expand_from_inner(record, store);
+        if self.selector != crate::query::ast::PathSelector::All {
+            self.apply_selector(first_new);
+        }
+        result
+    }
+
+    /// Keep only the paths the selector asks for, among those just produced.
+    ///
+    /// Two passes: the minimum length per end node, then the choice. Stable — the
+    /// surviving records keep their relative order, so `ANY` returns the path the
+    /// walk found first, which is a conforming choice and a reproducible one.
+    fn apply_selector(&mut self, from: usize) {
+        use crate::query::ast::PathSelector;
+        let mut best: std::collections::HashMap<NodeId, usize> = std::collections::HashMap::new();
+        if self.selector.is_shortest() {
+            for &(end, len) in self.pending_ends.iter().skip(from) {
+                best.entry(end).and_modify(|b| *b = (*b).min(len)).or_insert(len);
+            }
+        }
+        let mut taken: std::collections::HashSet<NodeId> = std::collections::HashSet::new();
+        let mut keep: Vec<bool> = Vec::with_capacity(self.pending.len() - from);
+        for &(end, len) in self.pending_ends.iter().skip(from) {
+            let long_enough = !self.selector.is_shortest() || best.get(&end) == Some(&len);
+            let wanted = long_enough && (!self.selector.is_single() || taken.insert(end));
+            keep.push(wanted);
+        }
+        // Rebuilt rather than filtered in place: `VecDeque::retain` would have to
+        // walk both deques in step, and one of them getting out of step is the
+        // failure this pairing exists to prevent.
+        let mut records: Vec<Record> = Vec::with_capacity(self.pending.len());
+        let mut ends: Vec<(NodeId, usize)> = Vec::with_capacity(self.pending_ends.len());
+        for (i, (rec, meta)) in self
+            .pending
+            .drain(..)
+            .zip(self.pending_ends.drain(..))
+            .enumerate()
+        {
+            if i < from || keep[i - from] {
+                records.push(rec);
+                ends.push(meta);
+            }
+        }
+        self.pending = records.into();
+        self.pending_ends = ends.into();
+        let _ = PathSelector::All;
+    }
+
+    fn expand_from_inner(&mut self, record: &Record, store: &GraphStore) -> ExecutionResult<()> {
         // `MATCH (first)-[rs*]->(second)` where `rs` is *already bound* to a
         // list of relationships is not a search at all. openCypher reads it as
         // "the walk is exactly `rs`", so there is one candidate path and the
@@ -7926,6 +8060,9 @@ impl VarLengthExpandOperator {
         edges: Vec<crate::graph::EdgeId>,
         store: &GraphStore,
     ) {
+        // Length is the edge count, which is the definition a selector orders by
+        // and is right for a zero-length match too.
+        self.pending_ends.push_back((target, edges.len()));
         let mut rec = base.clone();
         rec.bind(self.target_var.clone(), Value::NodeRef(target));
 

--- a/src/query/executor/plan_enumerator.rs
+++ b/src/query/executor/plan_enumerator.rs
@@ -370,6 +370,8 @@ mod tests {
 
     fn make_path(start_var: &str, start_labels: Vec<Label>, segments: Vec<PathSegment>) -> PathPattern {
         PathPattern {
+            restrictor: Default::default(),
+            selector: Default::default(),
             path_variable: None,
             path_type: PathType::Normal,
             start: NodePattern {

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -3704,6 +3704,11 @@ impl QueryPlanner {
                 {
                     expand = expand.with_trail_enumeration();
                 }
+                // The restrictor the query asked for, which overrides the inference
+                // above: `multiplicity_is_observable` guesses at intent from query
+                // shape, and a written `ACYCLIC` is not a guess (#1141).
+                expand = expand.with_restrictor(path.restrictor);
+                    expand = expand.with_selector(path.selector);
                         // Relationship isomorphism applies to a var-length segment too: an
                         // edge an earlier segment of this clause walked is not available to
                         // it. `ExpandOperator` has done this since #684; this path did not
@@ -4329,6 +4334,11 @@ impl QueryPlanner {
                 {
                     expand = expand.with_trail_enumeration();
                 }
+                // The restrictor the query asked for, which overrides the inference
+                // above: `multiplicity_is_observable` guesses at intent from query
+                // shape, and a written `ACYCLIC` is not a guess (#1141).
+                expand = expand.with_restrictor(path.restrictor);
+                    expand = expand.with_selector(path.selector);
                 // Relationship isomorphism applies to a var-length segment too: an
                 // edge an earlier segment of this clause walked is not available to
                 // it. `ExpandOperator` has done this since #684; this path did not
@@ -4487,6 +4497,11 @@ impl QueryPlanner {
                 {
                     expand = expand.with_trail_enumeration();
                 }
+                // The restrictor the query asked for, which overrides the inference
+                // above: `multiplicity_is_observable` guesses at intent from query
+                // shape, and a written `ACYCLIC` is not a guess (#1141).
+                expand = expand.with_restrictor(path.restrictor);
+                    expand = expand.with_selector(path.selector);
                 // Relationship isomorphism applies to a var-length segment too: an
                 // edge an earlier segment of this clause walked is not available to
                 // it. `ExpandOperator` has done this since #684; this path did not

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1665,12 +1665,25 @@ fn parse_pattern(pair: pest::iterators::Pair<Rule>) -> ParseResult<Pattern> {
 fn parse_named_path(pair: pest::iterators::Pair<Rule>) -> ParseResult<PathPattern> {
     let mut path_variable: Option<String> = None;
     let mut path_pattern: Option<PathPattern> = None;
+    let mut restrictor: Option<PathRestrictor> = None;
+    let mut selector: Option<PathSelector> = None;
 
     for inner in pair.into_inner() {
         match inner.as_rule() {
             Rule::variable => {
                 if path_variable.is_none() {
                     path_variable = Some(inner.as_str().to_string());
+                }
+            }
+            Rule::path_modes => {
+                for mode in inner.into_inner() {
+                    match mode.as_rule() {
+                        Rule::path_selector => selector = Some(parse_path_selector(mode.as_str())),
+                        Rule::path_restrictor => {
+                            restrictor = Some(parse_path_restrictor(mode.as_str()))
+                        }
+                        _ => {}
+                    }
                 }
             }
             Rule::path => {
@@ -1685,7 +1698,42 @@ fn parse_named_path(pair: pest::iterators::Pair<Rule>) -> ParseResult<PathPatter
 
     let mut pp = path_pattern.ok_or_else(|| ParseError::SemanticError("Named path missing path pattern".to_string()))?;
     pp.path_variable = path_variable;
+    if let Some(r) = restrictor {
+        pp.restrictor = r;
+    }
+    if let Some(s) = selector {
+        pp.selector = s;
+    }
     Ok(pp)
+}
+
+/// `WALK` / `TRAIL` / `ACYCLIC` / `SIMPLE`, case-insensitive.
+///
+/// Falls back to the default rather than erroring: the grammar has already
+/// restricted the input to these four, so an unknown string here would mean the
+/// grammar and this function had drifted, and a panic on a query is the wrong way
+/// to report that.
+fn parse_path_restrictor(text: &str) -> PathRestrictor {
+    match text.trim().to_ascii_uppercase().as_str() {
+        "WALK" => PathRestrictor::Walk,
+        "ACYCLIC" => PathRestrictor::Acyclic,
+        "SIMPLE" => PathRestrictor::Simple,
+        _ => PathRestrictor::Trail,
+    }
+}
+
+/// `ALL` / `ANY` / `ALL SHORTEST` / `ANY SHORTEST`, case-insensitive.
+///
+/// Whitespace-normalised before matching, because `ALL   SHORTEST` is the same
+/// selector and the grammar allows any separator between the two words.
+fn parse_path_selector(text: &str) -> PathSelector {
+    let norm = text.split_whitespace().collect::<Vec<_>>().join(" ").to_ascii_uppercase();
+    match norm.as_str() {
+        "ANY" => PathSelector::Any,
+        "ALL SHORTEST" => PathSelector::AllShortest,
+        "ANY SHORTEST" => PathSelector::AnyShortest,
+        _ => PathSelector::All,
+    }
 }
 
 fn parse_shortest_path_call(pair: pest::iterators::Pair<Rule>) -> ParseResult<PathPattern> {
@@ -1735,7 +1783,7 @@ fn parse_path(pair: pest::iterators::Pair<Rule>) -> ParseResult<PathPattern> {
         segments.push(PathSegment { edge, node });
     }
 
-    Ok(PathPattern { path_variable: None, path_type: PathType::Normal, start, segments })
+    Ok(PathPattern { path_variable: None, path_type: PathType::Normal, restrictor: Default::default(), selector: Default::default(), start, segments })
 }
 
 fn parse_node(pair: pest::iterators::Pair<Rule>) -> ParseResult<NodePattern> {

--- a/src/query/validate.rs
+++ b/src/query/validate.rs
@@ -29,6 +29,9 @@ pub enum ValidationError {
     CreateRelationshipWithoutType,
     CreateUndirectedRelationship,
     CreateVariableLengthRelationship,
+    /// `WALK` with an unbounded quantifier under `ALL` (#1141). Its own variant
+    /// rather than a generic message, so a caller can branch on it.
+    UnboundedWalk,
     CreateOnBoundRelationship(String),
     MergeRelationshipWithoutType,
     MergeVariableLengthRelationship,
@@ -106,6 +109,9 @@ impl ValidationError {
     pub fn code(&self) -> &'static str {
         use crate::query::error_code as c;
         match self {
+            // Its own class: the query is well-formed and the pattern is legal;
+            // the *combination* has no finite answer. Nothing to rebind or retype.
+            Self::UnboundedWalk => c::INVALID_PATTERN,
             Self::UnboundVariable { .. } => c::VARIABLE_NOT_BOUND,
             Self::UnboundPatternVariable { .. } => c::VARIABLE_NOT_BOUND,
             Self::OrderByUndefinedVariable { .. } => c::VARIABLE_NOT_BOUND,
@@ -326,6 +332,16 @@ impl std::fmt::Display for ValidationError {
             Self::CreateVariableLengthRelationship => write!(
                 f,
                 "Variable length relationships cannot be created"
+            ),
+            Self::UnboundedWalk => write!(
+                f,
+                "an unbounded WALK under ALL has no finite answer: a walk may reuse \
+                 edges and nodes, so any cycle makes the result infinite, and \
+                 ISO/IEC 39075 forbids the combination. Give the quantifier an upper \
+                 bound (`*1..4`), or use TRAIL, ACYCLIC or SIMPLE, each of which is \
+                 finite by construction. A shortest selector does not rescue it in \
+                 this engine: candidates are enumerated before the selector is \
+                 applied, so an unbounded walk never reaches it"
             ),
             Self::CreateOnBoundRelationship(name) => write!(
                 f,
@@ -2664,7 +2680,43 @@ fn validate_function_argument_kinds(query: &Query) -> Result<(), ValidationError
     Ok(())
 }
 
+/// `WALK` with an unbounded quantifier under `ALL` is refused (#1141).
+///
+/// ISO/IEC 39075 forbids the combination, and the reason is not pedantry: on any
+/// graph containing a cycle the answer is infinite, because a walk may reuse both
+/// edges and nodes without limit. Every other restrictor is finite by construction
+/// — `TRAIL` is bounded by the edge count, `ACYCLIC` and `SIMPLE` by the node count.
+///
+/// Refusing is the alternative to returning a capped subset and calling it the
+/// answer, which is the silent-wrong-answer class this engine treats as P0.
+///
+/// **Refused under every selector, not only `ALL`.** `ANY SHORTEST WALK` is finite
+/// in the standard — a shortest path cannot repeat a node — but it is not finite
+/// *here*, because this implementation enumerates the candidates and then applies
+/// the selector, so the selector never gets a turn. Allowing it hung the query.
+/// Making it work needs shortest-first traversal, which is a different operator;
+/// refusing until then is the honest position, and the message says which limit is
+/// being hit.
+fn validate_unbounded_walk_is_refused(query: &Query) -> Result<(), ValidationError> {
+    for mc in &query.match_clauses {
+        for path in &mc.pattern.paths {
+            if path.restrictor != crate::query::ast::PathRestrictor::Walk {
+                continue;
+            }
+            for seg in &path.segments {
+                if let Some(len) = &seg.edge.length {
+                    if len.max.is_none() {
+                        return Err(ValidationError::UnboundedWalk);
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 pub fn validate(query: &Query) -> Result<(), ValidationError> {
+    validate_unbounded_walk_is_refused(query)?;
     validate_variables_are_bound(query)?;
 
     validate_with_items_aliased(query)?;

--- a/tests/gql_path_modes.rs
+++ b/tests/gql_path_modes.rs
@@ -1,0 +1,216 @@
+//! GQL path restrictors and selectors (ISO/IEC 39075:2024), #1141.
+//!
+//! Four restrictors say which paths are candidates, four selectors say which
+//! candidates to return per endpoint pair. Before this the dialect had one of each:
+//! `TRAIL` implicitly, and `ALL`.
+//!
+//! The tests below assert the *differences between modes* rather than absolute row
+//! counts wherever the difference is the point. A count can be right for the wrong
+//! reason; TRAIL and ACYCLIC disagreeing on a cycle cannot be.
+
+use samyama::graph::GraphStore;
+use samyama::query::QueryEngine;
+
+const T: &str = "default";
+
+fn graph(edges: &[(&str, &str)]) -> GraphStore {
+    let engine = QueryEngine::new();
+    let mut store = GraphStore::new();
+    let mut names: Vec<&str> = edges.iter().flat_map(|&(a, b)| [a, b]).collect();
+    names.sort_unstable();
+    names.dedup();
+    for n in names {
+        engine.execute_mut(&format!("CREATE (:N {{eid: \"{n}\"}})"), &mut store, T).unwrap();
+    }
+    for &(a, b) in edges {
+        engine
+            .execute_mut(
+                &format!("MATCH (x:N {{eid: \"{a}\"}}), (y:N {{eid: \"{b}\"}}) CREATE (x)-[:E]->(y)"),
+                &mut store,
+                T,
+            )
+            .unwrap();
+    }
+    store
+}
+
+fn rows(store: &GraphStore, query: &str) -> usize {
+    QueryEngine::new()
+        .execute(query, store)
+        .unwrap_or_else(|e| panic!("{query}: {e}"))
+        .records
+        .len()
+}
+
+/// A directed triangle `a -> b -> c -> a`.
+const TRIANGLE: &[(&str, &str)] = &[("a", "b"), ("b", "c"), ("c", "a")];
+
+/// Two 2-hop routes and one 3-hop route from `a` to `d`.
+const LADDER: &[(&str, &str)] =
+    &[("a", "b"), ("b", "d"), ("a", "c"), ("c", "d"), ("a", "e"), ("e", "f"), ("f", "d")];
+
+/// The four restrictors are four different questions, and a cycle separates them.
+///
+/// Without a cycle every restrictor agrees, which is why a test on a tree would
+/// pass against an engine that ignored the keyword entirely.
+#[test]
+fn the_restrictors_disagree_on_a_cycle() {
+    let g = graph(TRIANGLE);
+    let q = |m: &str, hops: &str| {
+        format!("MATCH {m}(x:N {{eid: \"a\"}})-[:E{hops}]->(y) RETURN y.eid")
+    };
+
+    // TRAIL may revisit a node, so three hops returns to `a`: b, c, a.
+    assert_eq!(rows(&g, &q("TRAIL ", "*1..3")), 3);
+    // ACYCLIC may not, so the return to `a` is excluded: b, c.
+    assert_eq!(
+        rows(&g, &q("ACYCLIC ", "*1..3")),
+        2,
+        "ACYCLIC must exclude the path that returns to its own start"
+    );
+    // SIMPLE permits first == last, so the cycle is legal again: b, c, a.
+    assert_eq!(
+        rows(&g, &q("SIMPLE ", "*1..3")),
+        3,
+        "SIMPLE permits the endpoints to coincide, so a cycle is a simple path"
+    );
+    // WALK may reuse an edge, so a fourth hop reaches `b` a second time.
+    assert_eq!(
+        rows(&g, &q("WALK ", "*1..4")),
+        4,
+        "WALK may retake an edge; TRAIL at *1..4 still answers 3"
+    );
+    assert_eq!(rows(&g, &q("TRAIL ", "*1..4")), 3);
+
+    // The default is unchanged: an unannotated pattern is TRAIL, which is what
+    // openCypher's relationship-uniqueness rule already required.
+    assert_eq!(rows(&g, &q("", "*1..3")), rows(&g, &q("TRAIL ", "*1..3")));
+    assert_eq!(rows(&g, &q("", "*1..4")), rows(&g, &q("TRAIL ", "*1..4")));
+}
+
+/// SIMPLE is not prefix-closed, and this is the case that shows it.
+///
+/// A path that has returned to its source is complete: extending it would put the
+/// source in the interior, which SIMPLE forbids. So `a -> b -> c -> a` is legal and
+/// `a -> b -> c -> a -> b` is not, even though the second has the first as a prefix.
+#[test]
+fn a_simple_path_that_closes_cannot_be_extended() {
+    let g = graph(TRIANGLE);
+    let q = |hops: &str| {
+        format!("MATCH SIMPLE (x:N {{eid: \"a\"}})-[:E{hops}]->(y) RETURN y.eid")
+    };
+    // b, c, a at *1..3 — and nothing further at *1..4 or *1..5, because the only
+    // way onward is through `a`, which is now interior.
+    assert_eq!(rows(&g, &q("*1..3")), 3);
+    assert_eq!(rows(&g, &q("*1..4")), 3, "extending a closed simple path is not allowed");
+    assert_eq!(rows(&g, &q("*1..5")), 3);
+}
+
+/// The selectors partition on the endpoint pair and choose within it.
+#[test]
+fn the_selectors_choose_among_candidates_per_endpoint_pair() {
+    let g = graph(LADDER);
+    let q = |m: &str| {
+        format!("MATCH {m}(x:N {{eid: \"a\"}})-[:E*1..3]->(y:N {{eid: \"d\"}}) RETURN y.eid")
+    };
+    // Three paths a->d: two of length 2, one of length 3.
+    assert_eq!(rows(&g, &q("")), 3, "ALL is the default");
+    assert_eq!(rows(&g, &q("ALL ")), 3);
+    assert_eq!(rows(&g, &q("ALL SHORTEST ")), 2, "both length-2 paths, not the length-3");
+    assert_eq!(rows(&g, &q("ANY ")), 1);
+    assert_eq!(rows(&g, &q("ANY SHORTEST ")), 1);
+}
+
+/// A selector and a restrictor compose, and the restrictor applies first.
+#[test]
+fn a_selector_and_a_restrictor_compose() {
+    let g = graph(TRIANGLE);
+    let all = "MATCH ACYCLIC (x:N {eid: \"a\"})-[:E*1..3]->(y) RETURN y.eid";
+    let any = "MATCH ANY ACYCLIC (x:N {eid: \"a\"})-[:E*1..3]->(y) RETURN y.eid";
+    assert_eq!(rows(&g, all), 2, "ACYCLIC candidates: b, c");
+    // One per endpoint pair, and the pairs are (a,b) and (a,c) — so ANY does not
+    // reduce this to one row. A selector partitions; it does not take a global head.
+    assert_eq!(rows(&g, any), 2, "ANY is one path per endpoint pair, not one overall");
+}
+
+/// An unbounded WALK is refused rather than served from a capped subset.
+///
+/// The standard forbids it under `ALL` because the answer is infinite on any graph
+/// with a cycle. It is refused here under **every** selector, which is stricter than
+/// the standard and deliberately so: `ANY SHORTEST WALK` is finite in principle, but
+/// this implementation enumerates candidates and then applies the selector, so the
+/// selector never gets a turn. Allowing it hung this test. Refusing until there is a
+/// shortest-first traversal is the honest position, and the message says so.
+#[test]
+fn an_unbounded_walk_is_refused_and_the_alternatives_are_not() {
+    let g = graph(TRIANGLE);
+    let engine = QueryEngine::new();
+
+    let err = engine
+        .execute("MATCH WALK (a)-[:E*]->(b) RETURN b", &g)
+        .expect_err("an unbounded WALK under ALL has no finite answer");
+    let msg = err.to_string();
+    assert!(msg.contains("InvalidPattern"), "{msg}");
+    assert!(
+        msg.contains("*1..4") && msg.contains("TRAIL"),
+        "the error must name a way out, not only refuse: {msg}"
+    );
+    // And it must distinguish this engine's limit from the standard's, since the
+    // standard would allow a shortest selector here.
+    assert!(
+        msg.contains("enumerated before the selector"),
+        "the error must say which limit is being hit: {msg}"
+    );
+
+    // A shortest selector does not rescue it.
+    assert!(QueryEngine::new()
+        .execute("MATCH ANY SHORTEST WALK (a)-[:E*]->(b) RETURN b", &g)
+        .is_err());
+
+    // Each of the ways out actually works.
+    for ok in [
+        "MATCH WALK (a)-[:E*1..4]->(b) RETURN b",
+        "MATCH TRAIL (a)-[:E*]->(b) RETURN b",
+        "MATCH ACYCLIC (a)-[:E*]->(b) RETURN b",
+    ] {
+        engine.execute(ok, &g).unwrap_or_else(|e| panic!("{ok} must be allowed: {e}"));
+    }
+}
+
+/// Every spelling parses, including the combination and the named-path form.
+#[test]
+fn every_mode_parses_including_combinations() {
+    use samyama::query::parser::parse_query;
+    for q in [
+        "MATCH WALK (a)-[:E*1..3]->(b) RETURN b",
+        "MATCH TRAIL (a)-[:E*1..3]->(b) RETURN b",
+        "MATCH ACYCLIC (a)-[:E*1..3]->(b) RETURN b",
+        "MATCH SIMPLE (a)-[:E*1..3]->(b) RETURN b",
+        "MATCH ALL (a)-[:E*1..3]->(b) RETURN b",
+        "MATCH ANY (a)-[:E*1..3]->(b) RETURN b",
+        "MATCH ALL SHORTEST (a)-[:E*1..3]->(b) RETURN b",
+        "MATCH ANY SHORTEST (a)-[:E*1..3]->(b) RETURN b",
+        "MATCH ALL SHORTEST ACYCLIC (a)-[:E*1..3]->(b) RETURN b",
+        "MATCH ANY SHORTEST SIMPLE (a)-[:E*1..3]->(b) RETURN b",
+        "MATCH p = ACYCLIC (a)-[:E*1..3]->(b) RETURN p",
+        // Case-insensitive, like every other keyword in the dialect.
+        "MATCH any shortest acyclic (a)-[:E*1..3]->(b) RETURN b",
+    ] {
+        parse_query(q).unwrap_or_else(|e| panic!("{q}: {e}"));
+    }
+}
+
+/// `ALL` and `ANY` must not be shadowed as selectors when they are function calls
+/// or variable names — the PEG takes the first alternative and does not backtrack.
+#[test]
+fn all_and_any_still_work_as_functions_and_names() {
+    let g = graph(TRIANGLE);
+    let engine = QueryEngine::new();
+    for q in [
+        "MATCH (n:N) RETURN count(n)",
+        "RETURN all(x IN [1, 2] WHERE x > 0) AS r",
+        "RETURN any(x IN [1, 2] WHERE x > 1) AS r",
+    ] {
+        engine.execute(q, &g).unwrap_or_else(|e| panic!("{q}: {e}"));
+    }
+}


### PR DESCRIPTION
Closes #1141. All four items of the plan, smallest first.

```cypher
MATCH ACYCLIC (a)-[:R*1..3]->(b)
MATCH ALL SHORTEST (a)-[:R*1..3]->(b)
MATCH ANY SHORTEST ACYCLIC (a)-[:R*1..3]->(b)
MATCH p = SIMPLE (a)-[:R*1..3]->(b)
```

## Measured — the modes are four different questions

Directed triangle `a -> b -> c -> a`, from `a`:

| mode | rows | why |
|---|---|---|
| `TRAIL *1..3` | `b, c, a` | each edge once |
| `ACYCLIC *1..3` | `b, c` | returning to `a` repeats a node |
| `SIMPLE *1..3` | `b, c, a` | first == last permitted |
| `WALK *1..4` | `b, c, a, b` | edges may repeat (TRAIL still answers 3) |

Selectors, on two 2-hop routes and one 3-hop route from `a` to `d`:

| selector | rows |
|---|---|
| `ALL` (default) | 3 |
| `ALL SHORTEST` | 2 |
| `ANY` | 1 |
| `ANY SHORTEST` | 1 |

A cycle is required to separate the restrictors — on a tree they all agree, so a
test there would pass against an engine that ignored the keyword.

## Three decisions worth stating

**`SIMPLE` is not prefix-closed, and is not treated as if it were.** A prefix whose
first and last nodes coincide is legal only if the path stops there. So it prunes on
the interior condition and refuses to extend a path that has returned to its source:
`a->b->c->a` is legal, `a->b->c->a->b` is not, even though the second contains the
first. Pinned by `a_simple_path_that_closes_cannot_be_extended`.

**PEG ordering.** `ALL SHORTEST` and `ANY SHORTEST` come before `ALL` and `ANY` in
the grammar. The short forms first would consume `ALL` and leave `SHORTEST` to fail
as a node pattern — this grammar has been bitten by that before.

**`ANY` is one path per endpoint pair, not one overall.** Asserted directly, because
reading it as a global head is the easy mistake and both readings return "1" on a
one-pair fixture.

## An unbounded WALK is refused, more strictly than the standard

The standard forbids it under `ALL`: infinite on any graph with a cycle. Refused
here under **every** selector, and the message says why:

> A shortest selector does not rescue it in this engine: candidates are enumerated
> before the selector is applied, so an unbounded walk never reaches it

`ANY SHORTEST WALK` is finite in the standard and is not finite here. **It hung the
test that first allowed it** — I found this by writing the test, not by reasoning
about it. Shortest-first traversal is a different operator; refusing until it exists
is the honest position, and the error distinguishes this engine's limit from the
standard's rather than implying they are the same.

## Defaults unchanged, and the guess removed

An unannotated pattern is `TRAIL` + `ALL` — what openCypher's relationship-uniqueness
rule already required. The tests assert the annotated and unannotated forms agree.

The restrictor also removes a guess: `multiplicity_is_observable` infers intent from
query shape to choose between the first-reach BFS and the trail enumerator. A written
`ACYCLIC` is not a guess and overrides it. That inference is what #1140 was a bug in.

## Verification

- **TCK unchanged**: 3760 pass, **0 wrong results**, 3 errored, pass rate 0.9992 —
  identical to the recorded baseline.
- `cargo test --workspace --no-fail-fast`: 259 binaries, 4,118 passed, 0 failed.
- `ALL`/`ANY` still work as functions and variable names — pinned, since the grammar
  change could have shadowed them.