### PR TITLE
Quickstart pulls the 1.7.1 image, with an Apple Silicon pull command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     <strong>The graph database that queried 1 billion edges for $2.50</strong>
   </p>
   <p align="center">
-    <a href="https://github.com/samyama-ai/samyama-graph/releases"><img src="https://img.shields.io/badge/version-1.1.0-blue" alt="Version"></a>
+    <a href="https://github.com/samyama-ai/samyama-graph/releases"><img src="https://img.shields.io/badge/version-1.7.1-blue" alt="Version"></a>
     <a href="https://github.com/samyama-ai/samyama-graph/actions"><img src="https://img.shields.io/badge/tests-2238_passing-brightgreen" alt="Tests"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache_2.0-blue" alt="License"></a>
     <a href="https://graph.samyama.cloud/book/"><img src="https://img.shields.io/badge/book-read_the_docs-orange" alt="Book"></a>
@@ -35,9 +35,21 @@ It brings together graph traversal, OpenCypher-style querying, vector search, gr
 
 **Step 2 — Pull the Docker image**
 
+Intel Mac, Windows, and x86 Linux:
+
 ```bash
-docker pull public.ecr.aws/f9f6l5u4/samyama-graph:1.1.0
+docker pull public.ecr.aws/f9f6l5u4/samyama-graph:1.7.1
 ```
+
+Apple Silicon Mac (M1/M2/M3/M4):
+
+```bash
+docker pull --platform linux/amd64 public.ecr.aws/f9f6l5u4/samyama-graph:1.7.1
+```
+
+> 🍎 The image is published for `linux/amd64` only. On Apple Silicon, Docker Desktop runs it
+> under emulation — slower than native, but it works. Keep the `--platform linux/amd64` flag on
+> `docker run` too, or set `platform: linux/amd64` in the compose file as shown below.
 
 **Step 3 — Docker Compose setup**
 
@@ -65,7 +77,8 @@ notepad docker-compose.yml
 version: "3.9"
 services:
   samyama-graph:
-    image: public.ecr.aws/f9f6l5u4/samyama-graph:1.1.0
+    image: public.ecr.aws/f9f6l5u4/samyama-graph:1.7.1
+    # platform: linux/amd64   # uncomment on Apple Silicon Macs
     container_name: samyama-graph
     restart: unless-stopped
     ports:
@@ -124,10 +137,6 @@ curl -X POST http://localhost:8080/api/query \
   -H 'content-type: application/json' \
   -d '{"query":"MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a.name, b.name","graph":"default"}'
 ```
-
-> **Note on `-->`**: the published `1.1.0` image cannot parse the bare arrow
-> form (`MATCH (a)-->(b)`); write `-[]->` or name the relationship type until a
-> newer image is published ([#1038](https://github.com/samyama-ai/samyama-graph/issues/1038)).
 
 **Step 7 — Samyama Visualizer**
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -68,10 +68,12 @@ Note: Stop the conflicting process, or change the host port in `docker-compose.y
 <summary><strong>Issue 4 — Image fails to pull</strong></summary>
 
 ```bash
-docker pull public.ecr.aws/f9f6l5u4/samyama-graph:1.1.0
+docker pull public.ecr.aws/f9f6l5u4/samyama-graph:1.7.1
 ```
 
 Note: Ensure Docker Desktop is running and you have an active internet connection. The image is public — no credentials are required.
+
+If the error is `no matching manifest for linux/arm64/v8`, you are on an Apple Silicon Mac. The image is published for `linux/amd64` only — add `--platform linux/amd64` to the pull/run command, or `platform: linux/amd64` to the service in `docker-compose.yml`.
 
 </details>
 


### PR DESCRIPTION
 ## Summary

  Bumps the Quickstart and troubleshooting guide from the `1.1.0` image to `1.7.1`, and documents how to run the image on Apple Silicon Macs.

  ## Why

  The README and `docs/TROUBLESHOOTING.md` still pointed at `public.ecr.aws/f9f6l5u4/samyama-graph:1.1.0`, published on 2026-08-01. Tags `1.7.0` and `1.7.1` were pushed to the
  same public ECR repository on 2026-09-09, built from the `v1.7.0` and `v1.7.1` GitHub tags. New users following the Quickstart were getting a release six minor versions
  behind.

  Separately, the published images are `linux/amd64` only. On an Apple Silicon Mac a plain `docker pull` fails with:

  no matching manifest for linux/arm64/v8 in the manifest list entries

  Nothing in the docs explained this or how to get past it.

  ## What changed

  ### README.md

  - **Version badge** now reads 1.7.1.
  - **Step 2, pull the image** shows two commands instead of one:
    - Intel Mac, Windows, and x86 Linux: `docker pull public.ecr.aws/f9f6l5u4/samyama-graph:1.7.1`
    - Apple Silicon Mac: the same command with `--platform linux/amd64`
  - A callout below the commands explains that the image is amd64-only, that Docker Desktop runs it under emulation on Apple Silicon, that this is slower than native but works,
  and that the flag must also be kept on `docker run` or expressed as `platform: linux/amd64` in compose.
  - **Compose example** points at `1.7.1` and carries a commented `platform: linux/amd64` line directly under `image:`, ready to uncomment on Apple Silicon.
  - **Removed the `-->` caveat.** The note said the 1.1.0 image cannot parse the bare arrow form and pointed at #1038. The 1.7.1 image was checked directly: `MATCH (a)-->(b)
  RETURN a.name, b.name` returns the expected rows over the HTTP query endpoint, so the workaround is no longer needed.

  ### docs/TROUBLESHOOTING.md

  - **Issue 4, image fails to pull** now uses the `1.7.1` tag.
  - Adds a line mapping the exact `no matching manifest for linux/arm64/v8` error text to the `--platform linux/amd64` fix, so someone searching for the error lands on the
  answer.

  ## Verification

  - Built `samyama-graph:1.7.1` locally from the `v1.7.1` tag with the repo `Dockerfile`, started it, and confirmed the container reaches `healthy`, `/api/status` reports
  version `1.7.1`, and a CREATE plus MATCH round trip works over both RESP and HTTP.
  - Confirmed with `docker buildx imagetools inspect` that the ECR `1.7.0`, `1.7.1`, and `1.1.0` tags all carry `linux/amd64` only, which is what makes the Apple Silicon note
  necessary.
  - Verified on an Intel Mac. The Apple Silicon emulated path was not exercised on hardware; it relies on standard Docker Desktop behaviour for `--platform linux/amd64`.

  ## Not in this PR

  - No code changes.
  - No multi-arch rebuild. Publishing a `linux/arm64` variant would remove the need for the platform flag entirely and is left for a separate change.