### PR TITLE
A catalog states where its questions came from, and is scanned before publishing (#1159)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ async fn main() {
     match argv.get(1).map(|s| s.as_str()) {
         Some("verify") => std::process::exit(cmd_verify(&argv)),
         Some("catalog-build") => std::process::exit(cmd_catalog_build(&argv)),
+        Some("catalog-gate") => std::process::exit(cmd_catalog_gate(&argv)),
         _ => {}
     }
 
@@ -150,6 +151,54 @@ fn cmd_catalog_build(argv: &[String]) -> i32 {
             println!("wrote {out}: {} entries", catalog.entries.len());
             0
         }
+    }
+}
+
+/// `samyama catalog-gate <catalog.json> [--allow-observed]`
+///
+/// Refuses to publish a catalog drawn from traffic without an explicit flag,
+/// and scans every question and every parameter sample for personal data
+/// (#1159). A parameter sample is a data excerpt: it exists so the build-time
+/// execution gate has something to run, and on a KG holding personal data it is
+/// a real value about to be published.
+fn cmd_catalog_gate(argv: &[String]) -> i32 {
+    use samyama::snapshot::publish_gate::gate;
+    let Some(path) = argv.get(2).filter(|s| !s.starts_with("--")) else {
+        eprintln!("usage: samyama catalog-gate <catalog.json> [--allow-observed]");
+        return 64;
+    };
+    let allow_observed = argv.iter().any(|a| a == "--allow-observed");
+
+    let catalog: samyama::snapshot::verify::QueryCatalog = match std::fs::File::open(path)
+        .map_err(|e| e.to_string())
+        .and_then(|f| serde_json::from_reader(f).map_err(|e| e.to_string()))
+    {
+        Ok(c) => c,
+        Err(e) => { eprintln!("could not read {path}: {e}"); return 65; }
+    };
+
+    let mut texts: Vec<(String, String)> = Vec::new();
+    for e in &catalog.entries {
+        texts.push((e.id.clone(), e.cypher.clone()));
+        for p in &e.params {
+            texts.push((format!("{}.params.{}", e.id, p.name), p.sample.to_string()));
+        }
+    }
+
+    let v = gate(catalog.provenance, &texts, allow_observed);
+    println!("catalog-gate {path}");
+    println!("  provenance: {:?}, {} entries", catalog.provenance, catalog.entries.len());
+    for f in &v.findings {
+        println!("  FINDING {:<16} in {}  {}", f.kind, f.where_, f.excerpt);
+    }
+    for r in &v.reasons {
+        println!("  REFUSED {r}");
+    }
+    if v.publishable {
+        println!("  OK  publishable");
+        0
+    } else {
+        1
     }
 }
 

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -10,6 +10,7 @@
 pub mod format;
 pub mod persist;
 pub mod verify;
+pub mod publish_gate;
 
 use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Read, Write};

