### PR TITLE
A snapshot round trip carries node timestamps (#1124)

### DIFF
--- a/src/snapshot/format.rs
+++ b/src/snapshot/format.rs
@@ -32,6 +32,26 @@ pub struct SnapshotNode {
     pub id: u64,                  // Original NodeId
     pub labels: Vec<String>,
     pub props: HashMap<String, serde_json::Value>,
+    /// Creation timestamp, milliseconds since the epoch (#1124).
+    ///
+    /// Additive, in the same sense as `SnapshotHierarchyIndex` below: a snapshot
+    /// written before this field simply lacks it and defaults to 0, which is the
+    /// value import produced for every node until now, so old files load
+    /// unchanged and the format version does not move. Older readers ignore the
+    /// extra key.
+    ///
+    /// Zero means "not carried", not "created at the epoch". Import leaves the
+    /// node's own timestamp alone rather than writing 0 over it, so a v1 snapshot
+    /// does not stamp every node with a false creation time.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub created_at: i64,
+    /// Last-update timestamp, milliseconds since the epoch. See `created_at`.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub updated_at: i64,
+}
+
+fn is_zero(v: &i64) -> bool {
+    *v == 0
 }
 
 /// An edge record in the snapshot

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -213,6 +213,8 @@ pub fn export_tenant_with_compression(
             id: node.id.as_u64(),
             labels: node.labels.iter().map(|l| l.as_str().to_string()).collect(),
             props,
+            created_at: node.created_at,
+            updated_at: node.updated_at,
         };
         let node_json = serde_json::to_string(&snap_node)?;
         gz.write_all(node_json.as_bytes())?;
@@ -547,6 +549,16 @@ fn import_tenant_inner(
                 if let Some(node) = store.get_node_mut(new_id) {
                     for label in snap_node.labels.iter().skip(1) {
                         node.add_label(label.as_str());
+                    }
+                    // Restore the timestamps the snapshot carries (#1124). Zero
+                    // means the snapshot predates the fields, and writing it back
+                    // would stamp every node of an old file with a false creation
+                    // time, so the node keeps whatever it has in that case.
+                    if snap_node.created_at != 0 {
+                        node.created_at = snap_node.created_at;
+                    }
+                    if snap_node.updated_at != 0 {
+                        node.updated_at = snap_node.updated_at;
                     }
                 }
                 // Every property reaches the ColumnStore, whatever its type.

--- a/tests/query_parity_after_import.rs
+++ b/tests/query_parity_after_import.rs
@@ -189,11 +189,9 @@ fn built(engine: &QueryEngine) -> GraphStore {
 
 /// Compare every query's answer between two stores, reporting all divergences
 /// rather than the first: one failure per run turns a corpus into a queue.
-fn compare(engine: &QueryEngine, reference: &GraphStore, other: &GraphStore, what: &str) {
-    compare_with(engine, reference, other, what, false)
-}
-
-/// `mask_ts` exists for the restart check alone; see `mask_timestamps`.
+/// `mask_ts` exists for the restart check alone; see `mask_timestamps`. The
+/// snapshot check below builds its own diff loop and does not mask, which is what
+/// holds #1124 in place.
 fn compare_with(
     engine: &QueryEngine,
     reference: &GraphStore,

--- a/tests/query_parity_after_import.rs
+++ b/tests/query_parity_after_import.rs
@@ -100,12 +100,10 @@ const QUERIES: &[&str] = &[
 /// the same five entries come back in a different order — a false positive that
 /// would train a reader to ignore the test.
 fn canonical(s: &str) -> String {
-    // Node timestamps are struct metadata, not query answers, and a snapshot round
-    // trip resets them to 0 — a real gap, filed separately (#1124), and not one this
-    // check is about. Masked rather than left in, because a check that fails for a
-    // reason it is not testing gets muted.
-    let masked = mask_timestamps(s);
-    let s = masked.as_str();
+    // The mask that used to stand here hid #1124: a snapshot round trip reset both
+    // node timestamps to 0. The round trip now carries them, so the mask is gone
+    // and this check holds the line for free — if a future change drops them
+    // again, the parity queries below fail on the timestamps.
     let mut out = String::with_capacity(s.len());
     let mut rest = s;
     while let Some(open) = rest.find('{') {
@@ -130,7 +128,15 @@ fn canonical(s: &str) -> String {
     out
 }
 
+/// A result rendered as a comparable string. Column order and row order are part of
+/// the answer, so nothing is sorted there — the queries that need an order say so.
 /// Replace `created_at: <n>` / `updated_at: <n>` with a placeholder.
+///
+/// Used by the persistence-restart check only. A restart re-creates its nodes and
+/// stamps them at restore time, so the timestamps differ from the built graph's by
+/// construction -- a separate gap from #1124, which was about the snapshot round
+/// trip dropping them to 0 and is fixed. The snapshot check below does **not**
+/// mask, so it holds that fix in place.
 fn mask_timestamps(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut rest = s;
@@ -145,8 +151,10 @@ fn mask_timestamps(s: &str) -> String {
     out
 }
 
-/// A result rendered as a comparable string. Column order and row order are part of
-/// the answer, so nothing is sorted there — the queries that need an order say so.
+fn answer_masked(engine: &QueryEngine, store: &GraphStore, q: &str) -> String {
+    mask_timestamps(&answer(engine, store, q))
+}
+
 fn answer(engine: &QueryEngine, store: &GraphStore, q: &str) -> String {
     match engine.execute(q, store) {
         Ok(batch) => {
@@ -182,10 +190,24 @@ fn built(engine: &QueryEngine) -> GraphStore {
 /// Compare every query's answer between two stores, reporting all divergences
 /// rather than the first: one failure per run turns a corpus into a queue.
 fn compare(engine: &QueryEngine, reference: &GraphStore, other: &GraphStore, what: &str) {
+    compare_with(engine, reference, other, what, false)
+}
+
+/// `mask_ts` exists for the restart check alone; see `mask_timestamps`.
+fn compare_with(
+    engine: &QueryEngine,
+    reference: &GraphStore,
+    other: &GraphStore,
+    what: &str,
+    mask_ts: bool,
+) {
+    let render = |store: &GraphStore, q: &str| {
+        if mask_ts { answer_masked(engine, store, q) } else { answer(engine, store, q) }
+    };
     let mut diffs = Vec::new();
     for q in QUERIES {
-        let a = answer(engine, reference, q);
-        let b = answer(engine, other, q);
+        let a = render(reference, q);
+        let b = render(other, q);
         if a != b {
             diffs.push(format!("--- {q}\n  built: {a}\n  {what}: {b}"));
         }
@@ -255,7 +277,7 @@ fn every_query_answers_the_same_after_a_persistence_restart() {
         "recovery populated neither representation"
     );
 
-    compare(&engine, &source, &restored, "a persistence restart");
+    compare_with(&engine, &source, &restored, "a persistence restart", true);
 }
 
 #[test]

--- a/tests/snapshot_timestamps.rs
+++ b/tests/snapshot_timestamps.rs
@@ -1,0 +1,135 @@
+//! A snapshot round trip preserves node timestamps (#1124).
+//!
+//! `export_tenant` → `import_tenant` used to drop `created_at` and `updated_at`,
+//! so every imported node arrived stamped 0. Nothing in Cypher reads them today,
+//! which is why it sat unnoticed — and why it is worth a test rather than a
+//! comment: a field that silently arrives as 0 is discovered by whoever first
+//! depends on it.
+//!
+//! The compatibility half matters as much as the fix. The fields are additive
+//! and default to 0, so a snapshot written before them must still import, and
+//! must not have 0 written over the timestamps the fresh nodes were given.
+
+use samyama::graph::{GraphStore, Label, PropertyMap, PropertyValue};
+use samyama::snapshot::{export_tenant, import_tenant};
+
+fn seeded() -> GraphStore {
+    let mut store = GraphStore::new();
+    for i in 0..5i64 {
+        let mut props = PropertyMap::new();
+        props.insert("id".to_string(), PropertyValue::Integer(i));
+        props.insert("name".to_string(), PropertyValue::String(format!("n{i}")));
+        store.create_node_with_properties("default", vec![Label::new("Row")], props);
+    }
+    store
+}
+
+fn timestamps(store: &GraphStore) -> Vec<(i64, i64)> {
+    let mut v: Vec<(i64, i64)> = store
+        .get_nodes_by_label(&Label::new("Row"))
+        .iter()
+        .map(|n| (n.created_at, n.updated_at))
+        .collect();
+    v.sort_unstable();
+    v
+}
+
+#[test]
+fn a_round_trip_preserves_node_timestamps() {
+    let store = seeded();
+    let before = timestamps(&store);
+    assert!(
+        before.iter().all(|(c, u)| *c > 0 && *u > 0),
+        "the fixture must have real timestamps or this proves nothing: {before:?}"
+    );
+
+    let mut buf = Vec::new();
+    export_tenant(&store, &mut buf).expect("export");
+
+    let mut restored = GraphStore::new();
+    import_tenant(&mut restored, &buf[..]).expect("import");
+
+    assert_eq!(
+        timestamps(&restored),
+        before,
+        "the round trip changed the node timestamps"
+    );
+}
+
+/// A snapshot written before the fields must still import.
+///
+/// Its nodes arrive with timestamps of 0, and that is correct rather than a
+/// regression: the file does not carry them, and `create_node_stub` deliberately
+/// leaves them at 0 to skip a clock syscall per node on import. What the guard in
+/// `import_tenant` prevents is the opposite mistake — writing the snapshot's 0
+/// over a value the node already had.
+#[test]
+fn a_snapshot_without_the_fields_still_imports() {
+    use std::io::{Read, Write};
+
+    let store = seeded();
+    let mut buf = Vec::new();
+    export_tenant(&store, &mut buf).expect("export");
+
+    let raw = {
+        let mut gz = flate2::read::GzDecoder::new(&buf[..]);
+        let mut s = String::new();
+        gz.read_to_string(&mut s).expect("read");
+        s
+    };
+    assert!(
+        raw.lines().any(|l| l.contains("\"t\":\"n\"") && l.contains("created_at")),
+        "the fixture snapshot must carry the field on its node lines"
+    );
+
+    // Strip both keys from the node lines only. The header carries its own
+    // required `created_at` (an ISO 8601 string), so stripping every line breaks
+    // the header rather than simulating an older writer.
+    let stripped: String = raw
+        .lines()
+        .map(|l| {
+            let mut l = l.to_string();
+            if !l.contains("\"t\":\"n\"") {
+                return l;
+            }
+            for key in ["created_at", "updated_at"] {
+                let pat = format!(",\"{key}\":");
+                while let Some(p) = l.find(&pat) {
+                    let tail = &l[p + 1..];
+                    let end = tail
+                        .find(|c: char| c == ',' || c == '}')
+                        .map(|c| p + 1 + c)
+                        .unwrap_or(l.len());
+                    l.replace_range(p..end, "");
+                }
+            }
+            l
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    // Node lines only: the header keeps its own `created_at`, which is a
+    // different, required field.
+    assert!(
+        !stripped
+            .lines()
+            .any(|l| l.contains("\"t\":\"n\"") && l.contains("created_at")),
+        "strip failed on a node line"
+    );
+
+    let old_buf = {
+        let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        gz.write_all(stripped.as_bytes()).expect("write");
+        gz.finish().expect("finish")
+    };
+
+    let mut restored = GraphStore::new();
+    import_tenant(&mut restored, &old_buf[..]).expect("an older snapshot must import");
+
+    let after = timestamps(&restored);
+    assert_eq!(after.len(), 5, "not every node imported: {after:?}");
+    assert!(
+        after.iter().all(|(c, u)| *c == 0 && *u == 0),
+        "a snapshot that does not carry timestamps produced non-zero ones, so \
+         they came from somewhere other than the file: {after:?}"
+    );
+}

--- a/tests/snapshot_timestamps.rs
+++ b/tests/snapshot_timestamps.rs
@@ -97,7 +97,7 @@ fn a_snapshot_without_the_fields_still_imports() {
                 while let Some(p) = l.find(&pat) {
                     let tail = &l[p + 1..];
                     let end = tail
-                        .find(|c: char| c == ',' || c == '}')
+                        .find([',', '}'])
                         .map(|c| p + 1 + c)
                         .unwrap_or(l.len());
                     l.replace_range(p..end, "");


### PR DESCRIPTION
`export_tenant` → `import_tenant` preserved ids, labels and properties and dropped `created_at` and `updated_at`, so every imported node arrived stamped **0**.

#1124 framed this as a format decision: carry them, or document that the format does not. **Carrying them is additive**, in the same sense `SnapshotHierarchyIndex` already is — both fields default to 0 and are skipped when zero, so:

- a snapshot written before them lacks the keys and loads unchanged
- older readers ignore the extra keys
- **the format version does not move**

Import writes a timestamp back only when the snapshot carries a non-zero one. Zero means "not carried", not "created at the epoch", and writing it back would stamp every node of an older file with a false creation time.

## The mask, and what removing it found

#1124's note says: *"remove the mask when the round trip preserves them — the test will then hold the line for free."* Done for the snapshot check.

Removing it exposed **a second gap the single mask was hiding.** The *persistence restart* path does not lose timestamps — it **re-stamps** them at restore, so restored nodes carry the restore time rather than the original:

```
built:   created_at: 1788932588686
restart: created_at: 1788932588769
```

Different defect, different path, not fixed here. The mask survives for that check alone — scoped and explained rather than blanket, so it cannot hide the snapshot behaviour again. Worth its own issue; happy to file it if you agree it is a defect rather than intended (a restart arguably *does* create new nodes).

## Tests

`tests/snapshot_timestamps.rs`, 2 tests:

- the round trip preserves them
- a snapshot **without** the fields still imports, and its nodes come back with 0 — which is correct rather than a regression, because the file does not carry them and `create_node_stub` deliberately leaves them at 0 to skip a clock syscall per node

That second test caught two of my own errors before it was right: it first stripped `created_at` from the *header* line too (a required ISO 8601 field, unrelated), and then asserted the timestamps should be non-zero, which would have demanded the import invent them.

`cargo test --lib`: **2203 passed.** All five snapshot suites and the parity suite pass.