### PR TITLE
samyama verify: a snapshot that cannot reproduce its own answers has failed (#1157)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,15 @@ use std::io::{BufRead, BufReader};
 async fn main() {
     tracing_subscriber::fmt::init();
 
+    // Subcommands are handled before the demo and the server, so `verify` is a
+    // tool that exits with a status rather than a database that starts up.
+    let argv: Vec<String> = std::env::args().collect();
+    match argv.get(1).map(|s| s.as_str()) {
+        Some("verify") => std::process::exit(cmd_verify(&argv)),
+        Some("catalog-build") => std::process::exit(cmd_catalog_build(&argv)),
+        _ => {}
+    }
+
     println!("Samyama Graph Database v{}", samyama::version());
     println!("==========================================");
     println!();
@@ -25,6 +34,129 @@ async fn main() {
     println!();
 
     start_server().await;
+}
+
+/// `samyama verify <snapshot.sgsnap> --queries <catalog.json>`
+///
+/// Restores the snapshot into a fresh store and runs its shipped catalog. Exits
+/// non-zero on any mismatch, naming the entries that failed and the probable
+/// class -- not a diff, which tells the reader what changed rather than what
+/// broke (#1157).
+fn cmd_verify(argv: &[String]) -> i32 {
+    let flag = |name: &str| argv.iter().position(|a| a == name).and_then(|i| argv.get(i + 1));
+    let Some(snapshot) = argv.get(2).filter(|s| !s.starts_with("--")) else {
+        eprintln!("usage: samyama verify <snapshot.sgsnap> --queries <catalog.json>");
+        return 64;
+    };
+    let Some(catalog_path) = flag("--queries") else {
+        eprintln!("verify needs --queries <catalog.json>");
+        return 64;
+    };
+
+    let catalog: samyama::snapshot::verify::QueryCatalog = match std::fs::File::open(catalog_path)
+        .map_err(|e| e.to_string())
+        .and_then(|f| serde_json::from_reader(f).map_err(|e| e.to_string()))
+    {
+        Ok(c) => c,
+        Err(e) => { eprintln!("could not read catalog {catalog_path}: {e}"); return 65; }
+    };
+
+    let mut store = GraphStore::new();
+    let file = match std::fs::File::open(snapshot) {
+        Ok(f) => f,
+        Err(e) => { eprintln!("could not open {snapshot}: {e}"); return 66; }
+    };
+    if let Err(e) = samyama::snapshot::import_tenant(&mut store, file) {
+        // An import that fails is already a failed restore; say so plainly
+        // rather than going on to report every query as broken.
+        eprintln!("restore failed before any query ran: {e}");
+        return 1;
+    }
+
+    let report = match samyama::snapshot::verify::verify(&store, &catalog) {
+        Ok(r) => r,
+        Err(e) => { eprintln!("{e}"); return 65; }
+    };
+
+    let total = report.results.len();
+    let failed: Vec<_> = report.failed().collect();
+    println!("verify {snapshot}");
+    println!("  catalog {catalog_path}: {total} entries");
+    for r in &failed {
+        let class = r.failure.expect("failed entries carry a class");
+        println!("  FAIL {}  expected {} rows, got {}{}",
+                 r.id, r.expected_rows, r.actual_rows,
+                 if r.detail.is_empty() { String::new() } else { format!("  [{}]", r.detail) });
+        println!("       {}", class.explain());
+    }
+    if report.everything_empty {
+        println!("  FAIL every entry returned zero rows. That is what this catalog \
+                  looks like run against an empty graph, so the run is not evidence \
+                  of a good restore whatever the expectations say.");
+    }
+    if report.is_ok() {
+        println!("  OK  {total} entries reproduced");
+        0
+    } else {
+        println!("  {} of {total} entries failed", failed.len().max(1));
+        1
+    }
+}
+
+/// `samyama catalog-build <snapshot.sgsnap> --sql <queries.json> --out <catalog.json>`
+///
+/// Runs a list of queries against a snapshot and records what they returned, so
+/// the snapshot can later prove it still returns it.
+fn cmd_catalog_build(argv: &[String]) -> i32 {
+    let flag = |name: &str| argv.iter().position(|a| a == name).and_then(|i| argv.get(i + 1));
+    let Some(snapshot) = argv.get(2).filter(|s| !s.starts_with("--")) else {
+        eprintln!("usage: samyama catalog-build <snapshot.sgsnap> --queries <queries.json> \
+                   --out <catalog.json>");
+        return 64;
+    };
+    let (Some(queries_path), Some(out)) = (flag("--queries"), flag("--out")) else {
+        eprintln!("catalog-build needs --queries <queries.json> and --out <catalog.json>");
+        return 64;
+    };
+
+    // Input shape: [{"id": "...", "cypher": "...", "unanswerable": false}, ...]
+    #[derive(serde::Deserialize)]
+    struct InQuery { id: String, cypher: String, #[serde(default)] unanswerable: bool }
+    let queries: Vec<InQuery> = match std::fs::File::open(queries_path)
+        .map_err(|e| e.to_string())
+        .and_then(|f| serde_json::from_reader(f).map_err(|e| e.to_string()))
+    {
+        Ok(q) => q,
+        Err(e) => { eprintln!("could not read {queries_path}: {e}"); return 65; }
+    };
+
+    let mut store = GraphStore::new();
+    let file = match std::fs::File::open(snapshot) {
+        Ok(f) => f,
+        Err(e) => { eprintln!("could not open {snapshot}: {e}"); return 66; }
+    };
+    if let Err(e) = samyama::snapshot::import_tenant(&mut store, file) {
+        eprintln!("could not restore {snapshot}: {e}");
+        return 1;
+    }
+
+    let pairs: Vec<(String, String)> =
+        queries.iter().map(|q| (q.id.clone(), q.cypher.clone())).collect();
+    let unanswerable: Vec<String> =
+        queries.iter().filter(|q| q.unanswerable).map(|q| q.id.clone()).collect();
+
+    match samyama::snapshot::verify::build_catalog(&store, &pairs, &unanswerable) {
+        Err(e) => { eprintln!("{e}"); 1 }
+        Ok(catalog) => {
+            let json = serde_json::to_string_pretty(&catalog).expect("serialize");
+            if let Err(e) = std::fs::write(out, json) {
+                eprintln!("could not write {out}: {e}");
+                return 74;
+            }
+            println!("wrote {out}: {} entries", catalog.entries.len());
+            0
+        }
+    }
 }
 
 fn demo_property_graph() {

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -9,6 +9,7 @@
 
 pub mod format;
 pub mod persist;
+pub mod verify;
 
 use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Read, Write};

--- a/src/snapshot/verify.rs
+++ b/src/snapshot/verify.rs
@@ -1,0 +1,255 @@
+//! A snapshot that cannot reproduce its own answers is a failed restore (#1157).
+//!
+//! ADR-022 records that `.sgsnap` has no checksum on the body: "a truncated
+//! upload decompresses cleanly to a partial graph and silently imports." A
+//! checksum would only prove the file arrived. It cannot prove the graph is the
+//! graph, and every snapshot defect this codebase has shipped was of the second
+//! kind:
+//!
+//! * #303/#420 — imported graphs had empty `node.properties` and no property statistics
+//! * #1130 — an imported node has an empty row copy, so `SET` then restart loses
+//!   every property the update did not touch
+//! * #332 — a published snapshot was a degraded subset missing an edge type and half the labels
+//! * #1096 — export writes `edge_type:""` rather than failing, losing those edges silently
+//! * #1124 — a round trip resets `created_at`/`updated_at` to 0
+//! * #199 — import reported "unexpected end of file" and loaded the data anyway
+//!
+//! Each is a silent partial restore, and each would be caught by running real
+//! queries against the restored graph and comparing row counts and values.
+//!
+//! ## The trap
+//!
+//! A catalog whose queries return zero rows passes trivially. That has happened
+//! here: the OSS benchmark's SF1 defaults referenced person ids absent from the
+//! dataset and "returned 0 rows for every complex read and reported 21/21
+//! passed in 32 ms" (#449). So a zero-row expectation is refused at build time
+//! unless the entry is explicitly marked unanswerable, and a verify run in
+//! which *every* entry returns zero rows fails whatever the expectations say.
+
+use std::collections::BTreeMap;
+
+use crate::graph::GraphStore;
+use crate::query::{QueryEngine, RecordBatch};
+
+/// Format identifier written into a catalog, so a reader can refuse a shape it
+/// does not understand rather than misinterpreting it.
+pub const CATALOG_FORMAT: &str = "samyama.queries/1";
+
+/// One catalog entry: a query and what it produced when the snapshot was built.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CatalogEntry {
+    pub id: String,
+    pub cypher: String,
+    /// Rows the query returned against the snapshot this catalog describes.
+    pub rows: usize,
+    /// Order-canonical hash of the rendered rows. Sorted before hashing, so a
+    /// query without `ORDER BY` does not fail on row order -- which would be a
+    /// false alarm about the restore rather than a finding.
+    pub hash: String,
+    /// A query that legitimately returns nothing. KG-08 asks for these
+    /// deliberately, and they are the only entries allowed a zero-row
+    /// expectation.
+    #[serde(default)]
+    pub unanswerable: bool,
+}
+
+/// A shipped query catalog.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct QueryCatalog {
+    pub format: String,
+    pub generated_by: String,
+    pub entries: Vec<CatalogEntry>,
+}
+
+/// What a mismatch most likely means. Named rather than diffed, because a diff
+/// of two large result sets tells the reader what changed and not what broke.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureClass {
+    /// Expected rows, got none.
+    EmptyResult,
+    /// Got some rows, but fewer than expected.
+    PartialResult,
+    /// Got more rows than expected.
+    ExtraRows,
+    /// Right number of rows, different values.
+    ValuesDiffer,
+    /// The query itself failed.
+    QueryError,
+}
+
+impl FailureClass {
+    /// The probable cause, in the vocabulary of the defects this guards against.
+    pub fn explain(self) -> &'static str {
+        match self {
+            FailureClass::EmptyResult => {
+                "no rows where the catalog expects some: a label or edge type is \
+                 missing from the restored graph, or the body was truncated \
+                 (ADR-022 has no body checksum, so a partial file imports cleanly)"
+            }
+            FailureClass::PartialResult => {
+                "fewer rows than the catalog expects: nodes or edges are missing, \
+                 the shape of a degraded subset being published as if complete (#332)"
+            }
+            FailureClass::ExtraRows => {
+                "more rows than the catalog expects: the snapshot was imported \
+                 into a store that already held data, or an import ran twice"
+            }
+            FailureClass::ValuesDiffer => {
+                "the right number of rows with the wrong values: properties lost or \
+                 reset by the round trip (#303/#420 empty properties, #1130 the row \
+                 copy, #1124 timestamps reset to 0) -- or, for an aggregate, a \
+                 changed graph behind an unchanged row count, since `count(*)` \
+                 returns one row whatever it counted"
+            }
+            FailureClass::QueryError => "the query failed against the restored graph",
+        }
+    }
+}
+
+/// One entry's outcome.
+#[derive(Debug, Clone)]
+pub struct EntryResult {
+    pub id: String,
+    pub expected_rows: usize,
+    pub actual_rows: usize,
+    pub failure: Option<FailureClass>,
+    pub detail: String,
+}
+
+/// The whole run.
+#[derive(Debug, Clone)]
+pub struct VerifyReport {
+    pub results: Vec<EntryResult>,
+    /// Every entry returned zero rows. Treated as a failure on its own, because
+    /// it is what a catalog run against an empty graph looks like and it would
+    /// otherwise be indistinguishable from success for an all-unanswerable
+    /// catalog.
+    pub everything_empty: bool,
+}
+
+impl VerifyReport {
+    pub fn failed(&self) -> impl Iterator<Item = &EntryResult> {
+        self.results.iter().filter(|r| r.failure.is_some())
+    }
+
+    pub fn is_ok(&self) -> bool {
+        !self.everything_empty && self.failed().count() == 0
+    }
+}
+
+/// Render a result deterministically, then hash it order-independently.
+///
+/// Rows are rendered, sorted, and hashed. Sorting is what makes an unordered
+/// query stable across restores; without it this check would fail on row order
+/// and report a restore defect that is not one.
+pub fn canonical_hash(batch: &RecordBatch) -> String {
+    let mut rows: Vec<String> = Vec::with_capacity(batch.records.len());
+    for rec in &batch.records {
+        let mut cells: BTreeMap<&str, String> = BTreeMap::new();
+        for col in &batch.columns {
+            cells.insert(col.as_str(), format!("{:?}", rec.get(col)));
+        }
+        rows.push(
+            cells.iter().map(|(k, v)| format!("{k}={v}")).collect::<Vec<_>>().join("\u{1f}"),
+        );
+    }
+    rows.sort();
+
+    // FNV-1a over the joined rows. A cryptographic digest would be a new
+    // dependency for no gain: this detects accidental corruption, and a
+    // snapshot able to forge a hash could forge the rows too.
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in rows.join("\u{1e}").as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("fnv1a64:{h:016x}")
+}
+
+/// Build a catalog from queries run against a store.
+///
+/// Refuses a zero-row entry unless it is marked unanswerable. An entry that
+/// returns nothing at build time will return nothing after any restore,
+/// including a restore that lost the entire graph, so it cannot detect
+/// anything and its presence would inflate the count of passing checks.
+pub fn build_catalog(
+    store: &GraphStore,
+    queries: &[(String, String)],
+    unanswerable: &[String],
+) -> Result<QueryCatalog, String> {
+    let engine = QueryEngine::new();
+    let mut entries = Vec::with_capacity(queries.len());
+    for (id, cypher) in queries {
+        let batch = engine
+            .execute(cypher, store)
+            .map_err(|e| format!("{id}: query failed while building the catalog: {e}"))?;
+        let rows = batch.records.len();
+        let is_unanswerable = unanswerable.contains(id);
+        if rows == 0 && !is_unanswerable {
+            return Err(format!(
+                "{id}: returned 0 rows. A zero-row entry passes against any graph, \
+                 including an empty one, so it detects nothing. Fix the query, or \
+                 mark it unanswerable if returning nothing is the point."
+            ));
+        }
+        entries.push(CatalogEntry {
+            id: id.clone(),
+            cypher: cypher.clone(),
+            rows,
+            hash: canonical_hash(&batch),
+            unanswerable: is_unanswerable,
+        });
+    }
+    Ok(QueryCatalog {
+        format: CATALOG_FORMAT.to_string(),
+        generated_by: format!("samyama {}", crate::VERSION),
+        entries,
+    })
+}
+
+/// Run a catalog against a restored store.
+pub fn verify(store: &GraphStore, catalog: &QueryCatalog) -> Result<VerifyReport, String> {
+    if catalog.format != CATALOG_FORMAT {
+        return Err(format!(
+            "catalog format {:?} is not {CATALOG_FORMAT}; refusing to guess at its shape",
+            catalog.format
+        ));
+    }
+    let engine = QueryEngine::new();
+    let mut results = Vec::with_capacity(catalog.entries.len());
+
+    for e in &catalog.entries {
+        let (actual_rows, failure, detail) = match engine.execute(&e.cypher, store) {
+            Err(err) => (0, Some(FailureClass::QueryError), err.to_string()),
+            Ok(batch) => {
+                let rows = batch.records.len();
+                let hash = canonical_hash(&batch);
+                if rows == e.rows && hash == e.hash {
+                    (rows, None, String::new())
+                } else if rows == 0 && e.rows > 0 {
+                    (rows, Some(FailureClass::EmptyResult), String::new())
+                } else if rows < e.rows {
+                    (rows, Some(FailureClass::PartialResult),
+                     format!("{} of {} rows", rows, e.rows))
+                } else if rows > e.rows {
+                    (rows, Some(FailureClass::ExtraRows),
+                     format!("{} rows, expected {}", rows, e.rows))
+                } else {
+                    (rows, Some(FailureClass::ValuesDiffer),
+                     format!("hash {} != {}", hash, e.hash))
+                }
+            }
+        };
+        results.push(EntryResult {
+            id: e.id.clone(),
+            expected_rows: e.rows,
+            actual_rows,
+            failure,
+            detail,
+        });
+    }
+
+    // Guard against the #449 shape: everything answered, nothing returned.
+    let everything_empty = !results.is_empty() && results.iter().all(|r| r.actual_rows == 0);
+    Ok(VerifyReport { results, everything_empty })
+}

