### PR TITLE
Tell the user when an implicit path mode changed the answer (#1149)

### DIFF
--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -224,6 +224,10 @@ pub struct QueryResponse {
     records: Vec<Vec<serde_json::Value>>,
     /// The build that produced this result (TRUST-06).
     engine_version: &'static str,
+    /// Diagnostics the statement produced (#1149). Empty for almost every
+    /// query; a notification reports that the engine made a semantic choice the
+    /// query did not state and that the choice was observable in the rows.
+    notifications: Vec<crate::query::executor::operator::notifications::Notification>,
     /// The MVCC version the read saw, so a result can be tied to the data that
     /// produced it. Named `_version` and not `_hash` deliberately: it
     /// identifies the snapshot, it is not a content hash of it, and calling it
@@ -448,6 +452,7 @@ pub async fn query_handler(
                 columns: batch.columns,
                 records,
                 engine_version: crate::VERSION,
+                notifications: crate::query::executor::operator::notifications::take(),
                 snapshot_version,
             }).into_response()
         }
@@ -1338,6 +1343,93 @@ mod tests {
 
         assert_eq!(props.get("name").and_then(|v| v.as_str()), Some("String"), "{json}");
         assert_eq!(props.get("age").and_then(|v| v.as_str()), Some("Integer"), "{json}");
+    }
+
+    /// #1149. The engine tells the user when a path mode it was not asked for
+    /// changed the answer -- and stays quiet the rest of the time.
+    ///
+    /// The rows are asserted alongside the notification in every case. A
+    /// diagnostic that came at the cost of a changed answer would be a
+    /// regression, not a feature, and this is the test that would catch it.
+    #[tokio::test]
+    async fn an_implicit_path_mode_that_changed_the_answer_is_reported() {
+        async fn ask(setup: &[&str], q: &str) -> (usize, Vec<String>) {
+            let state = AppState {
+                store: Arc::new(RwLock::new(GraphStore::new())),
+                engine: Arc::new(QueryEngine::new()),
+                data_path: None,
+                tenant_manager: None,
+                embed_pipeline: None,
+                embed_cache: Arc::new(RwLock::new(std::collections::HashMap::new())),
+                persistence: None,
+            };
+            let app = Router::new()
+                .route("/api/query", axum::routing::post(query_handler))
+                .with_state(state);
+            let mut last = serde_json::Value::Null;
+            for stmt in setup.iter().chain(std::iter::once(&q)) {
+                let body = serde_json::json!({ "query": stmt, "graph": "default" });
+                let req = Request::builder()
+                    .method("POST")
+                    .uri("/api/query")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap();
+                let response = app.clone().oneshot(req).await.unwrap();
+                assert_eq!(response.status(), StatusCode::OK, "{stmt}");
+                let bytes = response.into_body().collect().await.unwrap().to_bytes();
+                last = serde_json::from_slice(&bytes).unwrap();
+            }
+            let codes = last["notifications"]
+                .as_array()
+                .expect("notifications array")
+                .iter()
+                .map(|n| n["code"].as_str().unwrap().to_string())
+                .collect();
+            (last["records"].as_array().expect("records").len(), codes)
+        }
+
+        // Two nodes and two edges, so `m -> n -> m` is a cycle. A bare `*1..4`
+        // is TRAIL and finds 2 paths; the standard's unrestricted reading finds 4.
+        const CYCLE: &[&str] = &[
+            r#"CREATE (a:N {name:"m"})-[:E]->(b:N {name:"n"})"#,
+            r#"MATCH (a:N {name:"n"}),(b:N {name:"m"}) CREATE (a)-[:E]->(b)"#,
+        ];
+        const CHAIN: &[&str] = &[
+            r#"CREATE (a:N {name:"a"})-[:E]->(b:N {name:"b"})-[:E]->(c:N {name:"c"})"#,
+        ];
+        let code = crate::query::executor::operator::notifications::PATH_MODE_AFFECTS_RESULT;
+
+        // The mode was not stated and it mattered: say so, and return TRAIL's rows.
+        let (rows, codes) = ask(CYCLE, r#"MATCH p=(x:N)-[:E*1..4]->(y:N) WHERE x.name="m" RETURN x.name"#).await;
+        assert_eq!(rows, 2, "TRAIL's answer must not change");
+        assert_eq!(codes, vec![code.to_string()]);
+
+        // The same query with no named path takes a different route through the
+        // planner. It must report the same thing, or the diagnostic is a lottery.
+        let (rows, codes) = ask(CYCLE, r#"MATCH (x:N)-[:E*1..4]->(y:N) WHERE x.name="m" RETURN x.name"#).await;
+        assert_eq!(rows, 2);
+        assert_eq!(codes, vec![code.to_string()], "unnamed path must report too");
+
+        // The user wrote TRAIL. They chose; telling them is noise.
+        let (rows, codes) = ask(CYCLE, r#"MATCH p=TRAIL (x:N)-[:E*1..4]->(y:N) WHERE x.name="m" RETURN x.name"#).await;
+        assert_eq!(rows, 2);
+        assert!(codes.is_empty(), "an explicit TRAIL must be silent: {codes:?}");
+
+        // The user wrote WALK. They get the standard's four paths and no advice.
+        let (rows, codes) = ask(CYCLE, r#"MATCH p=WALK (x:N)-[:E*1..4]->(y:N) WHERE x.name="m" RETURN x.name"#).await;
+        assert_eq!(rows, 4, "WALK's answer must not change");
+        assert!(codes.is_empty(), "an explicit WALK must be silent: {codes:?}");
+
+        // One hop cannot reuse an edge, so the mode cannot matter.
+        let (rows, codes) = ask(CYCLE, r#"MATCH p=(x:N)-[:E*1..1]->(y:N) WHERE x.name="m" RETURN x.name"#).await;
+        assert_eq!(rows, 1);
+        assert!(codes.is_empty(), "*1..1 must be silent: {codes:?}");
+
+        // No cycle, so no edge is ever reused and the two readings agree.
+        let (rows, codes) = ask(CHAIN, r#"MATCH p=(x:N)-[:E*1..4]->(y:N) WHERE x.name="a" RETURN x.name"#).await;
+        assert_eq!(rows, 2);
+        assert!(codes.is_empty(), "an acyclic graph must be silent: {codes:?}");
     }
 
     #[tokio::test]

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -473,6 +473,14 @@ pub struct PathPattern {
     /// GQL path restrictor: which paths are candidates. `Trail` by default, which
     /// is what an unannotated pattern has always meant here.
     pub restrictor: PathRestrictor,
+    /// Whether the restrictor was written in the query, as opposed to defaulted to.
+    ///
+    /// `Trail` is both the default and a thing a user can ask for, so the value
+    /// alone cannot tell the two apart. The difference matters exactly once: a
+    /// pattern that defaulted to `Trail` and whose answer would change under the
+    /// standard's unrestricted reading is worth a notification (#1149), and one
+    /// that said `TRAIL` out loud is not -- that user already chose.
+    pub restrictor_explicit: bool,
     /// GQL path selector: which candidates to return per endpoint pair.
     pub selector: PathSelector,
     /// Start node

--- a/src/query/executor/logical_plan.rs
+++ b/src/query/executor/logical_plan.rs
@@ -443,6 +443,7 @@ mod tests {
     fn make_path(start_var: &str, start_labels: Vec<Label>, segments: Vec<PathSegment>) -> PathPattern {
         PathPattern {
             restrictor: Default::default(),
+            restrictor_explicit: false,
             selector: Default::default(),
             path_variable: None,
             path_type: PathType::Normal,

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -419,6 +419,7 @@ impl<'a> QueryExecutor<'a> {
         // one query return the same instant (#793). The guard clears it on the
         // way out, including on an early return.
         let _clock = crate::query::executor::operator::statement_clock::begin();
+        crate::query::executor::operator::notifications::begin();
         // Substitute parameters if any
         let query = if !self.params.is_empty() || !query.params.is_empty() {
             let mut q = query.clone();
@@ -659,6 +660,7 @@ impl<'a> MutQueryExecutor<'a> {
     pub fn execute(&mut self, query: &Query) -> ExecutionResult<RecordBatch> {
         // See the read-only executor above: one clock per statement (#793).
         let _clock = crate::query::executor::operator::statement_clock::begin();
+        crate::query::executor::operator::notifications::begin();
         // Substitute parameters if any
         let query = if !self.params.is_empty() || !query.params.is_empty() {
             let mut q = query.clone();

--- a/src/query/executor/operator.rs
+++ b/src/query/executor/operator.rs
@@ -195,6 +195,62 @@ fn cypher_equals(a: &PropertyValue, b: &PropertyValue) -> Option<bool> {
 /// large change for a small need. Set by `QueryExecutor::execute` at the start
 /// of a statement and cleared by the guard on the way out, including on an
 /// early return, so a stale value cannot leak into the next statement (#793).
+/// Diagnostics a statement produced alongside its rows (#1149).
+///
+/// A notification never changes an answer. It reports that the engine made a
+/// choice the query did not state, and that the choice was observable -- which
+/// is the one thing a user cannot recover from the result set.
+///
+/// Collected in a thread-local rather than threaded through `RecordBatch`
+/// because 35 sites construct that struct literally, and a field none of them
+/// set would be 35 edits to carry one bool. Reset at statement start, exactly
+/// like `statement_clock` above; read by the transport after `execute` returns.
+pub(crate) mod notifications {
+    use std::cell::RefCell;
+
+    /// One diagnostic. Shaped after the GQL status object: a code a client can
+    /// match on, and a description a human can read.
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+    pub struct Notification {
+        pub code: &'static str,
+        pub severity: &'static str,
+        pub title: &'static str,
+        pub description: String,
+    }
+
+    thread_local! {
+        static PENDING: RefCell<Vec<Notification>> = const { RefCell::new(Vec::new()) };
+    }
+
+    /// Start a statement. Clears whatever the previous one on this thread left.
+    pub fn begin() {
+        PENDING.with(|p| p.borrow_mut().clear());
+    }
+
+    /// Record a diagnostic, unless an identical one is already pending.
+    ///
+    /// De-duplicated because the emitting site sits inside an expansion loop:
+    /// one pattern over a dense graph would otherwise report the same fact
+    /// thousands of times and bury the result it is annotating.
+    pub fn emit(n: Notification) {
+        PENDING.with(|p| {
+            let mut v = p.borrow_mut();
+            if !v.contains(&n) {
+                v.push(n);
+            }
+        });
+    }
+
+    /// Everything this statement recorded.
+    pub fn take() -> Vec<Notification> {
+        PENDING.with(|p| std::mem::take(&mut *p.borrow_mut()))
+    }
+
+    /// The path mode was not written down, and it changed the answer.
+    pub const PATH_MODE_AFFECTS_RESULT: &str =
+        "Samyama.Notification.Statement.PathModeAffectsResult";
+}
+
 pub(crate) mod statement_clock {
     use std::cell::Cell;
 
@@ -7002,6 +7058,8 @@ pub struct VarLengthExpandOperator {
     /// GQL path restrictor. `Trail` is the default and is what this operator has
     /// always enforced, so an unannotated pattern is unchanged (#1141).
     restrictor: crate::query::ast::PathRestrictor,
+    /// Whether the query named the restrictor. See `with_restrictor_explicit`.
+    restrictor_explicit: bool,
     input: OperatorBox,
     source_var: String,
     target_var: String,
@@ -7154,6 +7212,7 @@ impl VarLengthExpandOperator {
             direction,
             min_hops,
             restrictor: crate::query::ast::PathRestrictor::default(),
+            restrictor_explicit: false,
             max_hops,
             path_variable: None,
             rel_variable: None,
@@ -7489,6 +7548,16 @@ impl VarLengthExpandOperator {
         self
     }
 
+    /// Whether the query wrote the restrictor down (#1149).
+    ///
+    /// Only an *implicit* `Trail` is worth a notification. A pattern that said
+    /// `TRAIL` chose it, and telling that user their explicit choice was applied
+    /// is noise.
+    pub fn with_restrictor_explicit(mut self, explicit: bool) -> Self {
+        self.restrictor_explicit = explicit;
+        self
+    }
+
     pub fn with_trail_enumeration(mut self) -> Self {
         self.enumerate_trails = true;
         self
@@ -7646,19 +7715,41 @@ impl VarLengthExpandOperator {
         // `WALK` may reuse an edge; every other restrictor may not. Decided once
         // here rather than inside the loop, so the common case pays nothing.
         let reuse_edges = self.restrictor == crate::query::ast::PathRestrictor::Walk;
+        // #1149. An implicit `Trail` is the only case where the user did not say
+        // which path mode they meant, so it is the only case where being told the
+        // mode mattered is news. Computed once; the check inside the loop is a
+        // single `&&` against a bool that is false for every explicit pattern.
+        let watch_mode = !reuse_edges && !self.restrictor_explicit
+            && self.restrictor == crate::query::ast::PathRestrictor::Trail;
+        let mut mode_mattered = false;
         macro_rules! collect {
-            ($cur:expr, $used:expr) => {{
+            ($cur:expr, $used:expr, $depth:expr) => {{
                 let mut out = Vec::new();
+                let mut mattered = false;
                 self.for_each_neighbor($cur, type_filter, store, |nb, eid| {
                     if reuse_edges || !$used.contains(&eid) {
                         out.push((nb, eid));
+                    } else if watch_mode && !mattered {
+                        // This neighbour was rejected *only* because the edge is
+                        // already on the path. Under the standard's unrestricted
+                        // reading (WALK) it would extend the path. It is a real
+                        // extra answer, rather than a candidate that dies later,
+                        // exactly when the extension lands inside the hop bounds
+                        // and the end-node pattern accepts it.
+                        let d = $depth + 1;
+                        if d >= self.min_hops && d <= self.max_hops && self.emit_ok(nb, store) {
+                            mattered = true;
+                        }
                     }
                 });
+                if mattered {
+                    mode_mattered = true;
+                }
                 out
             }};
         }
 
-        stack.push(collect!(source_id, edges));
+        stack.push(collect!(source_id, edges, 0usize));
         let mut trails = 0usize;
 
         while let Some(frontier) = stack.last_mut() {
@@ -7738,11 +7829,25 @@ impl VarLengthExpandOperator {
             let simple_closed = self.restrictor == crate::query::ast::PathRestrictor::Simple
                 && nb == source_id;
             if depth < self.max_hops && !simple_closed {
-                stack.push(collect!(nb, edges));
+                stack.push(collect!(nb, edges, depth));
             } else {
                 path.pop();
                 edges.pop();
             }
+        }
+        if mode_mattered {
+            notifications::emit(notifications::Notification {
+                code: notifications::PATH_MODE_AFFECTS_RESULT,
+                severity: "INFORMATION",
+                title: "The path mode changed this answer",
+                description:
+                    "A quantified pattern was evaluated under TRAIL, openCypher's \
+                     relationship uniqueness, because the query did not name a path \
+                     mode. Under the unrestricted reading in ISO/IEC 39075:2024 \
+                     (WALK) it matches additional paths. Write WALK or TRAIL to say \
+                     which you mean."
+                        .to_string(),
+            });
         }
         Ok(())
     }

--- a/src/query/executor/plan_enumerator.rs
+++ b/src/query/executor/plan_enumerator.rs
@@ -371,6 +371,7 @@ mod tests {
     fn make_path(start_var: &str, start_labels: Vec<Label>, segments: Vec<PathSegment>) -> PathPattern {
         PathPattern {
             restrictor: Default::default(),
+            restrictor_explicit: false,
             selector: Default::default(),
             path_variable: None,
             path_type: PathType::Normal,

--- a/src/query/executor/planner.rs
+++ b/src/query/executor/planner.rs
@@ -3712,6 +3712,7 @@ impl QueryPlanner {
                 // above: `multiplicity_is_observable` guesses at intent from query
                 // shape, and a written `ACYCLIC` is not a guess (#1141).
                 expand = expand.with_restrictor(path.restrictor);
+                expand = expand.with_restrictor_explicit(path.restrictor_explicit);
                     expand = expand.with_selector(path.selector);
                         // Relationship isomorphism applies to a var-length segment too: an
                         // edge an earlier segment of this clause walked is not available to
@@ -4342,6 +4343,7 @@ impl QueryPlanner {
                 // above: `multiplicity_is_observable` guesses at intent from query
                 // shape, and a written `ACYCLIC` is not a guess (#1141).
                 expand = expand.with_restrictor(path.restrictor);
+                expand = expand.with_restrictor_explicit(path.restrictor_explicit);
                     expand = expand.with_selector(path.selector);
                 // Relationship isomorphism applies to a var-length segment too: an
                 // edge an earlier segment of this clause walked is not available to
@@ -4505,6 +4507,7 @@ impl QueryPlanner {
                 // above: `multiplicity_is_observable` guesses at intent from query
                 // shape, and a written `ACYCLIC` is not a guess (#1141).
                 expand = expand.with_restrictor(path.restrictor);
+                expand = expand.with_restrictor_explicit(path.restrictor_explicit);
                     expand = expand.with_selector(path.selector);
                 // Relationship isomorphism applies to a var-length segment too: an
                 // edge an earlier segment of this clause walked is not available to

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1700,6 +1700,7 @@ fn parse_named_path(pair: pest::iterators::Pair<Rule>) -> ParseResult<PathPatter
     pp.path_variable = path_variable;
     if let Some(r) = restrictor {
         pp.restrictor = r;
+        pp.restrictor_explicit = true;
     }
     if let Some(s) = selector {
         pp.selector = s;
@@ -1783,7 +1784,7 @@ fn parse_path(pair: pest::iterators::Pair<Rule>) -> ParseResult<PathPattern> {
         segments.push(PathSegment { edge, node });
     }
 
-    Ok(PathPattern { path_variable: None, path_type: PathType::Normal, restrictor: Default::default(), selector: Default::default(), start, segments })
+    Ok(PathPattern { path_variable: None, path_type: PathType::Normal, restrictor: Default::default(), restrictor_explicit: false, selector: Default::default(), start, segments })
 }
 
 fn parse_node(pair: pest::iterators::Pair<Rule>) -> ParseResult<NodePattern> {


### PR DESCRIPTION
Closes #1149.

## The problem

A bare quantifier `-[:E*1..4]->` means TRAIL in openCypher. The unrestricted reading in ISO/IEC 39075:2024 is WALK. On a cycle they differ, and we returned our answer with no signal:

```
MATCH p=(x:N)-[:E*1..4]->(y:N) WHERE x.name = "m"
  standard (WALK):  4 paths
  us, and Neo4j:    2 paths
```

In the GPML conformance suite this is what **silence ratio S2** counts. Ours is **1.00** — every disagreement we have with the standard is silent. Checked rather than assumed: `neo4j:5.26` returns the same 2-row TRAIL answer with `ResultSummary.notifications == None`. No engine in that study tells the user.

Expressiveness we already lead: 15 of 17 constructs conforming, the only engine with 0 inexpressible. But strip the 5 cells answered through our own syntax extension and we are **exactly tied** with Neo4j and Memgraph — 10/2/0/5, and the *same two* divergences case-for-case. The whole margin is the extension. S2 is the axis where nobody has moved.

## What this does not do

**It changes no answer.** TRAIL is correct for openCypher and is what we declare. The rows are asserted identical in every test case; a diagnostic bought with a changed answer would be a regression, and the test is written to fail on that.

## How it detects it

Not statically — deciding "could the mode matter" from query text needs the data and would fire on nearly every variable-length pattern, and noise is worse than silence. Instead, at the uniqueness-prune site in `expand_trails`: flag it when a neighbour is rejected **solely** because its edge is already on the path, **and** `depth + 1` lands inside the hop bounds, **and** `emit_ok` accepts it. Those last two are what make it a real extra WALK answer rather than a candidate that dies later.

- **No false negatives** — every TRAIL/WALK difference begins with such a prune.
- **False positives** only where a filter outside the operator would reject the extra path. Said in the issue rather than claimed away.
- **Cost** is one bool set inside a branch that already runs. No extra traversal.

Fires only for an *implicit* Trail, which is why `PathPattern.restrictor_explicit` exists: `Trail` is both the default and something a user can ask for, so the value alone could not tell them apart. Someone who wrote `TRAIL` chose it and is not nagged.

The channel is a `notifications` thread-local mirroring the existing `statement_clock`, **not** a field on `RecordBatch` — 35 sites construct that struct literally, and a field none of them set would be 35 edits to carry one bool. De-duplicated at emit, because the site sits inside an expansion loop and would otherwise bury the result it annotates.

## Evidence

| query (2-cycle unless noted) | rows | notification |
|---|---:|---|
| bare `*1..4` | 2 | fires |
| bare `*1..4`, no named path (different planner route) | 2 | fires |
| explicit `TRAIL` | 2 | silent |
| explicit `WALK` | 4 | silent |
| `*1..1` | 1 | silent |
| bare `*1..4`, acyclic chain | 2 | silent |

The unnamed-path row is the one worth keeping: a bare pattern takes a different route through the planner than `p=`, and without it the diagnostic would depend on how the query was written.

- `cargo test --workspace --no-fail-fast`: **261 binaries, 4,127 passed, 0 failed** (4,126 baseline + the new test).
- TCK: **3,760 pass, 0 wrong results, 3 errored, 99.9%** — identical to baseline, `CH-TCK` MET.

Two `#[cfg(test)]` `PathPattern` initializers are also fixed here; `cargo build --release --bin` never compiled them.

## Follow-up, not in this PR

Scoring this needs a change in the conformance artifact: samyama-ai/gpml-conformance#2. S2 counts only *errors* as speaking, so a warning still scores as silent. That proposes **S2b as a new metric, leaving the published S2 0.60 alone** — redefining a headline number while keeping its name is the failure that artifact exists to document in other people.

https://claude.ai/code/session_01TuWVfpSE7fWvaXRbozp1ke