### PR TITLE
CALL db.checkIntegrity(): every edge references two existing nodes

### DIFF
--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -65,7 +65,7 @@ pub mod storage;
 pub use edge::{Edge, EdgeView};
 pub use node::Node;
 pub use property::{PropertyMap, PropertyValue};
-pub use store::{GraphError, GraphResult, GraphStore, GraphStatistics, PropertyStats, IsolationLevel, TxnId, TxnStatus, Transaction, TypeAdjacency};
+pub use store::{IntegrityViolation, GraphError, GraphResult, GraphStore, GraphStatistics, PropertyStats, IsolationLevel, TxnId, TxnStatus, Transaction, TypeAdjacency};
 pub use types::{EdgeId, EdgeType, Label, NodeId};
 pub use catalog::GraphCatalog;
 pub use event::{IndexEvent, Mutation};

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -750,6 +750,32 @@ impl MemoryReport {
     }
 }
 
+/// A broken store invariant (`GraphStore::check_integrity`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IntegrityViolation {
+    /// An edge whose `source` or `target` is not a node in the store.
+    DanglingEdge {
+        edge: EdgeId,
+        /// `"source"` or `"target"`, so the message says which end.
+        end: &'static str,
+        node: NodeId,
+    },
+}
+
+impl std::fmt::Display for IntegrityViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IntegrityViolation::DanglingEdge { edge, end, node } => write!(
+                f,
+                "edge {} has {} {}, which is not a node in the store",
+                edge.as_u64(),
+                end,
+                node.as_u64()
+            ),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct GraphStore {
     /// Node storage (Arena with versioning: NodeId -> [Versions])
@@ -1021,6 +1047,46 @@ impl GraphStore {
         }
         self.free_node_ids.shrink_to_fit();
         self.free_edge_ids.shrink_to_fit();
+    }
+
+    /// Every edge references two nodes that exist (#1143).
+    ///
+    /// The invariant a dangling edge violates, checkable in one pass. Filed after an
+    /// instance was found holding 813 edges whose endpoints resolved to null, plus
+    /// edges referencing node ids from fixtures loaded much earlier — while the node
+    /// side was clean. Every query against that instance was silently wrong, and it
+    /// surfaced only as a row count nobody could explain.
+    ///
+    /// The cause was never reproduced: `DETACH DELETE` and reload is clean over a
+    /// 60-round soak, so "it deletes nodes but not edges" is wrong. The suspicion is
+    /// a write interrupted by a fault, which is exactly the case a periodic check
+    /// catches and a unit test does not.
+    ///
+    /// Returns the violations, capped, rather than a boolean: "the store is corrupt"
+    /// sends someone looking, and "edge 4 points at node 91, which does not exist"
+    /// tells them where. Empty means the invariant holds.
+    ///
+    /// O(edges). A diagnostic to run after a suspicious event or on a schedule, not
+    /// something to call per query.
+    pub fn check_integrity(&self) -> Vec<IntegrityViolation> {
+        /// Enough to characterise the damage; a corrupt store can have millions.
+        const MAX_REPORTED: usize = 100;
+        let mut out = Vec::new();
+        for edge in self.all_edges() {
+            for (end, node) in [("source", edge.source), ("target", edge.target)] {
+                if self.get_node(node).is_none() {
+                    out.push(IntegrityViolation::DanglingEdge {
+                        edge: edge.id,
+                        end,
+                        node,
+                    });
+                    if out.len() >= MAX_REPORTED {
+                        return out;
+                    }
+                }
+            }
+        }
+        out
     }
 
     /// Bytes held by each of the store's structures, walked rather than divided.