--- a/tests/snapshot_verify.rs
+++ b/tests/snapshot_verify.rs
@@ -1,0 +1,205 @@
+//! `samyama verify`: a restored snapshot must reproduce its own answers (#1157).
+//!
+//! Each test reproduces one of the silent-partial-restore classes this is meant
+//! to catch, rather than only checking the happy path. A checksum on the file
+//! would pass every one of them.
+
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::snapshot::verify::{
+    build_catalog, canonical_hash, verify, CatalogEntry, FailureClass, QueryCatalog,
+    CATALOG_FORMAT,
+};
+use samyama::query::QueryEngine;
+
+fn seeded() -> GraphStore {
+    let mut store = GraphStore::new();
+    let mut ids = Vec::new();
+    for i in 0..12i64 {
+        let mut props = samyama::graph::PropertyMap::new();
+        props.insert("id".into(), PropertyValue::Integer(i));
+        props.insert("name".into(), PropertyValue::String(format!("n{i:02}")));
+        ids.push(store.create_node_with_properties("default", vec![Label::new("Thing")], props));
+    }
+    for w in ids.windows(2) {
+        let _ = store.create_edge(w[0], w[1], "LINKS");
+    }
+    store
+}
+
+fn queries() -> Vec<(String, String)> {
+    vec![
+        ("q_nodes".into(), "MATCH (t:Thing) RETURN count(t) AS n".into()),
+        ("q_names".into(), "MATCH (t:Thing) RETURN t.name ORDER BY t.name".into()),
+        ("q_edges".into(), "MATCH (:Thing)-[:LINKS]->(:Thing) RETURN count(*) AS n".into()),
+        // Not an aggregate, on purpose. `count(*)` returns one row whether it
+        // counted 11 edges or none, so an aggregate alone cannot tell a missing
+        // edge type from a changed value.
+        ("q_edge_pairs".into(),
+         "MATCH (a:Thing)-[:LINKS]->(b:Thing) RETURN a.id, b.id ORDER BY a.id".into()),
+        ("q_props".into(), "MATCH (t:Thing) WHERE t.id < 5 RETURN t.id, t.name".into()),
+    ]
+}
+
+/// A snapshot that round-trips cleanly reproduces every answer.
+#[test]
+fn a_sound_round_trip_verifies() {
+    let store = seeded();
+    let catalog = build_catalog(&store, &queries(), &[]).expect("build");
+    assert_eq!(catalog.format, CATALOG_FORMAT);
+    assert_eq!(catalog.entries.len(), 5);
+
+    let mut buf = Vec::new();
+    samyama::snapshot::export_tenant(&store, &mut buf).expect("export");
+    let mut restored = GraphStore::new();
+    samyama::snapshot::import_tenant(&mut restored, &buf[..]).expect("import");
+
+    let report = verify(&restored, &catalog).expect("verify");
+    assert!(
+        report.is_ok(),
+        "a clean round trip failed its own catalog: {:?}",
+        report.failed().map(|r| (&r.id, r.failure, &r.detail)).collect::<Vec<_>>()
+    );
+}
+
+/// The #449 shape: a catalog entry that returns nothing passes against any
+/// graph, including one that lost everything, so it is refused at build time.
+#[test]
+fn a_zero_row_entry_is_refused_at_build_time() {
+    let store = seeded();
+    let mut q = queries();
+    q.push(("q_none".into(), "MATCH (x:Absent) RETURN x".into()));
+
+    let err = build_catalog(&store, &q, &[]).expect_err("a 0-row entry must be refused");
+    assert!(err.contains("q_none"), "{err}");
+    assert!(err.contains("detects nothing"), "{err}");
+
+    // Unless it is deliberately an unanswerable item, which KG-08 asks for.
+    let ok = build_catalog(&store, &q, &["q_none".to_string()]).expect("unanswerable allowed");
+    assert!(ok.entries.iter().any(|e| e.id == "q_none" && e.unanswerable && e.rows == 0));
+}
+
+/// A run where every entry returns nothing fails whatever the expectations say.
+#[test]
+fn an_all_empty_run_fails_even_when_expectations_match() {
+    let store = seeded();
+    // A catalog of nothing but unanswerable entries: every expectation is 0 and
+    // every result is 0, so entry-by-entry this run is perfect.
+    let catalog = QueryCatalog {
+        format: CATALOG_FORMAT.to_string(),
+        generated_by: "test".into(),
+        entries: vec![CatalogEntry {
+            id: "q_none".into(),
+            cypher: "MATCH (x:Absent) RETURN x".into(),
+            rows: 0,
+            hash: canonical_hash(&QueryEngine::new()
+                .execute("MATCH (x:Absent) RETURN x", &store).unwrap()),
+            unanswerable: true,
+        }],
+    };
+    let report = verify(&store, &catalog).expect("verify");
+    assert_eq!(report.failed().count(), 0, "no individual entry should fail");
+    assert!(report.everything_empty);
+    assert!(
+        !report.is_ok(),
+        "a run in which nothing returned a row reported success; that is what a \
+         catalog run against an empty graph looks like"
+    );
+}
+
+/// #303/#420 and #1130: the right rows with the properties gone.
+#[test]
+fn properties_lost_by_a_restore_are_caught_as_values_differing() {
+    let store = seeded();
+    let catalog = build_catalog(&store, &queries(), &[]).expect("build");
+
+    // Same nodes and edges, different property values -- the shape a restore
+    // takes when the row copy is empty and only some properties survive.
+    let mut damaged = seeded();
+    let targets: Vec<_> = damaged.get_nodes_by_label(&Label::new("Thing"))
+        .iter().map(|n| n.id).collect();
+    for id in targets {
+        damaged.set_node_property("default", id, "name", PropertyValue::String("".into()))
+            .expect("blank the name");
+    }
+
+    let report = verify(&damaged, &catalog).expect("verify");
+    assert!(!report.is_ok(), "blanked properties passed verification");
+    let classes: Vec<_> = report.failed().map(|r| r.failure.unwrap()).collect();
+    assert!(
+        classes.contains(&FailureClass::ValuesDiffer),
+        "expected ValuesDiffer, got {classes:?}"
+    );
+    // Row counts are untouched, which is the point: a count-only check misses this.
+    for r in report.failed() {
+        assert_eq!(r.actual_rows, r.expected_rows, "{}: rows changed too", r.id);
+    }
+}
+
+/// #332: a degraded subset published as if complete.
+#[test]
+fn a_missing_edge_type_is_caught_and_named() {
+    let store = seeded();
+    let catalog = build_catalog(&store, &queries(), &[]).expect("build");
+
+    let mut damaged = GraphStore::new();
+    for i in 0..12i64 {
+        let mut props = samyama::graph::PropertyMap::new();
+        props.insert("id".into(), PropertyValue::Integer(i));
+        props.insert("name".into(), PropertyValue::String(format!("n{i:02}")));
+        damaged.create_node_with_properties("default", vec![Label::new("Thing")], props);
+    }
+    // Nodes restored, edges lost.
+
+    let report = verify(&damaged, &catalog).expect("verify");
+    assert!(!report.is_ok(), "a graph with no edges passed a catalog that counts them");
+    // The aggregate can only report that its single row changed value.
+    let agg = report.results.iter().find(|r| r.id == "q_edges").expect("q_edges");
+    assert_eq!(agg.failure, Some(FailureClass::ValuesDiffer),
+               "count(*) returns one row either way, so this is a value change");
+
+    // The non-aggregate is the one that names the shape: 11 rows became none.
+    let pairs = report.results.iter().find(|r| r.id == "q_edge_pairs").expect("q_edge_pairs");
+    assert_eq!(pairs.failure, Some(FailureClass::EmptyResult),
+               "expected an empty result where the edges went missing");
+    assert!(pairs.failure.unwrap().explain().contains("edge type"),
+            "the failure should name a probable class: {}", pairs.failure.unwrap().explain());
+}
+
+/// Row order must not decide the verdict, or an unordered query reports a
+/// restore defect on every run.
+#[test]
+fn row_order_does_not_change_the_hash() {
+    let mut a = GraphStore::new();
+    let mut b = GraphStore::new();
+    for i in [3i64, 1, 2] {
+        let mut p = samyama::graph::PropertyMap::new();
+        p.insert("id".into(), PropertyValue::Integer(i));
+        a.create_node_with_properties("default", vec![Label::new("T")], p);
+    }
+    for i in [1i64, 2, 3] {
+        let mut p = samyama::graph::PropertyMap::new();
+        p.insert("id".into(), PropertyValue::Integer(i));
+        b.create_node_with_properties("default", vec![Label::new("T")], p);
+    }
+    let engine = QueryEngine::new();
+    let q = "MATCH (t:T) RETURN t.id";
+    assert_eq!(
+        canonical_hash(&engine.execute(q, &a).unwrap()),
+        canonical_hash(&engine.execute(q, &b).unwrap()),
+        "the hash depends on insertion order, so an unordered query would fail \
+         verification for a reason that is not a restore defect"
+    );
+}
+
+/// A catalog whose format string is unknown is refused rather than guessed at.
+#[test]
+fn an_unknown_catalog_format_is_refused() {
+    let store = seeded();
+    let bad = QueryCatalog {
+        format: "samyama.queries/99".into(),
+        generated_by: "test".into(),
+        entries: vec![],
+    };
+    let err = verify(&store, &bad).expect_err("unknown format must be refused");
+    assert!(err.contains("refusing to guess"), "{err}");
+}


