### PR TITLE
The release gate demanded a status CH-REGRESS never emits

### DIFF
--- a/scripts/check_release_gate.py
+++ b/scripts/check_release_gate.py
@@ -15,6 +15,35 @@ source-code change.
 not "it is fine" -- treating those as the same thing is the failure the whole
 harness is built to avoid, and a release is the last place to start.
 
+**A green CH-REGRESS run reports `partial`, not `pass`**, so this accepts both.
+The envelope's status is derived pessimistically (benchmarks repo,
+`harness/envelope.py`):
+
+    error      if any measurement errored
+    fail       if any measurement failed        <- a real regression lands here
+    partial    if any measurement is partial or unmeasured
+    pass       otherwise
+
+CH-REGRESS marks each of its 62 per-query timings `partial`, because a timing
+has no pass/fail target of its own -- so the run-level status is `partial`
+however green the suite is, and `pass` is unreachable. Requiring it blocked
+every release from 2026-08-28 (when this check landed) until this fix: twelve
+consecutive verdicts, none of them `pass`, and no tag cut in that window.
+
+The benchmarks repo's own `harness/gate.py` documents the trap it fell into
+here: *"testing for `"pass"` would be a condition that can never hold however
+green the suite is ... It is an easy shape to write and an invisible one to
+read, because 'not met' looks like work remaining rather than like a broken
+test."*
+
+Accepting `partial` does **not** weaken the gate against regressions: by the
+rollup above, a slower query produces `fail`, which is still refused.
+
+It does leave one narrower gap. `partial` also covers "a measurement declined
+to judge", and the verdict file carries no per-measurement detail to tell that
+apart from the ordinary timing case. Closing it needs the nightly to publish
+that detail -- see the note at the bottom of this file.
+
     python3 scripts/check_release_gate.py RELEASE-GATE.json [--max-age-days 3]
 """
 
@@ -60,13 +89,26 @@ def main() -> int:
               f"A gate with gaps nobody notices is not a gate.")
         return 1
 
-    if g.get("status") != "pass":
-        print(f"::error::CH-REGRESS is {g.get('status')!r}: {g.get('note')}")
+    # `pass` and `partial` are both green; everything else refuses. See the
+    # module docstring for why `pass` alone was unreachable.
+    status = g.get("status")
+    if status not in ("pass", "partial"):
+        print(f"::error::CH-REGRESS is {status!r}: {g.get('note')}")
         return 1
 
-    print(f"CH-REGRESS pass, {age}d old, host {g.get('host')!r}, "
+    print(f"CH-REGRESS {status}, {age}d old, host {g.get('host')!r}, "
           f"engine {g.get('engine_commit')}")
     return 0
+
+
+# FOLLOW-UP, for the benchmarks repo rather than here.
+#
+# `harness/nightly/publish_verdict.py` reduces the envelope to seven fields and
+# keeps no per-measurement detail, so this script cannot apply the definition
+# `harness/gate.py` settled on -- *green is no failed measurement and a headline
+# that actually judged*. Publishing two more fields (whether any measurement
+# failed, and whether the headline was withheld) would let this check refuse a
+# run that declined to judge, which today it cannot see.
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_release_gate.py
+++ b/scripts/test_check_release_gate.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""The release gate must refuse for *three* reasons, not one.
+"""The release gate must refuse for *three* reasons, not one -- and must not
+refuse for a fourth that is not a reason at all.
 
 A gate that only rejects a red verdict is not a gate. The two cases that
 actually happen are the nightly having stopped (stale) and never having run
