### PR TITLE
Catalog parameters are bound, typed and used; two of the risks are unreachable (#1156)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -119,10 +119,9 @@ fn cmd_catalog_build(argv: &[String]) -> i32 {
         return 64;
     };
 
-    // Input shape: [{"id": "...", "cypher": "...", "unanswerable": false}, ...]
-    #[derive(serde::Deserialize)]
-    struct InQuery { id: String, cypher: String, #[serde(default)] unanswerable: bool }
-    let queries: Vec<InQuery> = match std::fs::File::open(queries_path)
+    // Input shape: [{"id", "cypher", "unanswerable"?, "params"?}, ...]
+    use samyama::snapshot::verify::QuerySpec;
+    let queries: Vec<QuerySpec> = match std::fs::File::open(queries_path)
         .map_err(|e| e.to_string())
         .and_then(|f| serde_json::from_reader(f).map_err(|e| e.to_string()))
     {
@@ -140,12 +139,7 @@ fn cmd_catalog_build(argv: &[String]) -> i32 {
         return 1;
     }
 
-    let pairs: Vec<(String, String)> =
-        queries.iter().map(|q| (q.id.clone(), q.cypher.clone())).collect();
-    let unanswerable: Vec<String> =
-        queries.iter().filter(|q| q.unanswerable).map(|q| q.id.clone()).collect();
-
-    match samyama::snapshot::verify::build_catalog(&store, &pairs, &unanswerable) {
+    match samyama::snapshot::verify::build_catalog(&store, &queries, &[]) {
         Err(e) => { eprintln!("{e}"); 1 }
         Ok(catalog) => {
             let json = serde_json::to_string_pretty(&catalog).expect("serialize");

--- a/src/snapshot/verify.rs
+++ b/src/snapshot/verify.rs
@@ -35,6 +35,105 @@ use crate::query::{QueryEngine, RecordBatch};
 /// does not understand rather than misinterpreting it.
 pub const CATALOG_FORMAT: &str = "samyama.queries/1";
 
+/// Text that betrays a template filled by string substitution rather than by
+/// binding a parameter (#1156).
+///
+/// A catalog assembled by interpolation is a Cypher-injection surface that
+/// ships with the data. The parser has real parameters (`$name`,
+/// `Expression::Parameter`), so the safe form is available and the unsafe one
+/// is merely easier to write.
+///
+/// Note that a bare `{` is *not* a marker: Cypher uses it for map literals and
+/// inline property patterns, so refusing it would refuse ordinary queries.
+pub const INTERPOLATION_MARKERS: &[&str] = &["{{", "${", "%s", "%d", "#{", "<<", "}}"];
+
+/// A declared parameter.
+///
+/// The declared type is checked against the value that actually reaches the
+/// query, and the sample is executed at build time. That last part is what
+/// catches the failure this guards against: a string parameter compared to an
+/// integer property returns **zero rows and no error**, so the caller reads
+/// "no results" where the truth is "wrong type". Measured, not assumed --
+/// `n.age = $x` with `$x` as the string "30" against `age = 30` returns 0 rows,
+/// while the float 30.0 returns 1, so numeric coercion works and only the
+/// string case is silent.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ParamSpec {
+    pub name: String,
+    /// "int" | "float" | "string" | "bool"
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// A value that must produce rows at build time.
+    pub sample: serde_json::Value,
+    /// Permitted values, when the parameter is meant to be one of a set.
+    #[serde(default)]
+    pub enum_values: Option<Vec<serde_json::Value>>,
+}
+
+impl ParamSpec {
+    /// The type name of the sample as it is actually written.
+    fn sample_kind(&self) -> &'static str {
+        match &self.sample {
+            serde_json::Value::Bool(_) => "bool",
+            serde_json::Value::Number(n) if n.is_i64() || n.is_u64() => "int",
+            serde_json::Value::Number(_) => "float",
+            serde_json::Value::String(_) => "string",
+            _ => "other",
+        }
+    }
+
+    fn to_property(&self) -> Result<crate::graph::PropertyValue, String> {
+        use crate::graph::PropertyValue as P;
+        Ok(match (&self.sample, self.kind.as_str()) {
+            (serde_json::Value::Bool(b), "bool") => P::Boolean(*b),
+            (serde_json::Value::Number(n), "int") => P::Integer(
+                n.as_i64().ok_or_else(|| format!("{}: sample is not an integer", self.name))?,
+            ),
+            (serde_json::Value::Number(n), "float") => P::Float(
+                n.as_f64().ok_or_else(|| format!("{}: sample is not a float", self.name))?,
+            ),
+            (serde_json::Value::String(v), "string") => P::String(v.clone()),
+            _ => {
+                return Err(format!(
+                    "{}: declared type {:?} but the sample is a {}. A mis-declared \
+                     type is not caught at execution -- a string against an integer \
+                     property returns zero rows and no error.",
+                    self.name, self.kind, self.sample_kind()
+                ))
+            }
+        })
+    }
+}
+
+/// Every `$name` the query references, in order of first appearance.
+///
+/// A hand scan rather than a regex: the grammar is `"$" ~ (ALPHANUMERIC | "_")+`,
+/// which is small enough to read directly and avoids a dependency.
+pub fn referenced_params(cypher: &str) -> Vec<String> {
+    let b = cypher.as_bytes();
+    let mut out: Vec<String> = Vec::new();
+    let mut i = 0usize;
+    while i < b.len() {
+        if b[i] == b'$' {
+            let start = i + 1;
+            let mut j = start;
+            while j < b.len() && (b[j].is_ascii_alphanumeric() || b[j] == b'_') {
+                j += 1;
+            }
+            if j > start {
+                let name = cypher[start..j].to_string();
+                if !out.contains(&name) {
+                    out.push(name);
+                }
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
 /// One catalog entry: a query and what it produced when the snapshot was built.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CatalogEntry {
@@ -51,6 +150,10 @@ pub struct CatalogEntry {
     /// expectation.
     #[serde(default)]
     pub unanswerable: bool,
+    /// Declared parameters. Every `$name` in the query must appear here and
+    /// every entry here must be referenced by the query (#1156).
+    #[serde(default)]
+    pub params: Vec<ParamSpec>,
 }
 
 /// A shipped query catalog.
@@ -166,30 +269,113 @@ pub fn canonical_hash(batch: &RecordBatch) -> String {
     format!("fnv1a64:{h:016x}")
 }
 
+/// Run a catalog query with its declared parameters **bound**, never substituted.
+///
+/// Goes through `QueryExecutor::with_params`, so values reach the engine as
+/// `Expression::Parameter` bindings. Nothing here builds a query string from a
+/// value, which is the property #1156 asks for and the reason this helper
+/// exists rather than each caller formatting its own.
+pub fn run_bound(
+    store: &GraphStore,
+    cypher: &str,
+    params: &[ParamSpec],
+) -> Result<RecordBatch, String> {
+    let parsed = crate::query::parse_query(cypher).map_err(|e| e.to_string())?;
+    let mut bound = std::collections::HashMap::new();
+    for p in params {
+        bound.insert(p.name.clone(), p.to_property()?);
+    }
+    crate::query::QueryExecutor::new(store)
+        .with_params(bound)
+        .execute(&parsed)
+        .map_err(|e| e.to_string())
+}
+
+/// Refuse a query that is assembled rather than parameterized, and a parameter
+/// set that does not match the query (#1156).
+///
+/// Checked at both build and load. Checking only at build would leave a
+/// hand-edited catalog -- which is the form a published `.sgqueries` file takes
+/// once it leaves us -- unchecked at the point it is executed.
+pub fn validate_entry_shape(id: &str, cypher: &str, params: &[ParamSpec]) -> Result<(), String> {
+    for m in INTERPOLATION_MARKERS {
+        if cypher.contains(m) {
+            return Err(format!(
+                "{id}: query contains {m:?}, which is a template filled by string \
+                 substitution. A catalog assembled that way is a Cypher-injection \
+                 surface that ships with the data. Use a bound parameter ($name)."
+            ));
+        }
+    }
+    let referenced = referenced_params(cypher);
+    for name in &referenced {
+        if !params.iter().any(|p| &p.name == name) {
+            return Err(format!(
+                "{id}: query references ${name} but declares no type for it. An \
+                 undeclared parameter is one whose value nothing checks."
+            ));
+        }
+    }
+    for p in params {
+        if !referenced.contains(&p.name) {
+            return Err(format!(
+                "{id}: declares parameter {:?}, which the query never uses. A spec \
+                 that binds nothing gives false assurance about what is checked.",
+                p.name
+            ));
+        }
+        p.to_property()?;
+        if let Some(allowed) = &p.enum_values {
+            if !allowed.contains(&p.sample) {
+                return Err(format!(
+                    "{}: the sample value is not in the declared enum", p.name
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Build a catalog from queries run against a store.
 ///
 /// Refuses a zero-row entry unless it is marked unanswerable. An entry that
 /// returns nothing at build time will return nothing after any restore,
 /// including a restore that lost the entire graph, so it cannot detect
 /// anything and its presence would inflate the count of passing checks.
+/// A query offered for inclusion in a catalog.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct QuerySpec {
+    pub id: String,
+    pub cypher: String,
+    #[serde(default)]
+    pub unanswerable: bool,
+    #[serde(default)]
+    pub params: Vec<ParamSpec>,
+}
+
 pub fn build_catalog(
     store: &GraphStore,
-    queries: &[(String, String)],
+    queries: &[QuerySpec],
     unanswerable: &[String],
 ) -> Result<QueryCatalog, String> {
-    let engine = QueryEngine::new();
     let mut entries = Vec::with_capacity(queries.len());
-    for (id, cypher) in queries {
-        let batch = engine
-            .execute(cypher, store)
+    for q in queries {
+        let (id, cypher) = (&q.id, &q.cypher);
+        validate_entry_shape(id, cypher, &q.params)?;
+        let batch = run_bound(store, cypher, &q.params)
             .map_err(|e| format!("{id}: query failed while building the catalog: {e}"))?;
         let rows = batch.records.len();
-        let is_unanswerable = unanswerable.contains(id);
+        let is_unanswerable = q.unanswerable || unanswerable.contains(id);
         if rows == 0 && !is_unanswerable {
             return Err(format!(
                 "{id}: returned 0 rows. A zero-row entry passes against any graph, \
                  including an empty one, so it detects nothing. Fix the query, or \
-                 mark it unanswerable if returning nothing is the point."
+                 mark it unanswerable if returning nothing is the point.{}",
+                if q.params.is_empty() { "" } else {
+                    " With parameters, the usual cause is a type mismatch: a string \
+                     compared to an integer property matches nothing and raises no \
+                     error."
+                }
             ));
         }
         entries.push(CatalogEntry {
@@ -198,6 +384,7 @@ pub fn build_catalog(
             rows,
             hash: canonical_hash(&batch),
             unanswerable: is_unanswerable,
+            params: q.params.clone(),
         });
     }
     Ok(QueryCatalog {
@@ -215,12 +402,18 @@ pub fn verify(store: &GraphStore, catalog: &QueryCatalog) -> Result<VerifyReport
             catalog.format
         ));
     }
-    let engine = QueryEngine::new();
     let mut results = Vec::with_capacity(catalog.entries.len());
 
+    // Shape is re-checked here, not only at build. A published catalog is a
+    // file that leaves us and can be edited; executing it is the point at which
+    // an interpolated template would do harm.
     for e in &catalog.entries {
-        let (actual_rows, failure, detail) = match engine.execute(&e.cypher, store) {
-            Err(err) => (0, Some(FailureClass::QueryError), err.to_string()),
+        validate_entry_shape(&e.id, &e.cypher, &e.params)?;
+    }
+
+    for e in &catalog.entries {
+        let (actual_rows, failure, detail) = match run_bound(store, &e.cypher, &e.params) {
+            Err(err) => (0, Some(FailureClass::QueryError), err),
             Ok(batch) => {
                 let rows = batch.records.len();
                 let hash = canonical_hash(&batch);

--- a/tests/catalog_bound_params.rs
+++ b/tests/catalog_bound_params.rs
@@ -1,0 +1,190 @@
+//! Catalog parameters are bound, typed and used (#1156).
+//!
+//! The risk is that a "templatized, parameterized query" is filled by string
+//! substitution, which makes a published `.sgqueries` file a Cypher-injection
+//! surface that ships with the data. The parser has had real parameters all
+//! along (`$name`), so the safe form was always available and the unsafe one is
+//! merely easier to write.
+//!
+//! Two of the risks the issue lists turned out to be unreachable in this
+//! engine, and that is recorded here as a test rather than as a claim:
+//! `LIMIT $k` and `*1..$n` are both refused, the first by a semantic check and
+//! the second by the grammar.
+
+use samyama::graph::{GraphStore, Label, PropertyValue};
+use samyama::snapshot::verify::{
+    build_catalog, referenced_params, validate_entry_shape, verify, ParamSpec, QuerySpec,
+};
+use serde_json::json;
+
+fn seeded() -> GraphStore {
+    let mut store = GraphStore::new();
+    for i in 0..10i64 {
+        let mut p = samyama::graph::PropertyMap::new();
+        p.insert("age".into(), PropertyValue::Integer(20 + i));
+        p.insert("name".into(), PropertyValue::String(format!("p{i}")));
+        store.create_node_with_properties("default", vec![Label::new("P")], p);
+    }
+    store
+}
+
+fn param(name: &str, kind: &str, sample: serde_json::Value) -> ParamSpec {
+    ParamSpec { name: name.into(), kind: kind.into(), sample, enum_values: None }
+}
+
+#[test]
+fn a_bound_parameter_round_trips_through_build_and_verify() {
+    let store = seeded();
+    let q = vec![QuerySpec {
+        id: "by_age".into(),
+        cypher: "MATCH (n:P) WHERE n.age = $age RETURN n.name".into(),
+        unanswerable: false,
+        params: vec![param("age", "int", json!(25))],
+    }];
+    let catalog = build_catalog(&store, &q, &[]).expect("build");
+    assert_eq!(catalog.entries[0].rows, 1);
+    assert!(verify(&store, &catalog).expect("verify").is_ok());
+}
+
+/// The reachable type hazard, confirmed by measurement: a string parameter
+/// compared to an integer property returns zero rows and **no error**. The
+/// caller reads "no results" where the truth is "wrong type".
+///
+/// The zero-row rule catches it at build time, which is the point of having
+/// that rule apply to parameterized entries too.
+#[test]
+fn a_type_mismatch_is_refused_at_build_rather_than_returning_nothing() {
+    let store = seeded();
+    let q = vec![QuerySpec {
+        id: "by_age".into(),
+        cypher: "MATCH (n:P) WHERE n.age = $age RETURN n.name".into(),
+        unanswerable: false,
+        // "25" as a string against an integer property.
+        params: vec![param("age", "string", json!("25"))],
+    }];
+    let err = build_catalog(&store, &q, &[]).expect_err("a silent zero-row match must be refused");
+    assert!(err.contains("0 rows"), "{err}");
+    assert!(err.contains("type mismatch"), "the error should name the likely cause: {err}");
+}
+
+/// Numeric coercion does work, so the issue's stated worst case -- a float
+/// where the property holds an int -- is not silent through the bound path.
+#[test]
+fn a_float_parameter_matches_an_integer_property() {
+    let store = seeded();
+    let q = vec![QuerySpec {
+        id: "by_age".into(),
+        cypher: "MATCH (n:P) WHERE n.age = $age RETURN n.name".into(),
+        unanswerable: false,
+        params: vec![param("age", "float", json!(25.0))],
+    }];
+    let catalog = build_catalog(&store, &q, &[]).expect("float should coerce to int");
+    assert_eq!(catalog.entries[0].rows, 1);
+}
+
+#[test]
+fn an_interpolated_template_is_refused() {
+    for cypher in [
+        "MATCH (n:P) WHERE n.name = '{{name}}' RETURN n",
+        "MATCH (n:P) WHERE n.name = '${name}' RETURN n",
+        "MATCH (n:P) WHERE n.age = %d RETURN n",
+        "MATCH (n:P) WHERE n.name = '#{name}' RETURN n",
+    ] {
+        let err = validate_entry_shape("t", cypher, &[]).expect_err(cypher);
+        assert!(err.contains("injection"), "{err}");
+    }
+}
+
+/// A map literal is not interpolation, or every ordinary query would be refused.
+#[test]
+fn a_map_literal_is_not_mistaken_for_a_template() {
+    validate_entry_shape("t", "MATCH (n:P {name: 'p1'}) RETURN n", &[]).expect("map literal");
+    validate_entry_shape("t", "MATCH (n:P) RETURN {a: n.name}", &[]).expect("map projection");
+}
+
+#[test]
+fn an_undeclared_parameter_is_refused() {
+    let err = validate_entry_shape("t", "MATCH (n:P) WHERE n.age = $age RETURN n", &[])
+        .expect_err("undeclared parameter");
+    assert!(err.contains("$age"), "{err}");
+    assert!(err.contains("declares no type"), "{err}");
+}
+
+/// A spec that binds nothing gives false assurance about what is checked.
+#[test]
+fn a_declared_parameter_the_query_never_uses_is_refused() {
+    let err = validate_entry_shape(
+        "t", "MATCH (n:P) RETURN n.name", &[param("age", "int", json!(1))],
+    ).expect_err("unused parameter");
+    assert!(err.contains("never uses"), "{err}");
+}
+
+#[test]
+fn a_mis_declared_type_is_refused() {
+    let err = validate_entry_shape(
+        "t", "MATCH (n:P) WHERE n.age = $age RETURN n",
+        &[param("age", "int", json!("not a number"))],
+    ).expect_err("type/sample mismatch");
+    assert!(err.contains("declared type"), "{err}");
+}
+
+/// The hostile-value corpus (DoD 5). Every value is bound, so none of it is
+/// parsed as Cypher: the assertion is that the store is unchanged and no extra
+/// clause took effect.
+#[test]
+fn hostile_parameter_values_cannot_add_a_clause_or_write() {
+    let store = seeded();
+    let before_nodes = store.node_count();
+
+    const HOSTILE: &[&str] = &[
+        "' OR 1=1 --",
+        "x' RETURN n; MATCH (m) DETACH DELETE m; //",
+        "'} ) DETACH DELETE n //",
+        "\\\" OR true",
+        "p1' UNION MATCH (s) RETURN s //",
+        "$injected",
+        "{{name}}",
+        "'; CREATE (:Backdoor); //",
+    ];
+
+    for v in HOSTILE {
+        let q = vec![QuerySpec {
+            id: "hostile".into(),
+            cypher: "MATCH (n:P) WHERE n.name = $name RETURN n.name".into(),
+            unanswerable: true,
+            params: vec![param("name", "string", json!(v))],
+        }];
+        // The value is bound, so it is compared as a string and matches nothing.
+        // What must not happen is that any of it becomes syntax.
+        let catalog = build_catalog(&store, &q, &[]).expect(v);
+        assert_eq!(catalog.entries[0].rows, 0, "hostile value matched a node: {v}");
+    }
+
+    assert_eq!(
+        store.node_count(), before_nodes,
+        "the store changed while running hostile values through a read query"
+    );
+}
+
+/// Recorded as a test because it is the reason DoD 3's two named risks are not
+/// implemented: neither is expressible.
+#[test]
+fn a_parameter_cannot_reach_a_limit_or_a_var_length_bound() {
+    assert!(
+        samyama::query::parse_query("MATCH (n:P) RETURN n.name LIMIT $k").is_err(),
+        "LIMIT $k parsed; an unbounded LIMIT slot would then be reachable"
+    );
+    assert!(
+        samyama::query::parse_query("MATCH (a)-[:R*1..$n]->(b) RETURN a").is_err(),
+        "*1..$n parsed; an unbounded var-length exponent would then be reachable"
+    );
+}
+
+#[test]
+fn parameter_extraction_finds_each_name_once() {
+    assert_eq!(
+        referenced_params("MATCH (n) WHERE n.a = $x AND n.b = $y OR n.c = $x RETURN n"),
+        vec!["x".to_string(), "y".to_string()]
+    );
+    assert!(referenced_params("MATCH (n) RETURN n").is_empty());
+}

--- a/tests/snapshot_verify.rs
+++ b/tests/snapshot_verify.rs
@@ -7,7 +7,7 @@
 use samyama::graph::{GraphStore, Label, PropertyValue};
 use samyama::snapshot::verify::{
     build_catalog, canonical_hash, verify, CatalogEntry, FailureClass, QueryCatalog,
-    CATALOG_FORMAT,
+    QuerySpec, CATALOG_FORMAT,
 };
 use samyama::query::QueryEngine;
 
@@ -26,17 +26,21 @@ fn seeded() -> GraphStore {
     store
 }
 
-fn queries() -> Vec<(String, String)> {
+fn spec(id: &str, cypher: &str) -> QuerySpec {
+    QuerySpec { id: id.into(), cypher: cypher.into(), unanswerable: false, params: vec![] }
+}
+
+fn queries() -> Vec<QuerySpec> {
     vec![
-        ("q_nodes".into(), "MATCH (t:Thing) RETURN count(t) AS n".into()),
-        ("q_names".into(), "MATCH (t:Thing) RETURN t.name ORDER BY t.name".into()),
-        ("q_edges".into(), "MATCH (:Thing)-[:LINKS]->(:Thing) RETURN count(*) AS n".into()),
+        spec("q_nodes", "MATCH (t:Thing) RETURN count(t) AS n"),
+        spec("q_names", "MATCH (t:Thing) RETURN t.name ORDER BY t.name"),
+        spec("q_edges", "MATCH (:Thing)-[:LINKS]->(:Thing) RETURN count(*) AS n"),
         // Not an aggregate, on purpose. `count(*)` returns one row whether it
         // counted 11 edges or none, so an aggregate alone cannot tell a missing
         // edge type from a changed value.
-        ("q_edge_pairs".into(),
-         "MATCH (a:Thing)-[:LINKS]->(b:Thing) RETURN a.id, b.id ORDER BY a.id".into()),
-        ("q_props".into(), "MATCH (t:Thing) WHERE t.id < 5 RETURN t.id, t.name".into()),
+        spec("q_edge_pairs",
+             "MATCH (a:Thing)-[:LINKS]->(b:Thing) RETURN a.id, b.id ORDER BY a.id"),
+        spec("q_props", "MATCH (t:Thing) WHERE t.id < 5 RETURN t.id, t.name"),
     ]
 }
 
@@ -67,7 +71,7 @@ fn a_sound_round_trip_verifies() {
 fn a_zero_row_entry_is_refused_at_build_time() {
     let store = seeded();
     let mut q = queries();
-    q.push(("q_none".into(), "MATCH (x:Absent) RETURN x".into()));
+    q.push(spec("q_none", "MATCH (x:Absent) RETURN x"));
 
     let err = build_catalog(&store, &q, &[]).expect_err("a 0-row entry must be refused");
     assert!(err.contains("q_none"), "{err}");
@@ -94,6 +98,7 @@ fn an_all_empty_run_fails_even_when_expectations_match() {
             hash: canonical_hash(&QueryEngine::new()
                 .execute("MATCH (x:Absent) RETURN x", &store).unwrap()),
             unanswerable: true,
+            params: vec![],
         }],
     };
     let report = verify(&store, &catalog).expect("verify");


### PR DESCRIPTION
#1156, DoD 1, 2, 3 and 5. Builds on the catalog format from #1157.

Catalog entries gain declared parameters. Queries run through `QueryExecutor::with_params`, so values reach the engine as bindings — nothing builds a query string from a value.

## Refused, at build *and* at load

A published `.sgqueries` file leaves us and can be edited, so shape is re-checked at execution rather than only when written:

- a query containing `{{ }}`, `${ }`, `%s`, `%d`, `#{` or `<<` — string substitution
- a `$name` the entry declares no type for
- a declared parameter the query never uses, which gives false assurance about what is checked
- a declared type that disagrees with its own sample

A bare `{` is deliberately **not** a marker — Cypher uses it for map literals and inline property patterns, and refusing it would refuse ordinary queries. There is a test asserting that.

## Two of the four risks are unreachable in this engine

Recorded as a test rather than asserted:

| risk from the issue | what actually happens |
|---|---|
| "a `LIMIT` slot with no ceiling" | `LIMIT $k` is **refused** — "SKIP/LIMIT must not depend on the rows it is trimming" |
| "a var-length bound `*1..$n` with unbounded `n`" | **refused** — the grammar is `integer? ~ ".." ~ integer?` |

So there is no unbounded `LIMIT` slot and no var-length exponent to bound, and no `max` domain is implemented for either.

## The stated worst case is wrong for this path; the real one is next door

> "a float where the property holds an int, which silently matches nothing rather than erroring... the worst case"

Measured, not assumed. Through the bound path a **float does match an integer property** — `$age = 30.0` finds `age = 30`. Numeric coercion works.

The reachable hazard is the **string** case: `"30"` against `age = 30` returns **zero rows and no error**, so the caller reads "no results" where the truth is "wrong type". The existing zero-row rule catches it at build time, and the error now names that as the likely cause when the entry has parameters.

## DoD 4 is not implemented, deliberately

A per-template cost ceiling has nothing to read. Of 28 `ExecutionPlan` constructions in `planner.rs`, **22 set `chosen_plan_cost` to `0.0`**; five more assign a constant on hierarchy paths; the only computed value comes from the candidate enumerator, which runs solely under `graph_native` (off by default) and writes to `EXPLAIN` diagnostics rather than onto the executed plan.

A ceiling would compare `0.0 > 0.0 × factor` and refuse nothing — worse than no ceiling, because it reads as a guard in the security path. Detailed on the issue with two honest alternatives.

## Tests

Eleven new, including the CH-AI-SEC corpus (DoD 5): eight injection payloads bound as strings, asserting none becomes syntax and the store is unchanged.

`cargo test --workspace --no-fail-fast`: 264 binaries, **4,153 passed, 0 failed**.

## Still open on #1156

DoD 4 as discussed, and checking a declared type against the *graph's* property type rather than against the sample. The build-time execution already catches the mismatch that matters; reading the property's type from the store would name it earlier and more precisely.

https://claude.ai/code/session_01Km8V25fFdrdzqVhdHo611B