--- a/src/snapshot/publish_gate.rs
+++ b/src/snapshot/publish_gate.rs
@@ -1,0 +1,203 @@
+//! What a catalog may not carry into a published artifact (#1159).
+//!
+//! A catalog derived from observed traffic is user text. Publishing it
+//! publishes what people asked, including the entity names they asked about,
+//! which in several of our KGs are the sensitive part. Templates make this
+//! worse in one specific way: a parameter's `sample` value exists so the
+//! build-time execution gate has something to run, and on a KG holding personal
+//! or customer data that sample is a real value embedded in a published file.
+//!
+//! ## TRUST-10 has no scan to extend
+//!
+//! The issue asks that "the existing PII scan" cover the catalog. There is no
+//! existing scan: spec row TRUST-10 reads "policy by construction" for H1 and
+//! lists "automated scan in release CI" as the *next* horizon. So this is the
+//! first one, and it is written narrowly on purpose.
+//!
+//! ## Precision over recall, deliberately
+//!
+//! A scan that cries wolf gets switched off, and then it protects nothing. This
+//! codebase has the scar: a link checker over 3,278 URLs produced 2 real
+//! failures and 253 false ones. So every pattern here is one that is hard to
+//! trigger by accident:
+//!
+//! * email — requires a local part, `@`, a dotted domain, and a plausible TLD
+//! * card number — 13-19 digits **that pass Luhn**, so an arbitrary long number
+//!   does not match
+//! * US SSN — the `NNN-NN-NNNN` form with separators, not any nine digits
+//! * phone — an explicit `+` country prefix, not any run of digits
+//!
+//! Deliberately *not* matched: names, addresses, dates of birth, free text that
+//! looks personal. Those need judgement, and a regex claiming to find them
+//! would report mostly noise while implying the file had been checked.
+
+/// Where a catalog's questions came from. Required in the file: a reader must
+/// not have to infer it, and the safe default cannot be the silent one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Provenance {
+    /// Written by hand. The questions are ours.
+    Authored,
+    /// Derived from traffic an instance served. The questions are someone's.
+    Observed,
+}
+
+/// One thing the scan found.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Finding {
+    /// Catalog entry id, or `"<header>"`.
+    pub where_: String,
+    pub kind: &'static str,
+    /// The matched text, truncated. Enough to locate, not enough to leak the
+    /// whole value into a log that may itself be published.
+    pub excerpt: String,
+}
+
+fn redact(s: &str) -> String {
+    let n = s.chars().count();
+    if n <= 4 {
+        return "*".repeat(n);
+    }
+    let head: String = s.chars().take(2).collect();
+    let tail: String = s.chars().skip(n - 2).collect();
+    format!("{head}{}{tail}", "*".repeat(n - 4))
+}
+
+fn luhn_ok(digits: &[u8]) -> bool {
+    let mut sum = 0u32;
+    let mut double = false;
+    for d in digits.iter().rev() {
+        let mut v = u32::from(*d);
+        if double {
+            v *= 2;
+            if v > 9 {
+                v -= 9;
+            }
+        }
+        sum += v;
+        double = !double;
+    }
+    sum % 10 == 0
+}
+
+/// Scan one string. Returns every pattern hit.
+pub fn scan_text(where_: &str, text: &str) -> Vec<Finding> {
+    let mut out = Vec::new();
+    let bytes = text.as_bytes();
+
+    // email
+    for (i, _) in text.match_indices('@') {
+        let start = text[..i].rfind(|c: char| c.is_whitespace() || c == '\'' || c == '"' || c == '(')
+            .map(|p| p + 1).unwrap_or(0);
+        let end = text[i..].find(|c: char| c.is_whitespace() || c == '\'' || c == '"' || c == ')')
+            .map(|p| i + p).unwrap_or(text.len());
+        let cand = &text[start..end];
+        let (local, domain) = match cand.split_once('@') {
+            Some(x) => x,
+            None => continue,
+        };
+        let tld_ok = domain.rsplit('.').next().map(|t| t.len() >= 2 && t.chars().all(|c| c.is_ascii_alphabetic())).unwrap_or(false);
+        if !local.is_empty()
+            && local.chars().all(|c| c.is_ascii_alphanumeric() || "._%+-".contains(c))
+            && domain.contains('.')
+            && tld_ok
+            && domain.chars().all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-')
+        {
+            out.push(Finding { where_: where_.into(), kind: "email", excerpt: redact(cand) });
+        }
+    }
+
+    // card number: 13-19 digits, separators allowed, must pass Luhn
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_digit() {
+            let start = i;
+            let mut digits: Vec<u8> = Vec::new();
+            let mut j = i;
+            while j < bytes.len() && (bytes[j].is_ascii_digit() || bytes[j] == b'-' || bytes[j] == b' ') {
+                if bytes[j].is_ascii_digit() {
+                    digits.push(bytes[j] - b'0');
+                }
+                j += 1;
+            }
+            // Trim a trailing separator run.
+            let raw = text[start..j].trim_end_matches([' ', '-']);
+
+            if (13..=19).contains(&digits.len()) && luhn_ok(&digits) {
+                out.push(Finding { where_: where_.into(), kind: "card-number", excerpt: redact(raw) });
+            }
+            // US SSN, with separators only.
+            if digits.len() == 9 && raw.len() == 11 && raw.as_bytes()[3] == b'-' && raw.as_bytes()[6] == b'-' {
+                out.push(Finding { where_: where_.into(), kind: "us-ssn", excerpt: redact(raw) });
+            }
+            i = j;
+        } else if bytes[i] == b'+' {
+            // phone with an explicit country prefix
+            let start = i;
+            let mut j = i + 1;
+            let mut count = 0usize;
+            while j < bytes.len() && (bytes[j].is_ascii_digit() || bytes[j] == b'-' || bytes[j] == b' ') {
+                if bytes[j].is_ascii_digit() {
+                    count += 1;
+                }
+                j += 1;
+            }
+            if (10..=15).contains(&count) {
+                let raw = text[start..j].trim_end();
+                out.push(Finding { where_: where_.into(), kind: "phone", excerpt: redact(raw) });
+            }
+            i = j.max(i + 1);
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Whether a catalog may be published, and why not.
+#[derive(Debug, Clone)]
+pub struct GateVerdict {
+    pub publishable: bool,
+    pub reasons: Vec<String>,
+    pub findings: Vec<Finding>,
+}
+
+/// Decide whether a catalog may be published.
+///
+/// `allow_observed` is the explicit flag requirement 1 asks for. It does not
+/// silence the PII scan: a sign-off that the questions may be published is not
+/// a sign-off that a card number in one of them may be.
+pub fn gate(
+    provenance: Provenance,
+    texts: &[(String, String)],
+    allow_observed: bool,
+) -> GateVerdict {
+    let mut reasons = Vec::new();
+    let mut findings = Vec::new();
+
+    for (where_, text) in texts {
+        findings.extend(scan_text(where_, text));
+    }
+
+    if provenance == Provenance::Observed && !allow_observed {
+        reasons.push(
+            "the catalog is derived from observed traffic, so its questions are \
+             user text. Publishing needs --allow-observed and a recorded sign-off."
+                .to_string(),
+        );
+    }
+    if !findings.is_empty() {
+        let mut kinds: Vec<&str> = findings.iter().map(|f| f.kind).collect();
+        kinds.sort_unstable();
+        kinds.dedup();
+        reasons.push(format!(
+            "the scan found {} value(s) matching {}. --allow-observed does not \
+             cover this: agreeing to publish the questions is not agreeing to \
+             publish a card number inside one.",
+            findings.len(),
+            kinds.join(", ")
+        ));
+    }
+
+    GateVerdict { publishable: reasons.is_empty(), reasons, findings }
+}

--- a/src/snapshot/verify.rs
+++ b/src/snapshot/verify.rs
@@ -161,7 +161,23 @@ pub struct CatalogEntry {
 pub struct QueryCatalog {
     pub format: String,
     pub generated_by: String,
+    /// Whether the questions were written by us or drawn from traffic (#1159).
+    ///
+    /// Required rather than defaulted, so the safe answer is never the silent
+    /// one. An observed catalog is user text and may not be published without
+    /// an explicit flag.
+    #[serde(default = "default_provenance")]
+    pub provenance: crate::snapshot::publish_gate::Provenance,
     pub entries: Vec<CatalogEntry>,
+}
+
+/// A catalog with no stated provenance is treated as observed.
+///
+/// The unsafe reading is the conservative one here: an authored catalog
+/// mislabelled observed costs a flag, while an observed catalog mislabelled
+/// authored publishes someone's questions.
+fn default_provenance() -> crate::snapshot::publish_gate::Provenance {
+    crate::snapshot::publish_gate::Provenance::Observed
 }
 
 /// What a mismatch most likely means. Named rather than diffed, because a diff
@@ -390,6 +406,7 @@ pub fn build_catalog(
     Ok(QueryCatalog {
         format: CATALOG_FORMAT.to_string(),
         generated_by: format!("samyama {}", crate::VERSION),
+        provenance: crate::snapshot::publish_gate::Provenance::Authored,
         entries,
     })
 }

--- a/tests/catalog_publish_gate.rs
+++ b/tests/catalog_publish_gate.rs
@@ -1,0 +1,127 @@
+//! A catalog derived from traffic must not be published unchecked (#1159).
+//!
+//! The half of this that decides whether the check survives contact with a real
+//! KG is `realistic_graph_text_does_not_trip_the_scan`. A scan that cries wolf
+//! gets switched off, and then it protects nothing — this codebase already has
+//! that scar, from a link checker that produced 2 real failures and 253 false
+//! ones over 3,278 URLs.
+
+use samyama::snapshot::publish_gate::{gate, scan_text, Provenance};
+
+fn texts(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+    pairs.iter().map(|(a, b)| (a.to_string(), b.to_string())).collect()
+}
+
+#[test]
+fn an_authored_clean_catalog_is_publishable() {
+    let v = gate(
+        Provenance::Authored,
+        &texts(&[("q1", "What genes does Metformin target?")]),
+        false,
+    );
+    assert!(v.publishable, "{:?}", v.reasons);
+    assert!(v.findings.is_empty());
+}
+
+#[test]
+fn an_observed_catalog_needs_an_explicit_flag() {
+    let t = texts(&[("q1", "What genes does Metformin target?")]);
+    let v = gate(Provenance::Observed, &t, false);
+    assert!(!v.publishable);
+    assert!(v.reasons[0].contains("observed traffic"), "{:?}", v.reasons);
+
+    let v = gate(Provenance::Observed, &t, true);
+    assert!(v.publishable, "{:?}", v.reasons);
+}
+
+/// Agreeing to publish the questions is not agreeing to publish a card number
+/// inside one, so the flag does not silence the scan.
+#[test]
+fn the_observed_flag_does_not_silence_the_pii_scan() {
+    let t = texts(&[("q1", "Which orders used card 4111 1111 1111 1111 last week?")]);
+    let v = gate(Provenance::Observed, &t, true);
+    assert!(!v.publishable, "the flag suppressed a PII finding");
+    assert_eq!(v.findings.len(), 1);
+    assert_eq!(v.findings[0].kind, "card-number");
+    assert!(v.reasons.iter().any(|r| r.contains("does not cover this")), "{:?}", v.reasons);
+}
+
+/// A parameter sample is a data excerpt: it exists so the build-time execution
+/// gate has something to run, and on a KG holding personal data it is a real
+/// value in a published file.
+#[test]
+fn a_parameter_sample_is_scanned_like_any_other_text() {
+    let v = gate(
+        Provenance::Authored,
+        &texts(&[("q1.params.email", "priya.sharma@example.com")]),
+        false,
+    );
+    assert!(!v.publishable);
+    assert_eq!(v.findings[0].kind, "email");
+    // The excerpt locates the value without reproducing it.
+    assert!(!v.findings[0].excerpt.contains("priya.sharma"), "{:?}", v.findings[0]);
+    assert!(v.findings[0].excerpt.contains('*'));
+}
+
+#[test]
+fn each_pattern_is_found() {
+    for (text, kind) in [
+        ("contact a.b@sub.example.org for access", "email"),
+        ("card 4111111111111111", "card-number"),
+        ("ssn 123-45-6789", "us-ssn"),
+        ("call +91 98765 43210", "phone"),
+    ] {
+        let f = scan_text("t", text);
+        assert!(
+            f.iter().any(|x| x.kind == kind),
+            "{kind} not found in {text:?}, got {:?}", f.iter().map(|x| x.kind).collect::<Vec<_>>()
+        );
+    }
+}
+
+/// The precision test. Every string here is ordinary content from KGs we
+/// actually ship, and none of it may trigger a finding.
+#[test]
+fn realistic_graph_text_does_not_trip_the_scan() {
+    const CLEAN: &[&str] = &[
+        // identifiers that are long runs of digits
+        "What is the abstract of PMID 12345678?",
+        "Which adverse events were reported in trial NCT00835861?",
+        "Find the compound with CID 2244 and CAS 50-78-2",
+        "ISBN 9780262033848 is cited by how many papers?",
+        "Show gene ENSG00000141510 and its transcripts",
+        // versions, dates, sizes, ports
+        "Which nodes changed between 2026-09-08 and 2026-09-09?",
+        "Rows where value > 1234567890123456789",
+        "Which service listens on port 7687 at 192.168.1.10?",
+        "Return snapshots larger than 1073741824 bytes",
+        // an @ that is not an email
+        "Match the handle @maintainer in the commit message",
+        "Rate limit is 100 @ 60s",
+        // a hyphenated code with nine digits but the wrong shape
+        "Part number 12-3456789 in the bill of materials",
+        // ordinary questions
+        "What drugs interact with Warfarin?",
+        "Which pathways contain both TP53 and MDM2?",
+    ];
+    let mut noise = Vec::new();
+    for t in CLEAN {
+        let f = scan_text("t", t);
+        if !f.is_empty() {
+            noise.push((*t, f.iter().map(|x| x.kind).collect::<Vec<_>>()));
+        }
+    }
+    assert!(
+        noise.is_empty(),
+        "the scan fired on ordinary graph content, which is how a scan gets \
+         switched off: {noise:?}"
+    );
+}
+
+/// A 16-digit number that is not a card must not be reported as one. Luhn is
+/// what separates them; without it every long identifier matches.
+#[test]
+fn a_long_number_that_fails_luhn_is_not_a_card() {
+    assert!(scan_text("t", "4111111111111112").is_empty(), "Luhn is not being checked");
+    assert!(!scan_text("t", "4111111111111111").is_empty(), "a valid card was missed");
+}

--- a/tests/snapshot_verify.rs
+++ b/tests/snapshot_verify.rs
@@ -91,6 +91,7 @@ fn an_all_empty_run_fails_even_when_expectations_match() {
     let catalog = QueryCatalog {
         format: CATALOG_FORMAT.to_string(),
         generated_by: "test".into(),
+        provenance: samyama::snapshot::publish_gate::Provenance::Authored,
         entries: vec![CatalogEntry {
             id: "q_none".into(),
             cypher: "MATCH (x:Absent) RETURN x".into(),
@@ -203,6 +204,7 @@ fn an_unknown_catalog_format_is_refused() {
     let bad = QueryCatalog {
         format: "samyama.queries/99".into(),
         generated_by: "test".into(),
+        provenance: samyama::snapshot::publish_gate::Provenance::Authored,
         entries: vec![],
     };
     let err = verify(&store, &bad).expect_err("unknown format must be refused");


### PR DESCRIPTION
#1159. Catalogs gain `provenance` — authored or observed. `samyama catalog-gate` refuses to publish an observed catalog without `--allow-observed`, and scans every question and every parameter sample for personal data.

## Requirement 2 rests on something that does not exist

> "The existing PII scan covers it."

There is no existing scan. Spec row **TRUST-10 reads "policy by construction"** for H1 and lists "automated scan in release CI" as the *next* horizon. So this is the first one, and it is written narrowly on purpose.

## Precision over recall, deliberately

A scan that cries wolf gets switched off, and then it protects nothing. This codebase has the scar: a link checker over 3,278 URLs produced **2 real failures and 253 false ones**. Four patterns, each hard to trigger by accident:

| pattern | what it requires |
|---|---|
| email | local part, `@`, dotted domain, alphabetic TLD |
| card number | 13–19 digits **that pass Luhn** — a long identifier does not match |
| US SSN | the `NNN-NN-NNNN` form with separators, not any nine digits |
| phone | an explicit `+` country prefix, not any run of digits |

**Deliberately not matched:** names, addresses, dates of birth, free text that looks personal. Those need judgement, and a regex claiming to find them would report mostly noise while implying the file had been checked.

## The test that decides whether this survives a real KG

`realistic_graph_text_does_not_trip_the_scan` — 14 strings of ordinary content from KGs we ship, none of which may produce a finding:

```
PMID 12345678 · NCT00835861 · CAS 50-78-2 · ISBN 9780262033848
ENSG00000141510 · 2026-09-08 · port 7687 at 192.168.1.10
1073741824 bytes · @maintainer · "100 @ 60s" · part 12-3456789
```

Plus `a_long_number_that_fails_luhn_is_not_a_card`: `4111111111111112` must not match, `4111111111111111` must.

## Two decisions worth stating

- **A missing `provenance` defaults to observed.** An authored catalog mislabelled observed costs a flag; an observed catalog mislabelled authored publishes someone's questions.
- **`--allow-observed` does not silence the scan.** Agreeing to publish the questions is not agreeing to publish a card number inside one. There is a test for exactly that.

Findings are redacted to first and last two characters — enough to locate the value, not enough to leak it into a log that may itself be published.

Requirement 4 ("parameter samples are declared, not scraped") already holds by construction from #1169: samples live in the catalog and are written by the author.

## Verification

`cargo test --workspace --no-fail-fast`: 266 binaries, **4,168 passed, 0 failed**.

## Still open on #1159

Requirement 3 (TRUST-03 license and redistribution on sample values) and requirement 5 (`sgsnap publish` refusing a non-publishable header) — both need the release path, which lives outside this repo.
