### PR TITLE
Catalog entries carry the question; KG-08 becomes checkable; the #1158 number (#1154)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,6 +251,10 @@ name = "result_cache_gain"
 harness = false
 
 [[bench]]
+name = "cold_start_share"
+harness = false
+
+[[bench]]
 name = "ldbc_benchmark"
 harness = false
 

--- a/benches/cold_start_share.rs
+++ b/benches/cold_start_share.rs
@@ -84,12 +84,17 @@ fn main() {
     }
 
     println!("\nRestore is paid before any answer and materialized results cannot remove\n\
-              it. So the share above is the ceiling on what #1158 could save, per query,\n\
-              on this snapshot.\n\n\
-              Restore scales with the file; a point lookup does not. On a 10 GB published\n\
-              KG the restore term grows by roughly three orders of magnitude while a\n\
-              cheap query stays put, so these shares are an *upper* bound for the\n\
-              published-KG case #1158 targets. The exception is a genuinely expensive\n\
-              query, where execution dominates and materializing does pay -- which is\n\
-              why the numbers are reported per query rather than averaged.");
+              it. So the share above is the ceiling on what #1158 could save, per query.\n\n\
+              Do not average these. Measured on two snapshots the share moves in opposite\n\
+              directions with size, depending on the query:\n\n\
+                dbms-research   12.2 MB, 18.7k nodes    restore   0.266 s\n\
+                clinical-trials  711 MB, 7.78M nodes    restore 106.320 s\n\n\
+              Restore grew 400x for 415x the nodes -- roughly linear in node count, not in\n\
+              bytes, since the file grew only 58x. A cheap query stays flat so its share\n\
+              collapses: the count aggregate went 4.63% to 0.04%. An expensive query grows\n\
+              faster than restore does: the two-hop went 0.36% to 34.4%, at 56.9 s of\n\
+              execution against 106 s of restore.\n\n\
+              So the answer for #1158 is bimodal, not small. Materializing buys nothing for\n\
+              cheap catalog queries and a great deal for expensive ones, and which of those\n\
+              a KG ships is a property of its catalog, not of the engine.");
 }

