### PR TITLE
Bound the result cache in bytes, because an entry count cannot (#1153)

### DIFF
--- a/src/graph/property.rs
+++ b/src/graph/property.rs
@@ -446,6 +446,34 @@ impl std::hash::Hash for PropertyValue {
 }
 
 impl PropertyValue {
+    /// Approximate heap bytes this value owns, excluding its own inline size.
+    ///
+    /// For sizing a result cache, where the question is how much a held answer
+    /// costs and being a few percent out does not change a decision. Exact
+    /// accounting would have to walk allocator padding, which no caller needs.
+    pub fn approx_heap_bytes(&self) -> usize {
+        match self {
+            PropertyValue::String(s) => s.capacity(),
+            PropertyValue::Array(v) => {
+                v.capacity() * std::mem::size_of::<PropertyValue>()
+                    + v.iter().map(|e| e.approx_heap_bytes()).sum::<usize>()
+            }
+            PropertyValue::Map(m) => m
+                .iter()
+                .map(|(k, v)| {
+                    k.capacity()
+                        + std::mem::size_of::<PropertyValue>()
+                        + v.approx_heap_bytes()
+                })
+                .sum(),
+            PropertyValue::Vector(v) => v.capacity() * std::mem::size_of::<f32>(),
+            // Every other variant is inline scalars.
+            _ => 0,
+        }
+    }
+}
+
+impl PropertyValue {
     /// Check if value is null
     pub fn is_null(&self) -> bool {
         matches!(self, PropertyValue::Null)

--- a/src/query/executor/record.rs
+++ b/src/query/executor/record.rs
@@ -673,6 +673,49 @@ impl Value {
     }
 }
 
+impl Value {
+    /// Approximate heap bytes this value owns, for cache accounting.
+    ///
+    /// `NodeRef`/`EdgeRef` own nothing: late materialization (ADR-012) means a
+    /// scan produces those rather than full clones, so a cached scan result is
+    /// far smaller than the nodes it names. That is why the estimate has to walk
+    /// the value rather than multiply rows by a constant.
+    pub fn approx_heap_bytes(&self) -> usize {
+        match self {
+            Value::Node(_, n) => std::mem::size_of_val(&**n)
+                + n.properties.iter().map(|(k, v)| k.capacity() + v.approx_heap_bytes()).sum::<usize>(),
+            Value::Edge(_, e) => std::mem::size_of_val(&**e)
+                + e.properties.iter().map(|(k, v)| k.capacity() + v.approx_heap_bytes()).sum::<usize>(),
+            Value::Property(p) => p.approx_heap_bytes(),
+            Value::Path { nodes, edges } => {
+                nodes.capacity() * std::mem::size_of::<crate::graph::types::NodeId>()
+                    + edges.capacity() * std::mem::size_of::<crate::graph::types::EdgeId>()
+            }
+            Value::List(v) => {
+                v.capacity() * std::mem::size_of::<Value>()
+                    + v.iter().map(|e| e.approx_heap_bytes()).sum::<usize>()
+            }
+            Value::Map(m) => m
+                .iter()
+                .map(|(k, v)| k.capacity() + std::mem::size_of::<Value>() + v.approx_heap_bytes())
+                .sum(),
+            _ => 0,
+        }
+    }
+}
+
+impl Record {
+    /// Approximate heap bytes this record owns.
+    pub fn approx_heap_bytes(&self) -> usize {
+        self.bindings.capacity() * std::mem::size_of::<(std::sync::Arc<str>, Value)>()
+            + self
+                .bindings
+                .iter()
+                .map(|(k, v)| k.len() + v.approx_heap_bytes())
+                .sum::<usize>()
+    }
+}
+
 /// A batch of records (result set)
 #[derive(Debug, Clone)]
 pub struct RecordBatch {
@@ -683,6 +726,19 @@ pub struct RecordBatch {
 }
 
 impl RecordBatch {
+    /// Approximate heap bytes this batch owns.
+    ///
+    /// What a result cache must charge an entry. A row count is not a substitute:
+    /// measured on LDBC SF1, a 256-row entry costs 8.3 KB and a 100,000-row entry
+    /// 32.1 MB -- a 3,867x spread -- so a cache capped in entries can hold 8 MB or
+    /// 32.8 GB at the same setting (`benches/result_cache_gain.rs`).
+    pub fn approx_heap_bytes(&self) -> usize {
+        self.records.capacity() * std::mem::size_of::<Record>()
+            + self.records.iter().map(|r| r.approx_heap_bytes()).sum::<usize>()
+            + self.columns.capacity() * std::mem::size_of::<String>()
+            + self.columns.iter().map(|c| c.capacity()).sum::<usize>()
+    }
+
     /// Create a new empty batch
     pub fn new(columns: Vec<String>) -> Self {
         Self {

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -94,6 +94,17 @@ pub use executor::{
 /// Default LRU cache capacity
 const DEFAULT_CACHE_CAPACITY: usize = 1024;
 
+/// Bytes the result cache may hold before it evicts, regardless of entry count.
+///
+/// An entry count cannot bound this cache. Measured on LDBC SF1
+/// (`benches/result_cache_gain.rs`), a 256-row entry costs 8.3 KB and a
+/// 100,000-row entry 32.1 MB -- a **3,867x spread** -- so the same 1024-entry
+/// setting holds 8 MB of one workload or 32.8 GB of another. PERF-10 is a
+/// bytes/edge budget; a cache capped in entries cannot be budgeted against it.
+///
+/// 256 MB by default, overridable with `SAMYAMA_RESULT_CACHE_BYTES`.
+const DEFAULT_RESULT_CACHE_BYTES: usize = 256 * 1024 * 1024;
+
 /// Lock-free cache hit/miss counters.
 pub struct CacheStats {
     hits: AtomicU64,
@@ -150,6 +161,12 @@ pub struct QueryEngine {
     /// CH-REGRESS. Opt-in at the call site is a stronger guarantee than a
     /// config flag defaulting to off.
     result_cache: Mutex<LruCache<ResultKey, RecordBatch>>,
+    /// Bytes currently held by `result_cache`, kept in step with it under the
+    /// same lock. Tracked rather than recomputed: summing every entry on each
+    /// insert would walk the whole cache per query.
+    result_cache_bytes: Mutex<usize>,
+    /// The byte ceiling this engine enforces.
+    result_cache_budget: usize,
     /// Hit/miss counters for the result cache, separate from the AST cache's.
     result_stats: CacheStats,
 }
@@ -202,6 +219,10 @@ impl QueryEngine {
                 .ok().and_then(|s| s.parse().ok()).unwrap_or(120),
             row_budget: executor::budget::configured_budget(),
             result_cache: Mutex::new(LruCache::new(cap)),
+            result_cache_bytes: Mutex::new(0),
+            result_cache_budget: std::env::var("SAMYAMA_RESULT_CACHE_BYTES")
+                .ok().and_then(|v| v.parse().ok())
+                .unwrap_or(DEFAULT_RESULT_CACHE_BYTES),
             result_stats: CacheStats::new(),
         }
     }
@@ -350,15 +371,75 @@ impl QueryEngine {
         // nothing when the epoch moved is the honest outcome: the answer is
         // still returned, it is just not remembered.
         if store.epoch() == key.epoch {
-            self.result_cache.lock().unwrap().put(key, batch.clone());
+            self.insert_with_budget(key, batch.clone());
         }
         Ok((batch, false))
+    }
+
+    /// Bytes the result cache currently holds.
+    pub fn result_cache_bytes(&self) -> usize {
+        *self.result_cache_bytes.lock().unwrap()
+    }
+
+    /// The byte ceiling in force for this engine.
+    pub fn result_cache_budget(&self) -> usize {
+        self.result_cache_budget
+    }
+
+    /// Set the result cache's byte ceiling for this engine.
+    ///
+    /// A method rather than only the environment variable, because the budget
+    /// has to be settable per engine: tests run in one process and share it,
+    /// so an env var would make them fight over a global.
+    pub fn with_result_cache_budget(mut self, bytes: usize) -> Self {
+        self.result_cache_budget = bytes;
+        self
+    }
+
+    /// Insert under the byte budget, evicting least-recently-used entries until
+    /// the total fits.
+    ///
+    /// A single answer larger than the whole budget is **not cached at all**
+    /// rather than evicting everything to make room for it. Admitting it would
+    /// flush a warm cache to hold one result that the next query evicts again,
+    /// which is worse than not caching it: the memory spike happens *and* the
+    /// hit rate drops.
+    fn insert_with_budget(&self, key: ResultKey, batch: RecordBatch) {
+        let cost = batch.approx_heap_bytes();
+        if cost > self.result_cache_budget {
+            return;
+        }
+
+        let mut cache = self.result_cache.lock().unwrap();
+        let mut held = self.result_cache_bytes.lock().unwrap();
+
+        // Replacing an existing key returns what it displaced; charge the
+        // difference rather than the new entry, or the total drifts up forever.
+        if let Some(old) = cache.put(key, batch) {
+            *held = held.saturating_sub(old.approx_heap_bytes());
+        }
+        *held += cost;
+
+        while *held > self.result_cache_budget {
+            match cache.pop_lru() {
+                Some((_, evicted)) => {
+                    *held = held.saturating_sub(evicted.approx_heap_bytes());
+                }
+                // Nothing left to evict: the accounting and the map disagree,
+                // so trust the map and reset rather than spin.
+                None => {
+                    *held = 0;
+                    break;
+                }
+            }
+        }
     }
 
     /// Drop every cached result. For tests and for an operator who wants the
     /// memory back; correctness never depends on calling this.
     pub fn clear_result_cache(&self) {
         self.result_cache.lock().unwrap().clear();
+        *self.result_cache_bytes.lock().unwrap() = 0;
     }
 
     /// Parse and execute a write Cypher query (CREATE, DELETE, SET, etc.)

--- a/tests/result_cache_budget.rs
+++ b/tests/result_cache_budget.rs
@@ -1,0 +1,167 @@
+//! The result cache is bounded in bytes, not entries (#1153).
+//!
+//! An entry count cannot bound it. Measured on LDBC SF1
+//! (`benches/result_cache_gain.rs`), a 256-row entry costs 8.3 KB and a
+//! 100,000-row entry 32.1 MB — a 3,867x spread — so the same 1024-entry setting
+//! holds 8 MB of one workload or 32.8 GB of another. PERF-10 is a bytes/edge
+//! budget at 521 B/edge against a 256 B target; a cache capped in entries cannot
+//! be budgeted against it.
+
+use samyama::graph::{GraphStore, Label, PropertyMap, PropertyValue};
+use samyama::query::QueryEngine;
+
+/// A store whose rows are wide enough that a handful of them are worth real
+/// bytes, so a budget in the tens of KB is reached by a few entries rather than
+/// by thousands.
+fn padded_store(nodes: usize, pad: usize) -> GraphStore {
+    let mut store = GraphStore::new();
+    for i in 0..nodes {
+        let mut props = PropertyMap::new();
+        props.insert("id".to_string(), PropertyValue::Integer(i as i64));
+        props.insert("pad".to_string(), PropertyValue::String("x".repeat(pad)));
+        store.create_node_with_properties("default", vec![Label::new("N")], props);
+    }
+    store
+}
+
+/// Distinct query texts that return distinct, non-trivial answers.
+fn distinct_queries(n: usize) -> Vec<String> {
+    (1..=n)
+        .map(|i| format!("MATCH (n:N) RETURN n.id, n.pad ORDER BY n.id LIMIT {i}"))
+        .collect()
+}
+
+#[test]
+fn bytes_bound_the_cache_not_the_entry_count() {
+    let store = padded_store(40, 512);
+    // Entry cap far above what we insert, so only the byte budget can stop it.
+    let budget = 64 * 1024;
+    let engine = QueryEngine::with_capacity(4096).with_result_cache_budget(budget);
+
+    for q in distinct_queries(60) {
+        let _ = engine.execute_cached(&q, &store).expect(&q);
+    }
+
+    let held = engine.result_cache_bytes();
+    assert!(
+        held <= budget,
+        "cache holds {held} bytes against a {budget}-byte budget"
+    );
+    assert!(
+        engine.result_cache_len() < 60,
+        "all 60 entries survived a {budget}-byte budget, so the budget did \
+         nothing: {} entries, {held} bytes",
+        engine.result_cache_len()
+    );
+    assert!(
+        engine.result_cache_len() > 0,
+        "the budget evicted everything; it should hold what fits"
+    );
+}
+
+#[test]
+fn an_answer_larger_than_the_whole_budget_is_not_cached() {
+    let store = padded_store(200, 1024);
+    // Small enough that one 200-row answer cannot fit.
+    let engine = QueryEngine::with_capacity(64).with_result_cache_budget(4 * 1024);
+
+    let big = "MATCH (n:N) RETURN n.id, n.pad ORDER BY n.id";
+    let (rows, cached) = engine.execute_cached(big, &store).expect("big");
+    assert!(!cached);
+    assert_eq!(rows.records.len(), 200, "the query must actually return rows");
+
+    let (_, cached_again) = engine.execute_cached(big, &store).expect("big again");
+    assert!(
+        !cached_again,
+        "an answer bigger than the entire budget was admitted to the cache"
+    );
+    assert_eq!(engine.result_cache_bytes(), 0);
+}
+
+/// Admitting an oversized answer must not flush what is already warm.
+///
+/// Evicting a full cache to make room for something that cannot fit is worse
+/// than refusing it: the memory spike happens and the hit rate drops too.
+#[test]
+fn an_oversized_answer_does_not_flush_the_warm_entries() {
+    let store = padded_store(200, 1024);
+    let engine = QueryEngine::with_capacity(64).with_result_cache_budget(32 * 1024);
+
+    let small = "MATCH (n:N) RETURN n.id ORDER BY n.id LIMIT 3";
+    let _ = engine.execute_cached(small, &store).unwrap();
+    let (_, warm) = engine.execute_cached(small, &store).unwrap();
+    assert!(warm, "the small answer did not stay cached");
+    let entries_before = engine.result_cache_len();
+
+    let big = "MATCH (n:N) RETURN n.id, n.pad ORDER BY n.id";
+    let _ = engine.execute_cached(big, &store).unwrap();
+
+    assert_eq!(
+        engine.result_cache_len(), entries_before,
+        "the oversized answer changed the cache contents"
+    );
+    let (_, still_warm) = engine.execute_cached(small, &store).unwrap();
+    assert!(still_warm, "the oversized answer evicted a warm entry to hold nothing");
+}
+
+/// Re-inserting the same key charges the difference, not the whole entry.
+///
+/// Without this the tracked total climbs on every re-cache of the same query
+/// until the budget evicts a cache that is nowhere near full.
+#[test]
+fn re_caching_the_same_query_does_not_drift_the_total() {
+    let store = padded_store(20, 256);
+    let engine = QueryEngine::with_capacity(64).with_result_cache_budget(8 * 1024 * 1024);
+    let q = "MATCH (n:N) RETURN n.id, n.pad ORDER BY n.id LIMIT 5";
+
+    let _ = engine.execute_cached(q, &store).unwrap();
+    let after_first = engine.result_cache_bytes();
+    assert!(after_first > 0, "nothing was charged for the first insert");
+
+    // Clearing and re-inserting the same key many times must land on the same
+    // total, not a multiple of it.
+    for _ in 0..20 {
+        engine.clear_result_cache();
+        let _ = engine.execute_cached(q, &store).unwrap();
+    }
+    assert_eq!(
+        engine.result_cache_bytes(), after_first,
+        "the byte total drifted across repeated inserts of one key"
+    );
+}
+
+#[test]
+fn clearing_resets_the_accounting() {
+    let store = padded_store(20, 256);
+    let engine = QueryEngine::with_capacity(64).with_result_cache_budget(8 * 1024 * 1024);
+    for q in distinct_queries(5) {
+        let _ = engine.execute_cached(&q, &store).unwrap();
+    }
+    assert!(engine.result_cache_bytes() > 0);
+    engine.clear_result_cache();
+    assert_eq!(engine.result_cache_bytes(), 0, "clear left bytes charged");
+    assert_eq!(engine.result_cache_len(), 0);
+}
+
+/// The estimate must track the shape of the answer, not just its row count.
+///
+/// A row-count proxy would call these two the same size. They differ by 1000x.
+#[test]
+fn the_estimate_follows_payload_not_row_count() {
+    let narrow = padded_store(50, 4);
+    let wide = padded_store(50, 4096);
+    let q = "MATCH (n:N) RETURN n.id, n.pad ORDER BY n.id";
+
+    let e_narrow = QueryEngine::new();
+    let _ = e_narrow.execute_cached(q, &narrow).unwrap();
+    let e_wide = QueryEngine::new();
+    let _ = e_wide.execute_cached(q, &wide).unwrap();
+
+    let (n, w) = (e_narrow.result_cache_bytes(), e_wide.result_cache_bytes());
+    assert!(n > 0 && w > 0, "nothing charged: narrow {n}, wide {w}");
+    assert!(
+        w > n * 10,
+        "same row count, 1000x the payload, but the estimate moved from {n} to \
+         {w} — it is counting rows rather than bytes"
+    );
+}


### PR DESCRIPTION
Follow-up to #1165, which measured what a cache entry weighs and reported the consequence without fixing it. This fixes it.

## The number that disqualifies the entry cap

| workload | per entry | at the 1024-entry default |
|---|---:|---:|
| narrow (256 rows) | 8.3 KB | 8 MB |
| wide (100k rows) | 32.1 MB | **32.8 GB** |

A **3,867× spread** at one setting. PERF-10 is a bytes/edge budget — 521 B/edge against a 256 B H1 target — and a cache capped in entries cannot be budgeted against it.

## What this adds

`approx_heap_bytes()` on `PropertyValue`, `Value`, `Record` and `RecordBatch`, and a byte ceiling the cache enforces by evicting LRU entries until the total fits. 256 MB default, `SAMYAMA_RESULT_CACHE_BYTES` to override, `with_result_cache_budget()` per engine so tests do not fight over a process-global.

The estimate **walks the value** rather than multiplying rows by a constant. That matters here: late materialization (ADR-012) means a scan produces `NodeRef`, so a cached scan owns far less than the nodes it names. A row-count proxy would charge the two alike — and one test asserts exactly that, comparing two results with the same row count and 1000× the payload.

Two decisions worth stating:

- **An answer larger than the whole budget is not cached at all**, rather than evicting everything to make room. Admitting it would flush a warm cache to hold one result the next query evicts again — the memory spike happens *and* the hit rate drops.
- **Re-inserting a key charges the difference**, not the whole entry. Otherwise the tracked total climbs on every re-cache of the same query until the budget evicts a cache nowhere near full.

## Tests

`tests/result_cache_budget.rs`, 6 tests. **Negative-tested**: disabling the eviction loop fails with

```
cache holds 1158480 bytes against a 65536-byte budget
```

`cargo test --lib`: 2201 passed. `result_cache` + `result_cache_budget`: 11 passed.

https://claude.ai/code/session_01WaR8BbB5GW2Pen9f5cKhL4