### PR TITLE
LINT-RATCHET reported 0 warnings on a tree that has 943 (#1134)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
       - name: LINT-RATCHET — the clippy warning count may not rise
         # A ceiling, not a clean-tree gate: the debt stops growing while what
         # to do about the existing 769 stays open (#487).
-        run: ./scripts/check_lint_ratchet.sh 769
+        run: ./scripts/check_lint_ratchet.sh 795
 
       - name: CH-ALGO-PARITY — the algorithms still agree with NetworkX
         # ALGO-02. The reference values are regenerated from NetworkX on a

--- a/scripts/check_lint_ratchet.sh
+++ b/scripts/check_lint_ratchet.sh
@@ -16,24 +16,67 @@ set -uo pipefail
 
 CEILING="${1:-769}"
 
-# Two different things start with "warning:" — individual lints, and cargo's
-# per-crate summary ("warning: `samyama` (lib) generated 64 warnings"). The count
-# below includes both, which is what the ceiling was set against, so it stays that
-# way until the ceiling is re-measured on CI in the same commit.
+# --- the measurement must be a measurement (#1134) --------------------------
 #
-# It is worth knowing that the two move independently. The summary count is one
-# line per *crate that emitted anything*, so it shifts with toolchain version and
-# with how the workspace is split, neither of which is lint debt. Measured on
-# 2026-09-07 with rustc 1.96.1: 945 total = 799 lints + 146 summaries, while CI on
-# `stable` passed the 769 ceiling on the same commit. A number that differs between
-# a developer's machine and CI teaches people to ignore it, so both are printed.
-raw=$(cargo clippy --workspace --all-targets 2>&1)
-count=$(echo "$raw" | grep -cE "^warning")
-lints=$(echo "$raw" | grep -E "^warning" | grep -vc "generated")
-summaries=$((count - lints))
+# This gate passed on CI while reporting **0 clippy warnings** — run 34305145896,
+# 2026-09-09, on the same tree that reports 952 locally. A ceiling of 769 is
+# trivially satisfied by 0, so the step went green while measuring nothing, and
+# the script's own advice was "lower it to 0 and lock the gain in", which would
+# have made the gate permanently green and then broken the build the moment a
+# real count came back.
+#
+# Zero warnings from a workspace that has 952 of them is not a clean tree. It is
+# a failed measurement, and a gate that cannot tell the two apart is worse than
+# no gate: #1134 records that a local red that CI calls green trains people to
+# ignore the script.
+#
+# So: capture cargo's exit status and its output, and refuse to report a count
+# unless cargo actually said it did something. The previous version discarded
+# both — `raw=$(cargo clippy ... 2>&1)` with no status check — which is why the
+# CI log for that run contains no cargo output at all and the 0 could not be
+# diagnosed from it.
+raw=$(cargo clippy --workspace --all-targets --message-format=short 2>&1)
+status=$?
+
+# `Finished` is cargo's own statement that the check completed. `Checking` and
+# `Compiling` say units were actually analysed rather than served whole from a
+# warm target dir.
+finished=$(printf '%s\n' "$raw" | grep -cE "^\s*(Finished|Checking|Compiling)")
+
+if [ "$status" -ne 0 ]; then
+  echo "FAIL: cargo clippy exited $status — the count below would be an artefact"
+  echo "  of a failed run, not a lint count. Last 40 lines:"
+  printf '%s\n' "$raw" | tail -40
+  exit 1
+fi
+
+if [ "$finished" -eq 0 ]; then
+  echo "FAIL: cargo clippy produced no Finished/Checking/Compiling line, so"
+  echo "  nothing was measured. A count from this run means only that the"
+  echo "  output was empty (#1134). Last 40 lines:"
+  printf '%s\n' "$raw" | tail -40
+  exit 1
+fi
+
+# `--message-format=short` puts one diagnostic per line as
+# `path:line:col: warning: ...`, so the per-crate summary
+# ("warning: `samyama` (lib) generated 64 warnings") is the only thing that can
+# still start the line with `warning`. Counting both was #1134's original
+# complaint: the summary count is one line per crate that emitted anything, so
+# it moves with the toolchain and with how the workspace splits into units,
+# neither of which is lint debt.
+lints=$(printf '%s\n' "$raw" | grep -cE "^[^ ].*: warning: ")
+summaries=$(printf '%s\n' "$raw" | grep -cE "^warning: .* generated .* warning")
+count=$((lints + summaries))
+
 echo "clippy warnings: $count (ceiling $CEILING)"
 echo "  of which lints: $lints, per-crate summaries: $summaries"
+echo "  cargo reported $finished Finished/Checking/Compiling lines"
 
+# The ceiling still applies to the combined count, because that is the number it
+# was set against. Switching it to lints-only needs the lint-only figure read
+# off a CI run in the same commit, and until this script measures at all on CI
+# there is no such figure to read (#1134).
 if [ "$count" -gt "$CEILING" ]; then
   echo "FAIL: $((count - CEILING)) more clippy warnings than the ceiling."
   echo "  New code should not add to the backlog. Fix the new warnings, or"

--- a/scripts/check_lint_ratchet.sh
+++ b/scripts/check_lint_ratchet.sh
@@ -38,6 +38,15 @@ CEILING="${1:-769}"
 raw=$(cargo clippy --workspace --all-targets --message-format=short 2>&1)
 status=$?
 
+# Strip ANSI colour before counting anything. This is the whole bug: the
+# workflow sets CARGO_TERM_COLOR=always, so on CI every diagnostic line begins
+# with an escape sequence rather than the literal word, and the original
+# `grep -cE "^warning"` matched **nothing**. The ceiling of 769 was therefore
+# never enforced on CI at all -- the step reported 0 and passed on every commit
+# since it was added. Locally the pipe turns colour off, which is exactly why
+# the two disagreed (#1134).
+raw=$(printf '%s\n' "$raw" | sed -e 's/\x1b\[[0-9;]*[A-Za-z]//g')
+
 # `Finished` is cargo's own statement that the check completed. `Checking` and
 # `Compiling` say units were actually analysed rather than served whole from a
 # warm target dir.

--- a/scripts/check_lint_ratchet.sh
+++ b/scripts/check_lint_ratchet.sh
@@ -14,7 +14,7 @@
 #   usage: check_lint_ratchet.sh [clippy-ceiling]
 set -uo pipefail
 
-CEILING="${1:-769}"
+CEILING="${1:-795}"
 
 # --- the measurement must be a measurement (#1134) --------------------------
 #
@@ -76,18 +76,25 @@ fi
 # neither of which is lint debt.
 lints=$(printf '%s\n' "$raw" | grep -cE "^[^ ].*: warning: ")
 summaries=$(printf '%s\n' "$raw" | grep -cE "^warning: .* generated .* warning")
-count=$((lints + summaries))
 
-echo "clippy warnings: $count (ceiling $CEILING)"
-echo "  of which lints: $lints, per-crate summaries: $summaries"
+# The ceiling is on lints, not on lints plus summaries. A per-crate summary is
+# one line per crate that emitted anything, so it moves with the toolchain and
+# with how the workspace splits into compilation units, neither of which is lint
+# debt (#1134). It is still printed, because it is what the old combined number
+# was made of and leaving it out would make the two eras look incomparable.
+count=$lints
+
+echo "clippy lints: $count (ceiling $CEILING)"
+echo "  per-crate summaries, not counted: $summaries"
 echo "  cargo reported $finished Finished/Checking/Compiling lines"
 
-# The ceiling still applies to the combined count, because that is the number it
-# was set against. Switching it to lints-only needs the lint-only figure read
-# off a CI run in the same commit, and until this script measures at all on CI
-# there is no such figure to read (#1134).
+# 795 is the lint-only count measured **on CI**, run 34313013867, the first run
+# in which this script measured anything at all. This machine reads 793 on the
+# same commit, so the two now agree to within two lints where before they were
+# 941 apart. The remaining two are a toolchain difference and the ceiling is set
+# from CI's figure, since CI is what gates.
 if [ "$count" -gt "$CEILING" ]; then
-  echo "FAIL: $((count - CEILING)) more clippy warnings than the ceiling."
+  echo "FAIL: $((count - CEILING)) more clippy lints than the ceiling."
   echo "  New code should not add to the backlog. Fix the new warnings, or"
   echo "  raise the ceiling in the same commit and say why."
   exit 1


### PR DESCRIPTION
#1134 reported that LINT-RATCHET reads differently on CI than locally, and attributed it to counting per-crate summaries alongside lints. That is real, but it is secondary. **On CI nothing was counted at all.**

## What was happening

CI run [34305145896](https://github.com/samyama-ai/samyama-graph/actions/runs/34305145896), step green:

```
clippy warnings: 0 (ceiling 769)
OK: 769 below the ceiling — lower it to 0 and lock the gain in.
```

Same tree, locally: 941. The gate had passed on every commit since it was added, and its advice was to **lower the ceiling to 0** — which would have made it permanently green, then broken the build the first time a real count arrived.

**The cause is colour.** The workflow sets `CARGO_TERM_COLOR: always`, so on CI every diagnostic begins with an escape sequence:

```
src/query/executor/mod.rs:5568:37: ESC[1mESC[33mwarningESC[0m: unnecessary use of ...
```

`grep -cE "^warning"` matches none of that. Locally the pipe turns colour off, which is exactly why the two disagreed. Not cache warmth — a second local clippy on a fully warm target dir still reports every warning.

## Three commits, in the order the evidence arrived

1. **Refuse to report an unmeasured count.** Non-zero exit from cargo, or no `Finished`/`Checking`/`Compiling` line, now fails and prints the last 40 lines. The old script discarded both status and output, which is why that run's log contains no cargo output and the 0 could not be diagnosed from it.
2. **Strip ANSI before counting.** Found by reading the output commit 1 printed — the guard fired on the first CI run and produced the diagnosis.
3. **Count lints only, ceiling from CI.** What #1134 asked for, and it needed a CI run that measured something.

## The numbers

| | before | now |
|---|---:|---:|
| CI | 0 | **943** = 795 lints + 148 summaries |
| local | 941 | 941 = 793 lints + 148 summaries |
| gap | 941 | **2** |

Summary counts now agree exactly; the two remaining lints are a toolchain difference. The ceiling is **795 lints**, CI's figure, because CI is what gates. The workflow passes 795 rather than 769 — 769 was never enforced.

Summaries are still printed but not counted: one line per crate that emitted anything, so it moves with the toolchain and the workspace split, neither of which is lint debt.

## How it was found

By reading a **passing** CI log for a number, not by chasing a failure. The 0 was visible in the step output to anyone who looked.