### PR DESCRIPTION
Closes #1157 (DoD 1, 4, 5; see the bottom for 2 and 3).

```
samyama catalog-build <snap> --queries <queries.json> --out <catalog.json>
samyama verify <snap> --queries <catalog.json>
```

`verify` restores into a fresh store, runs every catalog entry, compares row count and an order-canonical hash, and exits non-zero naming the entries that failed and the probable class.

## Why a checksum is not this

ADR-022 records that `.sgsnap` has no checksum on the body — "a truncated upload decompresses cleanly to a partial graph and silently imports." A checksum proves the file arrived. It cannot prove the graph is the graph, and **every snapshot defect this codebase has shipped was the second kind**:

| defect | what a checksum sees | what a query sees |
|---|---|---|
| #303/#420 empty `node.properties` after import | fine | values gone |
| #1130 empty row copy loses untouched properties on restart | fine | values gone |
| #332 degraded subset published as complete | fine | rows missing |
| #1096 `edge_type:""` written rather than failing | fine | edges missing |
| #1124 round trip resets `created_at`/`updated_at` to 0 | fine | values changed |
| #199 import errors, loads anyway, no rollback | fine | rows wrong |

## Two guards against a check that cannot fail

- **A zero-row entry is refused at build time** unless explicitly marked unanswerable. Such an entry passes against any graph including an empty one — it detects nothing while adding to the count of things that passed. This has happened here: the OSS benchmark's SF1 defaults referenced person ids absent from the dataset and reported **21/21 passed in 32 ms over 0 rows** (#449).
- **A run where every entry returns zero rows fails** whatever the expectations say, since that is indistinguishable from running the catalog against an empty graph.

