### PR TITLE
Accept a path mode before the path variable, which is the order the standard uses

### DIFF
--- a/src/query/cypher.pest
+++ b/src/query/cypher.pest
@@ -181,7 +181,13 @@ create_stmt = { create_clause+ ~ return_clause? ~ order_by_clause? ~ skip_clause
 
 // Pattern matching
 pattern = { named_path ~ ("," ~ named_path)* }
-named_path = { (variable ~ "=" ~ shortest_path_call) | (variable ~ "=" ~ path_modes ~ path) | (variable ~ "=" ~ path) | shortest_path_call | (path_modes ~ path) | path }
+// `path_modes` may precede the path variable or follow it. ISO/IEC 39075 writes
+// the modes first -- `MATCH TRAIL p = (...)` -- and so do the worked examples in
+// the standard's reference exposition; we originally accepted only the inverted
+// form, so the specification's own queries did not parse (#1148). Both are taken.
+// Ordered choice: the modes-first alternative must precede `path_modes ~ path`,
+// which would otherwise consume the modes and then fail on the variable.
+named_path = { (variable ~ "=" ~ shortest_path_call) | (path_modes ~ variable ~ "=" ~ shortest_path_call) | (variable ~ "=" ~ path_modes ~ path) | (path_modes ~ variable ~ "=" ~ path) | (variable ~ "=" ~ path) | shortest_path_call | (path_modes ~ path) | path }
 
 // GQL path selectors and restrictors (ISO/IEC 39075:2024), as a prefix on a path
 // pattern: `MATCH ALL SHORTEST ACYCLIC (a)-[:R*1..3]->(b)`.

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -3871,6 +3871,68 @@ mod tests {
         assert_eq!(call.yield_items.len(), 2);
     }
 
+    /// #1148. ISO/IEC 39075 writes the restrictor before the path variable --
+    /// `MATCH TRAIL p = (...)` -- and so do the worked examples in the standard's
+    /// reference exposition (Deutsch et al., SIGMOD 2022). We accepted only the
+    /// inverted `MATCH p = TRAIL (...)`, so the queries printed in the specification
+    /// did not parse.
+    #[test]
+    fn test_path_mode_before_path_variable() {
+        for (q, want_restrictor, want_selector) in [
+            (
+                "MATCH TRAIL p = (a)-[:R*1..3]->(b) RETURN p",
+                PathRestrictor::Trail,
+                PathSelector::All,
+            ),
+            (
+                "MATCH ACYCLIC p = (a)-[:R*1..3]->(b) RETURN p",
+                PathRestrictor::Acyclic,
+                PathSelector::All,
+            ),
+            (
+                "MATCH SIMPLE p = (a)-[:R*1..3]->(b) RETURN p",
+                PathRestrictor::Simple,
+                PathSelector::All,
+            ),
+            (
+                "MATCH WALK p = (a)-[:R*1..3]->(b) RETURN p",
+                PathRestrictor::Walk,
+                PathSelector::All,
+            ),
+            (
+                "MATCH ANY SHORTEST p = (a)-[:R*1..3]->(b) RETURN p",
+                PathRestrictor::Trail,
+                PathSelector::AnyShortest,
+            ),
+            (
+                "MATCH ALL SHORTEST TRAIL p = (a)-[:R*1..3]->(b) RETURN p",
+                PathRestrictor::Trail,
+                PathSelector::AllShortest,
+            ),
+        ] {
+            let ast = parse_query(q).unwrap_or_else(|e| panic!("{q}: {e:?}"));
+            let pp = &ast.match_clauses[0].pattern.paths[0];
+            assert_eq!(pp.path_variable, Some("p".to_string()), "{q}");
+            assert_eq!(pp.restrictor, want_restrictor, "{q}");
+            assert_eq!(pp.selector, want_selector, "{q}");
+            // A restrictor written in this position is still written, so #1149 must
+            // not treat it as defaulted and warn about it.
+            assert!(pp.restrictor_explicit || !q.contains("TRAIL") && !q.contains("WALK")
+                    && !q.contains("ACYCLIC") && !q.contains("SIMPLE"), "{q}");
+        }
+    }
+
+    /// The inverted order we used to be alone in accepting keeps working, so
+    /// anything already written against it does not break.
+    #[test]
+    fn test_path_variable_before_path_mode_still_parses() {
+        let ast = parse_query("MATCH p = TRAIL (a)-[:R*1..3]->(b) RETURN p").unwrap();
+        let pp = &ast.match_clauses[0].pattern.paths[0];
+        assert_eq!(pp.path_variable, Some("p".to_string()));
+        assert_eq!(pp.restrictor, PathRestrictor::Trail);
+        assert!(pp.restrictor_explicit);
+    }
+
     #[test]
     fn test_parse_named_path_with_return_p() {
         let query = "MATCH p = (a:Person)-[:KNOWS]->(b:Person) RETURN p";

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -3878,36 +3878,44 @@ mod tests {
     /// did not parse.
     #[test]
     fn test_path_mode_before_path_variable() {
-        for (q, want_restrictor, want_selector) in [
+        for (q, want_restrictor, want_selector, want_explicit) in [
             (
                 "MATCH TRAIL p = (a)-[:R*1..3]->(b) RETURN p",
                 PathRestrictor::Trail,
                 PathSelector::All,
+                true,
             ),
             (
                 "MATCH ACYCLIC p = (a)-[:R*1..3]->(b) RETURN p",
                 PathRestrictor::Acyclic,
                 PathSelector::All,
+                true,
             ),
             (
                 "MATCH SIMPLE p = (a)-[:R*1..3]->(b) RETURN p",
                 PathRestrictor::Simple,
                 PathSelector::All,
+                true,
             ),
             (
                 "MATCH WALK p = (a)-[:R*1..3]->(b) RETURN p",
                 PathRestrictor::Walk,
                 PathSelector::All,
+                true,
             ),
             (
+                // No restrictor written: Trail is the default, and `explicit` must
+                // stay false so the path-mode notification still fires here.
                 "MATCH ANY SHORTEST p = (a)-[:R*1..3]->(b) RETURN p",
                 PathRestrictor::Trail,
                 PathSelector::AnyShortest,
+                false,
             ),
             (
                 "MATCH ALL SHORTEST TRAIL p = (a)-[:R*1..3]->(b) RETURN p",
                 PathRestrictor::Trail,
                 PathSelector::AllShortest,
+                true,
             ),
         ] {
             let ast = parse_query(q).unwrap_or_else(|e| panic!("{q}: {e:?}"));
@@ -3915,10 +3923,11 @@ mod tests {
             assert_eq!(pp.path_variable, Some("p".to_string()), "{q}");
             assert_eq!(pp.restrictor, want_restrictor, "{q}");
             assert_eq!(pp.selector, want_selector, "{q}");
-            // A restrictor written in this position is still written, so #1149 must
-            // not treat it as defaulted and warn about it.
-            assert!(pp.restrictor_explicit || !q.contains("TRAIL") && !q.contains("WALK")
-                    && !q.contains("ACYCLIC") && !q.contains("SIMPLE"), "{q}");
+            // A restrictor written in this position is still *written*, so #1149 must
+            // not treat it as defaulted and warn about a mode the user chose. The
+            // table carries the expectation; deriving it by searching `q` for keywords
+            // would re-implement the parser inside its own test.
+            assert_eq!(pp.restrictor_explicit, want_explicit, "{q}");
         }
     }
 


### PR DESCRIPTION
Fixes #1148.

ISO/IEC 39075 heads a path pattern with the restrictor and binds the variable to the whole thing. The worked examples in the standard's reference exposition (Deutsch et al., SIGMOD 2022 §5.1) are written that way:

```
MATCH TRAIL p = (a WHERE a.owner='Dave')-[t:Transfer]->*
               (b WHERE b.owner='Aretha')
```

We accepted only the inverted `MATCH p = TRAIL (...)`, so the specification's own queries did not parse. Without a path variable both orders already worked, which is why this survived until the conformance suite tried the standard's text verbatim.

## The change

One grammar rule. `named_path` gains two alternatives, placed **before** `path_modes ~ path` — pest is ordered choice, and that alternative would otherwise consume the modes and then fail on the variable. The parser side needed no change: `parse_named_path` matches inner pairs by rule, not by position.

The inverted order still parses, so nothing written against it breaks.

## Tests

- `test_path_mode_before_path_variable` — all four restrictors, both shortest selectors, and a selector-plus-restrictor combination. Also asserts `restrictor_explicit` stays true in the new position, so #1149 does not start warning about a mode the user did write.
- `test_path_variable_before_path_mode_still_parses` — regression guard on the inverted order.

`cargo test --lib`: **2200 passed, 0 failed.** Verified separately against a release build over HTTP — all four standard-order forms accepted, all three previously-accepted forms unchanged.

## Worth knowing: we are not alone in this

Probing **Neo4j 2026.04** with the same forms while extending the conformance suite:

| form | Neo4j 2026.04 |
|---|---|
| `MATCH ANY SHORTEST (...)` | accepted |
| `MATCH ANY SHORTEST p = (...)` | **rejected** — "Invalid input 'p'" |
| `MATCH TRAIL (x) (()-[:E]->()){1,3} (y)` | accepted |
| `MATCH TRAIL p = (x) (()-[:E]->()){1,3} (y)` | **rejected** — "Invalid input 'p'" |

Two independent implementations both reject the form the specification is written in. That makes the finding stronger than a quirk of ours, and it is going into the paper's measurement rather than staying an anecdote.

https://claude.ai/code/session_01CBksxoJ5qLPTgGQUNei53i