### PR TITLE
A typed column for DateTime: ~9 bytes a date instead of ~134 (#1195)

### DIFF
--- a/src/graph/storage/columnar.rs
+++ b/src/graph/storage/columnar.rs
@@ -364,6 +364,15 @@ fn clear_bit(words: &mut [u64], slot: usize) {
 #[derive(Debug, Clone)]
 pub enum Column {
     Int(ColumnData<i64>),
+    /// `PropertyValue::DateTime`, the epoch-millisecond `i64` it wraps.
+    ///
+    /// Before this variant a date went to `Other`: a hash-map entry holding a
+    /// whole 56-byte `PropertyValue`, about 134 bytes a value measured on LDBC
+    /// SNB SF10 against the ~9 an `i64` slot and its presence bit take here
+    /// (#1195). Dates are the commonest temporal property -- every message's
+    /// `creationDate` -- and a scan filtering or sorting on one read it
+    /// through a hash probe per row.
+    DateTime(ColumnData<i64>),
     Float(ColumnData<f64>),
     String(ColumnData<String>),
     Bool(ColumnData<bool>),
@@ -371,8 +380,8 @@ pub enum Column {
     ///
     /// Two things land here:
     ///
-    /// * **variants with no typed column** — `DateTime`, `Array`, `Map`,
-    ///   `Vector`, `Duration`. Before this they were dropped on the way in and
+    /// * **variants with no typed column** — `Array`, `Map`, `Vector`,
+    ///   `Duration` and the zoned/local temporal forms. Before this they were dropped on the way in and
     ///   survived only because row storage kept a second copy of every
     ///   property. That made the duplication load-bearing rather than
     ///   redundant, and blocked removing it (#545).
@@ -391,7 +400,7 @@ impl Column {
     /// Resident bytes of this column's data, at capacity.
     pub fn heap_bytes(&self) -> usize {
         match self {
-            Column::Int(d) => d.heap_bytes(std::mem::size_of::<i64>(), |_| 0),
+            Column::Int(d) | Column::DateTime(d) => d.heap_bytes(std::mem::size_of::<i64>(), |_| 0),
             Column::Float(d) => d.heap_bytes(std::mem::size_of::<f64>(), |_| 0),
             Column::Bool(d) => d.heap_bytes(std::mem::size_of::<bool>(), |_| 0),
             Column::String(d) => d.heap_bytes(std::mem::size_of::<String>(), |s: &String| s.len()),
@@ -424,6 +433,7 @@ fn property_value_heap(v: &PropertyValue) -> usize {
 
 impl Column {
     pub fn new_int() -> Self { Column::Int(ColumnData::new()) }
+    pub fn new_datetime() -> Self { Column::DateTime(ColumnData::new()) }
     pub fn new_float() -> Self { Column::Float(ColumnData::new()) }
     pub fn new_string() -> Self { Column::String(ColumnData::new()) }
     pub fn new_bool() -> Self { Column::Bool(ColumnData::new()) }
@@ -433,6 +443,7 @@ impl Column {
     pub fn for_value(value: &PropertyValue) -> Self {
         match value {
             PropertyValue::Integer(_) => Column::new_int(),
+            PropertyValue::DateTime(_) => Column::new_datetime(),
             PropertyValue::Float(_) => Column::new_float(),
             PropertyValue::String(_) => Column::new_string(),
             PropertyValue::Boolean(_) => Column::new_bool(),
@@ -443,6 +454,7 @@ impl Column {
     pub fn set(&mut self, idx: usize, value: PropertyValue) {
         match (&mut *self, value) {
             (Column::Int(m), PropertyValue::Integer(val)) => m.set(idx, val),
+            (Column::DateTime(m), PropertyValue::DateTime(val)) => m.set(idx, val),
             (Column::Float(m), PropertyValue::Float(val)) => m.set(idx, val),
             (Column::String(m), PropertyValue::String(val)) => m.set(idx, val),
             (Column::Bool(m), PropertyValue::Boolean(val)) => m.set(idx, val),
@@ -470,6 +482,7 @@ impl Column {
         let mut spilled: FxHashMap<usize, PropertyValue> = FxHashMap::default();
         match self {
             Column::Int(m) => m.for_each(|idx, v| { spilled.insert(idx, PropertyValue::Integer(*v)); }),
+            Column::DateTime(m) => m.for_each(|idx, v| { spilled.insert(idx, PropertyValue::DateTime(*v)); }),
             Column::Float(m) => m.for_each(|idx, v| { spilled.insert(idx, PropertyValue::Float(*v)); }),
             Column::Bool(m) => m.for_each(|idx, v| { spilled.insert(idx, PropertyValue::Boolean(*v)); }),
             Column::String(m) => m.for_each(|idx, v| { spilled.insert(idx, PropertyValue::String(v.clone())); }),
@@ -481,7 +494,7 @@ impl Column {
     /// Remove this row's value from the column, if present.
     pub fn remove(&mut self, idx: usize) {
         match self {
-            Column::Int(m) => m.remove(idx),
+            Column::Int(m) | Column::DateTime(m) => m.remove(idx),
             Column::Float(m) => m.remove(idx),
             Column::String(m) => m.remove(idx),
             Column::Bool(m) => m.remove(idx),
@@ -494,6 +507,7 @@ impl Column {
     pub fn get(&self, idx: usize) -> PropertyValue {
         match self {
             Column::Int(m) => m.get(idx).map(|&v| PropertyValue::Integer(v)).unwrap_or(PropertyValue::Null),
+            Column::DateTime(m) => m.get(idx).map(|&v| PropertyValue::DateTime(v)).unwrap_or(PropertyValue::Null),
             Column::Float(m) => m.get(idx).map(|&v| PropertyValue::Float(v)).unwrap_or(PropertyValue::Null),
             Column::Bool(m) => m.get(idx).map(|&v| PropertyValue::Boolean(v)).unwrap_or(PropertyValue::Null),
             Column::String(m) => m.get(idx).map(|s| PropertyValue::String(s.clone())).unwrap_or(PropertyValue::Null),
@@ -504,7 +518,7 @@ impl Column {
     /// Check if a value exists at the given index.
     pub fn has(&self, idx: usize) -> bool {
         match self {
-            Column::Int(m) => m.has(idx),
+            Column::Int(m) | Column::DateTime(m) => m.has(idx),
             Column::Float(m) => m.has(idx),
             Column::String(m) => m.has(idx),
             Column::Bool(m) => m.has(idx),
@@ -515,7 +529,7 @@ impl Column {
     /// Number of entries in this column.
     pub fn len(&self) -> usize {
         match self {
-            Column::Int(m) => m.len(),
+            Column::Int(m) | Column::DateTime(m) => m.len(),
             Column::Float(m) => m.len(),
             Column::String(m) => m.len(),
             Column::Bool(m) => m.len(),
@@ -527,7 +541,7 @@ impl Column {
     /// no caller should behave differently based on it.
     pub fn is_dense(&self) -> bool {
         match self {
-            Column::Int(m) => matches!(m, ColumnData::Dense { .. }),
+            Column::Int(m) | Column::DateTime(m) => matches!(m, ColumnData::Dense { .. }),
             Column::Float(m) => matches!(m, ColumnData::Dense { .. }),
             Column::String(m) => matches!(m, ColumnData::Dense { .. }),
             Column::Bool(m) => matches!(m, ColumnData::Dense { .. }),
@@ -918,6 +932,47 @@ mod tests {
         assert_eq!(col.get(DENSE_N - 1), PropertyValue::Integer(DENSE_N as i64 - 1));
         assert_eq!(col.get(DENSE_N + 1), PropertyValue::String("odd one out".to_string()));
         assert_eq!(col.get(DENSE_N), PropertyValue::Null, "the gap is still a gap");
+    }
+
+    #[test]
+    fn a_date_column_is_typed_and_a_fraction_of_the_spill_map() {
+        // #1195: dates went to `Other`, a hash map of whole `PropertyValue`s.
+        // The same dates in the typed column must round-trip and cost a small
+        // fraction of that -- a ratio in one process, not an absolute bound.
+        const N: usize = 50_000;
+        let mut typed = Column::for_value(&PropertyValue::DateTime(0));
+        let mut spilled = Column::Other(FxHashMap::default());
+        for i in 0..N {
+            let v = PropertyValue::DateTime(1_262_304_000_000 + i as i64 * 60_000);
+            typed.set(i, v.clone());
+            spilled.set(i, v);
+        }
+        assert!(matches!(typed, Column::DateTime(_)), "a date must get the typed column");
+        assert!(typed.is_dense(), "{N} contiguous dates should be stored densely");
+        assert_eq!(typed.len(), N);
+        for i in [0, 1, N / 2, N - 1] {
+            assert_eq!(typed.get(i), spilled.get(i), "row {i} reads differently");
+        }
+        assert_eq!(typed.get(N), PropertyValue::Null, "an unset row is still null");
+        let (t, o) = (typed.heap_bytes(), spilled.heap_bytes());
+        assert!(
+            t * 4 < o,
+            "typed date column {t} B against {o} B in the spill map: expected under a quarter"
+        );
+    }
+
+    #[test]
+    fn a_date_column_keeps_its_dates_when_it_meets_another_type() {
+        let mut col = Column::for_value(&PropertyValue::DateTime(5));
+        col.set(0, PropertyValue::DateTime(5));
+        col.set(1, PropertyValue::DateTime(6));
+        col.set(2, PropertyValue::Integer(7));
+        assert!(matches!(col, Column::Other(_)), "a mixed column promotes");
+        assert_eq!(col.get(0), PropertyValue::DateTime(5));
+        assert_eq!(col.get(1), PropertyValue::DateTime(6));
+        assert_eq!(col.get(2), PropertyValue::Integer(7));
+        col.remove(1);
+        assert_eq!(col.get(1), PropertyValue::Null);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1195.

`PropertyValue::DateTime` had no typed column, so every date in a `ColumnStore` went to `Column::Other`, a hash map of whole 56-byte `PropertyValue`s.

- **Memory (derived):** on LDBC SNB SF10, moving 47.9M relationship dates into the columns (#1194) cost 6.4 GB of peak RSS, ~134 B a value. An `i64` slot plus its presence bit is ~9. The same applies to node dates: every Post/Comment `creationDate`, 29.3M at SF10.
- **Latency (inferred, to be measured):** IC2's SF10 profile is 63% a Filter and a Sort that each read `m.creationDate` once per row through that map (#1195 comment).

`Column::DateTime(ColumnData<i64>)` holds the epoch-millisecond `i64`, sparse or dense by span like `Int`; a date column that meets another type promotes to `Other` and keeps its dates. The change is confined to `src/graph/storage/columnar.rs` — nothing else matches on `Column` variants.

## Tests
- `a_date_column_is_typed_and_a_fraction_of_the_spill_map`: 50,000 dates are typed, dense, round-trip, and cost under a quarter of the same dates in `Other` (ratio in one process). Fails on `main` at the first assert (a date gets `Other`).
- `a_date_column_keeps_its_dates_when_it_meets_another_type`: promotion preserves dates; `remove` works.
- The existing every-variant round-trip tests (unit and `tests/columnar_holds_every_variant.rs`) now run `DateTime` through the typed path.

Full suite: CI on this PR (built off the laptop).

## To measure before merge
SNB SF10 on one spot host, `main` vs this branch: peak RSS, and IC2's median with the same parameters.

https://claude.ai/code/session_01Uxo712ccCGoMTEhr6bKrBg