--- a/benches/cold_start_share.rs
+++ b/benches/cold_start_share.rs
@@ -1,0 +1,95 @@
+//! What could materializing results inside a `.sgsnap` actually save? (#1158)
+//!
+//! #1158 is deferred and says so: "Once [the runtime result cache] exists, we
+//! will have the number that decides whether this is worth building: if the
+//! warm cache already gets the speedup, materializing into the file buys only
+//! cold-start."
+//!
+//! The cache landed in #1153. This is that number.
+//!
+//! Time to first answer, from a cold process, is `restore + execute`.
+//! Materialized results can only remove the `execute` part -- the bytes still
+//! have to be read and the graph still has to be built before anything can be
+//! answered. So the question is what share of time-to-first-answer execution
+//! actually is. If it is small, materializing buys close to nothing while
+//! costing a format change, a size cap, an epoch binding, and a re-verification
+//! step in the release path.
+//!
+//! Usage: cargo bench --bench cold_start_share -- --snapshot <file.sgsnap>
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use samyama::graph::GraphStore;
+use samyama::query::QueryEngine;
+
+fn arg(args: &[String], name: &str) -> Option<String> {
+    args.iter().position(|a| a == name).and_then(|i| args.get(i + 1)).cloned()
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let snap = PathBuf::from(arg(&args, "--snapshot").unwrap_or_else(|| {
+        format!("{}/sgwork/dx01-cold/dbms-research.sgsnap",
+                std::env::var("HOME").unwrap_or_default())
+    }));
+    if !snap.exists() {
+        eprintln!("SKIP: no snapshot at {}", snap.display());
+        return;
+    }
+    let bytes = std::fs::metadata(&snap).map(|m| m.len()).unwrap_or(0);
+
+    let t = Instant::now();
+    let mut store = GraphStore::new();
+    let file = std::fs::File::open(&snap).expect("open");
+    samyama::snapshot::import_tenant(&mut store, file).expect("import");
+    let restore_s = t.elapsed().as_secs_f64();
+
+    let labels = store.all_labels();
+    let label = labels.first().map(|l| (*l).clone())
+        .unwrap_or_else(|| samyama::Label::new("Node"));
+    let l = label.as_str().to_string();
+
+    // A range of query costs, because the share is entirely a function of it.
+    // A bench that asked only a cheap query would report a small share and read
+    // as an argument against #1158; one that asked only an expensive query
+    // would read as an argument for it. Both would be the same mistake.
+    let queries: Vec<(&str, String)> = vec![
+        ("count aggregate", format!("MATCH (n:{l}) RETURN count(n) AS n")),
+        ("scan + project", format!("MATCH (n:{l}) RETURN n LIMIT 1000")),
+        ("filtered scan", format!("MATCH (n:{l}) WHERE n.name IS NOT NULL RETURN count(n) AS n")),
+        ("two-hop", format!("MATCH (a:{l})-[]->()-[]->(c) RETURN count(c) AS n")),
+    ];
+
+    let engine = QueryEngine::new();
+    println!("\nsnapshot        {} ({:.1} MB)", snap.display(), bytes as f64 / 1048576.0);
+    println!("nodes / edges   {} / {}", store.node_count(), store.edge_count());
+    println!("restore         {restore_s:.3} s  (paid once, before any answer)\n");
+    println!("{:<18} {:>12} {:>12} {:>16}", "query", "execute s", "warm s", "exec share of TTFA");
+    println!("{}", "-".repeat(62));
+
+    for (name, q) in &queries {
+        let t = Instant::now();
+        let cold = match engine.execute(q, &store) {
+            Ok(_) => t.elapsed().as_secs_f64(),
+            Err(e) => { println!("{name:<18} failed: {e}"); continue; }
+        };
+        let _ = engine.execute_cached(q, &store);
+        let t = Instant::now();
+        let (_, hit) = engine.execute_cached(q, &store).expect("warm");
+        let warm = t.elapsed().as_secs_f64();
+        assert!(hit, "{name}: warm call missed");
+        let share = cold / (restore_s + cold) * 100.0;
+        println!("{name:<18} {cold:>12.6} {warm:>12.6} {share:>15.3}%");
+    }
+
+    println!("\nRestore is paid before any answer and materialized results cannot remove\n\
+              it. So the share above is the ceiling on what #1158 could save, per query,\n\
+              on this snapshot.\n\n\
+              Restore scales with the file; a point lookup does not. On a 10 GB published\n\
+              KG the restore term grows by roughly three orders of magnitude while a\n\
+              cheap query stays put, so these shares are an *upper* bound for the\n\
+              published-KG case #1158 targets. The exception is a genuinely expensive\n\
+              query, where execution dominates and materializing does pay -- which is\n\
+              why the numbers are reported per query rather than averaged.");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,6 +188,22 @@ fn cmd_catalog_gate(argv: &[String]) -> i32 {
     let v = gate(catalog.provenance, &texts, allow_observed);
     println!("catalog-gate {path}");
     println!("  provenance: {:?}, {} entries", catalog.provenance, catalog.entries.len());
+    println!("  digest: {}", samyama::snapshot::verify::catalog_digest(
+        &serde_json::to_string(&catalog).unwrap_or_default()));
+
+    // KG-08 conformance, reported always and enforced on request. Reported
+    // always because a catalog that does not meet it is still worth publishing
+    // and the gap should be visible; enforced on request because KG-08 is a
+    // release requirement rather than a safety one.
+    let kg08 = samyama::snapshot::verify::kg08_conformance(&catalog);
+    for p in &kg08 {
+        println!("  KG-08 {p}");
+    }
+    let require_kg08 = argv.iter().any(|a| a == "--kg08");
+    if require_kg08 && !kg08.is_empty() {
+        println!("  REFUSED {} KG-08 problem(s), and --kg08 was given", kg08.len());
+        return 1;
+    }
     for f in &v.findings {
         println!("  FINDING {:<16} in {}  {}", f.kind, f.where_, f.excerpt);
     }

--- a/src/snapshot/verify.rs
+++ b/src/snapshot/verify.rs
@@ -29,7 +29,7 @@
 use std::collections::BTreeMap;
 
 use crate::graph::GraphStore;
-use crate::query::{QueryEngine, RecordBatch};
+use crate::query::RecordBatch;
 
 /// Format identifier written into a catalog, so a reader can refuse a shape it
 /// does not understand rather than misinterpreting it.

--- a/src/snapshot/verify.rs
+++ b/src/snapshot/verify.rs
@@ -138,6 +138,17 @@ pub fn referenced_params(cypher: &str) -> Vec<String> {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CatalogEntry {
     pub id: String,
+    /// The natural-language question, which is what KG-08 and DX-08 are about.
+    /// Empty is allowed so a purely structural catalog stays valid, but the
+    /// KG-08 conformance check requires it.
+    #[serde(default)]
+    pub question: String,
+    /// Other phrasings of the same question.
+    #[serde(default)]
+    pub paraphrases: Vec<String>,
+    /// "easy" | "medium" | "hard". KG-08 asks for difficulty labels.
+    #[serde(default)]
+    pub difficulty: String,
     pub cypher: String,
     /// Rows the query returned against the snapshot this catalog describes.
     pub rows: usize,
@@ -362,6 +373,12 @@ pub fn validate_entry_shape(id: &str, cypher: &str, params: &[ParamSpec]) -> Res
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct QuerySpec {
     pub id: String,
+    #[serde(default)]
+    pub question: String,
+    #[serde(default)]
+    pub paraphrases: Vec<String>,
+    #[serde(default)]
+    pub difficulty: String,
     pub cypher: String,
     #[serde(default)]
     pub unanswerable: bool,
@@ -396,6 +413,9 @@ pub fn build_catalog(
         }
         entries.push(CatalogEntry {
             id: id.clone(),
+            question: q.question.clone(),
+            paraphrases: q.paraphrases.clone(),
+            difficulty: q.difficulty.clone(),
             cypher: cypher.clone(),
             rows,
             hash: canonical_hash(&batch),
@@ -462,4 +482,60 @@ pub fn verify(store: &GraphStore, catalog: &QueryCatalog) -> Result<VerifyReport
     // Guard against the #449 shape: everything answered, nothing returned.
     let everything_empty = !results.is_empty() && results.iter().all(|r| r.actual_rows == 0);
     Ok(VerifyReport { results, everything_empty })
+}
+
+
+/// Whether a catalog meets what KG-08 and DX-08 already require (#1154).
+///
+/// Neither is a new requirement. KG-08 asks for "≥30 queries with gold answers,
+/// difficulty labels, and unanswerable items" per KG; DX-08 for "5 example
+/// questions and expected outputs". Both are recorded as partially met today
+/// because the queries live as prose in READMEs where nothing executes them.
+/// This is the check that makes them true or false rather than aspirational.
+pub fn kg08_conformance(catalog: &QueryCatalog) -> Vec<String> {
+    const MIN_ENTRIES: usize = 30;
+    const DIFFICULTIES: &[&str] = &["easy", "medium", "hard"];
+    let mut problems = Vec::new();
+
+    if catalog.entries.len() < MIN_ENTRIES {
+        problems.push(format!(
+            "KG-08 asks for at least {MIN_ENTRIES} queries; this catalog has {}",
+            catalog.entries.len()
+        ));
+    }
+    if !catalog.entries.iter().any(|e| e.unanswerable) {
+        problems.push(
+            "KG-08 asks for unanswerable items and there are none. They are not \
+             padding: refusing to answer is a correctness behaviour, and a suite \
+             without them cannot tell a model that declines from one that guesses."
+                .to_string(),
+        );
+    }
+    for e in &catalog.entries {
+        if e.question.trim().is_empty() {
+            problems.push(format!("{}: no question text; DX-08 is about the question", e.id));
+        }
+        if !DIFFICULTIES.contains(&e.difficulty.as_str()) {
+            problems.push(format!(
+                "{}: difficulty {:?} is not one of {DIFFICULTIES:?}", e.id, e.difficulty
+            ));
+        }
+    }
+    problems
+}
+
+/// Digest of a catalog file, for the snapshot to reference.
+///
+/// The catalog ships beside the `.sgsnap` rather than inside it: templates are
+/// schema-bound and get edited far more often than the data changes, and
+/// rebuilding a multi-GB artifact to fix a Cypher string is not a good trade
+/// (export runs at ~0.77 MB/s and is CPU-bound, #314). The digest is what makes
+/// a mismatched pair detectable anyway.
+pub fn catalog_digest(serialized: &str) -> String {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in serialized.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("fnv1a64:{h:016x}")
 }

--- a/tests/catalog_bound_params.rs
+++ b/tests/catalog_bound_params.rs
@@ -36,6 +36,7 @@ fn param(name: &str, kind: &str, sample: serde_json::Value) -> ParamSpec {
 fn a_bound_parameter_round_trips_through_build_and_verify() {
     let store = seeded();
     let q = vec![QuerySpec {
+        question: String::new(), paraphrases: vec![], difficulty: String::new(),
         id: "by_age".into(),
         cypher: "MATCH (n:P) WHERE n.age = $age RETURN n.name".into(),
         unanswerable: false,
@@ -56,6 +57,7 @@ fn a_bound_parameter_round_trips_through_build_and_verify() {
 fn a_type_mismatch_is_refused_at_build_rather_than_returning_nothing() {
     let store = seeded();
     let q = vec![QuerySpec {
+        question: String::new(), paraphrases: vec![], difficulty: String::new(),
         id: "by_age".into(),
         cypher: "MATCH (n:P) WHERE n.age = $age RETURN n.name".into(),
         unanswerable: false,
@@ -73,6 +75,7 @@ fn a_type_mismatch_is_refused_at_build_rather_than_returning_nothing() {
 fn a_float_parameter_matches_an_integer_property() {
     let store = seeded();
     let q = vec![QuerySpec {
+        question: String::new(), paraphrases: vec![], difficulty: String::new(),
         id: "by_age".into(),
         cypher: "MATCH (n:P) WHERE n.age = $age RETURN n.name".into(),
         unanswerable: false,
@@ -149,6 +152,7 @@ fn hostile_parameter_values_cannot_add_a_clause_or_write() {
 
     for v in HOSTILE {
         let q = vec![QuerySpec {
+            question: String::new(), paraphrases: vec![], difficulty: String::new(),
             id: "hostile".into(),
             cypher: "MATCH (n:P) WHERE n.name = $name RETURN n.name".into(),
             unanswerable: true,

--- a/tests/snapshot_verify.rs
+++ b/tests/snapshot_verify.rs
@@ -27,7 +27,15 @@ fn seeded() -> GraphStore {
 }
 
 fn spec(id: &str, cypher: &str) -> QuerySpec {
-    QuerySpec { id: id.into(), cypher: cypher.into(), unanswerable: false, params: vec![] }
+    QuerySpec {
+        id: id.into(),
+        question: format!("example question for {id}"),
+        paraphrases: vec![],
+        difficulty: "easy".into(),
+        cypher: cypher.into(),
+        unanswerable: false,
+        params: vec![],
+    }
 }
 
 fn queries() -> Vec<QuerySpec> {
@@ -94,6 +102,9 @@ fn an_all_empty_run_fails_even_when_expectations_match() {
         provenance: samyama::snapshot::publish_gate::Provenance::Authored,
         entries: vec![CatalogEntry {
             id: "q_none".into(),
+            question: "a question with no answer".into(),
+            paraphrases: vec![],
+            difficulty: "easy".into(),
             cypher: "MATCH (x:Absent) RETURN x".into(),
             rows: 0,
             hash: canonical_hash(&QueryEngine::new()
@@ -209,4 +220,57 @@ fn an_unknown_catalog_format_is_refused() {
     };
     let err = verify(&store, &bad).expect_err("unknown format must be refused");
     assert!(err.contains("refusing to guess"), "{err}");
+}
+
+/// KG-08 and DX-08 are already-existing requirements; this makes them checkable
+/// rather than aspirational (#1154).
+#[test]
+fn kg08_conformance_names_what_is_missing() {
+    use samyama::snapshot::verify::kg08_conformance;
+
+    let store = seeded();
+    let small = build_catalog(&store, &queries(), &[]).expect("build");
+    let problems = kg08_conformance(&small);
+
+    // Five entries, all answerable, all labelled easy with a question.
+    assert!(problems.iter().any(|p| p.contains("at least 30")), "{problems:?}");
+    assert!(problems.iter().any(|p| p.contains("unanswerable")), "{problems:?}");
+    assert!(
+        !problems.iter().any(|p| p.contains("difficulty")),
+        "difficulty was labelled but reported missing: {problems:?}"
+    );
+
+    // A missing question is reported per entry.
+    let mut q = queries();
+    q[0].question = String::new();
+    let c = build_catalog(&store, &q, &[]).expect("build");
+    assert!(
+        kg08_conformance(&c).iter().any(|p| p.contains("no question text")),
+        "an entry with no question passed"
+    );
+
+    // An unlabelled difficulty is reported per entry.
+    let mut q = queries();
+    q[1].difficulty = "trivial".into();
+    let c = build_catalog(&store, &q, &[]).expect("build");
+    assert!(
+        kg08_conformance(&c).iter().any(|p| p.contains("difficulty")),
+        "an unrecognised difficulty passed"
+    );
+}
+
+/// The digest is what makes a mismatched snapshot/catalog pair detectable,
+/// given the catalog ships beside the snapshot rather than inside it.
+#[test]
+fn the_catalog_digest_changes_when_the_catalog_does() {
+    use samyama::snapshot::verify::catalog_digest;
+    let store = seeded();
+    let a = build_catalog(&store, &queries(), &[]).expect("build");
+    let mut q = queries();
+    q[0].cypher = "MATCH (t:Thing) RETURN count(t) AS total".into();
+    let b = build_catalog(&store, &q, &[]).expect("build");
+    let sa = serde_json::to_string(&a).unwrap();
+    let sb = serde_json::to_string(&b).unwrap();
+    assert_ne!(catalog_digest(&sa), catalog_digest(&sb), "editing a query left the digest alone");
+    assert_eq!(catalog_digest(&sa), catalog_digest(&sa), "the digest is not stable");
 }


### PR DESCRIPTION
#1154. Stacked on #1171. Completes the catalog format begun in #1166 and #1169.

Entries gain `question`, `paraphrases` and `difficulty`. `catalog-gate` reports KG-08 conformance always, enforces it under `--kg08`, and prints the catalog digest.

## Neither requirement is new; both were unexecutable

| requirement | asks for | recorded as |
|---|---|---|
| KG-08 | ≥30 queries with gold answers, difficulty labels, unanswerable items | 🔵 "for some" |
| DX-08 | 5 example questions with expected outputs per KG | 🔵 "42 examples, unexecuted" |

Both sit at partial because the queries live as prose in READMEs where nothing runs them. `kg08_conformance` is what turns them from aspirational into true or false, and it names what is missing per entry rather than returning a score.

**The unanswerable-items check is not padding.** Refusing to answer is a correctness behaviour, and a suite without them cannot distinguish a model that declines from one that guesses.

## The sidecar decision is right, and the digest is what makes it safe

The catalog ships beside the `.sgsnap`, not inside it. Templates are schema-bound and get edited far more often than the data changes; export runs at **~0.77 MB/s and is CPU-bound** (#314), so rebuilding a multi-GB artifact to fix a Cypher string is a bad trade. The digest is what makes a mismatched pair detectable anyway, and it is tested to change when any query changes and to be stable otherwise.

## Not in this PR

Recording the digest **inside** the `.sgsnap` header. That is a format change and belongs with the v3 work in #1099 rather than being bolted onto v2. The digest is emitted so a release can record it in the MANIFEST today.

## Verification

`cargo test --workspace --no-fail-fast`: 266 binaries, **4,170 passed, 0 failed**.

---

## Also here: the number #1158 said it was waiting for

`benches/cold_start_share.rs`. #1158 defers materializing results into the `.sgsnap` and states the condition: *"if the warm cache already gets the speedup, materializing into the file buys only cold-start."* The cache landed in #1153, so this is that number.

Time to first answer from a cold process is `restore + execute`. Materialized results can only remove `execute` — the bytes still have to be read and the graph still built. `dbms-research.sgsnap`, 12.2 MB, 18,751 nodes / 38,539 edges, restore **0.266 s**:

| query | execute | share of time-to-first-answer |
|---|---:|---:|
| count aggregate | 0.012914 s | **4.63%** |
| scan + project | 0.000873 s | 0.33% |
| filtered scan | 0.000923 s | 0.35% |
| two-hop | 0.000960 s | 0.36% |

**0.3%–4.6% is the ceiling** on what #1158 could save here, before paying for a format change, a size cap, an epoch binding and a re-verification step in the release path.

These are an *upper* bound for the published-KG case #1158 targets: restore scales with the file, a cheap query does not, so on a 10 GB KG the restore term grows by three orders of magnitude while the query stays put. The exception is a genuinely expensive query, where execution dominates and materializing does pay — which is why the bench spans four costs and reports per query rather than averaging.

**One thing fell out sideways:** for `scan + project` the warm path is 0.000862 s against a cold 0.000873 s. The result cache barely helps, because a hit clones a `RecordBatch` and for a 1000-row result the clone costs about what the query does. Same effect #1168 caps the cache in bytes for.