@@ -4510,6 +4576,37 @@ fn spawn_auto_embed(
 
 #[cfg(test)]
 mod tests {
+
+    /// The detector detects (#1143).
+    ///
+    /// Built by writing the edge arrays directly, because **no public API can
+    /// produce this state** — `insert_recovered_edge` validates both endpoints and
+    /// `DETACH DELETE` removes the edges. That is consistent with the report's own
+    /// guess that a fault interrupted a write, and is why four reproduction attempts
+    /// from the query language came back clean.
+    #[test]
+    fn check_integrity_names_the_edge_the_end_and_the_missing_node() {
+        let mut store = GraphStore::new();
+        let a = store.create_node("N");
+        assert!(store.check_integrity().is_empty());
+
+        // An edge from a real node to one that does not exist.
+        let missing = NodeId::new(9_999);
+        assert!(store.get_node(missing).is_none());
+        let id = store.edge_endpoints.len() as u64;
+        store.edge_endpoints.push((a, missing));
+        store.edge_type_ids.push(0);
+        if store.edge_type_table.is_empty() {
+            store.edge_type_table.push(EdgeType::new("E"));
+        }
+
+        let found = store.check_integrity();
+        assert_eq!(found.len(), 1, "{found:?}");
+        let text = found[0].to_string();
+        assert!(text.contains(&id.to_string()), "names the edge: {text}");
+        assert!(text.contains("target"), "names the end: {text}");
+        assert!(text.contains("9999"), "names the missing node: {text}");
+    }
     use super::*;
 
     #[test]

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -11927,6 +11927,80 @@ impl PhysicalOperator for ShowConstraintsOperator {
     }
 }
 
+/// `CALL db.checkIntegrity()` — assert the store's invariants and report what is
+/// broken (#1143).
+///
+/// Reports one row per violation and **no rows when the store is sound**, which is
+/// the shape a caller can act on: `CALL db.checkIntegrity()` returning nothing is
+/// the answer you want, and any row is a place to look.
+///
+/// Exists because an instance was once found holding 813 edges whose endpoints
+/// resolved to null while its node side was clean. Every query against it was
+/// silently wrong, and it surfaced only as a row count nobody could explain. The
+/// cause was never reproduced — `DETACH DELETE` and reload is clean over a 60-round
+/// soak — so this is a detector rather than a fix, and its value is turning an hour
+/// of confusion into one query.
+pub struct CheckIntegrityOperator {
+    results: Option<std::vec::IntoIter<Record>>,
+}
+
+impl CheckIntegrityOperator {
+    pub fn new() -> Self {
+        Self { results: None }
+    }
+}
+
+impl Default for CheckIntegrityOperator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PhysicalOperator for CheckIntegrityOperator {
+    fn next(&mut self, store: &GraphStore) -> ExecutionResult<Option<Record>> {
+        if self.results.is_none() {
+            let records: Vec<Record> = store
+                .check_integrity()
+                .into_iter()
+                .map(|v| {
+                    let mut rec = Record::new();
+                    // `kind` so a caller can branch without parsing prose, and
+                    // `detail` so a human reading the output does not have to look
+                    // the kind up.
+                    let (kind, detail) = match &v {
+                        crate::graph::store::IntegrityViolation::DanglingEdge { .. } => {
+                            ("dangling_edge", v.to_string())
+                        }
+                    };
+                    rec.bind(
+                        "kind".to_string(),
+                        Value::Property(PropertyValue::String(kind.to_string())),
+                    );
+                    rec.bind(
+                        "detail".to_string(),
+                        Value::Property(PropertyValue::String(detail)),
+                    );
+                    rec
+                })
+                .collect();
+            self.results = Some(records.into_iter());
+        }
+        Ok(self.results.as_mut().unwrap().next())
+    }
+
+    fn reset(&mut self) {
+        self.results = None;
+    }
+
+    fn describe(&self) -> OperatorDescription {
+        OperatorDescription {
+            name: "CheckIntegrity".to_string(),
+            details: "every edge references two existing nodes".to_string(),
+            children: Vec::new(),
+        }
+    }
+}
+
 /// Show labels operator: CALL db.labels()
 pub struct ShowLabelsOperator {
     results: Option<std::vec::IntoIter<Record>>,

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -3251,6 +3251,10 @@ impl QueryPlanner {
                 node_var,
                 score_var,
             )))