Hashes sort rows before hashing, so a query without `ORDER BY` does not fail on row order — which would report a restore defect that is not one (DoD 4).

## A limit the tests found

`count(*)` returns one row whether it counted 11 edges or none. So when the edges vanish, an aggregate entry can only report that its single row **changed value**, not that rows went missing. A catalog needs at least one non-aggregate entry to tell a missing edge type from a changed one. The classifier says so in its failure text rather than claiming more precision than it has.

I had this backwards in the first draft of the test and asserted the wrong class. The classifier was right and the test was wrong.

## End to end

```
$ samyama verify good.sgsnap --queries catalog.json
  OK  3 entries reproduced                                    exit 0

$ samyama verify degraded.sgsnap --queries catalog.json
  FAIL q_pairs  expected 11 rows, got 0
       no rows where the catalog expects some: a label or edge type is
       missing from the restored graph, or the body was truncated
       (ADR-022 has no body checksum, so a partial file imports cleanly)
  1 of 3 entries failed                                       exit 1
```

Seven tests, each reproducing a defect class rather than only the happy path. `cargo test --workspace --no-fail-fast`: 262 binaries, **4,137 passed, 0 failed**.

## Not in this PR

- **DoD 2** — running it in the KG release path, which lives in another repo.
- **DoD 3** — the x86↔ARM round trip in CI, which needs an ARM runner. That is what KG-11 asks for and is still untested.

https://claude.ai/code/session_01Km8V25fFdrdzqVhdHo611B
