### PR TITLE
The NLQ write guard accepted any write that began with MATCH (#1156)

### DIFF
--- a/src/nlq/mod.rs
+++ b/src/nlq/mod.rs
@@ -99,13 +99,29 @@ impl NLQPipeline {
             .to_string()
     }
 
+    /// Whether a model-generated statement may be executed (AI-12).
+    ///
+    /// This used to be a prefix check on the uppercased text: a statement was
+    /// safe if it began with MATCH, RETURN, UNWIND, CALL or WITH. Almost every
+    /// destructive Cypher statement begins with MATCH, so
+    /// `MATCH (n) DETACH DELETE n` passed, as did `MATCH (n) SET ...`,
+    /// `MATCH ... MERGE ...` and `MATCH (n) REMOVE ...`. The tests did not
+    /// catch it because every negative case *started* with a write keyword --
+    /// they tested the check as written rather than the property it claims
+    /// (#1156).
+    ///
+    /// The engine already had the right answer. `Query::is_write()` reads the
+    /// parsed clause list, so it sees a write wherever it appears.
+    ///
+    /// Fails closed: a statement that does not parse is not safe. The old check
+    /// would accept unparseable text beginning with MATCH, leaving the parser
+    /// to reject it later -- which is a different component deciding a security
+    /// question by accident.
     pub fn is_safe_query(&self, query: &str) -> bool {
-        let trimmed = query.trim().to_uppercase();
-        trimmed.starts_with("MATCH") ||
-        trimmed.starts_with("RETURN") ||
-        trimmed.starts_with("UNWIND") ||
-        trimmed.starts_with("CALL") ||
-        trimmed.starts_with("WITH")
+        match crate::query::parse_query(query) {
+            Ok(parsed) => !parsed.is_write(),
+            Err(_) => false,
+        }
     }
 }
 
@@ -152,6 +168,46 @@ mod tests {
         assert!(!pipeline.is_safe_query("MERGE (n:Person {name: 'Alice'})"));
         assert!(!pipeline.is_safe_query("DROP INDEX my_index"));
         assert!(!pipeline.is_safe_query("REMOVE n.age"));
+    }
+
+    /// The gap the old prefix check left wide open (#1156).
+    ///
+    /// Every case here begins with MATCH, so the previous implementation --
+    /// "safe if it starts with MATCH" -- returned true for all of them. These
+    /// are not exotic: they are the ordinary way to write a destructive
+    /// statement in Cypher, and the NLQ pipeline runs whatever the model
+    /// returns once this says yes.
+    #[test]
+    fn a_write_that_begins_with_match_is_not_safe() {
+        let pipeline = make_pipeline();
+        for q in [
+            "MATCH (n) DETACH DELETE n",
+            "MATCH (n) DELETE n",
+            "MATCH (n:Person) SET n.pwned = 1 RETURN n",
+            "MATCH (a:Person) MERGE (b:Backdoor {x: 1}) RETURN a",
+            "MATCH (n) REMOVE n.age RETURN n",
+        ] {
+            assert!(
+                !pipeline.is_safe_query(q),
+                "accepted a destructive statement because it begins with MATCH: {q}"
+            );
+        }
+    }
+
+    /// Fail closed. The old check accepted unparseable text that began with a
+    /// permitted keyword and left the parser to refuse it later, which makes a
+    /// security decision a side effect of parsing.
+    #[test]
+    fn text_that_does_not_parse_is_not_safe() {
+        let pipeline = make_pipeline();
+        for q in [
+            "MATCH (((",
+            "MATCH n RETURN",
+            "WITH",
+            "",
+        ] {
+            assert!(!pipeline.is_safe_query(q), "accepted unparseable text: {q:?}");
+        }
     }
 
     // --- extract_cypher tests ---


### PR DESCRIPTION
Found while working #1156. Contributes to AI-12 ("NLQ/agents cannot escalate, exfiltrate, or mutate").

## The gap

`NLQPipeline::is_safe_query` decided whether to execute a model-generated statement with a prefix check on the uppercased text — safe if it starts with `MATCH`, `RETURN`, `UNWIND`, `CALL` or `WITH`.

**Almost every destructive Cypher statement begins with `MATCH`.** All of these passed, and `text_to_cypher` executes whatever the model returned once this says yes:

```
MATCH (n) DETACH DELETE n
MATCH (n) DELETE n
MATCH (n:Person) SET n.pwned = 1 RETURN n
MATCH (a:Person) MERGE (b:Backdoor {x: 1}) RETURN a
MATCH (n) REMOVE n.age RETURN n
```

## Why the tests passed

Every negative case in `test_unsafe_write_queries` **starts with** a write keyword: `CREATE`, `DELETE`, `SET`, `MERGE`, `DROP`, `REMOVE`. So the suite tested the check as written rather than the property it claims. It would have passed against any implementation that rejects leading write keywords — which is precisely what the check did, and all it did.

## The fix was already in the codebase

`Query::is_write()` reads the parsed clause list, so it sees a write wherever it appears. The HTTP path has used it via `statement_is_write` all along. Verified against the parser before changing anything: it returns `true` for all five statements above and `false` for a plain `MATCH ... RETURN` and for `CALL db.checkIntegrity()`.

`is_safe_query` is now parser-based and **fails closed** — text that does not parse is not safe. The old check accepted unparseable text beginning with `MATCH` and left the parser to refuse it later, which makes a security decision a side effect of parsing in a different component.

## Verification

Both new tests were run against the old implementation and fail there:

```
test nlq::tests::a_write_that_begins_with_match_is_not_safe ... FAILED
accepted a destructive statement because it begins with MATCH: MATCH (n) DETACH DELETE n
```

`cargo test --workspace --no-fail-fast`: 263 binaries, **4,144 passed, 0 failed**.

## Scope

This closes the prefix-check gap only. The rest of #1156 — bound parameters, declared types and domains, a per-template cost ceiling, and the CH-AI-SEC injection corpus — is separate and still open.

https://claude.ai/code/session_01Km8V25fFdrdzqVhdHo611B