@@ -41,8 +42,22 @@ def stamp(days_ago: int) -> str:
 CASES = [
     ("a fresh pass lets the tag through", 0,
      {"status": "pass", "measured_at": stamp(0), "host": "vm-1"}),
+    # The case this suite was missing, and the reason the gate never opened.
+    # CH-REGRESS marks each of its 62 per-query timings `partial` -- a timing
+    # has no pass/fail target -- so the run-level status is `partial` however
+    # green the suite is. Requiring `pass` blocked every release for the whole
+    # life of the check. A regression is `fail` by the envelope's rollup, so
+    # accepting `partial` does not weaken it.
+    ("a fresh partial lets the tag through", 0,
+     {"status": "partial", "measured_at": stamp(0), "host": "vm-1",
+      "note": "62 timings partial; no target of their own"}),
     ("a fresh fail blocks", 1,
      {"status": "fail", "measured_at": stamp(0), "note": "IC6 3.2x slower"}),
+    ("a fresh error blocks", 1,
+     {"status": "error", "measured_at": stamp(0), "note": "harness crashed"}),
+    # Stale applies to partial exactly as it does to pass.
+    ("a stale partial blocks", 1,
+     {"status": "partial", "measured_at": stamp(9), "host": "vm-1"}),
     # The nightly stopped a week ago. Nothing is red; nothing has looked.
     ("a stale pass blocks", 1,
      {"status": "pass", "measured_at": stamp(9), "host": "vm-1"}),


### PR DESCRIPTION
No tag has been cut since **2026-08-28**, the day `scripts/check_release_gate.py` landed. Not because anything regressed — because the condition could not hold.

## The bug

```python
if g.get("status") != "pass":
    return 1
```

The envelope's status is derived pessimistically (benchmarks repo, `harness/envelope.py`):

```
error      if any measurement errored
fail       if any measurement failed        <- a real regression lands here
partial    if any measurement is partial or unmeasured
pass       otherwise
```

CH-REGRESS marks each of its **62 per-query timings `partial`**, because a timing has no pass/fail target of its own. So the run-level status is `partial` however green the suite is, and `pass` is unreachable.

## Evidence it is categorical, not selective

| | |
|---|---|
| verdicts published since 2026-08-31 | 12 — all `partial` or `fail`, never once `pass` |
| this check landed | `4746793`, 2026-08-28 |
| release tags containing that commit | **0** |
| v1.7.1 tagged | 2026-08-27 — one day earlier, which is why it escaped |

v1.7.1 is the last installable release *because* it predates this check. Everything since has been stuck behind a gate that has never opened — including the fix for the unbounded-memory blow-up (#1183) that is live in what users install today.

## The benchmarks repo already named this trap

`harness/gate.py`, in the docstring for `_newest_envelope_status`:

> *"testing for `"pass"` would be a condition that can never hold however green the suite is … That is the third check today built so it could not pass; the other two were in the quiet-host sampler. It is an easy shape to write and an **invisible one to read**, because 'not met' looks like work remaining rather than like a broken test."*

That file uses the right definition. This one didn't.

## The fix

Accept `partial` alongside `pass`.

**This does not weaken the gate against regressions.** By the rollup above, a slower query yields `fail` — still refused, as are `error` and `unmeasured`. Staleness and a missing verdict still block exactly as before.

## The test was the other half

`scripts/test_check_release_gate.py` covered `pass`, `fail`, `unmeasured`, stale, a missing verdict, and the day-3/day-4 boundary. Thorough enough to look reassuring — and it **never tested `partial`**, the one status the suite actually produces. It passed in CI throughout.

The new case fails against the unfixed script, which is the point of adding it:

```
$ git stash -- scripts/check_release_gate.py    # revert to the original
$ python3 scripts/test_check_release_gate.py
...
FAIL
```

## Verified against the live verdict

Against the file currently on the `release-gate` branch:

```
$ python3 scripts/check_release_gate.py RELEASE-GATE.json
CH-REGRESS partial, 0d old, host 'vm-1', engine e728b28
$ echo $?
0
```

So this unblocks the tag **with no new measurement** and nothing needed on `vm-1`.

## One gap left open deliberately

`partial` also covers *"a measurement declined to judge"*, and the verdict file carries no per-measurement detail to tell that apart from the ordinary timing case. `harness/nightly/publish_verdict.py` reduces the envelope to seven fields.

Closing it needs the nightly to publish two more (whether any measurement failed, and whether the headline was withheld) so this check can apply `gate.py`'s full definition — *green is no failed measurement and a headline that actually judged*. That is a change for the benchmarks repo; noted in the script rather than silently left.

## Separately — this alone does not make a release installable

`tag-release.yml` creates the GitHub Release with `GH_TOKEN: ${{ github.token }}`, and GitHub does not trigger workflows from events raised by the default token. Every publish workflow triggers on `release: [published]`, so none ran for v1.7.1 — the tag and Release exist, the container registry stops at 1.7.0.

Not fixed here. It needs a PAT with `workflow` scope, or the publish jobs folded into `tag-release.yml` directly.