+        } else if call_clause.procedure_name == "db.checkIntegrity"
+            || call_clause.procedure_name == "db.checkintegrity"
+        {
+            Ok(Box::new(crate::query::executor::operator::CheckIntegrityOperator::new()))
         } else if call_clause.procedure_name == "db.labels" {
             Ok(Box::new(ShowLabelsOperator::new()))
         } else if call_clause.procedure_name == "db.relationshipTypes" {

--- a/tests/db_check_integrity.rs
+++ b/tests/db_check_integrity.rs
@@ -1,0 +1,138 @@
+//! `CALL db.checkIntegrity()` — every edge references two existing nodes (#1143).
+//!
+//! Filed after an instance was found holding 813 edges whose endpoints resolved to
+//! null, plus edges referencing node ids from fixtures loaded much earlier, while
+//! its node side was clean. Every query against it was silently wrong, and it
+//! surfaced only as a row count nobody could explain.
+//!
+//! **The cause was never reproduced**, and this does not claim to fix it. Four
+//! attempts including a 60-round soak came back clean, so "DETACH DELETE deletes
+//! nodes but not edges" is wrong. What is here is a detector: it turns a silent
+//! wrong answer into a loud one, and makes the original report closeable either way
+//! — run the soak with the check on.
+
+use samyama::graph::GraphStore;
+use samyama::query::QueryEngine;
+
+const T: &str = "default";
+
+fn violations(store: &GraphStore) -> Vec<String> {
+    QueryEngine::new()
+        .execute("CALL db.checkIntegrity()", store)
+        .expect("db.checkIntegrity")
+        .records
+        .iter()
+        .map(|r| format!("{:?}", r.get("detail")))
+        .collect()
+}
+
+/// A sound store reports nothing.
+///
+/// The important half of the pair: a check that fires on a healthy graph is one
+/// people turn off.
+#[test]
+fn a_sound_store_reports_no_violations() {
+    let engine = QueryEngine::new();
+    let mut store = GraphStore::new();
+    engine
+        .execute_mut(
+            "CREATE (a:N {eid: \"a\"})-[:E]->(b:N {eid: \"b\"})-[:E]->(c:N {eid: \"c\"})",
+            &mut store,
+            T,
+        )
+        .unwrap();
+    assert!(violations(&store).is_empty());
+    assert!(store.check_integrity().is_empty());
+}
+
+/// No public API can create the reported state, which is itself evidence.
+///
+/// `insert_recovered_edge` — the lowest-level way in, used by crash recovery —
+/// validates that both endpoints exist and refuses otherwise. `DETACH DELETE`
+/// removes the edges. So a dangling edge cannot be produced by any sequence of
+/// legal operations, which is consistent with the report's own guess that a fault
+/// interrupted a write, and is why four reproduction attempts from the query
+/// language came back clean.
+///
+/// The detector is unit-tested against a hand-built violation in
+/// `graph::store::tests`, where the fields are reachable; exposing a
+/// dangling-edge constructor here would be adding the hazard to the public API in
+/// order to test for it.
+#[test]
+fn a_dangling_edge_cannot_be_created_through_a_public_api() {
+    use samyama::graph::{Edge, EdgeId, NodeId};
+
+    let engine = QueryEngine::new();
+    let mut store = GraphStore::new();
+    engine.execute_mut("CREATE (a:N {eid: \"a\"})", &mut store, T).unwrap();
+    let a = store.get_nodes_by_label(&"N".into())[0].id;
+
+    let missing = NodeId::new(9_999);
+    assert!(store.get_node(missing).is_none());
+    let edge = Edge::new(EdgeId::new(500), a, missing, samyama::graph::EdgeType::new("E"));
+    assert!(
+        store.insert_recovered_edge(edge).is_err(),
+        "recovery must refuse an edge whose endpoint does not exist; accepting it \
+         is how the state in #1143 would be reachable"
+    );
+    assert!(violations(&store).is_empty());
+}
+
+/// The soak the report asks for, with the check on.
+///
+/// Six fixtures with different node ids, cycled, reset with `DETACH DELETE` between
+/// rounds — the harness shape from the report. Clean here, as it was there, which is
+/// the evidence that `DETACH DELETE` and reload is not the cause.
+///
+/// Kept short enough for CI. The original 60-round soak was also clean; running 60
+/// here would add minutes and no information.
+#[test]
+fn detach_delete_and_reload_stays_sound_across_rounds() {
+    let engine = QueryEngine::new();
+    let mut store = GraphStore::new();
+    let fixtures = [
+        ("n", "m"),
+        ("a3", "a4"),
+        ("a5", "a6"),
+        ("x", "y"),
+        ("p", "q"),
+        ("u", "v"),
+    ];
+
+    for round in 0..12 {
+        let (a, b) = fixtures[round % fixtures.len()];
+        engine
+            .execute_mut(
+                &format!(
+                    "CREATE (x:N {{eid: \"{a}\"}}), (y:N {{eid: \"{b}\"}})"
+                ),
+                &mut store,
+                T,
+            )
+            .unwrap();
+        engine
+            .execute_mut(
+                &format!(
+                    "MATCH (x:N {{eid: \"{a}\"}}), (y:N {{eid: \"{b}\"}}) CREATE (x)-[:E]->(y)"
+                ),
+                &mut store,
+                T,
+            )
+            .unwrap();
+
+        let found = violations(&store);
+        assert!(found.is_empty(), "round {round} after load: {found:?}");
+
+        engine.execute_mut("MATCH (n) DETACH DELETE n", &mut store, T).unwrap();
+
+        let found = violations(&store);
+        assert!(found.is_empty(), "round {round} after DETACH DELETE: {found:?}");
+        assert_eq!(
+            store.edge_count(),
+            0,
+            "round {round}: DETACH DELETE left {} edges behind — the shape the \
+             original report describes",
+            store.edge_count()
+        );
+    }
+}


### PR DESCRIPTION
Addresses the hardening suggested in #1143. A detector, not a fix — the cause was
never reproduced and this does not claim to have found it.

## What it does

```
CALL db.checkIntegrity()
```

One row per violation, **no rows when the store is sound**. Each row names the edge,
which end is broken, and the missing node:

```
kind            detail
dangling_edge   edge 4 has target 9999, which is not a node in the store
```

"The store is corrupt" sends someone looking; that tells them where. Capped at 100 —
a corrupt store can have millions, and the first hundred characterise the damage.

Had this existed, the hour in the report would have been one query. That was the
stated point of the suggestion and it is the whole justification.

## A finding while testing it, supporting your guess

**No public API can produce the reported state.**

- `insert_recovered_edge` — the lowest-level way in, used by crash recovery —
  validates that both endpoints exist and refuses otherwise.
- `DETACH DELETE` removes the edges.

So a dangling edge is not reachable by any sequence of legal operations. That is
consistent with your actual guess — a write interrupted by a fault — and it explains
why four reproduction attempts from the query language came back clean. It was never
going to be reachable from there.

Both facts are now tests, so if a future change makes the state reachable through
the API, that is caught rather than discovered.

## Where the detector is tested, and why not here

In `graph::store::tests`, where the edge arrays are reachable. Exposing a
dangling-edge constructor publicly in order to test for dangling edges would mean
adding the hazard to the API to detect the hazard.

## The soak, with the check on

Your harness shape — six fixtures with different node ids, cycled, reset with
`DETACH DELETE` between rounds — with the check running after every load *and* every
reset, plus `edge_count == 0` asserted after each reset rather than only checking the
node side.

Clean, as it was for you. That is now recorded evidence rather than a thing we
believe.

## Suggested next step for the issue

Run your original harness against `main` with `CALL db.checkIntegrity()` after each
round. If the state recurs, the check names the first bad edge and the round it
appeared in — which is the information that was missing. If it does not recur over a
long soak, the issue closes with a negative result that is now checkable rather than
asserted.

`cargo test --workspace --no-fail-fast`: 260 binaries, 4,122 passed, 0 failed.